### PR TITLE
[Azure Load Testing] Bug fix for two commands. Changing logical implementation.

### DIFF
--- a/src/load/HISTORY.rst
+++ b/src/load/HISTORY.rst
@@ -4,8 +4,9 @@ Release History
 ===============
 0.3.2
 ++++++
-* Fix to enhance usage of config files in 'az load test create' and 'az load test update' commands when using --load-test-config-file option.
-* Fix to accept null or "" in arguments such as env, certificate, etc while using 'az load test create' and 'az load test update' commands.
+* Added null support for argument --certificate and --subnet in commands "az load update" and "az load create" to remove those properties from test.
+* Added support to remove certificate, subnet from config file when provided in commands "az load update" and "az load create".
+* Logical implementation changed when using config file using argument --load-test-config-file in commands "az load test update" and "az load test create".  
 * Added test cases test_load_test_update_with_config to test the new fixes.
 
 0.3.1

--- a/src/load/HISTORY.rst
+++ b/src/load/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 0.3.2
 ++++++
 * Fix to enhance usage of config files in 'az load test create' and 'az load test update' commands when using --load-test-config-file option.
+* Fix to accept null or "" in arguments such as env, certificate, etc while using 'az load test create' and 'az load test update' commands.
 * Added test cases test_load_test_update_with_config to test the new fixes.
 
 0.3.1

--- a/src/load/HISTORY.rst
+++ b/src/load/HISTORY.rst
@@ -2,14 +2,15 @@
 
 Release History
 ===============
+0.3.2
+++++++
+* Fix to enhance usage of config files in 'az load test create' and 'az load test update' commands when using --load-test-config-file option.
+* Added test cases test_load_test_update_with_config to test the new fixes.
+
 0.3.1
 ++++++
 * Enhanced data plane test cases.
 * Fix for failure criteria when 'az load test create' and 'az load test update' commands when using --load-test-config-file option.
-
-0.3.0
-++++++
-* Initial release of Azure Load Testing data plane command groups.
 
 0.3.0
 ++++++

--- a/src/load/azext_load/data_plane/load_test/custom.py
+++ b/src/load/azext_load/data_plane/load_test/custom.py
@@ -9,7 +9,8 @@ import os
 
 from azext_load.data_plane.utils.utils import (
     convert_yaml_to_test,
-    create_or_update_body,
+    create_or_update_test_with_config,
+    create_or_update_test_without_config,
     download_file,
     get_admin_data_plane_client,
     load_yaml,
@@ -52,27 +53,41 @@ def create_test(
         msg = f"Test with given test ID : {test_id} already exist."
         logger.debug(msg)
         raise InvalidArgumentValueError(msg)
-    body = {}
+    body = {}    
     yaml, yaml_test_body = None, None
-    if load_test_config_file is not None:
-        yaml = load_yaml(load_test_config_file)
-        yaml_test_body = convert_yaml_to_test(yaml)
     if split_csv is None:
         split_csv = False
-    body = create_or_update_body(
-        test_id,
-        body,
-        yaml_test_body,
-        display_name=display_name,
-        test_description=test_description,
-        engine_instances=engine_instances,
-        env=env,
-        secrets=secrets,
-        certificate=certificate,
-        key_vault_reference_identity=key_vault_reference_identity,
-        subnet_id=subnet_id,
-        split_csv=split_csv,
-    )
+    if load_test_config_file is None:
+        body = create_or_update_test_without_config(
+            test_id,
+            body,
+            display_name=display_name,
+            test_description=test_description,
+            engine_instances=engine_instances,
+            env=env,
+            secrets=secrets,
+            certificate=certificate,
+            key_vault_reference_identity=key_vault_reference_identity,
+            subnet_id=subnet_id,
+            split_csv=split_csv,
+        )
+    else:
+        yaml = load_yaml(load_test_config_file)
+        yaml_test_body = convert_yaml_to_test(yaml)
+        body = create_or_update_test_with_config(
+            test_id,
+            body,
+            yaml_test_body,
+            display_name=display_name,
+            test_description=test_description,
+            engine_instances=engine_instances,
+            env=env,
+            secrets=secrets,
+            certificate=certificate,
+            key_vault_reference_identity=key_vault_reference_identity,
+            subnet_id=subnet_id,
+            split_csv=split_csv,
+        )
     logger.debug("Creating test with test ID: %s and body : %s", test_id, body)
     response = client.create_or_update_test(test_id=test_id, body=body)
     logger.debug(
@@ -118,21 +133,34 @@ def update_test(
     if load_test_config_file is not None:
         yaml = load_yaml(load_test_config_file)
         yaml_test_body = convert_yaml_to_test(yaml)
-
-    body = create_or_update_body(
-        test_id,
-        body,
-        yaml_test_body,
-        display_name=display_name,
-        test_description=test_description,
-        engine_instances=engine_instances,
-        env=env,
-        secrets=secrets,
-        certificate=certificate,
-        key_vault_reference_identity=key_vault_reference_identity,
-        subnet_id=subnet_id,
-        split_csv=split_csv,
-    )
+        body = create_or_update_test_with_config(
+            test_id,
+            body,
+            yaml_test_body,
+            display_name=display_name,
+            test_description=test_description,
+            engine_instances=engine_instances,
+            env=env,
+            secrets=secrets,
+            certificate=certificate,
+            key_vault_reference_identity=key_vault_reference_identity,
+            subnet_id=subnet_id,
+            split_csv=split_csv,
+        )
+    else:
+        body = create_or_update_test_without_config(
+            test_id,
+            body,
+            display_name=display_name,
+            test_description=test_description,
+            engine_instances=engine_instances,
+            env=env,
+            secrets=secrets,
+            certificate=certificate,
+            key_vault_reference_identity=key_vault_reference_identity,
+            subnet_id=subnet_id,
+            split_csv=split_csv,
+        )
     logger.info("Updating test with test ID: %s", test_id)
     response = client.create_or_update_test(test_id=test_id, body=body)
     logger.debug(

--- a/src/load/azext_load/data_plane/load_test/custom.py
+++ b/src/load/azext_load/data_plane/load_test/custom.py
@@ -94,7 +94,9 @@ def create_test(
         "Created test with test ID: %s and response obj is %s", test_id, response
     )
     logger.info("Uploading files to test %s", test_id)
-    upload_files_helper(client, test_id, yaml, test_plan, load_test_config_file, not custom_no_wait)
+    upload_files_helper(
+        client, test_id, yaml, test_plan, load_test_config_file, not custom_no_wait
+    )
     response = client.get_test(test_id)
     logger.info("Upload files to test %s has completed", test_id)
     logger.info("Test %s has been created successfully", test_id)
@@ -167,7 +169,9 @@ def update_test(
         "Updated test with test ID: %s and response obj is %s", test_id, response
     )
     logger.info("Uploading files to test %s", test_id)
-    upload_files_helper(client, test_id, yaml, test_plan, load_test_config_file, not custom_no_wait)
+    upload_files_helper(
+        client, test_id, yaml, test_plan, load_test_config_file, not custom_no_wait
+    )
     response = client.get_test(test_id)
     logger.info("Upload files to test %s has completed", test_id)
     logger.info("Test %s has been updated successfully", test_id)

--- a/src/load/azext_load/data_plane/load_test/custom.py
+++ b/src/load/azext_load/data_plane/load_test/custom.py
@@ -53,7 +53,7 @@ def create_test(
         msg = f"Test with given test ID : {test_id} already exist."
         logger.debug(msg)
         raise InvalidArgumentValueError(msg)
-    body = {}    
+    body = {}
     yaml, yaml_test_body = None, None
     if split_csv is None:
         split_csv = False

--- a/src/load/azext_load/data_plane/utils/utils.py
+++ b/src/load/azext_load/data_plane/utils/utils.py
@@ -398,7 +398,10 @@ def create_or_update_test_with_config(
         new_body["secrets"].update(secrets)
 
     if certificate is not None:
-        new_body["certificate"] = certificate
+        if certificate == "null":
+            new_body["certificate"] = None
+        else:
+            new_body["certificate"] = certificate
     elif yaml_test_body.get("certificate") is not None:
         new_body["certificate"] = yaml_test_body.get("certificate")
     else:

--- a/src/load/azext_load/data_plane/utils/utils.py
+++ b/src/load/azext_load/data_plane/utils/utils.py
@@ -369,12 +369,15 @@ def create_or_update_test_with_config(
     else:
         new_body["keyvaultReferenceIdentityType"] = IdentityType.SystemAssigned
     if new_body["keyvaultReferenceIdentityType"] == IdentityType.UserAssigned:
-        if new_body["keyvaultReferenceIdentityId"].casefold() in ["null", "none"]:
+        if new_body["keyvaultReferenceIdentityId"].casefold() in ["null", ""]:
             new_body["keyvaultReferenceIdentityType"] = IdentityType.SystemAssigned
             new_body.pop("keyvaultReferenceIdentityId")
     subnet_id = subnet_id or yaml_test_body.get("subnetId")
     if subnet_id:
-        new_body["subnetId"] = subnet_id
+        if subnet_id.casefold() in ["null",""]:
+            new_body["subnetId"] = None
+        else:
+            new_body["subnetId"] = subnet_id
     new_body["environmentVariables"] = {}
     if body.get("environmentVariables") is not None:
         for key in body.get("environmentVariables"):
@@ -467,12 +470,15 @@ def create_or_update_test_without_config(
             "keyvaultReferenceIdentityType", IdentityType.UserAssigned
         )
     if new_body["keyvaultReferenceIdentityType"] == IdentityType.UserAssigned:
-        if new_body["keyvaultReferenceIdentityId"].casefold() in ["null", "none"]:
+        if new_body["keyvaultReferenceIdentityId"].casefold() in ["null", ""]:
             new_body["keyvaultReferenceIdentityType"] = IdentityType.SystemAssigned
             new_body.pop("keyvaultReferenceIdentityId")
     subnet_id = subnet_id or body.get("subnetId")
     if subnet_id:
-        new_body["subnetId"] = subnet_id
+        if subnet_id.casefold() in ["null",""]:
+            new_body["subnetId"] = None
+        else:
+            new_body["subnetId"] = subnet_id
     if body.get("environmentVariables") is not None:
         new_body["environmentVariables"] = body.get("environmentVariables", {})
     else:
@@ -486,7 +492,10 @@ def create_or_update_test_without_config(
     if secrets is not None:
         new_body["secrets"].update(secrets)
     if certificate is not None:
-        new_body["certificate"] = certificate
+        if certificate == "null":
+            new_body["certificate"] = None
+        else:
+            new_body["certificate"] = certificate
     elif body.get("certificate"):
         new_body["certificate"] = body.get("certificate")
     new_body["loadTestConfiguration"] = body.get("loadTestConfiguration", {})

--- a/src/load/azext_load/data_plane/utils/utils.py
+++ b/src/load/azext_load/data_plane/utils/utils.py
@@ -325,7 +325,6 @@ def convert_yaml_to_test(data):
     logger.debug("Converted yaml to test body: %s", new_body)
     return new_body
 
-
 # pylint: disable=too-many-branches
 # pylint: disable=too-many-statements
 def create_or_update_test_with_config(test_id,
@@ -363,7 +362,6 @@ def create_or_update_test_with_config(test_id,
         new_body["keyvaultReferenceIdentityType"] = IdentityType.UserAssigned
     else:
         new_body["keyvaultReferenceIdentityType"] = IdentityType.SystemAssigned
-    
     if new_body["keyvaultReferenceIdentityType"] == IdentityType.UserAssigned:
         if new_body["keyvaultReferenceIdentityId"].casefold() in ["null", "none"]:
             new_body["keyvaultReferenceIdentityType"] = IdentityType.SystemAssigned
@@ -374,7 +372,7 @@ def create_or_update_test_with_config(test_id,
         new_body["subnetId"] = subnet_id
 
     new_body["environmentVariables"] = {}
-    if body.get("environmentVariables") is not None:    
+    if body.get("environmentVariables") is not None:
         for key in body.get("environmentVariables"):
             new_body["environmentVariables"].update({key: None})
     if yaml_test_body.get("environmentVariables") is not None:
@@ -410,7 +408,6 @@ def create_or_update_test_with_config(test_id,
         ]["engineInstances"]
     else:
         new_body["loadTestConfiguration"]["engineInstances"] = 1
-    
     # quick test is not supported in CLI
     new_body["loadTestConfiguration"]["quickStartTest"] = False
 
@@ -418,7 +415,6 @@ def create_or_update_test_with_config(test_id,
         new_body["passFailCriteria"][key] = None
     if yaml_test_body.get("passFailCriteria") is not None:
         new_body["passFailCriteria"] = yaml_test_body.get("passFailCriteria", {})
-    
     if split_csv is not None:
         new_body["loadTestConfiguration"]["splitAllCSVs"] = split_csv
     elif (
@@ -427,10 +423,8 @@ def create_or_update_test_with_config(test_id,
         new_body["loadTestConfiguration"]["splitAllCSVs"] = yaml_test_body[
             "loadTestConfiguration"
         ]["splitAllCSVs"]
-    
     logger.debug("Request body for create or update test: %s", new_body)
     return new_body
-
 
 # pylint: disable=too-many-branches
 # pylint: disable=too-many-statements
@@ -445,18 +439,16 @@ def create_or_update_test_without_config(test_id,
     key_vault_reference_identity=None,
     subnet_id=None,
     split_csv=None,):
-    logger.info("Creating a request body for create or update test using parameters and old test body (in case of update).")
+    logger.info("Creating a request body for test using parameters and old test body (in case of update).")
     new_body = {}
     new_body["displayName"] = (
         display_name or body.get("displayName") or test_id
     )
-
     test_description = (
         test_description or body.get("description")
     )
     if test_description:
         new_body["description"] = test_description
-
     new_body["keyvaultReferenceIdentityType"] = IdentityType.SystemAssigned
     if key_vault_reference_identity is not None:
         new_body["keyvaultReferenceIdentityId"] = key_vault_reference_identity
@@ -468,35 +460,29 @@ def create_or_update_test_without_config(test_id,
         new_body["keyvaultReferenceIdentityType"] = body.get(
             "keyvaultReferenceIdentityType", IdentityType.UserAssigned
         )
-
     if new_body["keyvaultReferenceIdentityType"] == IdentityType.UserAssigned:
         if new_body["keyvaultReferenceIdentityId"].casefold() in ["null", "none"]:
             new_body["keyvaultReferenceIdentityType"] = IdentityType.SystemAssigned
             new_body.pop("keyvaultReferenceIdentityId")
-    
     subnet_id = subnet_id or body.get("subnetId")
     if subnet_id:
         new_body["subnetId"] = subnet_id
-
     if body.get("environmentVariables") is not None:
         new_body["environmentVariables"] = body.get("environmentVariables", {})
     else:
         new_body["environmentVariables"] = {}
     if env is not None:
         new_body["environmentVariables"].update(env)
-    
     if body.get("secrets") is not None:
         new_body["secrets"] = body.get("secrets", {})
     else:
         new_body["secrets"] = {}
     if secrets is not None:
         new_body["secrets"].update(secrets)
-    
     if certificate is not None:
         new_body["certificate"] = certificate
     elif body.get("certificate"):
         new_body["certificate"] = body.get("certificate")
-
     new_body["loadTestConfiguration"] = body.get("loadTestConfiguration", {})
     if engine_instances:
         new_body["loadTestConfiguration"]["engineInstances"] = engine_instances
@@ -504,10 +490,8 @@ def create_or_update_test_without_config(test_id,
         new_body["loadTestConfiguration"]["engineInstances"] = body.get(
             "loadTestConfiguration", {}
         ).get("engineInstances", 1)
-    
     # quick test is not supported in CLI
     new_body["loadTestConfiguration"]["quickStartTest"] = False
-    
     if split_csv is not None:
         new_body["loadTestConfiguration"]["splitAllCSVs"] = split_csv
     elif body.get("loadTestConfiguration", {}).get("splitAllCSVs") is not None:
@@ -519,7 +503,6 @@ def create_or_update_test_without_config(test_id,
 
 # pylint: enable=too-many-branches
 # pylint: enable=too-many-statements
-
 
 def create_or_update_test_run_body(
     test_id,

--- a/src/load/azext_load/data_plane/utils/utils.py
+++ b/src/load/azext_load/data_plane/utils/utils.py
@@ -374,7 +374,7 @@ def create_or_update_test_with_config(
             new_body.pop("keyvaultReferenceIdentityId")
     subnet_id = subnet_id or yaml_test_body.get("subnetId")
     if subnet_id:
-        if subnet_id.casefold() in ["null",""]:
+        if subnet_id.casefold() in ["null", ""]:
             new_body["subnetId"] = None
         else:
             new_body["subnetId"] = subnet_id
@@ -478,7 +478,7 @@ def create_or_update_test_without_config(
             new_body.pop("keyvaultReferenceIdentityId")
     subnet_id = subnet_id or body.get("subnetId")
     if subnet_id:
-        if subnet_id.casefold() in ["null",""]:
+        if subnet_id.casefold() in ["null", ""]:
             new_body["subnetId"] = None
         else:
             new_body["subnetId"] = subnet_id

--- a/src/load/azext_load/data_plane/utils/utils.py
+++ b/src/load/azext_load/data_plane/utils/utils.py
@@ -325,9 +325,11 @@ def convert_yaml_to_test(data):
     logger.debug("Converted yaml to test body: %s", new_body)
     return new_body
 
+
 # pylint: disable=too-many-branches
 # pylint: disable=too-many-statements
-def create_or_update_test_with_config(test_id,
+def create_or_update_test_with_config(
+    test_id,
     body,
     yaml_test_body,
     display_name=None,
@@ -338,16 +340,20 @@ def create_or_update_test_with_config(test_id,
     certificate=None,
     key_vault_reference_identity=None,
     subnet_id=None,
-    split_csv=None,):
-    logger.info("Creating a request body for create or update test using config and parameters.")
+    split_csv=None,
+):
+    logger.info(
+        "Creating a request body for create or update test using config and parameters."
+    )
     new_body = {}
     new_body["displayName"] = (
-        display_name or yaml_test_body.get("displayName") or body.get("displayName") or test_id
+        display_name
+        or yaml_test_body.get("displayName")
+        or body.get("displayName")
+        or test_id
     )
 
-    test_description = (
-        test_description or yaml_test_body.get("description")
-    )
+    test_description = test_description or yaml_test_body.get("description")
     if test_description:
         new_body["description"] = test_description
 
@@ -366,20 +372,19 @@ def create_or_update_test_with_config(test_id,
         if new_body["keyvaultReferenceIdentityId"].casefold() in ["null", "none"]:
             new_body["keyvaultReferenceIdentityType"] = IdentityType.SystemAssigned
             new_body.pop("keyvaultReferenceIdentityId")
-
     subnet_id = subnet_id or yaml_test_body.get("subnetId")
     if subnet_id:
         new_body["subnetId"] = subnet_id
-
     new_body["environmentVariables"] = {}
     if body.get("environmentVariables") is not None:
         for key in body.get("environmentVariables"):
             new_body["environmentVariables"].update({key: None})
     if yaml_test_body.get("environmentVariables") is not None:
-        new_body["environmentVariables"].update(yaml_test_body.get("environmentVariables", {}))
+        new_body["environmentVariables"].update(
+            yaml_test_body.get("environmentVariables", {})
+        )
     if env is not None:
         new_body["environmentVariables"].update(env)
-
     new_body["secrets"] = {}
     if body.get("secrets") is not None:
         for key in body.get("secrets", {}):
@@ -426,9 +431,11 @@ def create_or_update_test_with_config(test_id,
     logger.debug("Request body for create or update test: %s", new_body)
     return new_body
 
+
 # pylint: disable=too-many-branches
 # pylint: disable=too-many-statements
-def create_or_update_test_without_config(test_id,
+def create_or_update_test_without_config(
+    test_id,
     body,
     display_name=None,
     test_description=None,
@@ -438,15 +445,14 @@ def create_or_update_test_without_config(test_id,
     certificate=None,
     key_vault_reference_identity=None,
     subnet_id=None,
-    split_csv=None,):
-    logger.info("Creating a request body for test using parameters and old test body (in case of update).")
+    split_csv=None,
+):
+    logger.info(
+        "Creating a request body for test using parameters and old test body (in case of update)."
+    )
     new_body = {}
-    new_body["displayName"] = (
-        display_name or body.get("displayName") or test_id
-    )
-    test_description = (
-        test_description or body.get("description")
-    )
+    new_body["displayName"] = display_name or body.get("displayName") or test_id
+    test_description = test_description or body.get("description")
     if test_description:
         new_body["description"] = test_description
     new_body["keyvaultReferenceIdentityType"] = IdentityType.SystemAssigned
@@ -501,9 +507,9 @@ def create_or_update_test_without_config(test_id,
     logger.debug("Request body for create or update test: %s", new_body)
     return new_body
 
+
 # pylint: enable=too-many-branches
 # pylint: enable=too-many-statements
-
 def create_or_update_test_run_body(
     test_id,
     display_name=None,

--- a/src/load/azext_load/data_plane/utils/utils.py
+++ b/src/load/azext_load/data_plane/utils/utils.py
@@ -269,8 +269,8 @@ def convert_yaml_to_test(data):
     new_body["loadTestConfiguration"]["engineInstances"] = data.get(
         "engineInstances", 1
     )
-    if data.get("certificate"):
-        new_body["certificate"] = parse_cert(data.get("certificate"))
+    if data.get("certificates"):
+        new_body["certificate"] = parse_cert(data.get("certificates"))
     if data.get("secrets"):
         new_body["secrets"] = parse_secrets(data.get("secrets"))
     if data.get("env"):
@@ -328,10 +328,9 @@ def convert_yaml_to_test(data):
 
 # pylint: disable=too-many-branches
 # pylint: disable=too-many-statements
-def create_or_update_body(
-    test_id,
+def create_or_update_test_with_config(test_id,
     body,
-    yaml_test_body=None,
+    yaml_test_body,
     display_name=None,
     test_description=None,
     engine_instances=None,
@@ -340,21 +339,15 @@ def create_or_update_body(
     certificate=None,
     key_vault_reference_identity=None,
     subnet_id=None,
-    split_csv=None,
-):
-    if yaml_test_body is None:
-        yaml_test_body = {}
-    logger.info("Creating a request body for create or update test")
+    split_csv=None,):
+    logger.info("Creating a request body for create or update test using config and parameters.")
     new_body = {}
-    display_name = (
-        display_name or yaml_test_body.get("displayName") or body.get("displayName")
+    new_body["displayName"] = (
+        display_name or yaml_test_body.get("displayName") or body.get("displayName") or test_id
     )
-    if display_name:
-        new_body["displayName"] = display_name
-    else:
-        new_body["displayName"] = test_id
+
     test_description = (
-        test_description or yaml_test_body.get("description") or body.get("description")
+        test_description or yaml_test_body.get("description")
     )
     if test_description:
         new_body["description"] = test_description
@@ -368,47 +361,42 @@ def create_or_update_body(
             "keyVaultReferenceIdentity"
         )
         new_body["keyvaultReferenceIdentityType"] = IdentityType.UserAssigned
-    elif body.get("keyvaultReferenceIdentityId") is not None:
-        new_body["keyvaultReferenceIdentityId"] = body.get(
-            "keyvaultReferenceIdentityId"
-        )
-        new_body["keyvaultReferenceIdentityType"] = body.get(
-            "keyvaultReferenceIdentityType", IdentityType.UserAssigned
-        )
+    else:
+        new_body["keyvaultReferenceIdentityType"] = IdentityType.SystemAssigned
+    
     if new_body["keyvaultReferenceIdentityType"] == IdentityType.UserAssigned:
         if new_body["keyvaultReferenceIdentityId"].casefold() in ["null", "none"]:
             new_body["keyvaultReferenceIdentityType"] = IdentityType.SystemAssigned
             new_body.pop("keyvaultReferenceIdentityId")
-    subnet_id = subnet_id or yaml_test_body.get("subnetId") or body.get("subnetId")
+
+    subnet_id = subnet_id or yaml_test_body.get("subnetId")
     if subnet_id:
         new_body["subnetId"] = subnet_id
 
-    if body.get("environmentVariables") is not None:
-        new_body["environmentVariables"] = body.get("environmentVariables", {})
-    else:
-        new_body["environmentVariables"] = {}
+    for key in body.get("environmentVariables", {}):
+        new_body["environmentVariables"][key] = None
     if yaml_test_body.get("environmentVariables") is not None:
-        new_body["environmentVariables"].update(
-            yaml_test_body.get("environmentVariables", {})
-        )
+        new_body["environmentVariables"] = yaml_test_body.get("environmentVariables", {})
+        
     if env is not None:
         new_body["environmentVariables"].update(env)
-    if body.get("secrets") is not None:
-        new_body["secrets"] = body.get("secrets", {})
-    else:
-        new_body["secrets"] = {}
+
+    new_body["secrets"] = {}
+    for key in body.get("secrets", {}):
+        new_body["secrets"][key] = None
     if yaml_test_body.get("secrets") is not None:
         new_body["secrets"].update(yaml_test_body.get("secrets", {}))
     if secrets is not None:
         new_body["secrets"].update(secrets)
+
     if certificate is not None:
         new_body["certificate"] = certificate
     elif yaml_test_body.get("certificate") is not None:
         new_body["certificate"] = yaml_test_body.get("certificate")
-    elif body.get("certificate"):
-        new_body["certificate"] = body.get("certificate")
+    else:
+        new_body["certificate"] = None
 
-    new_body["loadTestConfiguration"] = body.get("loadTestConfiguration", {})
+    new_body["loadTestConfiguration"] = {}
     if engine_instances:
         new_body["loadTestConfiguration"]["engineInstances"] = engine_instances
     elif (
@@ -419,13 +407,16 @@ def create_or_update_body(
             "loadTestConfiguration"
         ]["engineInstances"]
     else:
-        new_body["loadTestConfiguration"]["engineInstances"] = body.get(
-            "loadTestConfiguration", {}
-        ).get("engineInstances", 1)
+        new_body["loadTestConfiguration"]["engineInstances"] = 1
+    
     # quick test is not supported in CLI
     new_body["loadTestConfiguration"]["quickStartTest"] = False
+
+    for key in body.get("passFailCriteria", {}):
+        new_body["passFailCriteria"][key] = None
     if yaml_test_body.get("passFailCriteria") is not None:
         new_body["passFailCriteria"] = yaml_test_body.get("passFailCriteria", {})
+    
     if split_csv is not None:
         new_body["loadTestConfiguration"]["splitAllCSVs"] = split_csv
     elif (
@@ -434,13 +425,95 @@ def create_or_update_body(
         new_body["loadTestConfiguration"]["splitAllCSVs"] = yaml_test_body[
             "loadTestConfiguration"
         ]["splitAllCSVs"]
+    
+    logger.debug("Request body for create or update test: %s", new_body)
+    return new_body
+
+
+# pylint: disable=too-many-branches
+# pylint: disable=too-many-statements
+def create_or_update_test_without_config(test_id,
+    body,
+    display_name=None,
+    test_description=None,
+    engine_instances=None,
+    env=None,
+    secrets=None,
+    certificate=None,
+    key_vault_reference_identity=None,
+    subnet_id=None,
+    split_csv=None,):
+    logger.info("Creating a request body for create or update test using parameters and old test body (in case of update).")
+    new_body = {}
+    new_body["displayName"] = (
+        display_name or body.get("displayName") or test_id
+    )
+
+    test_description = (
+        test_description or body.get("description")
+    )
+    if test_description:
+        new_body["description"] = test_description
+
+    new_body["keyvaultReferenceIdentityType"] = IdentityType.SystemAssigned
+    if key_vault_reference_identity is not None:
+        new_body["keyvaultReferenceIdentityId"] = key_vault_reference_identity
+        new_body["keyvaultReferenceIdentityType"] = IdentityType.UserAssigned
+    elif body.get("keyvaultReferenceIdentityId") is not None:
+        new_body["keyvaultReferenceIdentityId"] = body.get(
+            "keyvaultReferenceIdentityId"
+        )
+        new_body["keyvaultReferenceIdentityType"] = body.get(
+            "keyvaultReferenceIdentityType", IdentityType.UserAssigned
+        )
+
+    if new_body["keyvaultReferenceIdentityType"] == IdentityType.UserAssigned:
+        if new_body["keyvaultReferenceIdentityId"].casefold() in ["null", "none"]:
+            new_body["keyvaultReferenceIdentityType"] = IdentityType.SystemAssigned
+            new_body.pop("keyvaultReferenceIdentityId")
+    
+    subnet_id = subnet_id or body.get("subnetId")
+    if subnet_id:
+        new_body["subnetId"] = subnet_id
+
+    if body.get("environmentVariables") is not None:
+        new_body["environmentVariables"] = body.get("environmentVariables", {})
+    else:
+        new_body["environmentVariables"] = {}
+    if env is not None:
+        new_body["environmentVariables"].update(env)
+    
+    if body.get("secrets") is not None:
+        new_body["secrets"] = body.get("secrets", {})
+    else:
+        new_body["secrets"] = {}
+    if secrets is not None:
+        new_body["secrets"].update(secrets)
+    
+    if certificate is not None:
+        new_body["certificate"] = certificate
+    elif body.get("certificate"):
+        new_body["certificate"] = body.get("certificate")
+
+    new_body["loadTestConfiguration"] = body.get("loadTestConfiguration", {})
+    if engine_instances:
+        new_body["loadTestConfiguration"]["engineInstances"] = engine_instances
+    else:
+        new_body["loadTestConfiguration"]["engineInstances"] = body.get(
+            "loadTestConfiguration", {}
+        ).get("engineInstances", 1)
+    
+    # quick test is not supported in CLI
+    new_body["loadTestConfiguration"]["quickStartTest"] = False
+    
+    if split_csv is not None:
+        new_body["loadTestConfiguration"]["splitAllCSVs"] = split_csv
     elif body.get("loadTestConfiguration", {}).get("splitAllCSVs") is not None:
         new_body["loadTestConfiguration"]["splitAllCSVs"] = body[
             "loadTestConfiguration"
         ]["splitAllCSVs"]
     logger.debug("Request body for create or update test: %s", new_body)
     return new_body
-
 
 # pylint: enable=too-many-branches
 # pylint: enable=too-many-statements

--- a/src/load/azext_load/data_plane/utils/utils.py
+++ b/src/load/azext_load/data_plane/utils/utils.py
@@ -373,17 +373,19 @@ def create_or_update_test_with_config(test_id,
     if subnet_id:
         new_body["subnetId"] = subnet_id
 
-    for key in body.get("environmentVariables", {}):
-        new_body["environmentVariables"][key] = None
+    new_body["environmentVariables"] = {}
+    if body.get("environmentVariables") is not None:    
+        for key in body.get("environmentVariables"):
+            new_body["environmentVariables"].update({key: None})
     if yaml_test_body.get("environmentVariables") is not None:
-        new_body["environmentVariables"] = yaml_test_body.get("environmentVariables", {})
-        
+        new_body["environmentVariables"].update(yaml_test_body.get("environmentVariables", {}))
     if env is not None:
         new_body["environmentVariables"].update(env)
 
     new_body["secrets"] = {}
-    for key in body.get("secrets", {}):
-        new_body["secrets"][key] = None
+    if body.get("secrets") is not None:
+        for key in body.get("secrets", {}):
+            new_body["secrets"].update({key: None})
     if yaml_test_body.get("secrets") is not None:
         new_body["secrets"].update(yaml_test_body.get("secrets", {}))
     if secrets is not None:

--- a/src/load/azext_load/data_plane/utils/validators.py
+++ b/src/load/azext_load/data_plane/utils/validators.py
@@ -64,7 +64,7 @@ def _validate_env_var(string):
         comps = string.split("=", 1)
         if len(comps) != 2:
             raise InvalidArgumentValueError(f"Invalid env argument: {string}")
-        if comps[1] == "":
+        if comps[1].casefold() in ["null", ""]:
             result = {comps[0]: None}
         else:
             result = {comps[0]: comps[1]}
@@ -87,7 +87,7 @@ def _validate_secret(string):
         comps = string.split("=", 1)
         if len(comps) != 2:
             raise InvalidArgumentValueError(f"Invalid secret argument: {string}")
-        if comps[1] == "":
+        if comps[1].casefold() in ["null", ""]:
             result = {comps[0]: None}
         elif not _validate_akv_url(comps[1], "secrets"):
             raise InvalidArgumentValueError(
@@ -114,20 +114,26 @@ def validate_certificate(namespace):
         )
     comps = certificate.split("=", 1)
     if len(comps) != 2:
-        raise InvalidArgumentValueError(f"Invalid certificate argument: {certificate}")
-    if not _validate_akv_url(comps[1], "certificates"):
+        raise InvalidArgumentValueError(f"Invalid certificate argument: {certificate}")    
+    if (comps[1].casefold() not in ["", "null"]) and not _validate_akv_url(comps[1], "certificates"):
         raise InvalidArgumentValueError(
             f"Invalid Azure Key Vault Certificate URL: {comps[1]}"
         )
-    namespace.certificate = {
-        "name": comps[0],
-        "type": "AKV_CERT_URI",
-        "value": comps[1],
-    }
+    if comps[1].casefold() in ["null", ""]:
+        namespace.certificate = "null"
+    else:
+        namespace.certificate = {
+            "name": comps[0],
+            "type": "AKV_CERT_URI",
+            "value": comps[1],
+        }
 
 
 def validate_subnet_id(namespace):
     if namespace.subnet_id is None:
+        return
+    if namespace.subnet_id.casefold() in ["null", ""]:
+        namespace.subnet_id = "null"
         return
     if not is_valid_resource_id(namespace.subnet_id):
         raise InvalidArgumentValueError(

--- a/src/load/azext_load/data_plane/utils/validators.py
+++ b/src/load/azext_load/data_plane/utils/validators.py
@@ -64,7 +64,7 @@ def _validate_env_var(string):
         comps = string.split("=", 1)
         if len(comps) != 2:
             raise InvalidArgumentValueError(f"Invalid env argument: {string}")
-        if comps[1].casefold() in ["null", ""]:
+        if comps[1] in ["null", ""]:
             result = {comps[0]: None}
         else:
             result = {comps[0]: comps[1]}
@@ -87,7 +87,7 @@ def _validate_secret(string):
         comps = string.split("=", 1)
         if len(comps) != 2:
             raise InvalidArgumentValueError(f"Invalid secret argument: {string}")
-        if comps[1].casefold() in ["null", ""]:
+        if comps[1] in ["null", ""]:
             result = {comps[0]: None}
         elif not _validate_akv_url(comps[1], "secrets"):
             raise InvalidArgumentValueError(
@@ -115,11 +115,11 @@ def validate_certificate(namespace):
     comps = certificate.split("=", 1)
     if len(comps) != 2:
         raise InvalidArgumentValueError(f"Invalid certificate argument: {certificate}")    
-    if (comps[1].casefold() not in ["", "null"]) and not _validate_akv_url(comps[1], "certificates"):
+    if (comps[1] not in ["", "null"]) and not _validate_akv_url(comps[1], "certificates"):
         raise InvalidArgumentValueError(
             f"Invalid Azure Key Vault Certificate URL: {comps[1]}"
         )
-    if comps[1].casefold() in ["null", ""]:
+    if comps[1] in ["null", ""]:
         namespace.certificate = "null"
     else:
         namespace.certificate = {
@@ -132,7 +132,7 @@ def validate_certificate(namespace):
 def validate_subnet_id(namespace):
     if namespace.subnet_id is None:
         return
-    if namespace.subnet_id.casefold() in ["null", ""]:
+    if namespace.subnet_id in ["null", ""]:
         namespace.subnet_id = "null"
         return
     if not is_valid_resource_id(namespace.subnet_id):

--- a/src/load/azext_load/data_plane/utils/validators.py
+++ b/src/load/azext_load/data_plane/utils/validators.py
@@ -114,7 +114,7 @@ def validate_certificate(namespace):
         )
     comps = certificate.split("=", 1)
     if len(comps) != 2:
-        raise InvalidArgumentValueError(f"Invalid certificate argument: {certificate}")    
+        raise InvalidArgumentValueError(f"Invalid certificate argument: {certificate}")
     if (comps[1] not in ["", "null"]) and not _validate_akv_url(comps[1], "certificates"):
         raise InvalidArgumentValueError(
             f"Invalid Azure Key Vault Certificate URL: {comps[1]}"

--- a/src/load/azext_load/tests/latest/constants.py
+++ b/src/load/azext_load/tests/latest/constants.py
@@ -36,7 +36,7 @@ class LoadConstants:
     SPLIT_CSV_FALSE = "false"
 
     INVALID_SUBNET_ID = r"/subscriptions/invalid/resource/id"
-    KEYVAULT_REFERENCE_ID = r"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi"
+    KEYVAULT_REFERENCE_ID = r"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi"
     # App Component constants
     APP_COMPONENT_ID = r"/subscriptions/0a00b000-0aa0-0aa0-aaa0-000000000/resourceGroups/sample-rg/providers/Microsoft.Compute/virtualMachineScaleSets/sample-vmss"
     APP_COMPONENT_TYPE = r"Microsoft.Compute/virtualMachineScaleSets"

--- a/src/load/azext_load/tests/latest/constants.py
+++ b/src/load/azext_load/tests/latest/constants.py
@@ -36,9 +36,9 @@ class LoadConstants:
     SPLIT_CSV_FALSE = "false"
 
     INVALID_SUBNET_ID = r"/subscriptions/invalid/resource/id"
-    KEYVAULT_REFERENCE_ID = r"/subscriptions/{subscription_id}/resourceGroups/sample-rg/providers/Microsoft.KeyVault/vaults/sample-kv"
+    KEYVAULT_REFERENCE_ID = r"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi"
     # App Component constants
-    APP_COMPONENT_ID = r"/subscriptions/{subscription_id}/resourceGroups/hbisht-rg/providers/Microsoft.Compute/virtualMachineScaleSets/hbisht-temp-vmss"
+    APP_COMPONENT_ID = r"/subscriptions/0a00b000-0aa0-0aa0-aaa0-000000000/resourceGroups/sample-rg/providers/Microsoft.Compute/virtualMachineScaleSets/sample-vmss"
     APP_COMPONENT_TYPE = r"Microsoft.Compute/virtualMachineScaleSets"
     APP_COMPONENT_NAME = r"temp-vmss"
 
@@ -57,6 +57,7 @@ class LoadConstants:
 
 class LoadTestConstants(LoadConstants):
     # Test IDs for load test commands
+    UPDATE_WITH_CONFIG_TEST_ID = "update-with-config-test-case"
     DELETE_TEST_ID = "delete-test-case"
     CREATE_TEST_ID = "create-test-case"
     UPDATE_TEST_ID = "update-test-case"

--- a/src/load/azext_load/tests/latest/recordings/test_load_app_component.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_app_component.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:30.9716153Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:30.9716153Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:31.3771816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:31.3771816Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:28 GMT
+      - Fri, 13 Oct 2023 13:52:31 GMT
       etag:
-      - '"5600ef16-0000-0100-0000-652452090000"'
+      - '"d8015be9-0000-0100-0000-65294b650000"'
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:19:29 GMT
+      - Fri, 13 Oct 2023 13:52:32 GMT
       mise-correlation-id:
-      - dfb5bacf-abb1-4709-8381-e828e3d64927
+      - 5c0795c5-df0a-44e0-a338-d880d560a626
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"edbac2db-f6a3-4803-9ac1-6d344cd7196e": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "75b13386-0b49-4125-8e94-65d3bf40c008":
+      {"passFailMetrics": {"6a2773f5-ca19-4133-a010-b33c58812b8e": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "52c44c55-9403-4c9a-baf0-87504612ca95": {"aggregate": "avg", "clientMetric":
+      "50"}, "97336d72-d70a-4a05-a0a8-99a5f81f786e": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -104,13 +104,13 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:29.791Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:29.791Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:32.455Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:32.455Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:29 GMT
+      - Fri, 13 Oct 2023 13:52:32 GMT
       location:
-      - https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+      - https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - f83e5c1e-46af-472a-bc86-aacb25daaee9
+      - 0fe68265-7484-428b-ad0f-bc778d7998c7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -143,9 +143,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:30 GMT
+      - Fri, 13 Oct 2023 13:52:32 GMT
       mise-correlation-id:
-      - f9d28bb4-a79f-4733-86fa-4c11a1fe1eba
+      - 2102d86d-b2ff-408c-9bdc-c1fb61b746f3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -273,27 +273,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A30Z&sr=b&sp=r&sig=uE%2FSVRkH%2FpV0c3ckPJWlwCXu3AJFH3Plr2hLT68IGl8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:30.6985902","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A33Z&sr=b&sp=r&sig=7KWBNz9EQ%2B%2BxJkhzvGIVt9AzeAKSF%2BpRv3VG94p7hcM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:33.7756985","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:30 GMT
+      - Fri, 13 Oct 2023 13:52:33 GMT
       location:
-      - https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - a5341136-0267-435e-80e5-dadab82ab48c
+      - ce4cb1df-aac0-4356-a3fb-606a1ade46c2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -311,48 +311,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A31Z&sr=b&sp=r&sig=dqDWXQuNhirwq7LrTYH%2BydWTQxl3fhxlhEqTIUTn%2BVs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:31.063591","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '552'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:19:31 GMT
-      mise-correlation-id:
-      - 59e4ff14-5e57-4e9e-8601-62071285b3ad
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A37Z&sr=b&sp=r&sig=JVPZ7FfozLbJCsrbrx9sIJzVeyAk89xDJIIpIwQU6W0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:37.1355627","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A34Z&sr=b&sp=r&sig=dqbaM8egGh7IyYbPDZG7PecA2CVJMUhhY3u5gXPdf2c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:34.0244969","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:37 GMT
+      - Fri, 13 Oct 2023 13:52:34 GMT
       mise-correlation-id:
-      - f45ee9c3-4228-448d-8182-f58ff8e36222
+      - 50fd162b-fe29-4d46-877a-ca7df75a2565
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -383,25 +347,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A42Z&sr=b&sp=r&sig=51MTnLV2EhZZk6FDsXvKo%2F88x2tVtqXWbqJ6pHGrcdQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:42.4126941","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A39Z&sr=b&sp=r&sig=nDTP3ZhJ6uaJJSEfDIBY4MTwi3ldoKNChGPMxNOdCxs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:39.2950248","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:42 GMT
+      - Fri, 13 Oct 2023 13:52:39 GMT
       mise-correlation-id:
-      - 0b66ff23-d3c3-453b-bbe1-d90295486431
+      - 06da760e-21b2-4f36-835e-8af47aa941a3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -419,12 +383,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A47Z&sr=b&sp=r&sig=8Z7scCb%2BHq0GiKEJjzbqje0ailITDLdbMH1%2BU2A%2FHU4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:47.7656298","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A44Z&sr=b&sp=r&sig=b3pG9iRhPo8%2B8T%2FPy7G7RGnaCelf4wQ4blO8wGATsyM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:44.5528783","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:47 GMT
+      - Fri, 13 Oct 2023 13:52:44 GMT
       mise-correlation-id:
-      - 94155d3f-e005-46d4-a3ad-9a30e4b03495
+      - 85c9a7dd-40ad-4593-a596-9c20e6e0812e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -455,26 +419,62 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A48Z&sr=b&sp=r&sig=55v5fLJmQoSEBKUg5VJtEAlaVBM9eV8PycSXSaHqjig%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:48.0233801","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:29.791Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:43.096Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A49Z&sr=b&sp=r&sig=nsU%2FuULtFvH1Sf0D6W5lLoZkYkFxizgcWbJq41tMsgY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:49.8718079","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1584'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:48 GMT
+      - Fri, 13 Oct 2023 13:52:49 GMT
       mise-correlation-id:
-      - 9f5f42ba-06f2-4f54-a7ce-cb73f53071a5
+      - a544ec31-299a-4d84-86c9-ba28d45d7d9b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A50Z&sr=b&sp=r&sig=Ajo4VW2PRSkFIp9b8Xau3%2Fdzl4nts91FVmTPzXqhtHg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:50.1300692","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:32.455Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:46.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1586'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:52:50 GMT
+      mise-correlation-id:
+      - 5618971c-b3af-4cfe-8594-2a0136ef72a6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:30.9716153Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:30.9716153Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:31.3771816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:31.3771816Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:49 GMT
+      - Fri, 13 Oct 2023 13:52:51 GMT
       etag:
-      - '"5600ef16-0000-0100-0000-652452090000"'
+      - '"d8015be9-0000-0100-0000-65294b650000"'
       expires:
       - '-1'
       pragma:
@@ -536,26 +536,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A50Z&sr=b&sp=r&sig=7MCjq9a5hlK6QYFTbFHjvZcd0S2oLjKPv9cMsCl9J2k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:50.4519711","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:29.791Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:43.096Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A52Z&sr=b&sp=r&sig=jiNdeJUPQtXMpsevgLLUTaSVPjTaQ9IriAZ%2BqWWRQBA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:52.4879945","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:32.455Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:46.092Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1596'
+      - '1598'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:50 GMT
+      - Fri, 13 Oct 2023 13:52:52 GMT
       mise-correlation-id:
-      - 2445659b-0578-4dbc-b2c2-1d49ebca0abe
+      - d5cd4bdc-e0ce-4651-a0dd-73250fbc629f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:30.9716153Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:30.9716153Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:31.3771816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:31.3771816Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:50 GMT
+      - Fri, 13 Oct 2023 13:52:54 GMT
       etag:
-      - '"5600ef16-0000-0100-0000-652452090000"'
+      - '"d8015be9-0000-0100-0000-65294b650000"'
       expires:
       - '-1'
       pragma:
@@ -617,9 +617,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:19:52 GMT
+      - Fri, 13 Oct 2023 13:52:54 GMT
       mise-correlation-id:
-      - 43081980-d7d6-41a8-af5d-9465aa649e87
+      - 3fa7dd9c-3d43-4eac-be4a-98cc6567837b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -660,27 +660,27 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A53Z&sr=b&sp=r&sig=nujhwZsnPxnNBr10QuL%2F4T5MBTBFAJ88AZiVRQQ51Bg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:53.1235641","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A53Z&sr=b&sp=r&sig=q%2FkXVQOAPToOfORZFYx1z7iHBBCqGXiiif%2FmtS%2F4NpI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:53.123464","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A53Z&sr=b&sp=r&sig=L2VOMOVNgDSsXcMgnaeALVAqSOAKaCg1xrLZuV0UKQI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:53.1235898","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:53.041Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A55Z&sr=b&sp=r&sig=iXMzsrWjLHbpU%2Fg%2BBh56KT%2FAlBB29x%2FVmx9CJVwJ2zM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:55.6930292","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A55Z&sr=b&sp=r&sig=C%2Bb6bTYhH52z%2BTNiC2gBx%2FjvwLExne8O2ZHH0nu7xMk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:55.6929303","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A55Z&sr=b&sp=r&sig=MNYJwClsLIVzugEp3bLptLidkfKbw4NHhuPoR%2BBjTdU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:55.693053","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:55.602Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3189'
+      - '3198'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:53 GMT
+      - Fri, 13 Oct 2023 13:52:55 GMT
       location:
-      - https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+      - https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - c17ad8af-d009-4420-96de-877d6a9169aa
+      - 7dd42021-96d7-49df-9201-239625287ad2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -698,25 +698,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A53Z&sr=b&sp=r&sig=%2BG0BwB9mfRlv8Sj1bhZQygXFouPfgMvBA3hf5RbU024%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:53.6951196","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A53Z&sr=b&sp=r&sig=9E7A7ql%2F0Nwxz6vRurNhaSruQBpMAmk4GJpedEalwNA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:53.6950308","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A53Z&sr=b&sp=r&sig=eN6iH2dlXopHMOrGHwqom1RbkTXycyRPCWj6fjEPljw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:53.6951345","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:53.578Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A56Z&sr=b&sp=r&sig=3PPfCTobJycD06vdgevjKjNq%2FUdJNfEtLpeydqG13TU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:56.1400685","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A56Z&sr=b&sp=r&sig=54i6kU%2BN49htUsZrfiO%2Ft9j7HyHnpNlh56d6pTCt2m4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:56.1399707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A56Z&sr=b&sp=r&sig=wzz2ADMQsfEK3JFLR8XcR045GWJoVfCgPsdLEwdlFro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:56.1400905","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:55.602Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3231'
+      - '3189'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:53 GMT
+      - Fri, 13 Oct 2023 13:52:56 GMT
       mise-correlation-id:
-      - 4c413631-2d51-4857-b5f8-25699223e982
+      - 76511a02-2863-446a-91d8-11a83eab5e30
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -734,624 +734,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A59Z&sr=b&sp=r&sig=HwcXCXTd%2B4mwxxGuoZTm7EBk8UJIEnseUKA6bNvzTAw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:59.0070033","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A59Z&sr=b&sp=r&sig=UDQav66cSS47WIV%2FIx3e3hrj6JnD8UDD0qlmcJQgSTE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:59.0069038","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A59Z&sr=b&sp=r&sig=m1Zwkm8LaVzJd%2FYwcFmEJgWiliVC%2Ff90M0aqYMydKCE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:59.0070241","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:54.364Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:19:59 GMT
-      mise-correlation-id:
-      - 6b223f08-2d08-42e8-ba1b-e0c34608f0e1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A04Z&sr=b&sp=r&sig=WNziEDo1ITWFLqzu9gUv%2B5cbPvAYbSroJZ3v7rDow60%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:04.3317753","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A04Z&sr=b&sp=r&sig=uhkf7FkSgmOxBLxl%2B5qOd%2BPa1GQpInRq5OCERPzvSm4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:04.3316946","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A04Z&sr=b&sp=r&sig=ReC0VmnubqaOOvzvTccXP9wnyd%2FfQwSmE4z27c3aV5o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:04.3317904","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:54.364Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:04 GMT
-      mise-correlation-id:
-      - b6bc9c0d-3e29-45ac-95c7-a3ef72864439
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A09Z&sr=b&sp=r&sig=iTX2jz4HGfoxfxkRwE4Mw8Xhl4rgBD5tdSW4A3A12UA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:09.5958945","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A09Z&sr=b&sp=r&sig=AjpgTh5H8kPRpQGp7Y1ypXB5KYNZL4ug5ZWUVjpPtpo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:09.5958104","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A09Z&sr=b&sp=r&sig=SWrROVXPavjbgU3twg4VVjjwS%2Bi%2BEPOUHrhdxeEZDdo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:09.5959155","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:54.364Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3233'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:09 GMT
-      mise-correlation-id:
-      - bdaba7ed-9387-4be2-93f5-b181940b5b29
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=zoajNML%2BhmPVGYzNzEpUFBG9Ki7riiB7crgkSQy65ow%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:14.8660331","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=fQSbsIMxKCOgzF%2BQIhgWJ2y351enW%2Bf9NDaYJaKhnh0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:14.8659394","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=vBc5Ws13%2Fa7nFqsbt%2BYTqHvfUszQMdZUCbrPbZRY9gc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:14.8660553","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:54.364Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3239'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:14 GMT
-      mise-correlation-id:
-      - 8f5853c1-24fc-4f00-8f3f-b364c10e6a64
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A21Z&sr=b&sp=r&sig=IEjVHpxu7sVg3Wg9MqXafJG2c6MG2GuPs3EyaqzUGK8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:21.028276","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A21Z&sr=b&sp=r&sig=AzpIuq1JE%2FICAYEE69lMiCMDB%2F9%2FrUjCzAmLK19hLEY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:21.0281955","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A21Z&sr=b&sp=r&sig=CbvM7Nbd%2BVKnYdg4FQoLAWEx%2FG%2FC9BDAKiVjJ%2FKjWHo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:21.0282937","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:54.364Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3242'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:21 GMT
-      mise-correlation-id:
-      - 476f4dcd-107e-40d6-a478-1bf2243a1f67
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A26Z&sr=b&sp=r&sig=h9v8z39zZ19aruWXarasTeLk1gMV%2FeTxOcmd6WFRSlI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:26.3412173","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A26Z&sr=b&sp=r&sig=DlPXCEkwzxzAFFFyCghqB6viqcaGq6ChV5IozfFTJbw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:26.3411482","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A26Z&sr=b&sp=r&sig=a6Rk%2FkX%2FKNbcU5f1AT5LKqYfmIeUo6CrVch3DLGstwQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:26.3412328","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:54.364Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:26 GMT
-      mise-correlation-id:
-      - 75bfb4c2-4937-4319-864b-a5634541a124
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A31Z&sr=b&sp=r&sig=EKazFi51op9UhtD%2BVv%2B4jyy11ApFgToKQ17np55oXLs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:31.6088106","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A31Z&sr=b&sp=r&sig=yqEKiwrtXLb9fR8FntcuYtNl6Cx238YqXfblTk49C%2BM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:31.6087247","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A31Z&sr=b&sp=r&sig=Nda%2FvPE0Q1zyo9UDMzK0DolNeZqnFTtLR8ki1jf3ot0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:31.6088317","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:54.364Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:31 GMT
-      mise-correlation-id:
-      - bcf58a94-e2d0-4e35-b7b2-4312b0c0ae07
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A36Z&sr=b&sp=r&sig=GlNBrnm%2B1qMwRgN2GowQ4YGZNKFVEFt%2FjmydYWinaXU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:36.9058028","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A36Z&sr=b&sp=r&sig=ctAUmKK76v5iwLP0OA0kMPWaoMEVcl%2BuBWPGhCb%2FxL4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:36.9057116","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A36Z&sr=b&sp=r&sig=YpSEXZI%2BQ8UMObMiNUveRj%2BoUgXiiyLq0LuE9YGj4bs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:36.9058265","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:54.364Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3241'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:36 GMT
-      mise-correlation-id:
-      - 46ab7807-2570-4774-a390-2e1713042544
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A42Z&sr=b&sp=r&sig=vT26mFPDQ3t2pxJfHQQoxvEdLiLyxXJSn%2B2EAZFkqfk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:42.2296176","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A42Z&sr=b&sp=r&sig=pNOjsA1oQ2VRwu8MSn%2FuicX7L7w%2FdBq4BfidG5PRKFw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:42.2295279","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A42Z&sr=b&sp=r&sig=yj1%2Bg%2Bmw6DcPVMYGGIwdC3S1MBs5DR0Ytcun1eZ0Q6U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:42.2296327","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:42.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3238'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:42 GMT
-      mise-correlation-id:
-      - c06791e3-4965-4721-a97c-670c611247b7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A47Z&sr=b&sp=r&sig=TFAMspi0iIhNJjY8i1WOcEjQJkFOcbJ%2BJyJpWp1G6uI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:47.550707","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A47Z&sr=b&sp=r&sig=tj2syllMPykAnojR8F%2FW2ef2QMLvYQMCHZNyFxfNAzM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:47.5506271","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A47Z&sr=b&sp=r&sig=gtZfYa%2BECa46cMqvJHFUmOPFmcg%2FnHGeh%2F%2FdCmvWmLk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:47.5507225","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:47 GMT
-      mise-correlation-id:
-      - 9104b53c-8266-4bf7-ab09-1d0b56cd402c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A52Z&sr=b&sp=r&sig=DjpcLadT8LPtDrSyA0t%2FO43vSggEJLKtpkTGRkx1bnw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:52.8675808","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A52Z&sr=b&sp=r&sig=s3HBVEELrRXYvjodRaUQiNAl4XcfgMS%2Bxq%2BUsSofHWM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:52.8674873","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A52Z&sr=b&sp=r&sig=oA%2FjsaP6xA3HvefUH3LQlkEoF%2FJtbL5k1%2B2QsYbrTNc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:52.8676024","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3238'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:52 GMT
-      mise-correlation-id:
-      - c7651e8a-9835-4b01-87ec-f3bd701c195c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A58Z&sr=b&sp=r&sig=LuABQwvSYomOs8I2oE%2FMwIoVwCDwgA9joWGqj3Dsyco%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:58.1451772","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A58Z&sr=b&sp=r&sig=x6z%2BGtZyxLjJhr%2Fknx4XAcMfJVQFy1JLYBvXT5OmJNw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:58.1450912","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A58Z&sr=b&sp=r&sig=ZdAlUiaOlVuE8kSIYw%2BWk%2F3%2BeFoZAycgWZTRNJSJRgw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:58.1451982","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3238'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:58 GMT
-      mise-correlation-id:
-      - 68680806-803b-4c0f-9f54-a5ca836adf9b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A03Z&sr=b&sp=r&sig=l7jS4%2FrSdfAwNQ2UQqMTrygLjSt5XEsG1BBgYWO98Ik%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:03.4208756","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A03Z&sr=b&sp=r&sig=U50xLOYyczMVZV0i1wzouxU9X61gu0rPOom0nWRWLac%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:03.4207906","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A03Z&sr=b&sp=r&sig=qhSWWSVhvuWDFTzXK3eRuIe08XVPG6qKMTgDdJWMDaY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:03.4209001","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3228'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:03 GMT
-      mise-correlation-id:
-      - dd1d74c2-5281-471f-9555-bb6fa13372db
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A08Z&sr=b&sp=r&sig=xPzyd7VN3R5k4HJ6jW%2BAS5PbJ3TynxPeh8H6CSu9oWo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:08.7487732","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A08Z&sr=b&sp=r&sig=KB5%2FMkQbXA3BZeael5VG12xhETkfiV5oYTX2KLieCRs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:08.748692","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A08Z&sr=b&sp=r&sig=5NnpOwZvg9JsZhtlGpAvQzsOKrwDoIxfI%2F00aHXDB5E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:08.7487887","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3231'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:08 GMT
-      mise-correlation-id:
-      - 6a4f47e4-f7ee-45e8-b25c-fc57b520efa9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A14Z&sr=b&sp=r&sig=daaW4Fk1q4YUBJMZEJjJMh7UEfuo3GfdcuXh5Z%2Fshfo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:14.0775565","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A14Z&sr=b&sp=r&sig=5%2FtS%2FNh6uQM40nlnu58CtPjVQH2NcqUAJw6w%2Fg2D7Qw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:14.0774654","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A14Z&sr=b&sp=r&sig=owWxa6ey0WE0v0NyY2K1I4qYiBBmNZzIj2jEO9eCCcw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:14.0775712","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:14 GMT
-      mise-correlation-id:
-      - eeebf519-60cc-498e-be1b-389d3b75ebfa
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A19Z&sr=b&sp=r&sig=7Ygy8BtOqXoxVBCJIYfaapLRHV3VmhmG4A3jflkfnDA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:19.4121623","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A19Z&sr=b&sp=r&sig=gWs4MAW1zKIWL%2F7UOcQq3Udgl4ya6YAhuOE8GBjfG1Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:19.4120812","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A19Z&sr=b&sp=r&sig=ytZKToATVC%2Fp4hMXS8Bshq1ZmEJJ7NQA2b%2FvXaa0qFU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:19.4121775","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3232'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:19 GMT
-      mise-correlation-id:
-      - d6f72594-e087-4bbd-b526-ed6448d4b281
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A24Z&sr=b&sp=r&sig=eU1MVFKe7%2FW9M7zMkzDimgzg0ZRz7a9xNliqBe5vIso%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:24.7221011","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A24Z&sr=b&sp=r&sig=nHmXDnTrWWYjvIO7g3JUa4e3dYYkAcUN0qz8FIJhoDY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:24.722015","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A24Z&sr=b&sp=r&sig=DuNr2R1UHr0TvXpJVmOi4Xpe90Euirwza2yPsb39pSw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:24.722123","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3226'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:24 GMT
-      mise-correlation-id:
-      - 944b2020-67a2-42ec-85b2-629fcbc4544d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A30Z&sr=b&sp=r&sig=A09ui6IKX7Ps1p9XZqsVAgKn6vs1IyHLcBjO1Cgspwk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:30.031415","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A30Z&sr=b&sp=r&sig=kXKZt73fDxnPvAWk%2FTo8BhtWr766nucKZv5eupzO86s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:30.0313229","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A30Z&sr=b&sp=r&sig=RJ3cneInil9bUp2gvIk6hCwgWPFjIosco3s%2F7ENSaM0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:30.0314392","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A01Z&sr=b&sp=r&sig=H6pwbygbsWWlpCWLoknA1f9PHE4eJLnH3pn8bGUlfTU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:01.4063428","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A01Z&sr=b&sp=r&sig=fsgMZPlEpR8etkaZ63bhU7xXmU0yZ8cxl2m6I1IzXeU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:01.4062442","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A01Z&sr=b&sp=r&sig=UFenkxTdzOnkWKDqnCToXaqMpmfplhDf6AIFn5LNlkA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:01.4063668","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:56.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1362,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:21:30 GMT
+      - Fri, 13 Oct 2023 13:53:01 GMT
       mise-correlation-id:
-      - 9da0e665-e444-41c8-b9ed-a03dbe38b1cd
+      - 18bc4f9c-76d2-4305-bbcf-2436421eecf4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1382,228 +770,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A36Z&sr=b&sp=r&sig=SOHk9UY3%2FdF4s6mofm9SiTySqEQTSZ%2F3BnOVUfTiodc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:36.3455087","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A36Z&sr=b&sp=r&sig=NQy3%2BW2TQ0sgZxWTmHt458nqPFJ4KPSQd6h%2B3g57F48%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:36.3454234","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A36Z&sr=b&sp=r&sig=Pq%2FocKvYpTK4PAumn6oWB06Hd255e%2BVJ7ZHodasBSUg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:36.3455231","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3238'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:36 GMT
-      mise-correlation-id:
-      - 08f89206-5a3c-4fd9-a55d-565b7060dde7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A41Z&sr=b&sp=r&sig=yUEubmM0NwAAO%2FjNgXdJGD3rPTpr0V0S3H3qhDA0iVY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:41.7036693","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A41Z&sr=b&sp=r&sig=kkUH9x6DOBhuGBe5Lv9nObYM5Y%2BzTvK%2FrK22fg%2BYSX8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:41.7035769","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A41Z&sr=b&sp=r&sig=1WZajK9%2FuF%2F3mVyj6nZeovJTQfW0gwH90kVtjI9cjWc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:41.7036898","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3238'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:41 GMT
-      mise-correlation-id:
-      - a9df65b7-ee53-49d3-8aba-79960287619f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A47Z&sr=b&sp=r&sig=sP3LcGW3gM0515pYhqAAz21oMB5mcaciREQUju71cJw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:47.0525085","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A47Z&sr=b&sp=r&sig=OYj1OrSd6dUxOTx5tAGkrFruJIxPpuH2wMzAXN6VVck%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:47.0524326","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A47Z&sr=b&sp=r&sig=SETeA3qaRYPlP59R3o%2B%2FUP5oiELOnqLV9okL3FPpjPo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:47.0525265","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3230'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:47 GMT
-      mise-correlation-id:
-      - 06dd70e1-e772-4a16-b833-9c5985718a66
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A52Z&sr=b&sp=r&sig=Y1ytmf2cycgm9t6YHihmzDUFQ5ixy2vmOO9gY1mH08I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:52.3051837","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A52Z&sr=b&sp=r&sig=WfZNSkEtCliBGVW0OoMM3rwVKJKWNV9nC%2FDbkfzJA8c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:52.3050973","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A52Z&sr=b&sp=r&sig=prfI7nMJZqHda8Z%2Bvp7yYg%2BbT%2B176tNAZRSSCpAx4Aw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:52.3052048","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:52 GMT
-      mise-correlation-id:
-      - 4776181d-efbc-4475-98bc-26b70483c6ae
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A57Z&sr=b&sp=r&sig=xiYNfu5260jPUZiDR36DGBBFC5zMt3s67vfhr5Yif08%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:57.5777906","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A57Z&sr=b&sp=r&sig=iQ6N12wkHpJ3EObQQ0dTQ84ySaKealZVNjDldeh8ojg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:57.5776743","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A57Z&sr=b&sp=r&sig=GR%2B5CpStV0vlMDSlisYVcwCLRDTbomeEQVKXcahXCsw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:57.5778172","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3228'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:57 GMT
-      mise-correlation-id:
-      - eb490280-2158-427b-9232-1e1f5d97f863
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A02Z&sr=b&sp=r&sig=XNjQBkyHzP8NNulDt1Fi4HUaeAigmkRzgVq8TBQosG8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:02.9054523","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A02Z&sr=b&sp=r&sig=20NIF6soigU2cYX9WS8mysXgOLE7MkUXZiYs8AkUim4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:02.9053578","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A02Z&sr=b&sp=r&sig=2o83m2merxBAHC41GfZURRp17cpCEIqfA%2FmwR0i3m0k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:02.905475","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3227'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:22:02 GMT
-      mise-correlation-id:
-      - 3e989473-7b98-4e3a-8f33-5a47de56988b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A08Z&sr=b&sp=r&sig=gghHZgROhedLNVRUZDghaWkGDKwL%2FNClNPd1aYBJ9Lw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:08.2175385","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A08Z&sr=b&sp=r&sig=yP7qtXS8uwPGk773C%2FWsh1BNPVo6ucN9DMVPdEGERTQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:08.217457","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A08Z&sr=b&sp=r&sig=5kDzVQVtwQfhENg1Crec8L%2Bo3XyfXKTGB%2BXuIU1HSks%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:08.2175597","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A06Z&sr=b&sp=r&sig=xc%2FdhGqDWTmCQLX%2FrG83jVdBDzrcZTsMdOeaYNhMEHQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:06.6928499","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A06Z&sr=b&sp=r&sig=11HRGOjyt46aKF7hISQVYtB7Z7tsFdb3c2DDMPaDIeA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:06.6927823","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A06Z&sr=b&sp=r&sig=2WOSZPMZE4rnM85xB1tLtqVzFxlrcOTfqtj7yi6oPfQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:06.6928665","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:56.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1614,9 +786,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:08 GMT
+      - Fri, 13 Oct 2023 13:53:06 GMT
       mise-correlation-id:
-      - 934eb167-54f4-44ae-8bf3-81b296ad94b1
+      - 18251400-ad54-430d-a54a-845e132b736b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1634,25 +806,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A13Z&sr=b&sp=r&sig=BvrAbNZ%2FBgsDOGeYsLGZK8%2B1N%2FrTaWEB4uygvh7ksVQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:13.4846083","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A13Z&sr=b&sp=r&sig=j1%2B8%2BxBxVp0snsGbEv19CgQt3j%2FuXnU7k%2FCzpR5C49Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:13.4845131","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A13Z&sr=b&sp=r&sig=PiBBFPFEfItsjtYJKnsthVsviOaX8gyQbDddjBsi7fI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:13.4846288","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A11Z&sr=b&sp=r&sig=rTsCQfrddas1EPezNgybu5xg%2FHp%2FeYlT72FuQ2d5vkI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:11.9637808","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A11Z&sr=b&sp=r&sig=MdYqUu8ABWZU56s1fGmPWGbEeEAKZcNvg7vVuIySqNk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:11.9636967","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A11Z&sr=b&sp=r&sig=EUuV%2B0A12q40qBMsFl9PY9vgBDQi5H85mi%2FvioJVfTs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:11.9638027","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:56.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3240'
+      - '3237'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:13 GMT
+      - Fri, 13 Oct 2023 13:53:11 GMT
       mise-correlation-id:
-      - a17013fd-e45a-4a38-85b0-6a693c5439c4
+      - adf14fdc-7787-406e-8423-a49f4a8cd96a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1670,25 +842,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A18Z&sr=b&sp=r&sig=1xC2laXoFEzrRwShsI8alb8XzzTRYAMz1SlylLRZx0Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:18.7481895","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A18Z&sr=b&sp=r&sig=hBYc4hBFLKpFhvcfoKN%2BhrKKR4fgOP2WHe4q07Rt81w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:18.7480605","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A18Z&sr=b&sp=r&sig=%2B9jdV6TIqh4Hy5nm2TR9VrKYHXQ2jycproqMP0VHoyg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:18.7482124","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A17Z&sr=b&sp=r&sig=9jXkblvF6pcah3J6bPW4L8sXGAug3LSE9itNLz6LcRc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:17.2475389","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A17Z&sr=b&sp=r&sig=Lpsb%2Be35xYszFN1ujacP3jU%2F2Tm4hBEh37jjkOy5bic%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:17.2474542","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A17Z&sr=b&sp=r&sig=chmjMyds%2FjAqWa3NCj10wlpGjXN7tmuKRaZpBUgK124%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:17.2475559","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:56.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3230'
+      - '3235'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:18 GMT
+      - Fri, 13 Oct 2023 13:53:17 GMT
       mise-correlation-id:
-      - cf868a99-d34d-472f-b170-3f718c3bc7e1
+      - 40d643fc-b2db-4dc0-9a07-5d9aa027f679
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1706,48 +878,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A24Z&sr=b&sp=r&sig=2epy5F8t5vJ7ie%2BlAU%2FpYoZLL0mXxqRJzEqoPV6b2iM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:24.0430906","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A24Z&sr=b&sp=r&sig=mL%2BWdgE2%2FN7eTBbi0sAz95PAyuyFIk%2F0ga%2BW%2Bo1Y2Yk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:24.0429513","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A24Z&sr=b&sp=r&sig=ThJwD8mmFaxFEoqORfg%2FnX2HtS%2BkixazhkyzxiQHHFY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:24.0431117","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3244'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:22:24 GMT
-      mise-correlation-id:
-      - a71822fc-988f-45cd-8179-e67786501e27
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A29Z&sr=b&sp=r&sig=FO9NtA6Cy0Bi8o%2BcwdLJGAOYoIdiJnIgwEeMTnL5ONY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:29.4026895","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A29Z&sr=b&sp=r&sig=IHc%2BHp5jgt0fyaHtLHZc3cU%2Ba87Xoe1RRR4v%2FvIjYi4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:29.4025872","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A29Z&sr=b&sp=r&sig=TNI1YYWbvE6GDaT%2F9Q1GR3CuJCtyk0HN40XUy4MOuAU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:29.4027123","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A22Z&sr=b&sp=r&sig=pUHI0qob17Ux%2B6Kd22%2FX4n3Ka7qHyH36rhxF29DGVjM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:22.506954","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A22Z&sr=b&sp=r&sig=zXUMRBREkEMzzFqmEPgW6D5Gxjivm%2BRqYQuKlJxE7Dk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:22.5068846","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A22Z&sr=b&sp=r&sig=DcuUc8tPoRIbawdG1UMXclUMWwSJIya2StLBuiIXY%2FQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:22.5069701","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:56.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +894,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:29 GMT
+      - Fri, 13 Oct 2023 13:53:22 GMT
       mise-correlation-id:
-      - db6994cc-8e78-4bbd-bba3-e50bac69eba2
+      - 42f0e84c-fb73-4499-b953-26a8bde2a8f3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1778,12 +914,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A34Z&sr=b&sp=r&sig=qSNIon9vmlKXx9vUc2CDuKOiMlS22kkERhE36VVPFwU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:34.661683","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A34Z&sr=b&sp=r&sig=xSBl2MKKL2T863EprrLI6MiPbwin7D9E%2BRP6FDxUMFo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:34.6615548","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A34Z&sr=b&sp=r&sig=B1EBlSeV99vdFiUtsKbB8284p33XTMgkCoW%2Fu8DMJ%2Bo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:34.6617112","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A27Z&sr=b&sp=r&sig=QoykFKpTEr3hrOXpNWbxgrNiDXZYjfXXt0ZHqESXwTg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:27.8030329","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A27Z&sr=b&sp=r&sig=Lx%2BQHs1YLc9jAoFHImEzIYFoBkd6RBF7ovcp01eeLIs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:27.8029449","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A27Z&sr=b&sp=r&sig=WxFxwWr6pUPWdJfWZiYFO0iGSmCaMgpPirSuKVkhm88%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:27.8030545","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:56.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1794,9 +930,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:34 GMT
+      - Fri, 13 Oct 2023 13:53:27 GMT
       mise-correlation-id:
-      - 7caee6a0-cf38-465a-b592-6b6099e02875
+      - 700bd299-2c35-4106-a3e1-ce16b66344d1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1814,26 +950,854 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A39Z&sr=b&sp=r&sig=ut7XpDZFDbX2qgLkgwkreR5aytj7%2BGzX9sw2Q2O6rJ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:39.9692748","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A39Z&sr=b&sp=r&sig=nu56Djwv1MS55hvHEkmiTOVw7YV2FnUcLnzjgCtV%2BM0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:39.9692007","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A39Z&sr=b&sp=r&sig=9rGHVf4rq3qbiMmm2Jyi7jbmTF69n47%2BzirKJdHC2UM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:39.9692969","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-09T19:19:53.578Z","endDateTime":"2023-10-09T19:22:39.859Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:39.938Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A33Z&sr=b&sp=r&sig=jD4nTbT%2FsTb1mpce0UtpcMfd5kwOUyw3kgetFlP8WHw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:33.0564959","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A33Z&sr=b&sp=r&sig=z%2FrZ%2BIB13WbEF5LxFm3nOlidh6Qoc3twkiK4auIUprM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:33.056423","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A33Z&sr=b&sp=r&sig=pQxG29WZ7lZa0DwDjz0DhwtVKT0SSy%2B0ipVNQeUzKCM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:33.0565103","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:56.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3367'
+      - '3236'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:39 GMT
+      - Fri, 13 Oct 2023 13:53:33 GMT
       mise-correlation-id:
-      - a87bbe19-f203-440c-befc-741a0b514d22
+      - 3aed55e1-5068-44bc-ba72-b3c85011b668
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A38Z&sr=b&sp=r&sig=h1DiQ9KQAw%2BEvi30izkaOeOcDFQwi62bOfs1FG%2Bj%2B14%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:38.3375172","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A38Z&sr=b&sp=r&sig=b%2Fh%2BlP3IoDgjcOxZTnuD0jiJ34RvwxUTeMgnC0VddyE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:38.3374343","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A38Z&sr=b&sp=r&sig=U8jx%2FsaFC71HQnNiJZk3jBPSw4wmz7iHo9Q5jvgKwDM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:38.3375374","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONED","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:38.285Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3240'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:38 GMT
+      mise-correlation-id:
+      - 9d9c562b-5cbb-437c-a25c-95359bde261b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A43Z&sr=b&sp=r&sig=sX9F43Xc9CqMRXJ%2BifpB9GLVkpwfZyzD9m%2BRq1%2BNUgQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:43.6174177","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A43Z&sr=b&sp=r&sig=wooMgUuAjzMTu6jPCWZH8qSzB%2BAY2DUDD%2BjQk1XEh8Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:43.6173249","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A43Z&sr=b&sp=r&sig=Mv5PtuqKSmfs5rW7V3L4NWgxdYDRQ5sjtcz5AqcUXgc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:43.6174331","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"CONFIGURING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:38.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3238'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:43 GMT
+      mise-correlation-id:
+      - 7d1474ae-3311-4fa7-ab47-0001f19cfd64
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A48Z&sr=b&sp=r&sig=QhzACba2GUlHjC3Rkp6sKldrhGbFprVn5s7%2BqkQlxs0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:48.8864763","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A48Z&sr=b&sp=r&sig=H3XsLtTk3Nn0u5TAomGiD2cLiTdsQZnWxBwY2ZIZhgQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:48.8863857","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A48Z&sr=b&sp=r&sig=wujkUYIgfwGL%2BThXbSBLfOPxQMjVeEuPUuuMkBuBNeU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:48.8864984","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3230'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:48 GMT
+      mise-correlation-id:
+      - f11eb5aa-6391-4dd1-b8fc-e6029cc2307f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A54Z&sr=b&sp=r&sig=%2F3JmuEaqiGmPy8usDN1HLaptdFosnTXkuE31myUc5JM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:54.1448012","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A54Z&sr=b&sp=r&sig=SAzI7gXDEp48rXhzJUoKaqwnvKynu1%2BJy%2F7F2fkFgug%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:54.1447174","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A54Z&sr=b&sp=r&sig=JQPbZHAPWDD1Wkzte2Ide1TDyMMhgeot%2B%2FbHC9ei66c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:54.1448217","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:54 GMT
+      mise-correlation-id:
+      - d3668a0f-fa20-4db4-a998-9092afa10989
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A59Z&sr=b&sp=r&sig=DAVWYBS8%2FfSrKseDa8OlCMczv%2FPZ2yf6hf1kT7%2B30jg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:59.4329788","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A59Z&sr=b&sp=r&sig=sT8mBUA0rLqQuYZrhh9nMvsDxfDnq2lqoKIVunRit40%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:59.4328879","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A59Z&sr=b&sp=r&sig=P6qIpFg4olF47388tDyni5%2BZ%2BjKrfcGYbC6UXZJPmhU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:59.4330013","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:59 GMT
+      mise-correlation-id:
+      - 5f97dd53-f342-4e5b-a97a-4eb309bb2e97
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A04Z&sr=b&sp=r&sig=lcxzjgQcZY4PGgXFbGS9WRTAqD%2BV9mMXM1OwLrC7Xps%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:04.7773697","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A04Z&sr=b&sp=r&sig=t86kTb0oXgwKjv9oRVkebypB1fvEf7W9FN6gIq4wSNU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:04.7772762","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A04Z&sr=b&sp=r&sig=jtF3BNdqIUHoaIscsB63sw0RMcWOMpUgWBBjYT8v8Ro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:04.7773907","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3228'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:04 GMT
+      mise-correlation-id:
+      - 06c5935f-c32f-4f89-a174-a5f9716c4131
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A10Z&sr=b&sp=r&sig=bUfiKpevIec3Z%2B99eaG4oFAL3rkpWKZYETQ1aKpoWzY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:10.092042","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A10Z&sr=b&sp=r&sig=eCGWDmE7zrdB9QGe6bavFtsNMe5%2F1%2BuWqGMEc4UHypc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:10.0919687","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A10Z&sr=b&sp=r&sig=19sS8TYqHCD384mlLb4OSW3oJUo5lAwWLJYb%2BhqDiMc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:10.0920565","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:10 GMT
+      mise-correlation-id:
+      - 8e7f4064-a5dc-4da3-adc2-37b57324b43f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A15Z&sr=b&sp=r&sig=IbesBTsF6UP2c%2BZxqOQwUnZKZtsR4n8%2BcVHQgBU98ac%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:15.413653","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A15Z&sr=b&sp=r&sig=gUpKqYkJHVS3gK%2FsAYHwxu7Hg3ECOJXXKqRXUbEHH%2FA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:15.4135858","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A15Z&sr=b&sp=r&sig=yXqB%2FL89tywfTcHkL9%2BlltyTdiu5AhHjIb91jGvbDcM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:15.4136687","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:15 GMT
+      mise-correlation-id:
+      - dd3cf396-ec81-4e4f-97cd-40758a1c9a11
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A20Z&sr=b&sp=r&sig=yH34kenRAeAzUgFaHPZxcBQ3vcA%2BTYutVE3Dfcqq7Ww%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:20.6802651","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A20Z&sr=b&sp=r&sig=AVAjjns9j%2BsucBnXtsyS29eMoSI1Y1IStG5d3ayO4tY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:20.6801925","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A20Z&sr=b&sp=r&sig=qt9YBJ%2Fige5vns%2BQMqvK52iCshPotJ9iCzL81PpKIOE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:20.6802796","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:20 GMT
+      mise-correlation-id:
+      - 805fcc84-7dc9-4635-a7c4-0a3ef47c55ec
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A25Z&sr=b&sp=r&sig=rHg07S1ui45dMR27oro79DLR9trIcll4ew1jFvwOjzk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:25.969794","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A25Z&sr=b&sp=r&sig=HUP6%2BV9IFuo08YHbB40FJ6SsXarFZkQ4nT4Z7bh99eg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:25.969707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A25Z&sr=b&sp=r&sig=1aldUy6a9E%2FXPdIRa%2FJKAF0Vvz23L8eG8hPpm7hY%2FlI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:25.9698135","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:25 GMT
+      mise-correlation-id:
+      - 7143e5a9-6725-4ab6-95d2-9972855df62f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A31Z&sr=b&sp=r&sig=LA3w2KJ%2Ftq0t89R3JDhqI4N4L7zqh1JJH%2F289XRQxXc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:31.2339247","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A31Z&sr=b&sp=r&sig=126oZxbOskvPJq4jJaUcXbyWVSwYj%2FlRieRfZTjW5TU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:31.2338556","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A31Z&sr=b&sp=r&sig=Xc5AwKZFdebtYceculujwi2wLEEIXV%2BCsNR7GY6XpWw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:31.2339404","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:31 GMT
+      mise-correlation-id:
+      - eb5b247d-9e5a-4e70-a437-432752f98c20
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A36Z&sr=b&sp=r&sig=qfE%2BOb65p7hwtc0Y3t3kpb02s0l2tWJFanlLOihUDnE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:36.5165905","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A36Z&sr=b&sp=r&sig=DaXbHcQb9sgPHbS7X4N7fWtb8o5hWtLJURzV8nx51k4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:36.5164788","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A36Z&sr=b&sp=r&sig=julGPG9pI3EB98uH08E6lxLZcAKxT8APH3ACojBIX5U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:36.5166171","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3228'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:36 GMT
+      mise-correlation-id:
+      - 2cf47510-ba4b-4a15-b7bc-7a990c689708
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A41Z&sr=b&sp=r&sig=ZXXIddtHa3O%2FnuEPzsZDEc4gZ%2F4KgXG85A7o7dn%2BKhU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:41.8391394","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A41Z&sr=b&sp=r&sig=Nzq5FqBNt6czCADOI1qAShT4WSGzx4VIfDzNZVsKLyU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:41.8390676","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A41Z&sr=b&sp=r&sig=Xz%2FQd7IS%2BB2IDVd55YC13dIbJ02epTd4GJv57X90h6k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:41.8391532","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:41 GMT
+      mise-correlation-id:
+      - 208b72eb-259a-4d04-a40e-a89aaa813715
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A47Z&sr=b&sp=r&sig=6PROxeFkeRKtFhIaoSuWUECr7U52u%2F479xunHGG%2FSWQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:47.148674","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A47Z&sr=b&sp=r&sig=qBezfIV9ob48Dnungu2g%2Bkz7b28JElTCruxXbdGC3Ns%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:47.1486052","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A47Z&sr=b&sp=r&sig=wOv2mRuZ0xJ4UeXNFy4XgJcFUFUjP6ktIwmhxw8qMCg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:47.1486898","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:47 GMT
+      mise-correlation-id:
+      - 4afcc4f3-d60a-4e1d-990b-deffe6a6c90f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A52Z&sr=b&sp=r&sig=A4Y9IV9fhFjQ5lff1223ActmrZFEa5vleSeeOYiBq3E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:52.4894546","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A52Z&sr=b&sp=r&sig=5OwHJmUMXOT1k81hdNtZud2cXNHXNkCipFJXMtiTiOI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:52.4893638","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A52Z&sr=b&sp=r&sig=BHC8k8mfJAW9WR9nHiEqKP0lqRFtd%2B0LVtSqWIgK8T0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:52.4894758","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3228'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:52 GMT
+      mise-correlation-id:
+      - e730ba28-2119-4eb2-8fbd-96c7832f837b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A57Z&sr=b&sp=r&sig=Go%2F7Gx03KLbYp%2F5CmTUcU7IxknzTEurm6%2FxlqPTfm3w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:57.7394133","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A57Z&sr=b&sp=r&sig=rmT5q4nt5ksQjKOpji7ITQuPy1Qp%2BrNR%2BRyBTbaXa7w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:57.739327","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A57Z&sr=b&sp=r&sig=Gi0A18B6Bs7MKDseIFld6FMyUu3bZr5HUjorEg7XIqA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:57.7394352","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:57 GMT
+      mise-correlation-id:
+      - 6f35d08f-b2cb-4642-9ec9-aac66026b9a6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A03Z&sr=b&sp=r&sig=im3%2BZoDzuciFm49v2wYlKbwYdnPfPQT8YijASH%2FcOaY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:03.0285466","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A03Z&sr=b&sp=r&sig=Io2%2BLaGBs0Fo9Yb3okfk8DoNQOiFqBHlkDlJIBhPuLg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:03.0284678","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A03Z&sr=b&sp=r&sig=DkL2pZTKoOTn3p5x1T0UCe4Zi6253uUJGqXtAx0AJpA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:03.0285619","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:03 GMT
+      mise-correlation-id:
+      - d5a4239e-334d-49d6-9916-a7a56f7e69d6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A08Z&sr=b&sp=r&sig=tEHH%2Fr3W5PzlP%2FA1DvGylV5Pfu%2B9wuftVfgob0E5MxE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:08.316854","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A08Z&sr=b&sp=r&sig=aTMyJ5Z5fv5ERL8CV8mKGjUZUTtGjiGW%2FLkw54X2Mm0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:08.3167493","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A08Z&sr=b&sp=r&sig=L51jvIzlG%2BR6mTfGUZ%2B9ui%2FEMwPWTo0kBjGW8Dk536g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:08.3168828","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3239'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:08 GMT
+      mise-correlation-id:
+      - f5e2e806-b7d8-4b7b-90b5-9460390354a5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A13Z&sr=b&sp=r&sig=lpVvLX5XlLoGa%2ByA4wjr6gNeDE8RSSuGAzxu23H79%2BQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:13.5763192","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A13Z&sr=b&sp=r&sig=ftEL1NvjgN7su4j%2BTKYrtaepX6MwmnlmIMwHkGdc7Uk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:13.5762353","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A13Z&sr=b&sp=r&sig=YHeueMWLYTFDK6IwwZ%2ByaqqQivfJAmg2KcCbX5S1cmE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:13.5763356","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:13 GMT
+      mise-correlation-id:
+      - bae3fd16-1039-41b1-9e48-172a1d66c746
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A18Z&sr=b&sp=r&sig=hROrnD6159eeKSoTZPFHerRQrRG1dKSwxDoePbJMtLw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:18.9264441","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A18Z&sr=b&sp=r&sig=eWgWBtsM3c6DATqg1EPsmiDnPdRYRkOJBm%2BVuGJWfXs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:18.9263579","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A18Z&sr=b&sp=r&sig=WYKeIeSHOG5cS%2FkpaLP9gI5RcToeIVld8yEICo16%2F3g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:18.926465","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:18 GMT
+      mise-correlation-id:
+      - 158138de-b498-4511-910b-21885dd72901
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A24Z&sr=b&sp=r&sig=4%2BuAljgV53ELLkI22%2BjKD37fkfzZBZGdJbuVxhUWVZk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:24.1681565","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A24Z&sr=b&sp=r&sig=Dkk%2FNj44BUfvXHaqb38Lh5ngHFSICC%2B94u1D4g0wxqs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:24.1680878","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A24Z&sr=b&sp=r&sig=kDkAZILR6VuT5DuJHX1o9uYaVi4Giw3pxMi0ls1Kyn0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:24.1681719","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:24 GMT
+      mise-correlation-id:
+      - 9612ef24-7cc8-4aa1-89c6-72bbb2e418aa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A29Z&sr=b&sp=r&sig=1ptjmUs%2BewzISEOtvBmzQddr3ABP%2BQeLHLphw97gc%2FM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:29.5600739","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A29Z&sr=b&sp=r&sig=z4BPORHgfZRlE1dr8G%2BjigZ5Lf%2FDavBmv8OpKRYEynQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:29.5599926","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A29Z&sr=b&sp=r&sig=IHy%2BRW1U8b%2B8Kvm6gLwEZqw50tKeVsrx%2Fu93AHHm8UY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:29.5600926","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3242'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:29 GMT
+      mise-correlation-id:
+      - e9cf6e99-f0fb-4fec-9183-e03dc506a7cd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A34Z&sr=b&sp=r&sig=0m%2FdhqM4h8RalFllFdvaOmhJBcrT0mXKAI%2FdhJtTgo4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:34.8245247","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A34Z&sr=b&sp=r&sig=5MEEBqI0Ws5XuJU8P1FNshyER4HeFR8Jotd6966bpbU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:34.8244612","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A34Z&sr=b&sp=r&sig=%2FrHppSVVV7UwF1eafWFbTu%2F8fN9bYYuXYzuxqZVUfPw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:34.8245391","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-13T13:52:56.26Z","endDateTime":"2023-10-13T13:55:33.671Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:33.94Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3368'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:34 GMT
+      mise-correlation-id:
+      - fc5a42ad-92b5-485e-b9b1-0de88e26cf6f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1856,7 +1820,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:30.9716153Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:30.9716153Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:31.3771816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:31.3771816Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1865,9 +1829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:41 GMT
+      - Fri, 13 Oct 2023 13:55:35 GMT
       etag:
-      - '"5600ef16-0000-0100-0000-652452090000"'
+      - '"d8015be9-0000-0100-0000-65294b650000"'
       expires:
       - '-1'
       pragma:
@@ -1895,26 +1859,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=app-component-test-case&api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=app-component-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A42Z&sr=b&sp=r&sig=JS1YUTn0vK6kJcc1vdgsf%2BHFCb6TnpnCytzicMjCBw8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:42.245244","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A42Z&sr=b&sp=r&sig=DX3ImZ7mIWLBqxXwyN3PxkGY9WYX4MYfi%2Bvvt1vGGIg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:42.245171","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A42Z&sr=b&sp=r&sig=aDjitIv6lo1409xwDvNREM8d7LlsEjThMm2TLMPx0EE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:42.2452614","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-09T19:19:53.578Z","endDateTime":"2023-10-09T19:22:39.859Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:39.938Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A36Z&sr=b&sp=r&sig=WOqE7hdZefGpH5jYDlv9JJQXR9zA85lk3RSn86DR040%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:36.9659495","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A36Z&sr=b&sp=r&sig=opQFrkUhiHE3PQTT%2BRYJdW9WJdkfNU1GMQMmLa8Ipbk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:36.965882","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A36Z&sr=b&sp=r&sig=qpg4qe5JvjdXIco1vnRh3GOE%2F3x%2F47m5vvHIUT2A%2BWo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:36.9659647","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-13T13:52:56.26Z","endDateTime":"2023-10-13T13:55:33.671Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:36.731Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3375'
+      - '3380'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:42 GMT
+      - Fri, 13 Oct 2023 13:55:36 GMT
       mise-correlation-id:
-      - d5548e24-4c7b-4c3e-a8e0-afc7d4e63a5f
+      - c864fcf0-2be9-4463-9cec-8dee725bcc14
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1936,12 +1900,12 @@ interactions:
       ParameterSetName:
       - --name --resource-group
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-09T19:19:06.2113337Z","key2":"2023-10-09T19:19:06.2113337Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T19:19:06.2269525Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T19:19:06.2269525Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-09T19:19:06.0238654Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-13T13:52:07.8854004Z","key2":"2023-10-13T13:52:07.8854004Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-13T13:52:07.9010353Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-13T13:52:07.9010353Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-13T13:52:07.6979000Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -1950,7 +1914,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:22:52 GMT
+      - Fri, 13 Oct 2023 13:55:47 GMT
       expires:
       - '-1'
       pragma:
@@ -1983,7 +1947,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:30.9716153Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:30.9716153Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:31.3771816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:31.3771816Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1992,9 +1956,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:53 GMT
+      - Fri, 13 Oct 2023 13:55:48 GMT
       etag:
-      - '"5600ef16-0000-0100-0000-652452090000"'
+      - '"d8015be9-0000-0100-0000-65294b650000"'
       expires:
       - '-1'
       pragma:
@@ -2013,9 +1977,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ydnn7ff3t3qwkq5td/providers/Microsoft.Storage/storageAccounts/clitestloadxggg3gf52":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ydnn7ff3t3qwkq5td/providers/Microsoft.Storage/storageAccounts/clitestloadxggg3gf52",
-      "resourceName": "clitestloadxggg3gf52", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-76ptndwpfn6wjyxre/providers/Microsoft.Storage/storageAccounts/clitestloadywvr6c5il":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-76ptndwpfn6wjyxre/providers/Microsoft.Storage/storageAccounts/clitestloadywvr6c5il",
+      "resourceName": "clitestloadywvr6c5il", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -2029,12 +1993,12 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-09T19:22:55.664Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:55.664Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-13T13:55:49.458Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:49.458Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2045,11 +2009,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:55 GMT
+      - Fri, 13 Oct 2023 13:55:49 GMT
       location:
-      - https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+      - https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - 190966ff-a484-45a0-b457-195286a9232e
+      - ce62418f-8b95-45f8-8cda-fec720a12fae
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2072,7 +2036,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:30.9716153Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:30.9716153Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:31.3771816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:31.3771816Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2081,9 +2045,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:56 GMT
+      - Fri, 13 Oct 2023 13:55:51 GMT
       etag:
-      - '"5600ef16-0000-0100-0000-652452090000"'
+      - '"d8015be9-0000-0100-0000-65294b650000"'
       expires:
       - '-1'
       pragma:
@@ -2111,12 +2075,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-09T19:22:55.664Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:55.664Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-13T13:55:49.458Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:49.458Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2127,9 +2091,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:58 GMT
+      - Fri, 13 Oct 2023 13:55:51 GMT
       mise-correlation-id:
-      - e2bc9fc5-765a-46dc-be1c-517060b0e9d9
+      - dc132bd7-1eab-463c-bf07-2ff3bdc0a431
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2152,7 +2116,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:30.9716153Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:30.9716153Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:31.3771816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:31.3771816Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2161,9 +2125,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:59 GMT
+      - Fri, 13 Oct 2023 13:55:53 GMT
       etag:
-      - '"5600ef16-0000-0100-0000-652452090000"'
+      - '"d8015be9-0000-0100-0000-65294b650000"'
       expires:
       - '-1'
       pragma:
@@ -2182,7 +2146,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ydnn7ff3t3qwkq5td/providers/Microsoft.Storage/storageAccounts/clitestloadxggg3gf52":
+    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-76ptndwpfn6wjyxre/providers/Microsoft.Storage/storageAccounts/clitestloadywvr6c5il":
       null}}'
     headers:
       Accept:
@@ -2196,12 +2160,12 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-09T19:22:55.664Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:00.474Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-13T13:55:49.458Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:54.546Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2212,9 +2176,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:00 GMT
+      - Fri, 13 Oct 2023 13:55:54 GMT
       mise-correlation-id:
-      - a0256f52-cab8-4aa3-b018-c313b7da7b50
+      - 10f7b5d1-aab3-4b22-a8e9-b34280b99cc6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2237,7 +2201,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:30.9716153Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:30.9716153Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:31.3771816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:31.3771816Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2246,9 +2210,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:01 GMT
+      - Fri, 13 Oct 2023 13:55:56 GMT
       etag:
-      - '"5600ef16-0000-0100-0000-652452090000"'
+      - '"d8015be9-0000-0100-0000-65294b650000"'
       expires:
       - '-1'
       pragma:
@@ -2276,12 +2240,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-09T19:22:55.664Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:00.474Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-13T13:55:49.458Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:54.546Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2292,9 +2256,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:02 GMT
+      - Fri, 13 Oct 2023 13:55:57 GMT
       mise-correlation-id:
-      - 2a6b2745-e6a5-4954-a650-370b1cc6e06a
+      - 22d7c19d-55b5-4f1e-b79d-85ba021d723b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_app_component.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_app_component.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:31.3771816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:31.3771816Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:28.2169395Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:28.2169395Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:31 GMT
+      - Wed, 18 Oct 2023 20:52:23 GMT
       etag:
-      - '"d8015be9-0000-0100-0000-65294b650000"'
+      - '"75005e4d-0000-0100-0000-653045510000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:52:32 GMT
+      - Wed, 18 Oct 2023 20:52:25 GMT
       mise-correlation-id:
-      - 5c0795c5-df0a-44e0-a338-d880d560a626
+      - dfe9fcb9-6367-4359-a124-92861af11091
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"6a2773f5-ca19-4133-a010-b33c58812b8e": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":
+      {"passFailMetrics": {"31ad3a4f-8712-4ddf-ad8f-15b5105c3361": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "0f16e512-990f-4caf-8c5e-39e040ec0e27":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "97336d72-d70a-4a05-a0a8-99a5f81f786e": {"aggregate": "avg", "clientMetric":
+      "50"}, "57a98ded-236c-415f-9ad5-d16cafcafc93": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:32.455Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:32.455Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:52:25.693Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:25.693Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:32 GMT
+      - Wed, 18 Oct 2023 20:52:25 GMT
       location:
-      - https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+      - https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 0fe68265-7484-428b-ad0f-bc778d7998c7
+      - b10d7756-b4e3-4515-b3ba-926b37ac1077
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:32 GMT
+      - Wed, 18 Oct 2023 20:52:26 GMT
       mise-correlation-id:
-      - 2102d86d-b2ff-408c-9bdc-c1fb61b746f3
+      - e839cd3f-ffd1-4899-aa90-a1d9ed43eb5b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A33Z&sr=b&sp=r&sig=7KWBNz9EQ%2B%2BxJkhzvGIVt9AzeAKSF%2BpRv3VG94p7hcM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:33.7756985","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A27Z&sr=b&sp=r&sig=QguXEqEClfynN0ifLqzWUwusGryXhWRXUDDa8RUFqWE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:27.4694908","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:33 GMT
+      - Wed, 18 Oct 2023 20:52:27 GMT
       location:
-      - https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - ce4cb1df-aac0-4356-a3fb-606a1ade46c2
+      - 7af8220f-b75d-4723-addd-29e7e942aac5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A34Z&sr=b&sp=r&sig=dqbaM8egGh7IyYbPDZG7PecA2CVJMUhhY3u5gXPdf2c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:34.0244969","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A27Z&sr=b&sp=r&sig=zlNvNCZg81%2F5tOFZdoRDGccZ5%2F2F8%2Bc%2FC037s%2F7SKkQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:27.7254367","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '559'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:52:27 GMT
+      mise-correlation-id:
+      - 0cda6d72-69c4-4d98-9247-7a617993d3d3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A32Z&sr=b&sp=r&sig=PrOFxGY2tKb7%2BB7URBYHMJF%2Bg6%2FMyUc3JBE1d0g4Yf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:32.9922908","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '555'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:52:32 GMT
+      mise-correlation-id:
+      - d1d0368f-76dc-4fd6-890b-5096da8db762
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A38Z&sr=b&sp=r&sig=zMtmzj3QsCihbS7mVbUdKM1VV%2FjJCvrslaYCNNolYZU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:38.2488445","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:52:38 GMT
+      mise-correlation-id:
+      - 69cb39d8-eef8-4872-a382-856a8c088a24
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A43Z&sr=b&sp=r&sig=cs9fG6TEDp4Hg3jmg7aM4Mtw6Ko8wJLjGSxE%2Fh8ZGC0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:43.5310639","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:34 GMT
+      - Wed, 18 Oct 2023 20:52:43 GMT
       mise-correlation-id:
-      - 50fd162b-fe29-4d46-877a-ca7df75a2565
+      - 4953835a-28db-44a5-8ac4-677221b2933d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,132 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A39Z&sr=b&sp=r&sig=nDTP3ZhJ6uaJJSEfDIBY4MTwi3ldoKNChGPMxNOdCxs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:39.2950248","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A43Z&sr=b&sp=r&sig=gyRWdvK48124nB2qsQjOA9hRoRLMXnvAqTU5E8q4wK0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:43.8243025","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:52:25.693Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.793Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '1584'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:39 GMT
+      - Wed, 18 Oct 2023 20:52:43 GMT
       mise-correlation-id:
-      - 06da760e-21b2-4f36-835e-8af47aa941a3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A44Z&sr=b&sp=r&sig=b3pG9iRhPo8%2B8T%2FPy7G7RGnaCelf4wQ4blO8wGATsyM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:44.5528783","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:52:44 GMT
-      mise-correlation-id:
-      - 85c9a7dd-40ad-4593-a596-9c20e6e0812e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A49Z&sr=b&sp=r&sig=nsU%2FuULtFvH1Sf0D6W5lLoZkYkFxizgcWbJq41tMsgY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:49.8718079","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:52:49 GMT
-      mise-correlation-id:
-      - a544ec31-299a-4d84-86c9-ba28d45d7d9b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A50Z&sr=b&sp=r&sig=Ajo4VW2PRSkFIp9b8Xau3%2Fdzl4nts91FVmTPzXqhtHg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:50.1300692","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:32.455Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:46.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1586'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:52:50 GMT
-      mise-correlation-id:
-      - 5618971c-b3af-4cfe-8594-2a0136ef72a6
+      - 3c8d1f7f-1afa-492d-8b7b-fa06ce9590fc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:31.3771816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:31.3771816Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:28.2169395Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:28.2169395Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:51 GMT
+      - Wed, 18 Oct 2023 20:52:44 GMT
       etag:
-      - '"d8015be9-0000-0100-0000-65294b650000"'
+      - '"75005e4d-0000-0100-0000-653045510000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A52Z&sr=b&sp=r&sig=jiNdeJUPQtXMpsevgLLUTaSVPjTaQ9IriAZ%2BqWWRQBA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:52.4879945","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:32.455Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:46.092Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A46Z&sr=b&sp=r&sig=kJxEoqOmKzmOBx%2FTHV%2BIqC2%2BPFGnjbObT4iB4Oy1lFo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:46.179303","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:52:25.693Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.793Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1598'
+      - '1601'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:52 GMT
+      - Wed, 18 Oct 2023 20:52:46 GMT
       mise-correlation-id:
-      - d5cd4bdc-e0ce-4651-a0dd-73250fbc629f
+      - ff949646-8b2a-432a-a0f9-90e625fdb7ef
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:31.3771816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:31.3771816Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:28.2169395Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:28.2169395Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:54 GMT
+      - Wed, 18 Oct 2023 20:52:47 GMT
       etag:
-      - '"d8015be9-0000-0100-0000-65294b650000"'
+      - '"75005e4d-0000-0100-0000-653045510000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:52:54 GMT
+      - Wed, 18 Oct 2023 20:52:48 GMT
       mise-correlation-id:
-      - 3fa7dd9c-3d43-4eac-be4a-98cc6567837b
+      - d5883ba3-a62f-4dc1-b4e5-c20c86d7ce4f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A55Z&sr=b&sp=r&sig=iXMzsrWjLHbpU%2Fg%2BBh56KT%2FAlBB29x%2FVmx9CJVwJ2zM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:55.6930292","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A55Z&sr=b&sp=r&sig=C%2Bb6bTYhH52z%2BTNiC2gBx%2FjvwLExne8O2ZHH0nu7xMk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:55.6929303","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A55Z&sr=b&sp=r&sig=MNYJwClsLIVzugEp3bLptLidkfKbw4NHhuPoR%2BBjTdU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:55.693053","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:55.602Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A50Z&sr=b&sp=r&sig=wF2TOd%2F2qGVQ0xCcD9f%2BcQtqfg6ckLsIOGYVt%2FdpGeY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:50.0441471","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A50Z&sr=b&sp=r&sig=UgfNs4iA%2BJaNOX5PKmVMUFXPf9658fR3zDEsKo%2FwHUM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:50.0440355","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A50Z&sr=b&sp=r&sig=AxkF3ybLX8ZnnfjRW%2FYe1kQjxiZPraKpLDxBDK4MKqM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:50.0441811","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:49.978Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3198'
+      - '3195'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:55 GMT
+      - Wed, 18 Oct 2023 20:52:50 GMT
       location:
-      - https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+      - https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 7dd42021-96d7-49df-9201-239625287ad2
+      - 0fd6ea20-51ba-47c4-bd31-983434ea6bb3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A56Z&sr=b&sp=r&sig=3PPfCTobJycD06vdgevjKjNq%2FUdJNfEtLpeydqG13TU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:56.1400685","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A56Z&sr=b&sp=r&sig=54i6kU%2BN49htUsZrfiO%2Ft9j7HyHnpNlh56d6pTCt2m4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:56.1399707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A56Z&sr=b&sp=r&sig=wzz2ADMQsfEK3JFLR8XcR045GWJoVfCgPsdLEwdlFro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:56.1400905","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:55.602Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A50Z&sr=b&sp=r&sig=Qdj%2FBFieIV%2FRpp1WNP8hWUb3MnN%2FGRNLuqugBk9Tofo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:50.4821015","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A50Z&sr=b&sp=r&sig=qwDHo4pSh5hZ3uqK52s0lQd0dyUDYsp%2F%2B1N%2FQA%2FP3CI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:50.4819848","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A50Z&sr=b&sp=r&sig=vDr928vl6ztEdFswjKBDub4Mt3hn3VsQkyK%2Bm%2FQyVnk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:50.4821269","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"NOTSTARTED","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:50.372Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3189'
+      - '3246'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:56 GMT
+      - Wed, 18 Oct 2023 20:52:50 GMT
       mise-correlation-id:
-      - 76511a02-2863-446a-91d8-11a83eab5e30
+      - 338d9580-6b7c-4cac-863b-8d09335e8d4d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A01Z&sr=b&sp=r&sig=H6pwbygbsWWlpCWLoknA1f9PHE4eJLnH3pn8bGUlfTU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:01.4063428","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A01Z&sr=b&sp=r&sig=fsgMZPlEpR8etkaZ63bhU7xXmU0yZ8cxl2m6I1IzXeU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:01.4062442","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A01Z&sr=b&sp=r&sig=UFenkxTdzOnkWKDqnCToXaqMpmfplhDf6AIFn5LNlkA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:01.4063668","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:56.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A55Z&sr=b&sp=r&sig=JgmALIz9JwdBINXTKg4wZCtDpYljoL1a2h0HTrCsyYo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:55.7889425","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A55Z&sr=b&sp=r&sig=4YpPXb0VVqrFveQO3k1u3bkaXlwW2fwrsWW2RecTOsE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:55.7888492","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A55Z&sr=b&sp=r&sig=EdlYXUbuwcBBFEVltp0M55ZwozuH4dW%2FoB8Mw5WnZnU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:55.7889667","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:50.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3229'
+      - '3232'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:01 GMT
+      - Wed, 18 Oct 2023 20:52:55 GMT
       mise-correlation-id:
-      - 18bc4f9c-76d2-4305-bbcf-2436421eecf4
+      - d049be7c-1b4e-4f81-847c-47247837ba05
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A06Z&sr=b&sp=r&sig=xc%2FdhGqDWTmCQLX%2FrG83jVdBDzrcZTsMdOeaYNhMEHQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:06.6928499","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A06Z&sr=b&sp=r&sig=11HRGOjyt46aKF7hISQVYtB7Z7tsFdb3c2DDMPaDIeA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:06.6927823","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A06Z&sr=b&sp=r&sig=2WOSZPMZE4rnM85xB1tLtqVzFxlrcOTfqtj7yi6oPfQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:06.6928665","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:56.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A01Z&sr=b&sp=r&sig=9l6v5ZfJ97iD2unY7C9zIjYgb5kIOEaE4IsHeU68RuI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:01.1198965","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A01Z&sr=b&sp=r&sig=zvVBzi3LwM8RIqUCLxP6GCtSkO2Hw0OLdc8u%2FAFyLLM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:01.1198281","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A01Z&sr=b&sp=r&sig=7wtDNkPF5Otj7D5Y91VSzxj6nAoP7FNSTL5RYfHxJr4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:01.1199126","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:50.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3233'
+      - '3232'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:06 GMT
+      - Wed, 18 Oct 2023 20:53:01 GMT
       mise-correlation-id:
-      - 18251400-ad54-430d-a54a-845e132b736b
+      - f1d8e080-8815-4ee1-a695-8768c25f39ab
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,226 +808,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A11Z&sr=b&sp=r&sig=rTsCQfrddas1EPezNgybu5xg%2FHp%2FeYlT72FuQ2d5vkI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:11.9637808","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A11Z&sr=b&sp=r&sig=MdYqUu8ABWZU56s1fGmPWGbEeEAKZcNvg7vVuIySqNk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:11.9636967","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A11Z&sr=b&sp=r&sig=EUuV%2B0A12q40qBMsFl9PY9vgBDQi5H85mi%2FvioJVfTs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:11.9638027","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:56.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:11 GMT
-      mise-correlation-id:
-      - adf14fdc-7787-406e-8423-a49f4a8cd96a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A17Z&sr=b&sp=r&sig=9jXkblvF6pcah3J6bPW4L8sXGAug3LSE9itNLz6LcRc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:17.2475389","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A17Z&sr=b&sp=r&sig=Lpsb%2Be35xYszFN1ujacP3jU%2F2Tm4hBEh37jjkOy5bic%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:17.2474542","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A17Z&sr=b&sp=r&sig=chmjMyds%2FjAqWa3NCj10wlpGjXN7tmuKRaZpBUgK124%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:17.2475559","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:56.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:17 GMT
-      mise-correlation-id:
-      - 40d643fc-b2db-4dc0-9a07-5d9aa027f679
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A22Z&sr=b&sp=r&sig=pUHI0qob17Ux%2B6Kd22%2FX4n3Ka7qHyH36rhxF29DGVjM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:22.506954","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A22Z&sr=b&sp=r&sig=zXUMRBREkEMzzFqmEPgW6D5Gxjivm%2BRqYQuKlJxE7Dk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:22.5068846","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A22Z&sr=b&sp=r&sig=DcuUc8tPoRIbawdG1UMXclUMWwSJIya2StLBuiIXY%2FQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:22.5069701","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:56.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3236'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:22 GMT
-      mise-correlation-id:
-      - 42f0e84c-fb73-4499-b953-26a8bde2a8f3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A27Z&sr=b&sp=r&sig=QoykFKpTEr3hrOXpNWbxgrNiDXZYjfXXt0ZHqESXwTg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:27.8030329","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A27Z&sr=b&sp=r&sig=Lx%2BQHs1YLc9jAoFHImEzIYFoBkd6RBF7ovcp01eeLIs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:27.8029449","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A27Z&sr=b&sp=r&sig=WxFxwWr6pUPWdJfWZiYFO0iGSmCaMgpPirSuKVkhm88%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:27.8030545","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:56.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3231'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:27 GMT
-      mise-correlation-id:
-      - 700bd299-2c35-4106-a3e1-ce16b66344d1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A33Z&sr=b&sp=r&sig=jD4nTbT%2FsTb1mpce0UtpcMfd5kwOUyw3kgetFlP8WHw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:33.0564959","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A33Z&sr=b&sp=r&sig=z%2FrZ%2BIB13WbEF5LxFm3nOlidh6Qoc3twkiK4auIUprM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:33.056423","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A33Z&sr=b&sp=r&sig=pQxG29WZ7lZa0DwDjz0DhwtVKT0SSy%2B0ipVNQeUzKCM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:33.0565103","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:56.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3236'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:33 GMT
-      mise-correlation-id:
-      - 3aed55e1-5068-44bc-ba72-b3c85011b668
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A38Z&sr=b&sp=r&sig=h1DiQ9KQAw%2BEvi30izkaOeOcDFQwi62bOfs1FG%2Bj%2B14%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:38.3375172","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A38Z&sr=b&sp=r&sig=b%2Fh%2BlP3IoDgjcOxZTnuD0jiJ34RvwxUTeMgnC0VddyE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:38.3374343","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A38Z&sr=b&sp=r&sig=U8jx%2FsaFC71HQnNiJZk3jBPSw4wmz7iHo9Q5jvgKwDM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:38.3375374","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONED","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:38.285Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3240'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:38 GMT
-      mise-correlation-id:
-      - 9d9c562b-5cbb-437c-a25c-95359bde261b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A43Z&sr=b&sp=r&sig=sX9F43Xc9CqMRXJ%2BifpB9GLVkpwfZyzD9m%2BRq1%2BNUgQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:43.6174177","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A43Z&sr=b&sp=r&sig=wooMgUuAjzMTu6jPCWZH8qSzB%2BAY2DUDD%2BjQk1XEh8Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:43.6173249","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A43Z&sr=b&sp=r&sig=Mv5PtuqKSmfs5rW7V3L4NWgxdYDRQ5sjtcz5AqcUXgc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:43.6174331","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"CONFIGURING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:38.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A06Z&sr=b&sp=r&sig=lYIsvHjGj2hNVNqW3rZ%2Fd73rSEu04zdEwV%2F80LFSeRU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:06.3935792","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A06Z&sr=b&sp=r&sig=ar2CC3MWB3VWQAYsB2KAWFETvMlBAy7Z8olcgRtOC04%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:06.3935084","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A06Z&sr=b&sp=r&sig=y5RFfsUhgDo%2BZEtaBAMXMY8Fq9P4rFhe%2B5xNMF8TddI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:06.3935938","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:50.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1038,9 +822,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:43 GMT
+      - Wed, 18 Oct 2023 20:53:06 GMT
       mise-correlation-id:
-      - 7d1474ae-3311-4fa7-ab47-0001f19cfd64
+      - 72af5562-39a6-4816-b9df-e07d1d072ce4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A48Z&sr=b&sp=r&sig=QhzACba2GUlHjC3Rkp6sKldrhGbFprVn5s7%2BqkQlxs0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:48.8864763","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A48Z&sr=b&sp=r&sig=H3XsLtTk3Nn0u5TAomGiD2cLiTdsQZnWxBwY2ZIZhgQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:48.8863857","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A48Z&sr=b&sp=r&sig=wujkUYIgfwGL%2BThXbSBLfOPxQMjVeEuPUuuMkBuBNeU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:48.8864984","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A11Z&sr=b&sp=r&sig=fas0XAUZXNB4Nb7m6UUS7vxPYwdycEMcjLXxIbH%2BoJs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:11.6843526","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A11Z&sr=b&sp=r&sig=Y7lGSABk7Fk49TrRmWGARvZvrGBc0sURJvyICeBJA2w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:11.6842771","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A11Z&sr=b&sp=r&sig=I1QFfo8ZA3u30nkDU7xtGFRAMTSzxMrhJ4k2pf0Aquw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:11.6843675","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:50.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3230'
+      - '3232'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:48 GMT
+      - Wed, 18 Oct 2023 20:53:11 GMT
       mise-correlation-id:
-      - f11eb5aa-6391-4dd1-b8fc-e6029cc2307f
+      - be2e2b03-3f06-409f-a2f2-8b24a9548f62
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1096,10 +880,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A54Z&sr=b&sp=r&sig=%2F3JmuEaqiGmPy8usDN1HLaptdFosnTXkuE31myUc5JM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:54.1448012","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A54Z&sr=b&sp=r&sig=SAzI7gXDEp48rXhzJUoKaqwnvKynu1%2BJy%2F7F2fkFgug%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:54.1447174","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A54Z&sr=b&sp=r&sig=JQPbZHAPWDD1Wkzte2Ide1TDyMMhgeot%2B%2FbHC9ei66c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:54.1448217","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A17Z&sr=b&sp=r&sig=DOp%2FsF6Oda1%2FV2QFVYtfQ89tjGlTe%2Frn0kF80Rl9Ses%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:17.0107188","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A17Z&sr=b&sp=r&sig=XI%2FmSB5ytVdClfADZ2tBbAZbY1WLQv8vwiGVxc40sF0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:17.0106437","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A17Z&sr=b&sp=r&sig=MPcno5wMxzQxYEYnpu9ytL3j0LvM72Mm%2B9lidPZ6XcA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:17.0107336","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:50.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3240'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:17 GMT
+      mise-correlation-id:
+      - 0a056b4e-2712-4852-aee2-6311f11afbba
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A22Z&sr=b&sp=r&sig=3lRi8hZ51O9jpN92Y9nSSLhxEqgvRGRU9ey9NBSScQM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:22.3346174","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A22Z&sr=b&sp=r&sig=clxgPw2qb6h%2FCaJSBU%2BYPf6a%2F%2B9l0%2Blb5NvYtKu0NQ0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:22.3345395","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A22Z&sr=b&sp=r&sig=VVE1lCwUAUvYjYoRhnYRRza5IZJ5TTMkQOXQYUmedlA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:22.3346326","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:50.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3240'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:22 GMT
+      mise-correlation-id:
+      - 5a1dea3c-1b42-4a64-bbf9-dc4ff7e85fd8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A27Z&sr=b&sp=r&sig=aKePusCcaI%2FjtzFKOFLkU8bBQVEvWQIc16BwTOt0rp0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:27.6312709","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A27Z&sr=b&sp=r&sig=O4lmlV3vBbBNrvBqHFSJOLQtF1Vs%2FMuAb7sYcU3MBlk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:27.6311725","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A27Z&sr=b&sp=r&sig=eJgTNGCtkzKAbay392pU9sT%2BuGt2nkrA2e8YObZxHbg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:27.6312906","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:50.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1110,9 +966,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:54 GMT
+      - Wed, 18 Oct 2023 20:53:27 GMT
       mise-correlation-id:
-      - d3668a0f-fa20-4db4-a998-9092afa10989
+      - 37663d6e-6c7e-4df6-a835-b13e2047151a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1132,23 +988,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A59Z&sr=b&sp=r&sig=DAVWYBS8%2FfSrKseDa8OlCMczv%2FPZ2yf6hf1kT7%2B30jg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:59.4329788","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A59Z&sr=b&sp=r&sig=sT8mBUA0rLqQuYZrhh9nMvsDxfDnq2lqoKIVunRit40%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:59.4328879","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A59Z&sr=b&sp=r&sig=P6qIpFg4olF47388tDyni5%2BZ%2BjKrfcGYbC6UXZJPmhU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:59.4330013","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A32Z&sr=b&sp=r&sig=FswCuSYLFxHlO8vS6GYftvXdl2Op5E7r5TFghTfWwbo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:32.9607652","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A32Z&sr=b&sp=r&sig=BLLcuiMLEvdC4ZWdd1ir56CnuDKeyxwMzhrgSvdKsnY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:32.9606879","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A32Z&sr=b&sp=r&sig=PcM8%2FItS5kFbc7seRMVt0ynqfbP3TCkM8aT39TJfsZI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:32.9607794","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:50.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3236'
+      - '3232'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:59 GMT
+      - Wed, 18 Oct 2023 20:53:32 GMT
       mise-correlation-id:
-      - 5f97dd53-f342-4e5b-a97a-4eb309bb2e97
+      - f8fac27a-55ea-4eff-abae-630416bb5ba0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1168,23 +1024,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A04Z&sr=b&sp=r&sig=lcxzjgQcZY4PGgXFbGS9WRTAqD%2BV9mMXM1OwLrC7Xps%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:04.7773697","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A04Z&sr=b&sp=r&sig=t86kTb0oXgwKjv9oRVkebypB1fvEf7W9FN6gIq4wSNU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:04.7772762","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A04Z&sr=b&sp=r&sig=jtF3BNdqIUHoaIscsB63sw0RMcWOMpUgWBBjYT8v8Ro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:04.7773907","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A38Z&sr=b&sp=r&sig=5T2WxbEbfQN4idrwa3KeL60r6NCt5XFCifNRODdOKZI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:38.2951967","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A38Z&sr=b&sp=r&sig=PKYJYTk2l3iQNl1PPQqhAvrzFDHWvOVqeHsOfubncc0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:38.2951055","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A38Z&sr=b&sp=r&sig=xaioWyKuIrQqUqtQAbyOqjrEIq%2BLZ7MvOVNQ5Ma2CDM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:38.2952174","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3228'
+      - '3229'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:54:04 GMT
+      - Wed, 18 Oct 2023 20:53:38 GMT
       mise-correlation-id:
-      - 06c5935f-c32f-4f89-a174-a5f9716c4131
+      - c39847e4-4612-45fb-99bd-626f8e9ff4e7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1204,23 +1060,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A10Z&sr=b&sp=r&sig=bUfiKpevIec3Z%2B99eaG4oFAL3rkpWKZYETQ1aKpoWzY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:10.092042","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A10Z&sr=b&sp=r&sig=eCGWDmE7zrdB9QGe6bavFtsNMe5%2F1%2BuWqGMEc4UHypc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:10.0919687","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A10Z&sr=b&sp=r&sig=19sS8TYqHCD384mlLb4OSW3oJUo5lAwWLJYb%2BhqDiMc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:10.0920565","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A43Z&sr=b&sp=r&sig=wbDLZ77aZbVIyFBMOeDRvnwjZOOCDJpMI2aYeEVfSW8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:43.6367102","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A43Z&sr=b&sp=r&sig=VGmVT9q1IBoHi2evE9iGEcg0fOBzSD%2FFIpZpWVo3BP4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:43.6366129","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A43Z&sr=b&sp=r&sig=5FDzTrUtqc9WEG2PuHPx4l68QvhtrxHPSouMnWFMRgE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:43.6367316","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3233'
+      - '3229'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:54:10 GMT
+      - Wed, 18 Oct 2023 20:53:43 GMT
       mise-correlation-id:
-      - 8e7f4064-a5dc-4da3-adc2-37b57324b43f
+      - 0a72e8ee-f0d4-4d9e-8316-be8e991e6a54
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1240,10 +1096,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A15Z&sr=b&sp=r&sig=IbesBTsF6UP2c%2BZxqOQwUnZKZtsR4n8%2BcVHQgBU98ac%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:15.413653","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A15Z&sr=b&sp=r&sig=gUpKqYkJHVS3gK%2FsAYHwxu7Hg3ECOJXXKqRXUbEHH%2FA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:15.4135858","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A15Z&sr=b&sp=r&sig=yXqB%2FL89tywfTcHkL9%2BlltyTdiu5AhHjIb91jGvbDcM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:15.4136687","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A48Z&sr=b&sp=r&sig=I0HhLyU7IQGB9c%2Ble0%2BwW5LoKhZZNOhtTuVkr%2FhS8AE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:48.9081694","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A48Z&sr=b&sp=r&sig=173SrAjTRWOHn1orWtoKlM9HXt%2B8Jipu3qEHH6xsKlk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:48.9080932","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A48Z&sr=b&sp=r&sig=Nah6y1udo0taC0kZrkyUbOxzAy3x7ElBC%2FVfYuN4M30%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:48.9081833","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1254,9 +1110,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:54:15 GMT
+      - Wed, 18 Oct 2023 20:53:48 GMT
       mise-correlation-id:
-      - dd3cf396-ec81-4e4f-97cd-40758a1c9a11
+      - a5fcdc79-6eb6-4428-aafe-1e41792d5646
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1276,262 +1132,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A20Z&sr=b&sp=r&sig=yH34kenRAeAzUgFaHPZxcBQ3vcA%2BTYutVE3Dfcqq7Ww%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:20.6802651","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A20Z&sr=b&sp=r&sig=AVAjjns9j%2BsucBnXtsyS29eMoSI1Y1IStG5d3ayO4tY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:20.6801925","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A20Z&sr=b&sp=r&sig=qt9YBJ%2Fige5vns%2BQMqvK52iCshPotJ9iCzL81PpKIOE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:20.6802796","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:20 GMT
-      mise-correlation-id:
-      - 805fcc84-7dc9-4635-a7c4-0a3ef47c55ec
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A25Z&sr=b&sp=r&sig=rHg07S1ui45dMR27oro79DLR9trIcll4ew1jFvwOjzk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:25.969794","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A25Z&sr=b&sp=r&sig=HUP6%2BV9IFuo08YHbB40FJ6SsXarFZkQ4nT4Z7bh99eg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:25.969707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A25Z&sr=b&sp=r&sig=1aldUy6a9E%2FXPdIRa%2FJKAF0Vvz23L8eG8hPpm7hY%2FlI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:25.9698135","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3232'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:25 GMT
-      mise-correlation-id:
-      - 7143e5a9-6725-4ab6-95d2-9972855df62f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A31Z&sr=b&sp=r&sig=LA3w2KJ%2Ftq0t89R3JDhqI4N4L7zqh1JJH%2F289XRQxXc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:31.2339247","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A31Z&sr=b&sp=r&sig=126oZxbOskvPJq4jJaUcXbyWVSwYj%2FlRieRfZTjW5TU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:31.2338556","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A31Z&sr=b&sp=r&sig=Xc5AwKZFdebtYceculujwi2wLEEIXV%2BCsNR7GY6XpWw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:31.2339404","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:31 GMT
-      mise-correlation-id:
-      - eb5b247d-9e5a-4e70-a437-432752f98c20
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A36Z&sr=b&sp=r&sig=qfE%2BOb65p7hwtc0Y3t3kpb02s0l2tWJFanlLOihUDnE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:36.5165905","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A36Z&sr=b&sp=r&sig=DaXbHcQb9sgPHbS7X4N7fWtb8o5hWtLJURzV8nx51k4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:36.5164788","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A36Z&sr=b&sp=r&sig=julGPG9pI3EB98uH08E6lxLZcAKxT8APH3ACojBIX5U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:36.5166171","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3228'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:36 GMT
-      mise-correlation-id:
-      - 2cf47510-ba4b-4a15-b7bc-7a990c689708
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A41Z&sr=b&sp=r&sig=ZXXIddtHa3O%2FnuEPzsZDEc4gZ%2F4KgXG85A7o7dn%2BKhU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:41.8391394","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A41Z&sr=b&sp=r&sig=Nzq5FqBNt6czCADOI1qAShT4WSGzx4VIfDzNZVsKLyU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:41.8390676","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A41Z&sr=b&sp=r&sig=Xz%2FQd7IS%2BB2IDVd55YC13dIbJ02epTd4GJv57X90h6k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:41.8391532","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3236'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:41 GMT
-      mise-correlation-id:
-      - 208b72eb-259a-4d04-a40e-a89aaa813715
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A47Z&sr=b&sp=r&sig=6PROxeFkeRKtFhIaoSuWUECr7U52u%2F479xunHGG%2FSWQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:47.148674","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A47Z&sr=b&sp=r&sig=qBezfIV9ob48Dnungu2g%2Bkz7b28JElTCruxXbdGC3Ns%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:47.1486052","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A47Z&sr=b&sp=r&sig=wOv2mRuZ0xJ4UeXNFy4XgJcFUFUjP6ktIwmhxw8qMCg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:47.1486898","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3231'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:47 GMT
-      mise-correlation-id:
-      - 4afcc4f3-d60a-4e1d-990b-deffe6a6c90f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A52Z&sr=b&sp=r&sig=A4Y9IV9fhFjQ5lff1223ActmrZFEa5vleSeeOYiBq3E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:52.4894546","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A52Z&sr=b&sp=r&sig=5OwHJmUMXOT1k81hdNtZud2cXNHXNkCipFJXMtiTiOI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:52.4893638","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A52Z&sr=b&sp=r&sig=BHC8k8mfJAW9WR9nHiEqKP0lqRFtd%2B0LVtSqWIgK8T0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:52.4894758","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3228'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:52 GMT
-      mise-correlation-id:
-      - e730ba28-2119-4eb2-8fbd-96c7832f837b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A57Z&sr=b&sp=r&sig=Go%2F7Gx03KLbYp%2F5CmTUcU7IxknzTEurm6%2FxlqPTfm3w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:57.7394133","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A57Z&sr=b&sp=r&sig=rmT5q4nt5ksQjKOpji7ITQuPy1Qp%2BrNR%2BRyBTbaXa7w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:57.739327","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A57Z&sr=b&sp=r&sig=Gi0A18B6Bs7MKDseIFld6FMyUu3bZr5HUjorEg7XIqA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:57.7394352","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A54Z&sr=b&sp=r&sig=ge%2F1VSPSA3iBuPJJPYQJci0KWFvw6BfUvbxshnaxfM8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:54.1761916","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A54Z&sr=b&sp=r&sig=ECeAcMpBVJMTFAGkYwkt1lm1qwjhfJoJ4wW7RRiO7M4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:54.1760989","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A54Z&sr=b&sp=r&sig=jSv%2FKvReObFDEs5VN0Y1%2FL62395eNYC%2BMsO8ts4X5yM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:54.1762141","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1542,9 +1146,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:54:57 GMT
+      - Wed, 18 Oct 2023 20:53:54 GMT
       mise-correlation-id:
-      - 6f35d08f-b2cb-4642-9ec9-aac66026b9a6
+      - ab9471ca-54df-45f5-876c-03a54fee770a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,23 +1168,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A03Z&sr=b&sp=r&sig=im3%2BZoDzuciFm49v2wYlKbwYdnPfPQT8YijASH%2FcOaY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:03.0285466","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A03Z&sr=b&sp=r&sig=Io2%2BLaGBs0Fo9Yb3okfk8DoNQOiFqBHlkDlJIBhPuLg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:03.0284678","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A03Z&sr=b&sp=r&sig=DkL2pZTKoOTn3p5x1T0UCe4Zi6253uUJGqXtAx0AJpA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:03.0285619","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A59Z&sr=b&sp=r&sig=oldR7wOGpl9Pps3YRdiS2AAKldxcbpT4t5dLyg24CV8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:59.5240187","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A59Z&sr=b&sp=r&sig=9EB6tSPRVAYP0Csl2v31UMC90huLn3iQTwG4oS%2FD%2Fbc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:59.5239427","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A59Z&sr=b&sp=r&sig=%2BObUicDZdXFykLehq9BOmqnbYcTCNgrjbIVuWHl0Fig%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:59.5240324","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3232'
+      - '3233'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:03 GMT
+      - Wed, 18 Oct 2023 20:53:59 GMT
       mise-correlation-id:
-      - d5a4239e-334d-49d6-9916-a7a56f7e69d6
+      - 323ad84f-0600-4d2d-8a03-673f4f0d8f40
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,10 +1204,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A08Z&sr=b&sp=r&sig=tEHH%2Fr3W5PzlP%2FA1DvGylV5Pfu%2B9wuftVfgob0E5MxE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:08.316854","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A08Z&sr=b&sp=r&sig=aTMyJ5Z5fv5ERL8CV8mKGjUZUTtGjiGW%2FLkw54X2Mm0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:08.3167493","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A08Z&sr=b&sp=r&sig=L51jvIzlG%2BR6mTfGUZ%2B9ui%2FEMwPWTo0kBjGW8Dk536g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:08.3168828","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A04Z&sr=b&sp=r&sig=mieBbdMhD1%2BUAMmCbqu03WlpPdYqKtj1owYQzjbNiQ0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:04.8450344","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A04Z&sr=b&sp=r&sig=1Qj%2B0DZlLVGJij9v8F9G2uZaVVGmkeXEoFbjwpGt%2F%2F0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:04.8449633","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A04Z&sr=b&sp=r&sig=qJvU6%2F31x5%2BJil6CklwJJEMJmKUzZL0YDUVkBfWc8vk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:04.8450488","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1614,9 +1218,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:08 GMT
+      - Wed, 18 Oct 2023 20:54:04 GMT
       mise-correlation-id:
-      - f5e2e806-b7d8-4b7b-90b5-9460390354a5
+      - 1b9583ab-ce5f-456c-85f5-61a2e1a35a41
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,10 +1240,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A13Z&sr=b&sp=r&sig=lpVvLX5XlLoGa%2ByA4wjr6gNeDE8RSSuGAzxu23H79%2BQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:13.5763192","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A13Z&sr=b&sp=r&sig=ftEL1NvjgN7su4j%2BTKYrtaepX6MwmnlmIMwHkGdc7Uk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:13.5762353","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A13Z&sr=b&sp=r&sig=YHeueMWLYTFDK6IwwZ%2ByaqqQivfJAmg2KcCbX5S1cmE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:13.5763356","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A10Z&sr=b&sp=r&sig=KFZtA7%2F8zBU92Hay7kYJK9H8crWxg66LA2ho1BR6GQE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:10.1494642","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A10Z&sr=b&sp=r&sig=hMiEGIrXet1BC5YF9V3e8Xp7u9jOORNnhC0%2FOpXWrDk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:10.1493681","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A10Z&sr=b&sp=r&sig=3QWVaxq74%2BpbBYXqeVMrGrSM0xRPs%2BBaRUN1vlOsUOk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:10.1494879","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:10 GMT
+      mise-correlation-id:
+      - 21391e23-ef10-475d-8165-4d7a1d0bccc4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A15Z&sr=b&sp=r&sig=9A1HTOJKECGq0gakZIijHA%2FWD5r3dvf21zQjWrGaWEA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:15.4349354","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A15Z&sr=b&sp=r&sig=F8b9xDlU805IzJm9gZ8jANME5WU6HEMMrhX%2FEEqx0tw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:15.4348496","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A15Z&sr=b&sp=r&sig=DJhGzfBQ3XssOZIwPThOCDnccrCO1%2FvvLK6fTGyYq30%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:15.4349503","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:15 GMT
+      mise-correlation-id:
+      - 42dc2958-2caa-44bd-a696-1d9271165b19
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A20Z&sr=b&sp=r&sig=cZMPSXLP2MY%2FUE1P%2BancNSHte4xbG1oJ1A4ohKAf0ME%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:20.7218845","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A20Z&sr=b&sp=r&sig=VmSue4MSbUeWERh5yv2K8OeHtYEiUBUUnnBkfSWUEQU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:20.7217478","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A20Z&sr=b&sp=r&sig=oi3m5vAQlNIvznkGFNxqQvJXq8LT3IPLvmexAgbtdkM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:20.721915","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3230'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:20 GMT
+      mise-correlation-id:
+      - 122e13f0-a791-438b-8ff5-d176c505de33
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A26Z&sr=b&sp=r&sig=1Pu70gsN8tV4%2BaobonWkXkPuMWE0Lv3zU1IEGH%2BEcCs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:26.0279096","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A26Z&sr=b&sp=r&sig=QcuUzvFa38pT5FVHsxqQkCH0s2HwaI8Weg3ufJKouMk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:26.0278363","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A26Z&sr=b&sp=r&sig=4EqqmqOsfYT3%2FAY1scMy4jwbIQjLsBsez0yZd%2BzimL0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:26.027925","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1650,9 +1362,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:13 GMT
+      - Wed, 18 Oct 2023 20:54:26 GMT
       mise-correlation-id:
-      - bae3fd16-1039-41b1-9e48-172a1d66c746
+      - 7541ffae-970d-4b70-bf7b-197c928139bc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,10 +1384,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A18Z&sr=b&sp=r&sig=hROrnD6159eeKSoTZPFHerRQrRG1dKSwxDoePbJMtLw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:18.9264441","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A18Z&sr=b&sp=r&sig=eWgWBtsM3c6DATqg1EPsmiDnPdRYRkOJBm%2BVuGJWfXs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:18.9263579","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A18Z&sr=b&sp=r&sig=WYKeIeSHOG5cS%2FkpaLP9gI5RcToeIVld8yEICo16%2F3g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:18.926465","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A31Z&sr=b&sp=r&sig=cGc4p14Cv8q6EYr2TgkExESywwAdjm%2FAhLkDwZcnX7I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:31.3527255","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A31Z&sr=b&sp=r&sig=PPlYA0qkEnv4tYR3zbjfL3wscDwkp0JxQ9Tb%2Bqy6zMg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:31.3526488","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A31Z&sr=b&sp=r&sig=RNYj0t4kJ0ocSwpFmOb4sBgzSQuLwZXAbwWC1w2prjY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:31.3527398","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1686,9 +1398,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:18 GMT
+      - Wed, 18 Oct 2023 20:54:31 GMT
       mise-correlation-id:
-      - 158138de-b498-4511-910b-21885dd72901
+      - f342daea-c9a6-41f1-8b42-7e6569929e8b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,23 +1420,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A24Z&sr=b&sp=r&sig=4%2BuAljgV53ELLkI22%2BjKD37fkfzZBZGdJbuVxhUWVZk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:24.1681565","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A24Z&sr=b&sp=r&sig=Dkk%2FNj44BUfvXHaqb38Lh5ngHFSICC%2B94u1D4g0wxqs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:24.1680878","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A24Z&sr=b&sp=r&sig=kDkAZILR6VuT5DuJHX1o9uYaVi4Giw3pxMi0ls1Kyn0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:24.1681719","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A36Z&sr=b&sp=r&sig=X%2FxVpuaOyh4%2BSuHifpa4v%2F3n7hG0d8BQ%2FNzD2TzUOxw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:36.682347","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A36Z&sr=b&sp=r&sig=2fc4T6%2F95fMhwe%2F%2BHEvLE7uIpEcB%2BVeUbDZq7s8Raso%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:36.6822528","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A36Z&sr=b&sp=r&sig=LvN8GbweTudceOLsjMEj%2FZ3A5nV%2BIhQky9TUwmoc62c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:36.6823626","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3234'
+      - '3246'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:24 GMT
+      - Wed, 18 Oct 2023 20:54:36 GMT
       mise-correlation-id:
-      - 9612ef24-7cc8-4aa1-89c6-72bbb2e418aa
+      - 0bf48d03-62ab-4199-aa3a-85d58f60d634
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,10 +1456,262 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A29Z&sr=b&sp=r&sig=1ptjmUs%2BewzISEOtvBmzQddr3ABP%2BQeLHLphw97gc%2FM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:29.5600739","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A29Z&sr=b&sp=r&sig=z4BPORHgfZRlE1dr8G%2BjigZ5Lf%2FDavBmv8OpKRYEynQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:29.5599926","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A29Z&sr=b&sp=r&sig=IHy%2BRW1U8b%2B8Kvm6gLwEZqw50tKeVsrx%2Fu93AHHm8UY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:29.5600926","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:52:56.26Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:44.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A42Z&sr=b&sp=r&sig=Ym1jmu1cKQ2zbWjJRAlOd0MOaaqx4zkL8oA%2Fn7npcxs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:42.0124238","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A42Z&sr=b&sp=r&sig=X%2FxFoHzY92m0EGEgeevr8yfRZCh69QYOzQtc%2FdjfV60%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:42.0123243","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A42Z&sr=b&sp=r&sig=aznmP2WO2t2QEPxbGs9IefFTIYpqYhwCJfF6DkGnCMk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:42.012447","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:42 GMT
+      mise-correlation-id:
+      - fa367ac3-2933-44c2-b7b2-c0ae8cd81084
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A47Z&sr=b&sp=r&sig=lLvfZb3PTUx87KhmTlkC3shAu64W1eFDxVRmFN6x4Is%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:47.3372258","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A47Z&sr=b&sp=r&sig=Ol9sLcXPBXvY5p%2BphTMaJMJc%2FiKjU7hUWQxOaeh8ZbE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:47.3371396","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A47Z&sr=b&sp=r&sig=cVsSTvXPyBNaTsUBLTTjbhB%2BLTXuq%2BxKg3I5VPciyc4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:47.3372475","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:47 GMT
+      mise-correlation-id:
+      - 6dfff755-e11e-4ff2-b6e1-bd9f02ee74d1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A52Z&sr=b&sp=r&sig=NGPaffqiFLET8aqEEoAFqzTVc9ok4EwM1oIqyipNBds%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:52.6616687","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A52Z&sr=b&sp=r&sig=pokxLQFzdDl6FL9FsHWKUC07fVzPZEVW45ZqeVQG%2FK4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:52.6615903","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A52Z&sr=b&sp=r&sig=NnytxFdrGwqIP9KrVWRMRf%2FnCpyQLL4ceKJJ7%2B24vzc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:52.661685","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:52 GMT
+      mise-correlation-id:
+      - 809c9f75-25f9-49ce-b62d-bdcc7f57a205
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A57Z&sr=b&sp=r&sig=8keSXUxMPajZ1CVFNw0Qb5cjhwumGf8Xe%2BigrEcUeNE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:57.9688559","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A57Z&sr=b&sp=r&sig=EgFYCHo7oQG5WXWeB8WgacrgyPXJwh2UOiqTauOYJi4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:57.968757","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A57Z&sr=b&sp=r&sig=6tkzWOXgKURHwMjNUr9ZVoX6GsQR5mkO%2FWE5KOqc%2B9E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:57.968881","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:57 GMT
+      mise-correlation-id:
+      - 2613a444-dfd6-4a5b-93bd-9193fa534fd1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A03Z&sr=b&sp=r&sig=GKrjWPGPOr%2FtlvyU3VPTZP2fq5TOd6h3Ua1voeCqG5s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:03.284446","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A03Z&sr=b&sp=r&sig=YMvtqNhD2D5SV%2F0%2Fpe6yMqT8E3AEvd88KD4kr%2FXATEM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:03.284374","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A03Z&sr=b&sp=r&sig=HqW5UyPaLuVtenE4gIsR7B%2BTjQMOXy3h5VCPS9N%2Fvqo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:03.2844615","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:03 GMT
+      mise-correlation-id:
+      - 29549b3f-dfeb-4e89-9e10-ad165fd54483
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A08Z&sr=b&sp=r&sig=XUDZsyyVqw9tq8FRlU0nB5DZY7y8ir40b4QPS%2FM6yEo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:08.5462372","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A08Z&sr=b&sp=r&sig=3yULhL8zAN0%2Bst%2Bra8nfF8glJkMHYhBEAdSCNy2H88E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:08.5461376","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A08Z&sr=b&sp=r&sig=i%2F3lZfPm%2FtZLXgbj%2Fjnjfimy%2Bv0VoJtLeky%2FkQ2R6fM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:08.5462605","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3243'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:08 GMT
+      mise-correlation-id:
+      - 8cd443a6-1d23-442c-a087-6ba035679744
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A13Z&sr=b&sp=r&sig=dtSOAKC4l3jdp6yr6yrytELOcKIJfej1jVh%2ByvbnqkA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:13.8347912","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A13Z&sr=b&sp=r&sig=UqmL4gShQ20RM2oKybzVSONUXKVHgJO%2BbO765hda4iE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:13.8347256","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A13Z&sr=b&sp=r&sig=CAYdpH%2Ftjb%2F7gcFf6B8bNtqIUST06jII0VEz1iNDPVQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:13.8348071","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:13 GMT
+      mise-correlation-id:
+      - 71ce69fa-76c0-4238-90d1-323a5c894ecf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A19Z&sr=b&sp=r&sig=SB0RtHrhDKai41z%2B4%2Bnb%2Ba1qdMVHeslidaSNm9V%2FlMw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:19.152459","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A19Z&sr=b&sp=r&sig=Xag%2FVa18CIMzf4nSofZCqeRHswFO0NXknN4Emrqu%2Btc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:19.1523945","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A19Z&sr=b&sp=r&sig=Btz2jTDxruwvI%2BqHmVA%2F7f6tSy7RkENPMaJ4X2KmiPk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:19.1524737","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +1722,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:29 GMT
+      - Wed, 18 Oct 2023 20:55:19 GMT
       mise-correlation-id:
-      - e9cf6e99-f0fb-4fec-9183-e03dc506a7cd
+      - 851ee872-8962-4480-8adc-f5d68f1ec075
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,24 +1744,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A34Z&sr=b&sp=r&sig=0m%2FdhqM4h8RalFllFdvaOmhJBcrT0mXKAI%2FdhJtTgo4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:34.8245247","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A34Z&sr=b&sp=r&sig=5MEEBqI0Ws5XuJU8P1FNshyER4HeFR8Jotd6966bpbU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:34.8244612","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A34Z&sr=b&sp=r&sig=%2FrHppSVVV7UwF1eafWFbTu%2F8fN9bYYuXYzuxqZVUfPw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:34.8245391","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-13T13:52:56.26Z","endDateTime":"2023-10-13T13:55:33.671Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:33.94Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A24Z&sr=b&sp=r&sig=wRg0TLpVpmixV6X2OGG1VeIF2rH%2B4tg8Cc%2F3oUDqqx4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:24.4989765","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A24Z&sr=b&sp=r&sig=varCFcms8iYYZ0B90bJRWqr8x%2BwC83YYq0REf%2FFCDA4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:24.4988761","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A24Z&sr=b&sp=r&sig=iIKRPfcb%2BHrw0tuo4Yj1DvzTkYONXICiK0ftJVWlLJc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:24.4990011","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3368'
+      - '3237'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:34 GMT
+      - Wed, 18 Oct 2023 20:55:24 GMT
       mise-correlation-id:
-      - fc5a42ad-92b5-485e-b9b1-0de88e26cf6f
+      - 28644e65-eb34-4087-b962-66a82eee1fb5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A29Z&sr=b&sp=r&sig=qEWKjzemQ1v%2FQjCRFxMYC9I1zOtLNjpQJ8kIcCZn1fQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:29.7597269","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A29Z&sr=b&sp=r&sig=Fj5wGXbxo2gLIZex22xTrUo5%2B8AnXuWubUPzHLkOp1M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:29.7595982","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A29Z&sr=b&sp=r&sig=zxh46ZCEwI3%2F%2BCwZodYOLonPXPX5VxIZKgsP4VOuYks%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:29.75975","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:29 GMT
+      mise-correlation-id:
+      - a3228e35-7953-4158-9b79-4c47ede4d7e7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A35Z&sr=b&sp=r&sig=kF6t%2BPkTaGq2iYvuuPmTeBWv0wKXmpKIcReBOp%2BDD9s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:35.0117063","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A35Z&sr=b&sp=r&sig=jtIKxvY37oX1pAJZlpRVWu0HS%2FonqdP8vP0kAGuAnZo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:35.0116356","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A35Z&sr=b&sp=r&sig=rnzddUn75ofXopRp%2FPD3c9YT7r6EzyxFNt2GBFf59rA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:35.0117204","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-18T20:52:50.372Z","endDateTime":"2023-10-18T20:55:30.069Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:31.699Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3370'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:35 GMT
+      mise-correlation-id:
+      - c2b8fb44-14bb-49ed-a585-fbcc1bca72c0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,7 +1856,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:31.3771816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:31.3771816Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:28.2169395Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:28.2169395Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1829,9 +1865,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:35 GMT
+      - Wed, 18 Oct 2023 20:55:35 GMT
       etag:
-      - '"d8015be9-0000-0100-0000-65294b650000"'
+      - '"75005e4d-0000-0100-0000-653045510000"'
       expires:
       - '-1'
       pragma:
@@ -1861,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=app-component-test-case&api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=app-component-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"6a2773f5-ca19-4133-a010-b33c58812b8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"12cea7ab-4933-4bdf-92b9-f071fdf3f8b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"97336d72-d70a-4a05-a0a8-99a5f81f786e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/c2cbe42c-6e34-4bbe-aa99-fc1ee2730e8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A36Z&sr=b&sp=r&sig=WOqE7hdZefGpH5jYDlv9JJQXR9zA85lk3RSn86DR040%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:36.9659495","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/0d069aea-4ce5-4606-a7cb-8956f0076cf5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A36Z&sr=b&sp=r&sig=opQFrkUhiHE3PQTT%2BRYJdW9WJdkfNU1GMQMmLa8Ipbk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:36.965882","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/02e50b71-564c-43d8-9c37-bab6c4f54d11/ac0ae9d1-8386-4405-9078-830a58ee4cfe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A36Z&sr=b&sp=r&sig=qpg4qe5JvjdXIco1vnRh3GOE%2F3x%2F47m5vvHIUT2A%2BWo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:36.9659647","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-13T13:52:56.26Z","endDateTime":"2023-10-13T13:55:33.671Z","executedDateTime":"2023-10-13T13:52:55.341Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-13T13:52:55.602Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:36.731Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A37Z&sr=b&sp=r&sig=JbgpvdStcaiMdXRvV495wCKMr%2BupVQKugyBsQotS38s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:37.2862365","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A37Z&sr=b&sp=r&sig=yi7s92wNwDhtzPqL%2FGjS5fPppVbhIBKVba%2BNYom5kTE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:37.286167","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A37Z&sr=b&sp=r&sig=YEF2D0BASRftJQjY4GE6xZq9f17yovR5sKFnlGATs74%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:37.2862517","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-18T20:52:50.372Z","endDateTime":"2023-10-18T20:55:30.069Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:31.699Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3380'
+      - '3379'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:36 GMT
+      - Wed, 18 Oct 2023 20:55:37 GMT
       mise-correlation-id:
-      - c864fcf0-2be9-4463-9cec-8dee725bcc14
+      - bf414ae2-41f8-4574-b5a6-fafb2ff76441
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1905,7 +1941,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-13T13:52:07.8854004Z","key2":"2023-10-13T13:52:07.8854004Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-13T13:52:07.9010353Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-13T13:52:07.9010353Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-13T13:52:07.6979000Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-18T20:52:02.3537236Z","key2":"2023-10-18T20:52:02.3537236Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-18T20:52:02.3693170Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-18T20:52:02.3693170Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-18T20:52:02.1661927Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -1914,7 +1950,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:55:47 GMT
+      - Wed, 18 Oct 2023 20:55:47 GMT
       expires:
       - '-1'
       pragma:
@@ -1947,7 +1983,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:31.3771816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:31.3771816Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:28.2169395Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:28.2169395Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1956,9 +1992,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:48 GMT
+      - Wed, 18 Oct 2023 20:55:48 GMT
       etag:
-      - '"d8015be9-0000-0100-0000-65294b650000"'
+      - '"75005e4d-0000-0100-0000-653045510000"'
       expires:
       - '-1'
       pragma:
@@ -1977,9 +2013,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-76ptndwpfn6wjyxre/providers/Microsoft.Storage/storageAccounts/clitestloadywvr6c5il":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-76ptndwpfn6wjyxre/providers/Microsoft.Storage/storageAccounts/clitestloadywvr6c5il",
-      "resourceName": "clitestloadywvr6c5il", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-xfqy55dmgr7cp5zjy/providers/Microsoft.Storage/storageAccounts/clitestloadhrktmktjb":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-xfqy55dmgr7cp5zjy/providers/Microsoft.Storage/storageAccounts/clitestloadhrktmktjb",
+      "resourceName": "clitestloadhrktmktjb", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -1995,10 +2031,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-13T13:55:49.458Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:49.458Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-18T20:55:50.392Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:50.392Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2009,11 +2045,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:49 GMT
+      - Wed, 18 Oct 2023 20:55:50 GMT
       location:
-      - https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+      - https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - ce62418f-8b95-45f8-8cda-fec720a12fae
+      - 6e698bcd-29d7-4d6c-afcb-2b8ac0d2b65a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2036,7 +2072,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:31.3771816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:31.3771816Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:28.2169395Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:28.2169395Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2045,9 +2081,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:51 GMT
+      - Wed, 18 Oct 2023 20:55:51 GMT
       etag:
-      - '"d8015be9-0000-0100-0000-65294b650000"'
+      - '"75005e4d-0000-0100-0000-653045510000"'
       expires:
       - '-1'
       pragma:
@@ -2077,10 +2113,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-13T13:55:49.458Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:49.458Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-18T20:55:50.392Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:50.392Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2091,9 +2127,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:51 GMT
+      - Wed, 18 Oct 2023 20:55:53 GMT
       mise-correlation-id:
-      - dc132bd7-1eab-463c-bf07-2ff3bdc0a431
+      - 8b84c357-6658-49c5-ac71-f6a18c7b7260
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2116,7 +2152,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:31.3771816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:31.3771816Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:28.2169395Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:28.2169395Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2125,9 +2161,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:53 GMT
+      - Wed, 18 Oct 2023 20:55:53 GMT
       etag:
-      - '"d8015be9-0000-0100-0000-65294b650000"'
+      - '"75005e4d-0000-0100-0000-653045510000"'
       expires:
       - '-1'
       pragma:
@@ -2146,7 +2182,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-76ptndwpfn6wjyxre/providers/Microsoft.Storage/storageAccounts/clitestloadywvr6c5il":
+    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-xfqy55dmgr7cp5zjy/providers/Microsoft.Storage/storageAccounts/clitestloadhrktmktjb":
       null}}'
     headers:
       Accept:
@@ -2162,10 +2198,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-13T13:55:49.458Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:54.546Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-18T20:55:50.392Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:54.941Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2176,9 +2212,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:54 GMT
+      - Wed, 18 Oct 2023 20:55:54 GMT
       mise-correlation-id:
-      - 10f7b5d1-aab3-4b22-a8e9-b34280b99cc6
+      - 286309f0-1699-4cdc-b40a-2477cd64d6ca
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2201,7 +2237,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:31.3771816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:31.3771816Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:28.2169395Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:28.2169395Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2210,9 +2246,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:56 GMT
+      - Wed, 18 Oct 2023 20:55:55 GMT
       etag:
-      - '"d8015be9-0000-0100-0000-65294b650000"'
+      - '"75005e4d-0000-0100-0000-653045510000"'
       expires:
       - '-1'
       pragma:
@@ -2242,10 +2278,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60939ea6-1308-4564-bb03-d2b002264103.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-13T13:55:49.458Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:54.546Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-18T20:55:50.392Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:54.941Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2256,9 +2292,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:57 GMT
+      - Wed, 18 Oct 2023 20:55:57 GMT
       mise-correlation-id:
-      - 22d7c19d-55b5-4f1e-b79d-85ba021d723b
+      - dd3fe8f8-4567-408d-9b10-bc32962461fc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_app_component.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_app_component.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:10.6516578Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:10.6516578Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:00.9207417Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:00.9207417Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:08 GMT
+      - Sun, 29 Oct 2023 22:21:58 GMT
       etag:
-      - '"d300da3b-0000-0100-0000-6537b85c0000"'
+      - '"3c003d28-0000-0100-0000-653edacf0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:29:08 GMT
+      - Sun, 29 Oct 2023 22:21:59 GMT
       mise-correlation-id:
-      - 427328f3-72cc-4b1f-b520-5ba87eed3c44
+      - 9d1c2648-1cb3-4034-8a56-bde0e59a3093
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"0823c9ca-c379-4eea-a06d-d21fd6ec75db": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "043cecbc-0424-42a7-bf14-76f36fa3c56c":
+      {"passFailMetrics": {"3641458f-9f86-4d48-b54d-2afc955e4211": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "d7c5c239-9478-425e-8312-559c57b34fda":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "9dffc865-f428-47fd-bac0-fc382d724331": {"aggregate": "avg", "clientMetric":
+      "50"}, "505a1c97-3b9e-42ff-a88b-d7b9547cfaf7": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:29:10.005Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:10.005Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:22:00.266Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:00.266Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:10 GMT
+      - Sun, 29 Oct 2023 22:22:00 GMT
       location:
-      - https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+      - https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 21247209-cd46-48c1-a4fe-7a58a520761f
+      - 28a8f7a1-59db-4530-8769-1419c710942c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:10 GMT
+      - Sun, 29 Oct 2023 22:22:00 GMT
       mise-correlation-id:
-      - 5e0a33d7-a39b-4997-9911-88d1d27ef95f
+      - 56880678-bcae-4433-a2f5-252e54b7b047
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A12Z&sr=b&sp=r&sig=Sgt6Du%2F4qVUje9a9iyrRWeDsomU7xodJD7vJuoY8Xi8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:12.1012494","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A01Z&sr=b&sp=r&sig=ocOUgiBGt0h5drwJ0iPK1S%2BZSmbjMZSHym8gtKc1%2BUk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:01.7741128","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:12 GMT
+      - Sun, 29 Oct 2023 22:22:01 GMT
       location:
-      - https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - ced1d77f-26da-4be6-9dd6-2d673e54053b
+      - 03f25aa0-f3b6-40aa-b51d-5974cc0d1d09
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A12Z&sr=b&sp=r&sig=GVOHtmWwAG8MoAZbs6xBc6GTwLdd2734FM7kxDZBTIo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:12.3567529","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:29:12 GMT
-      mise-correlation-id:
-      - b6e20f72-b7c8-4686-b64e-2f471f4601ab
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A17Z&sr=b&sp=r&sig=kmRgvM6vS%2Bcki%2Fcq%2BpxY6JgBlvf87HLV6i59TZREML4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:17.8410868","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:29:17 GMT
-      mise-correlation-id:
-      - a267fbfc-a846-43a2-a1d9-911f5e4d0e9d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A23Z&sr=b&sp=r&sig=xLUsZcqBJILe2SVGB6Xswhby0W1AUsx8CavuA%2FeNL%2Fg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:23.2009324","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A02Z&sr=b&sp=r&sig=0DWX%2BujSv0K8q6fRuQ%2BGo084q4A2Huuj9D34yds0j28%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:02.0113781","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:23 GMT
+      - Sun, 29 Oct 2023 22:22:02 GMT
       mise-correlation-id:
-      - f072a659-4f65-4b24-868d-3465cd445da8
+      - b39c23fb-40c6-4aaa-b9df-40456852060d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,10 +349,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A28Z&sr=b&sp=r&sig=za2bCpVOrDA2GsicqnUVIM0IOODrzEkHgt9uGHA3WkA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:28.5518454","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A07Z&sr=b&sp=r&sig=unaIAtgtEKlKsnB3%2Fo%2FMatbxavTg8J1sE6Yb2Ubwy7M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:07.3391233","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:22:07 GMT
+      mise-correlation-id:
+      - 265e8ad5-4f6a-4a89-9dda-0d961d2ec96c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A12Z&sr=b&sp=r&sig=T1HD9%2BJqJU1129HPGA43ccRSFglL5Q2iGLmC4P54670%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:12.6114642","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:22:12 GMT
+      mise-correlation-id:
+      - a4165445-3de3-4d13-b9fa-ef46dc0b9497
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A17Z&sr=b&sp=r&sig=Jl8EFSO77hZWeyqAkzJ5CLjhFYgRpy3eHIYrhBM20Hk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:17.8921659","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:28 GMT
+      - Sun, 29 Oct 2023 22:22:17 GMT
       mise-correlation-id:
-      - 2b948903-d161-46b8-8479-800646ce7d52
+      - 303a353e-21d3-412e-ad6d-6c40d45afb76
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A28Z&sr=b&sp=r&sig=%2BhN2iyefiWNxK0ri4IwhoLxFM36Uh9VU0Uk18THoGqE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:28.8428059","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:29:10.005Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:27.201Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A18Z&sr=b&sp=r&sig=DRluhveBPObJSXlz5CYVvhlIB%2FihkQ5GvZwVrfzk%2FNc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:18.1489714","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:22:00.266Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:14.991Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1586'
+      - '1588'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:28 GMT
+      - Sun, 29 Oct 2023 22:22:18 GMT
       mise-correlation-id:
-      - 3c386574-ec11-4eea-b52f-6c42c4d52f7e
+      - cba63fb4-3ce7-4600-908d-ea8c94e53c27
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:10.6516578Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:10.6516578Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:00.9207417Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:00.9207417Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:30 GMT
+      - Sun, 29 Oct 2023 22:22:19 GMT
       etag:
-      - '"d300da3b-0000-0100-0000-6537b85c0000"'
+      - '"3c003d28-0000-0100-0000-653edacf0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A31Z&sr=b&sp=r&sig=NGULBEmzbwrUS8jmopVO0tnKVfM%2B3C7Ij7zIYkP70wY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:31.295437","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:29:10.005Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:27.201Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A20Z&sr=b&sp=r&sig=uMbMKOEGT57mZOYHEmPy%2Fl2tfcUpaGlw3Pg5kuJnGJg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:20.3827162","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:22:00.266Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:14.991Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1597'
+      - '1598'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:31 GMT
+      - Sun, 29 Oct 2023 22:22:20 GMT
       mise-correlation-id:
-      - 9ec0262a-840a-41db-a0fa-b204e78fb0ae
+      - 6e04acd6-a486-4635-9f17-138da9df6100
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:10.6516578Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:10.6516578Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:00.9207417Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:00.9207417Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:31 GMT
+      - Sun, 29 Oct 2023 22:22:21 GMT
       etag:
-      - '"d300da3b-0000-0100-0000-6537b85c0000"'
+      - '"3c003d28-0000-0100-0000-653edacf0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:29:33 GMT
+      - Sun, 29 Oct 2023 22:22:22 GMT
       mise-correlation-id:
-      - c3333af2-b6f0-4139-8fe8-fb540c35cbb8
+      - 6d467318-cb88-45c5-a5c9-31ae9058243f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A34Z&sr=b&sp=r&sig=wf56qSk3CQLV84iPsRulllDmnAI9HL8CLv4l7XJMYdI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:34.8145835","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A34Z&sr=b&sp=r&sig=WHYQAiFB%2Buuy2tb5YCpGWDFx681J47P8gcin942CvC8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:34.8144366","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A34Z&sr=b&sp=r&sig=F%2BYgZfnw7Tvo6jpjNrxaaQIDZic2NPIC0BmmyvNXFXw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:34.8146107","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:34.741Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A23Z&sr=b&sp=r&sig=qh1mmCA8Fo%2FhIYTcamTZmakSoDLKjUib%2BhdKzDtdwGU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:23.3435431","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A23Z&sr=b&sp=r&sig=o6AHzOBX42HexqhC3HqZ3PQbMjYfa1S3qzK%2FcDdmjHQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:23.3433685","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A23Z&sr=b&sp=r&sig=IarYgXj1FVPOEb4IYlFefeEXPJEQXyjaVkM4G7ApR2I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:23.343584","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:23.258Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3187'
+      - '3188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:35 GMT
+      - Sun, 29 Oct 2023 22:22:23 GMT
       location:
-      - https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+      - https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 654107fd-4164-4c32-a3b7-039de4e040f9
+      - abee526d-fce1-4848-a6be-3975b1210867
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,586 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A35Z&sr=b&sp=r&sig=AP2n2zdwVuPl%2F0LUohfVLnZkEgwzwg4prk%2BCUF0c%2BBY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:35.4376147","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A35Z&sr=b&sp=r&sig=AQli09uoW2aQaFuMUlW3fs8H9gMz5yw6HyGiVxNdtpQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:35.4375456","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A35Z&sr=b&sp=r&sig=Kd4JUuFdXuxtiA5RyKqkPqFOM64fcEFVUECcCOOdfbc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:35.4376299","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"NOTSTARTED","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:35.295Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:29:35 GMT
-      mise-correlation-id:
-      - 6a484bcb-851e-4a0c-92df-7e5c76e1b47b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A40Z&sr=b&sp=r&sig=pw4ZPYbBVA0R54V07SeW3RVznRhQ9n5eTcShZ0Ax%2Fpc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:40.7305292","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A40Z&sr=b&sp=r&sig=CEGVsJlKQsMsYS25Mlj2L6rpOzxj0DLCjHGqWAyq5rU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:40.7304506","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A40Z&sr=b&sp=r&sig=8qiu569A1pP%2F5D0hbBn%2FnFUlMXlQC2LizW01tB7k05Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:40.7305458","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:36.396Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3236'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:29:40 GMT
-      mise-correlation-id:
-      - 99f20c7d-c413-4760-a31b-984d0f4b890d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A46Z&sr=b&sp=r&sig=8KsRrMSycYqReqt%2BpIc9P2I6%2B%2BmuYuh4IAz6H43reZQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:46.408717","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A46Z&sr=b&sp=r&sig=kJqHnIC47aIeqlQT2FgjKhLMSEzyYN30%2F2leVeIxikE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:46.4086479","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A46Z&sr=b&sp=r&sig=UhpP8twagTq4Hdr9McgtlSNNVjgRhaL9SYZSZ%2F%2BZS3E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:46.4087317","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:36.396Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3241'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:29:46 GMT
-      mise-correlation-id:
-      - 92e66421-f8fe-4d28-b31a-71485c1fdfcb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A51Z&sr=b&sp=r&sig=X2ehByjE%2FCls0T7bxspODbKfgwZa57EJJiuj3TmCMgk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:51.9075159","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A51Z&sr=b&sp=r&sig=38bLaJ2%2FMD0%2B89R34EzutlA4FVZ2xQoJisDT6RXTSfA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:51.9074625","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A51Z&sr=b&sp=r&sig=URpgHYdwD0UbXRv67MaaIFzo9y%2FO7svQnFlW%2Bw843SQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:51.9075299","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:36.396Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3240'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:29:51 GMT
-      mise-correlation-id:
-      - d426b95c-0e67-4fac-81c7-4d5e5a05e2cd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A57Z&sr=b&sp=r&sig=e%2BFvcDFg0T9FxMx%2FDJORQpiTQwD%2Fu9DVzsLpULM9eQ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:57.786014","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A57Z&sr=b&sp=r&sig=qMqGGfN55K7x%2BCxiNQn1iZu9ZPbf79T25pkN9mpp9zk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:57.7859416","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A57Z&sr=b&sp=r&sig=At%2BP3WxKEUZAtAwXXjPpOlo4VOaDpjeJ%2FZdoedW%2BGr0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:57.7860301","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:36.396Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3243'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:29:57 GMT
-      mise-correlation-id:
-      - 978d2daf-ccb2-479e-8abf-88763894a4e0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A03Z&sr=b&sp=r&sig=YRKhafweqjbL%2BDe4ZPrO71xAmC0BcCW0Y6qekLdcnNI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:03.1397166","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A03Z&sr=b&sp=r&sig=fao16lb1FfinrXhk0g7JNBKVDTxDe8D7nxM%2BEM2Vfuk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:03.1396247","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A03Z&sr=b&sp=r&sig=9uYEXpoU%2F6UDLQlB8EdOATY5ajf1X5nzZWcMUIlFOro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:03.1397376","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:36.396Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3236'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:03 GMT
-      mise-correlation-id:
-      - cb1b3bb2-fa48-4c8d-8441-edaa257e06a8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A08Z&sr=b&sp=r&sig=G7Bfz4HbSGH71Bp7ALCYU1cx1D%2BqJgHUN%2BAKZt8Nv%2Bk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:08.8212255","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A08Z&sr=b&sp=r&sig=o%2F7mKxK5crlq8BTf4UhoK2tvGmg%2FVFHpbaYYTY0LdO4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:08.8211366","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A08Z&sr=b&sp=r&sig=kvehxPdxUropeRoPkS6VAf8MGb4LiAAlJHBFb7VZFX8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:08.8212472","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:36.396Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3240'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:08 GMT
-      mise-correlation-id:
-      - 6f833f3b-397d-4441-bd9c-6319662fdeec
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A14Z&sr=b&sp=r&sig=rjSHeaTiFQqcAd1TIEr5w1gZi347e0bh6wyCsB9fFtQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:14.1173519","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A14Z&sr=b&sp=r&sig=qPdkgIcFam9DEcbBR%2B4WY4%2BTKnI0o6W4Wgi%2BSmHwEc8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:14.1172835","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A14Z&sr=b&sp=r&sig=D3mlLVvh6c2SQxbIaR9XjrXjexiJMi5eBPLnXs4%2BGFw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:14.1173663","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:36.396Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3238'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:14 GMT
-      mise-correlation-id:
-      - 78b30813-10d3-40e1-bffc-e592e82abc36
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A19Z&sr=b&sp=r&sig=jWtLh1QagpEABfN6Ot0SGvEsEQ44OlRa%2BUC9RM6EQFM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:19.4406261","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A19Z&sr=b&sp=r&sig=ul0VnfpxnjQd95a0UsAf0iM3waoAp9sdRmd85hxSuKg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:19.4405501","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A19Z&sr=b&sp=r&sig=CQZo%2BzyYNLxpxTr0m7oc2ZLFycf7od%2Ft3MyStvsiCdU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:19.4406399","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:36.396Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3236'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:19 GMT
-      mise-correlation-id:
-      - e86aefe8-8ee8-4be5-8faa-31104a916000
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A24Z&sr=b&sp=r&sig=NDA26kFhekPKpRqJyfLZ1E2yDJKcBP%2FhGrFaaAOuvn8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:24.7322768","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A24Z&sr=b&sp=r&sig=REc5hZ3dlxdX61nrGE8c0oFTSYuCt5w0G96ydL9QhNc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:24.732189","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A24Z&sr=b&sp=r&sig=fTRPOYgE9CwaozLzd1lq2hBU8CC%2BvY%2BWDM7sXBRxojc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:24.7322978","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"CONFIGURING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:21.715Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:24 GMT
-      mise-correlation-id:
-      - 9c37791b-3f5c-4f49-be1c-382574d183cc
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A30Z&sr=b&sp=r&sig=fMBSapx72JvM%2BY8L0vIZSDp7x2U1BLAq5il3dX7OJJY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:30.0761298","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A30Z&sr=b&sp=r&sig=he1TIjhNAyKWZhOxS1yDvI%2B%2BlGS3eJKQAH5kHaXQNoE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:30.0760552","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A30Z&sr=b&sp=r&sig=r43zOxRvKwTZDi83HvGtTMIiW%2BmHzkjXrK6s3NNGzKE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:30.0761443","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:30 GMT
-      mise-correlation-id:
-      - f57fd59c-455f-4fcf-b575-84b0e791f590
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A35Z&sr=b&sp=r&sig=OnqUXiurAv7hsEOLO2ptv%2FuBVaAFK%2F02UMWibKcc5fM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:35.3927648","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A35Z&sr=b&sp=r&sig=sqeVZ2KwQ9rrf6kQCWq%2FJzDsBFniDcYC9qcvyisSVIs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:35.3926522","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A35Z&sr=b&sp=r&sig=p5wS%2BWeiDsmuDwt2BIjfLkYQMsGRox52KxrVnkZuf70%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:35.3927921","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:35 GMT
-      mise-correlation-id:
-      - 061e36b0-0a76-4336-91f4-2cedc1b69a8c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A40Z&sr=b&sp=r&sig=hFBRuENFL9YIWrpFmAa3SGv8%2FVuRfgDX9T37g4BXVow%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:40.7281405","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A40Z&sr=b&sp=r&sig=43W0czN81nHk1bCyE8q0Y85HtQJxQXdXCpAyr8RfcDk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:40.7280626","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A40Z&sr=b&sp=r&sig=yNwiQSmPckB2MRwp8rlbyu6zjiR9URLK73Kbe%2BiAblU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:40.7281552","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3231'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:40 GMT
-      mise-correlation-id:
-      - 11587441-0317-4b2c-aa59-7516084da2f8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A46Z&sr=b&sp=r&sig=a8vCOl1M%2BtullfBj7Xif856qQyy86OpercFR2vkOtxg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:46.053909","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A46Z&sr=b&sp=r&sig=C8l71Dfsj8ECAXujRxi2%2FDc7NjZOko0aXPRuCqqXQYU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:46.0538405","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A46Z&sr=b&sp=r&sig=noBHjXLWQZjyxn0SC5KDZHMUjDlfJf69%2FongM%2FJ0ZDU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:46.0539233","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:46 GMT
-      mise-correlation-id:
-      - c2f1cbf8-49e1-419f-9b28-6896a8b6f775
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A51Z&sr=b&sp=r&sig=TyS7d2tXoQWLowv0pa852%2BcQ4P%2B7XaLbZEXvELHPzaM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:51.3312914","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A51Z&sr=b&sp=r&sig=kZ8h3SeXMq%2Bvspv44rwmro9SyyudqnRrQVIIs0ZKTOE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:51.3312068","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A51Z&sr=b&sp=r&sig=tkUzxOk4I084B4IaFkCDQvJh%2F79lV7GNngYs3qESpN8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:51.3313148","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:51 GMT
-      mise-correlation-id:
-      - 38542fec-d1e8-4281-b077-f255d47567eb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A56Z&sr=b&sp=r&sig=Xe7fFnMRjCYDTkENfypi4qx2TJ3UnM8bsHRc9E6Yg8k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:56.7111367","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A56Z&sr=b&sp=r&sig=xuZCNZxQFfpW5cAAKvZez5T2PIH8HQpmjhjvcCgMhQA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:56.7110667","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A56Z&sr=b&sp=r&sig=QqTB2v7Ex7Bt%2B5XYetY0EfyTR7f7BL2Ys4s%2B9DTfTRk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:56.7111517","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3231'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:56 GMT
-      mise-correlation-id:
-      - c56381dd-2ec5-4c8e-a632-8504544a4917
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A02Z&sr=b&sp=r&sig=yiYJAvxC7dRiltpVQQoSSYBCQe55d0vFX2k1haLazbk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:02.0277399","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A02Z&sr=b&sp=r&sig=iP8AumF3XFLsyFEofuU%2BvuYcgzmMN7i6pvvhr%2Bb2vL8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:02.0276579","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A02Z&sr=b&sp=r&sig=TB93qjVKU9yVQr6qezdRuneOdL%2Fh1qGFG94wF94r5aI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:02.0277554","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A23Z&sr=b&sp=r&sig=bBRdl3q8Ht5O0HY7YxxJWRD4oD1ouWx42KB4OGTzO8M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:23.8461707","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A23Z&sr=b&sp=r&sig=vCMhnh01LrRh4%2FZATw98KgGyH%2Fef3MOYgG9CfD7dtC0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:23.846101","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A23Z&sr=b&sp=r&sig=L3pNAPu2yT0nqU1AGGsiSavkBmpk%2FwlM6OghsANHT0s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:23.8461862","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"NOTSTARTED","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:23.802Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1290,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:02 GMT
+      - Sun, 29 Oct 2023 22:22:23 GMT
       mise-correlation-id:
-      - e1886490-23a8-4dbc-a1e7-d0b2580ebe62
+      - 20fbd330-1946-442c-97a0-b01f9a8b7c84
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1312,46 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A07Z&sr=b&sp=r&sig=wEQlmofS7BYYKHV8ZxL8mct7kMZQ6UxbnAaW2VQRDSU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:07.6943663","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A07Z&sr=b&sp=r&sig=e7JQT5ZPSP7COq9QEq9kGqZU%2FOPTyvg%2F99nSIDJYTYw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:07.6942968","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A07Z&sr=b&sp=r&sig=lgCGdx9hpHRQ0G7jYr3SagLR578KGghQPVM4kOPx17E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:07.694382","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3230'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:07 GMT
-      mise-correlation-id:
-      - a6d625bd-1efc-49b4-b0a6-2f859f395238
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A12Z&sr=b&sp=r&sig=%2BMMScx%2FL4HEq85bcJ7TlqGzfp3xIUlJkXW3IooxtpHM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:12.9788771","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A12Z&sr=b&sp=r&sig=ArH8jZNs%2BeNoHV1MW%2BM2SpKps5b5kWLhymUuTBm054A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:12.9787931","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A12Z&sr=b&sp=r&sig=RUEozae3mapqectJJzfaNTXDi%2Fa7Qls1AZuZjWSaQJA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:12.9788985","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A29Z&sr=b&sp=r&sig=UtyCO1JrgY%2BeHqvlHBPK8aVTkHeW3Z1TOXS0MS4lkic%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:29.114898","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A29Z&sr=b&sp=r&sig=4lvvnkvkQSFuA0PFmi9%2FMp29El0eCgic3%2FxhQ9Y16hk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:29.1148309","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A29Z&sr=b&sp=r&sig=ASo%2FnTgqAiOXL6BDeZBsNjwP049GMlVxEfWdLAqyTwo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:29.1149119","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:24.005Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1362,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:12 GMT
+      - Sun, 29 Oct 2023 22:22:29 GMT
       mise-correlation-id:
-      - 7751f073-e3a7-4e98-8ca9-63a5ea225c21
+      - d781e149-3230-4bda-aa9f-dea09563d20e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1384,406 +772,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A18Z&sr=b&sp=r&sig=OGZxTgUKPnT27darJl2ZzVCaiGxMidoJImOyoCFclpE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:18.2541667","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A18Z&sr=b&sp=r&sig=fk4M6gdpPQdUOtiw%2Bezx5ZDNz6HkNpfWCZL3vYhhyag%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:18.2540787","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A18Z&sr=b&sp=r&sig=7CqgPxs77KYZ07HJ2PhuQqvwb9CNunBQm%2FsCb1DGfX8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:18.2541865","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3231'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:18 GMT
-      mise-correlation-id:
-      - 09abab3e-2baa-493d-9eee-374f617a2380
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A23Z&sr=b&sp=r&sig=1EVbLWUTQDAwqetoZACu%2B71NfwpHXQJRoI%2BXO62EzUc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:23.5379053","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A23Z&sr=b&sp=r&sig=853BAyMQjDmLfUl1y4by0RTjpCdvYHr77tK1yRqRur4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:23.537815","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A23Z&sr=b&sp=r&sig=1s15Lq2Ipli6ODndAyf50uCiTor7o7Mo%2F17y7I9diUw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:23.5379392","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3232'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:23 GMT
-      mise-correlation-id:
-      - 59ea4c7e-54c8-4814-ad75-270eaf969e0c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A28Z&sr=b&sp=r&sig=2cb6Sfnwga0%2Bq4zldZvStbFuWLS2Iuvf9bgydp%2Fk3i0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:28.861725","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A28Z&sr=b&sp=r&sig=VB7QZvTuNVcL0RHYfES4HwYCbJ0ATfPKoa9Pi0mCzLg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:28.8616452","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A28Z&sr=b&sp=r&sig=jDlkVYq78SKRzWRaJPG3%2BerNVHCbHh7uUI0qVr3nCLc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:28.8617397","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3232'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:28 GMT
-      mise-correlation-id:
-      - 3fb11208-0981-4195-a73f-d5c9934ebdbd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A34Z&sr=b&sp=r&sig=zB%2FnQ%2BZ1EkYbguHzRpskfO2yq5i2%2BYYYN8M19f6nkLY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:34.1827606","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A34Z&sr=b&sp=r&sig=38HbcdUhNEn0J9iU9aqQ1LNxpEabZgnvExVK9PkxOas%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:34.1826669","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A34Z&sr=b&sp=r&sig=l4XrM6ZtO%2BVap0tgnEpOes6SJ%2FVAdKtkeIeZ%2F7VRmFw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:34.1827758","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3239'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:34 GMT
-      mise-correlation-id:
-      - 1684d51a-e083-4a96-8e61-eedccbb85480
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A39Z&sr=b&sp=r&sig=tOtExo4SVLUCYvyocKNIYyIZ5WeH9mJ0aURxrgW%2BlzI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:39.4612862","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A39Z&sr=b&sp=r&sig=CettTF%2FTcMgqq0%2FGEWjt3wpBhsvGYpJiom%2FurxcLqjE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:39.4612075","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A39Z&sr=b&sp=r&sig=GG6V6d0%2FtXCDFW2IkJe2U75Gg%2FVcAOa8E5B7HD14L3Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:39.4613007","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3239'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:39 GMT
-      mise-correlation-id:
-      - 3716a896-7968-4ee5-aeed-37090588e5b4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A44Z&sr=b&sp=r&sig=Ht1MpmDN505A77Q40F2jliOtkFWjIf%2Bjf37cupLSZQM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:44.7315468","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A44Z&sr=b&sp=r&sig=UEzvM1wj%2FnmAWEo6jkTz80WoKTtESWblkJxWzw4mPCc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:44.7314708","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A44Z&sr=b&sp=r&sig=1zUpUcJKuRw92mZb8oX%2F4QO8h6ft5YiH6OsFMNMk%2BfI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:44.7315613","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:44 GMT
-      mise-correlation-id:
-      - b58dc670-77d4-4e88-9343-b5de7320fd04
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A50Z&sr=b&sp=r&sig=Rpg2albfT%2Fe5nzpDPOxIb8nmfEIPpki2AniyhIBuhpo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:50.0674488","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A50Z&sr=b&sp=r&sig=OX2wg8qkD7fAU1cWaZYp%2FStuAdng6sfpyUxYEY7fN4E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:50.0673798","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A50Z&sr=b&sp=r&sig=S93PQSLUte8s10fGeH95KUE%2F9NqLjydb1E02jKIDn4E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:50.067463","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3232'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:50 GMT
-      mise-correlation-id:
-      - f69df66d-4ea4-4615-8b23-ce25c27f6872
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A55Z&sr=b&sp=r&sig=s%2B7viMy4OMOE3bdkviudrsCvaorMSiVIfVO%2FaNpZdi0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:55.3424925","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A55Z&sr=b&sp=r&sig=%2FKvLxHc1mh%2BYHm9PsNsUoea04r7oDwjLT%2B5IXvCJ6y4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:55.3424118","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A55Z&sr=b&sp=r&sig=4c%2B%2BBWKLzSfjF%2BJvPDnGncetNRS3xKlKJir%2BEy051sQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:55.342514","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3244'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:55 GMT
-      mise-correlation-id:
-      - 056cbafc-213d-401c-8e39-08897acc00d7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A00Z&sr=b&sp=r&sig=6Xt4M1Pu%2F3i8L9OqnDNMX22AKfh4frU883k1mfzAaOQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:00.7185657","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A00Z&sr=b&sp=r&sig=I6sc7b%2BZNAp1vMA7FcZv1DGT61muzEgGc9t5oJE5QoE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:00.7184962","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A00Z&sr=b&sp=r&sig=M2A%2BVg95B0%2BMd%2Bra6IU7pdPUA7z4GtPH%2F5VrcmKkC58%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:00.7185799","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3239'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:32:00 GMT
-      mise-correlation-id:
-      - 54b71713-ea45-47c0-81e4-7aab9454ab8f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A05Z&sr=b&sp=r&sig=DpOT6Zqk7TZdbmg0we33EqugnisEd0CIDDixtyPA7S8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:05.9995312","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A05Z&sr=b&sp=r&sig=ABI22fc0pqDSC9egtP5dXPpEDIeBmjahMzDCSRRjesw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:05.999461","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A05Z&sr=b&sp=r&sig=wiUT72FxBvhDRp6d13Rycl1GY9EdAEjyGRbXFkgU%2Fno%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:05.9995462","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3228'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:32:06 GMT
-      mise-correlation-id:
-      - 758e87f8-9e07-4e4a-998b-1da2e147b411
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A11Z&sr=b&sp=r&sig=Y75wLA7PwS56KUqU0woz1Lo185RPnRfvY80T4LRPj%2FA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:11.3470169","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A11Z&sr=b&sp=r&sig=SLrMBUner%2BdY4Uxk2tedPDLsHIdxW5fnLYoM8TUIWys%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:11.3469305","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A11Z&sr=b&sp=r&sig=5B%2B7jxm%2FP3h1bD8pnxKixm8jtEwkYBioIiAb3qLlnG0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:11.3470313","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:32:11 GMT
-      mise-correlation-id:
-      - a92a3efe-09ec-46f7-81b2-d8d6b477a1e4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A16Z&sr=b&sp=r&sig=ivQA7bXvrVlUALSk8V2LyY%2BDtafKheesfVIjIDeiipU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:16.6023343","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A16Z&sr=b&sp=r&sig=eNQJzZtaMsoDGzFmqkIuQixGrDNpp9dwIEJ1myBo8bs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:16.6022638","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A16Z&sr=b&sp=r&sig=tE%2F%2FexIpQPErSwsGVadX9JmZXXPs%2FP41wIM%2Bbp4XMjQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:16.602351","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A34Z&sr=b&sp=r&sig=zKoc8M%2Bd39BZmyQelvczLqehdnyL3rPOSde2xGL2W48%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:34.4053167","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A34Z&sr=b&sp=r&sig=KJb2n%2B6f0uWCKoSOArTsG1%2FfXxCcsEv7SgZiypBELs8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:34.4052349","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A34Z&sr=b&sp=r&sig=b120dkfHUM5vnuKDV1UJsFcSpQDRWnhfEaga9CDlF84%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:34.4053343","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:24.005Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1794,9 +786,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:16 GMT
+      - Sun, 29 Oct 2023 22:22:34 GMT
       mise-correlation-id:
-      - 1d72b52f-62b4-4603-aba7-098a61939aff
+      - 0bde6c3e-1d37-42ae-bea0-c4a9b8dfc305
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1816,24 +808,1032 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A21Z&sr=b&sp=r&sig=GkZxQhY%2BqvrpY1BP%2BSNX%2BjTc4rNSDRWp%2BApR2pEWl%2BA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:21.8943718","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A21Z&sr=b&sp=r&sig=B5KDQab8OSqQTNDIxqPeUcR1AP8yXtUhTxa7RITmpSA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:21.8943037","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A21Z&sr=b&sp=r&sig=gqyKhG0W6YWCphNC1EvzoPP7ioi2Ft7AqARfEZOsvNs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:21.8943855","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-24T12:29:35.295Z","endDateTime":"2023-10-24T12:32:19.175Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:19.247Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A39Z&sr=b&sp=r&sig=PXOrdLgRvbnQfVIP2iRxWXIjplucANP%2BbuaOQGUnb64%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:39.6833367","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A39Z&sr=b&sp=r&sig=UYQhModZkDedCj72TpSsPAJ3Fxv8ElT6u3qNAaXolnA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:39.6832694","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A39Z&sr=b&sp=r&sig=dp%2BuqRUBH1lqfseWf95WjzxxAwWjj31VwK0UxOCrQZs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:39.6833516","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:24.005Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3372'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:21 GMT
+      - Sun, 29 Oct 2023 22:22:39 GMT
       mise-correlation-id:
-      - 5f66abb1-cd4f-4dab-abef-a11a013f356c
+      - 9c40b77f-f0ed-44a4-a1a5-43240b0ae974
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A44Z&sr=b&sp=r&sig=iG%2BOHQOMwNCcBnugfkpZ8FHKN%2BMgHf9ZNqKUcUBi6Ks%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:44.9441296","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A44Z&sr=b&sp=r&sig=qtbcnYqatw1Sa60aIEbiIZ6a%2BiqG339LIbMghK6G6ok%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:44.9440317","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A44Z&sr=b&sp=r&sig=2JzgnJx0XJNpBqtc63%2BEtzBNEBAeySfwApQY9sYiwxQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:44.9441437","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:24.005Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3238'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:22:44 GMT
+      mise-correlation-id:
+      - 170fd92d-af42-47fe-ac7b-cd12a2536d27
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A50Z&sr=b&sp=r&sig=GSFi%2FJLPfvnQ1TIey%2B6LfNplksMFmTHzB%2FyRaBIRL04%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:50.2633424","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A50Z&sr=b&sp=r&sig=L1H7V14BHarAGP214p5NQ%2F2tZ5jcDw%2BnVtBg6OEb8dA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:50.263272","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A50Z&sr=b&sp=r&sig=6CBofTGG7G92SnpM%2BuSpvsync%2FElV2cDc3F0O4nrIz4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:50.2633565","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:24.005Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3243'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:22:50 GMT
+      mise-correlation-id:
+      - 62ac1692-5781-4235-b151-00fc3b738492
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A55Z&sr=b&sp=r&sig=S%2B6mrbcqBIYKCp%2BTw2He8QpWW0M5g6YBoURKv0OlUww%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:55.5639871","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A55Z&sr=b&sp=r&sig=k52BPAaJUf7IABwvYvgNbms8hIUWX52Xjb9oZOo6HEo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:55.5639191","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A55Z&sr=b&sp=r&sig=vcXuIox%2BpJmdcYAY%2FME0c3cC0x0kMdnohwLY9cIeY3U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:55.5640014","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:24.005Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3238'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:22:55 GMT
+      mise-correlation-id:
+      - 5ed4ac3a-ee7f-4d2f-a2f1-ad27c8df7742
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A00Z&sr=b&sp=r&sig=mD0sHKnZFZOG26qPLA0nLrTeUw65pGZdPHfT%2F%2FABtHY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:00.8944415","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A00Z&sr=b&sp=r&sig=PCSIKDSI2aFOSlqpcr4GZBo7xLcENVmUnGs%2B8KJ%2B9io%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:00.8943537","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A00Z&sr=b&sp=r&sig=mHNQQAteGEB8gyhlqRum09qx4VJa2wF4cJ6s0Vi4H%2BE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:00.8944631","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:24.005Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3240'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:00 GMT
+      mise-correlation-id:
+      - ffae8822-c7c8-44c7-b77e-632ddcbad68a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A06Z&sr=b&sp=r&sig=swezC8iKuQ691ZOnnffUaKpd%2BjfoclDJooGZn94RBS4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:06.2114389","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A06Z&sr=b&sp=r&sig=RifiuzqxFgRRmyoS7ybErKiQAYYNEfOm0vzL0NMO90Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:06.2113674","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A06Z&sr=b&sp=r&sig=S1GbRgNQMPl9NFZFg7dQsd48MvDBYhgqgShO1hVYGek%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:06.2114527","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:24.005Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:06 GMT
+      mise-correlation-id:
+      - 03ea6e8a-a81d-43a0-b6cd-04f6c29242e6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A11Z&sr=b&sp=r&sig=oaK7n%2BXDOGboYHg365QHU2NPHk4Rt6o%2B1rIK4LVEXVs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:11.4627402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A11Z&sr=b&sp=r&sig=FrPDB4RPJLu5Sii2ZYSLkQA0rRJdhqNJwGeKDglxHgg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:11.4626502","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A11Z&sr=b&sp=r&sig=HLZHJT5mD5m74MSHZ9sWQyw7mWQ2mhiHK5pEXlyGhW4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:11.4627623","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"CONFIGURING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:10.709Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:11 GMT
+      mise-correlation-id:
+      - c2c05698-d23c-4f14-823a-443019cc757e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A16Z&sr=b&sp=r&sig=N%2BQRGdC6gr62B2cj7d6X%2BLTzRZ%2FdV24U3MpsDZpGyVo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:16.7685896","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A16Z&sr=b&sp=r&sig=ROzqb%2F9hSIJ%2BoAQqkCtpLlCyJsqE6ywqiHmDItNkpow%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:16.7685162","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A16Z&sr=b&sp=r&sig=UHUTyR%2BmS%2B7vRp9A7oF2tLUrH8heArmIzvCfUj3Jaf8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:16.7686059","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3240'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:16 GMT
+      mise-correlation-id:
+      - 252ad9da-5bca-412d-a184-56d00b5f6a14
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A22Z&sr=b&sp=r&sig=IH1%2B%2BvVNAOihVIkgIZvnZLs1enTc2K6Pdd0kb7HXNmY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:22.0272983","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A22Z&sr=b&sp=r&sig=tcw8kLMXnwY1HnO4W9l3My7miPLGOGmsZN5qO6wThxU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:22.0272104","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A22Z&sr=b&sp=r&sig=%2B57iUdaQY7GM3QBKPwSj5paKTwO9iPI4gceZoN%2BESDA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:22.0273156","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:22 GMT
+      mise-correlation-id:
+      - 01661ede-ae50-448d-b531-e8b0b9db2ba7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A27Z&sr=b&sp=r&sig=PzV0SdfRODDx1oiBYTNa5T%2BYdCGDDRujUIsdLjQuAzM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:27.2959589","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A27Z&sr=b&sp=r&sig=XEx2gcR8pfqmg7YG8DVSHNUQfz%2FuWLRfg9AwtP4AJ78%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:27.2958776","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A27Z&sr=b&sp=r&sig=aF9Cds%2Fs7ljsM8b3jGzgUAnGmL%2FVz5B8GOCxybrnC2U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:27.2959732","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:27 GMT
+      mise-correlation-id:
+      - 5dd0d4e3-b13b-488e-9591-c927184a48c6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A32Z&sr=b&sp=r&sig=ph9zB7QEyjq25wX5edbURwDNo5ocQhqYQidYy1NplOo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:32.5849402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A32Z&sr=b&sp=r&sig=l13l3SF01%2Fy6fDhRxSJ7w4wuTq%2FWZDsK%2BqQ2tYlY9es%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:32.5848511","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A32Z&sr=b&sp=r&sig=sNHEhe3h0q22xg3WGsythHQsIUXCugXgKp7F8Q44%2BD8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:32.5849557","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:32 GMT
+      mise-correlation-id:
+      - e8427e13-9961-4d29-938a-ccd127998344
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A37Z&sr=b&sp=r&sig=EvHPw%2B8St76k3ljL6M3deIgGOgUk6H2ZEs%2BO9DhvVNc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:37.8323447","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A37Z&sr=b&sp=r&sig=vEdeBWy%2BplI8WUjI2mCXlwrMA%2B3tG31%2Fk6YbBKG10bQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:37.832275","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A37Z&sr=b&sp=r&sig=wKBi%2Fam66Osvl9nHBNfYw%2Bjx%2BBMvCQSLTr1DySqIrxw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:37.8323588","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3241'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:37 GMT
+      mise-correlation-id:
+      - 00356888-1f74-4fd8-845a-3999c256ae8b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A43Z&sr=b&sp=r&sig=sOAAmjDbhrQajS9%2FWeKLrL6sRo4CXwqnidYw1zGcl5Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:43.4028054","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A43Z&sr=b&sp=r&sig=qBcPhDbWJjBQO%2FU0vPHmvlKUU9NkP41GUWnnA9tqPAU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:43.4027057","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A43Z&sr=b&sp=r&sig=iN8WZZfbeVWJD6GnQrk0X3swzkactLbQ6Pv4mnbSCVI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:43.4028262","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3230'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:43 GMT
+      mise-correlation-id:
+      - af00a301-ac49-47e4-b534-5ba62a2da1c2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A48Z&sr=b&sp=r&sig=HUWXkjUf8wzuGERHEglSaTavEQ0cyPW89xScBGMvlSE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:48.7057788","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A48Z&sr=b&sp=r&sig=RxAuLQhCulpepj2GGNgMo3vEab4c9jJpn2HNZsI%2BiVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:48.7056872","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A48Z&sr=b&sp=r&sig=oAol9ZU32PAMKdsixyu4uDrLQ5UEF6Yry9Z5Gtp%2F8Q8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:48.7057996","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3230'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:48 GMT
+      mise-correlation-id:
+      - 9724105c-0b7d-4025-ad4d-665d24480bee
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A54Z&sr=b&sp=r&sig=dx5wnm%2FLqNPXRjGtrMMX8yXQmqeg4Kev0EC9LIUyph0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:54.0562051","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A54Z&sr=b&sp=r&sig=YHPQWwW98yJZvQK%2Fg2qBJqgMhD3m%2FTGFgyomwg50TN8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:54.0561161","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A54Z&sr=b&sp=r&sig=jDnf04oUGL1%2Bb1yBjn5ROqHpY94TzuNyn%2FLaCiW0sJs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:54.0562263","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:54 GMT
+      mise-correlation-id:
+      - d0b90500-21d0-45ef-b0a9-322484a6ac6f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A59Z&sr=b&sp=r&sig=eKGdEWbBjDAh%2BkLlM1uikaOlKnABFLYbEHGjSptk1EE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:59.315162","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A59Z&sr=b&sp=r&sig=W0zdVjhVk5nJsYiCIfY3wxl%2FOsBROlQnSzAuALVPHgo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:59.3150692","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A59Z&sr=b&sp=r&sig=llxB0F1gcUGCq3RrqQEYimtDQuEDrlQ9t6RZB%2BBwBlE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:59.3151784","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:59 GMT
+      mise-correlation-id:
+      - 0af835f6-4bb6-41eb-a464-5becb82c55b1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A04Z&sr=b&sp=r&sig=kp8QT0rmV8WkvfXEFI0eiruKUIPZYmze0ktrHIEr8d8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:04.8834016","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A04Z&sr=b&sp=r&sig=LwbQ1c8Rp%2BMs6bWPMAHo24NYcP%2BBWMHYg3BNavEK19c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:04.8833145","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A04Z&sr=b&sp=r&sig=W9b%2BRaf2awb6QmsX5Oqyal4ns9vwDwM11FBMJhRzX7g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:04.8834259","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:04 GMT
+      mise-correlation-id:
+      - 20c46b43-5dc2-43bc-8d65-f90121ba8d8d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A10Z&sr=b&sp=r&sig=yXv2rwWZN1M%2FcNJ%2FibWXlTfp%2B29x68w1tPbKKqxw4Pg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:10.2157403","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A10Z&sr=b&sp=r&sig=sa6qR3%2BmGfoAGMC%2Bc1R0Yy5iNjFa3VIdgEWoYZBdWdA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:10.2156518","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A10Z&sr=b&sp=r&sig=nfaA351nBHjeduOamFmyHVjLc4eVgpg9vHcDh1IsgvI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:10.2157637","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:10 GMT
+      mise-correlation-id:
+      - fca9ab04-66aa-4153-9c52-3e8d6a0956ec
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A15Z&sr=b&sp=r&sig=NwriBTEmYzMDfWiieqe2zDE6tVNZyyuBqNOt1JOqCBk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:15.4839175","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A15Z&sr=b&sp=r&sig=Gwb6irZsoPLEiN3xlAghVMU9xaQwMzHps%2By4Xgqoerg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:15.4838491","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A15Z&sr=b&sp=r&sig=giBN2u11H0rkyqRRxIMzpjtjOnWF3cj87Vv0XP3qLD8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:15.4839314","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3228'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:15 GMT
+      mise-correlation-id:
+      - 972bf4b6-c0cf-4fd6-8e71-47833c10a16a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A20Z&sr=b&sp=r&sig=iaI39UsN0EZDoYoNpLd3sHF7rqIcL860IlOGqdbEhmA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:20.7316879","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A20Z&sr=b&sp=r&sig=bGtgW0ExmoBerjSRlm1c90fbKWFp%2F7y16Zty9s%2BM20Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:20.7316158","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A20Z&sr=b&sp=r&sig=fwr2Go4sFhAL9Egi11Z6gx4bXhW7WJI0BdoHyO1xmEU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:20.7317021","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3230'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:20 GMT
+      mise-correlation-id:
+      - d77d8bc1-f96a-4733-8d03-3ece15052ba2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A25Z&sr=b&sp=r&sig=ZOx60pWn7yq9ZD7uawMcbAH3l7EyGtY4vyrJmjEXiJQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:25.977562","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A25Z&sr=b&sp=r&sig=Poi8P4qVW0foB6sNQb%2F9guvHP4oiqa6UBd64L0Nq2Bk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:25.977475","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A25Z&sr=b&sp=r&sig=hekBEPFuRDVuzQ0sukkeGB9VeH4zIOKMQodYK2sO6Rg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:25.9775851","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3226'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:25 GMT
+      mise-correlation-id:
+      - fb53b47c-a3a4-4501-954e-fa69edd679e4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A31Z&sr=b&sp=r&sig=sT7T%2Fx6NK5TRncBbSOon17sJ5SUW0X9MTfEd5MRH0VE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:31.2303315","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A31Z&sr=b&sp=r&sig=A4chWD8isr4lZGCvlRVmric1SQ9%2BriPtDcLts0%2Bbq7Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:31.2302507","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A31Z&sr=b&sp=r&sig=vtGAKmC1g79W9tjTOJD7bpYgUqCGy907W54amV6AbAU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:31.23035","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3230'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:31 GMT
+      mise-correlation-id:
+      - 9cd22e45-0a51-4764-bae4-a0bcb0cac3b1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A36Z&sr=b&sp=r&sig=f3szotiAxFb70UKOfI8Ln821aymmqb%2BRO2BbqpCDzQY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:36.4927076","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A36Z&sr=b&sp=r&sig=FNjRMcP657DoMLpu5ESOGWjA0uZGiBK95n3CpJtlC70%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:36.492623","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A36Z&sr=b&sp=r&sig=NrzEhsFpD4p8Y1bSiiKU8WuEsCAWlBhJnUEQ3OX%2Fi7U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:36.4927247","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3229'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:36 GMT
+      mise-correlation-id:
+      - e47a5e59-d445-423d-b164-fc8a0c8ab710
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A41Z&sr=b&sp=r&sig=Jc02RkZwgzAZYgvZFbONnHheAeGpFmOy16DIF06zGb4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:41.75518","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A41Z&sr=b&sp=r&sig=HeTFM0NY85aPn8NVt1rgRIW2bbgS%2BBvRH9FkExVG3cs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:41.7550973","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A41Z&sr=b&sp=r&sig=iFZkZ0pjwRpVFj4zsLRwBvDU%2F%2Fa9SzlSxCrIoDzCBCc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:41.7552013","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3230'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:41 GMT
+      mise-correlation-id:
+      - 722f1a6b-da56-435a-8fb3-758f7ba14ee9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A47Z&sr=b&sp=r&sig=GJsY2IgrMxT1O0XxmRAnV2d31DhnvnC483SljUsjCc8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:47.0024942","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A47Z&sr=b&sp=r&sig=ElqZk721gfmtxlMtvuF%2FboH7WCH4Snzg9q7hLTKjSGc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:47.0024132","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A47Z&sr=b&sp=r&sig=Z2ZpkQW9RMlq3Q%2F%2BddW1WqL%2FMii3uQD8M8vUq%2FojqBk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:47.0025115","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:47 GMT
+      mise-correlation-id:
+      - d3366da9-7ecf-4573-a2f5-7db34508cd25
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A52Z&sr=b&sp=r&sig=9s9A8qLEKi9us%2F%2FWmhwOxrsGgQ61DvDh9zNZcyTD2fI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:52.2489987","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A52Z&sr=b&sp=r&sig=qka%2BUXBvTbYciRVBdrySwhT2egNPX6rMXGDuYpKsRWE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:52.2489302","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A52Z&sr=b&sp=r&sig=lGKhbcrfJ6xnkVZtAJQGoEVPXkIstmGQDucQvgi4aL0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:52.2490126","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:52 GMT
+      mise-correlation-id:
+      - 630170f4-1cc3-42c8-ac8a-8abf13afb27d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A57Z&sr=b&sp=r&sig=JMTRfAqwQwSt9Ok6VomLqtxJt%2FNpdzE3GFuVuEzw4N0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:57.5223696","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A57Z&sr=b&sp=r&sig=8%2FQkwjOZdE77y%2FOG0c0v1zGKmwODUF5Srn6YKujG6h8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:57.5223016","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A57Z&sr=b&sp=r&sig=TCrQUriQlPKWmUaPvmX%2B5D%2Bx6KHGlPDj7hFc9DoRbiU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:57.5223839","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:57 GMT
+      mise-correlation-id:
+      - 6b50180d-ac4c-46e8-ae1f-49f358108293
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A02Z&sr=b&sp=r&sig=V9SiIo%2BGKIogTCQ0cblaV1TjhJRb0B4ysYrdckgPOSQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:02.8056583","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A02Z&sr=b&sp=r&sig=BudvqdzPg2a8OkfAOuN9ub905raBoVmQLkmDSiFnESo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:02.8055865","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A02Z&sr=b&sp=r&sig=pacMHYXERd8IE8eBBC%2Bm4wpMXfs4whUolDjn3OKkp00%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:02.8056721","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3230'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:25:02 GMT
+      mise-correlation-id:
+      - b151b4b6-5772-4128-83ca-314811d41a0f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A08Z&sr=b&sp=r&sig=xZM%2FcgobqH7pwf61Ty7jfDDDMbyH9LwrkguTlpDPgoE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:08.0655236","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A08Z&sr=b&sp=r&sig=BdMomZ4GGHJMSFkALWdIi7qOJ9GWtzGFhh1f%2Fp2i7LA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:08.0654456","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A08Z&sr=b&sp=r&sig=XlVA3B3jCs5C%2B55JdIaKVTpepZ3OMWblTjFTHJ%2F4Bm4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:08.0655396","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-29T22:22:23.802Z","endDateTime":"2023-10-29T22:25:06.637Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:06.729Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3370'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:25:08 GMT
+      mise-correlation-id:
+      - 4bc2d63e-0944-48b8-bf16-10ef5026bbf9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1856,18 +1856,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:10.6516578Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:10.6516578Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:00.9207417Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:00.9207417Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:23 GMT
+      - Sun, 29 Oct 2023 22:25:08 GMT
       etag:
-      - '"d300da3b-0000-0100-0000-6537b85c0000"'
+      - '"3c003d28-0000-0100-0000-653edacf0000"'
       expires:
       - '-1'
       pragma:
@@ -1897,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=app-component-test-case&api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=app-component-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A25Z&sr=b&sp=r&sig=lWirbw2BkTV8PLg28K4wg4NfAkrkGjime7tri5p4t0g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:25.0695275","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A25Z&sr=b&sp=r&sig=dc057dxVTfPcmFeUAKTIqtbfj6byirn48U00i2w97hg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:25.0694276","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A25Z&sr=b&sp=r&sig=B0%2F1Crtid8DSJN%2BlvRLO75iDkowLDhhjUvC%2FRnYkYnY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:25.0695505","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-24T12:29:35.295Z","endDateTime":"2023-10-24T12:32:19.175Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:19.247Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A09Z&sr=b&sp=r&sig=1H5ETJZt%2F5PUHrO5OjDu901cstugthsYzNwmIMHXBIo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:09.5580613","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A09Z&sr=b&sp=r&sig=6M1XEh9O%2FiH%2FNmS1lbWyCFphaWsuDFOvt8FJMVcp6xY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:09.557973","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A09Z&sr=b&sp=r&sig=AQt45u33Za%2BWeayCmTWFxX4JwLbiL8Bhz%2BeTrxeWSPw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:09.5580825","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-29T22:22:23.802Z","endDateTime":"2023-10-29T22:25:06.637Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:06.729Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3380'
+      - '3383'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:25 GMT
+      - Sun, 29 Oct 2023 22:25:09 GMT
       mise-correlation-id:
-      - f5b86518-a708-4f0e-8142-8d6d982174b0
+      - a7f3b0d6-381d-491c-912f-77e3a2adc040
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1941,7 +1941,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-24T12:28:46.5429960Z","key2":"2023-10-24T12:28:46.5429960Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-24T12:28:46.5585938Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-24T12:28:46.5585938Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-24T12:28:46.3554736Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-29T22:21:35.7556061Z","key2":"2023-10-29T22:21:35.7556061Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-29T22:21:35.7556061Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-29T22:21:35.7556061Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-29T22:21:35.5837216Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -1950,7 +1950,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:32:35 GMT
+      - Sun, 29 Oct 2023 22:25:19 GMT
       expires:
       - '-1'
       pragma:
@@ -1983,18 +1983,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:10.6516578Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:10.6516578Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:00.9207417Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:00.9207417Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:36 GMT
+      - Sun, 29 Oct 2023 22:25:20 GMT
       etag:
-      - '"d300da3b-0000-0100-0000-6537b85c0000"'
+      - '"3c003d28-0000-0100-0000-653edacf0000"'
       expires:
       - '-1'
       pragma:
@@ -2013,9 +2013,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-2tcg3hznsh4th4b4v/providers/Microsoft.Storage/storageAccounts/clitestloadua7e5w3yq":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-2tcg3hznsh4th4b4v/providers/Microsoft.Storage/storageAccounts/clitestloadua7e5w3yq",
-      "resourceName": "clitestloadua7e5w3yq", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-estdzn7pj7eu2dksz/providers/Microsoft.Storage/storageAccounts/clitestload36zigb76n":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-estdzn7pj7eu2dksz/providers/Microsoft.Storage/storageAccounts/clitestload36zigb76n",
+      "resourceName": "clitestload36zigb76n", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -2031,10 +2031,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-24T12:32:38.175Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:38.175Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-29T22:25:22.306Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:22.306Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2045,11 +2045,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:38 GMT
+      - Sun, 29 Oct 2023 22:25:22 GMT
       location:
-      - https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+      - https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - 2ea55b75-1bea-497a-aaa0-f68a66c47edb
+      - 3ac30ca5-6411-41fa-9727-bdef84e8094f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2072,18 +2072,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:10.6516578Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:10.6516578Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:00.9207417Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:00.9207417Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:39 GMT
+      - Sun, 29 Oct 2023 22:25:23 GMT
       etag:
-      - '"d300da3b-0000-0100-0000-6537b85c0000"'
+      - '"3c003d28-0000-0100-0000-653edacf0000"'
       expires:
       - '-1'
       pragma:
@@ -2113,10 +2113,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-24T12:32:38.175Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:38.175Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-29T22:25:22.306Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:22.306Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2127,9 +2127,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:40 GMT
+      - Sun, 29 Oct 2023 22:25:24 GMT
       mise-correlation-id:
-      - 38c6a32b-d161-481b-bd28-838182bfb2ca
+      - 5d835255-910a-4dc0-ab40-049803312b00
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2152,18 +2152,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:10.6516578Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:10.6516578Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:00.9207417Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:00.9207417Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:41 GMT
+      - Sun, 29 Oct 2023 22:25:26 GMT
       etag:
-      - '"d300da3b-0000-0100-0000-6537b85c0000"'
+      - '"3c003d28-0000-0100-0000-653edacf0000"'
       expires:
       - '-1'
       pragma:
@@ -2182,7 +2182,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-2tcg3hznsh4th4b4v/providers/Microsoft.Storage/storageAccounts/clitestloadua7e5w3yq":
+    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-estdzn7pj7eu2dksz/providers/Microsoft.Storage/storageAccounts/clitestload36zigb76n":
       null}}'
     headers:
       Accept:
@@ -2198,10 +2198,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-24T12:32:38.175Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:42.137Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-29T22:25:22.306Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:26.937Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2212,9 +2212,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:42 GMT
+      - Sun, 29 Oct 2023 22:25:26 GMT
       mise-correlation-id:
-      - ad048e11-d585-4062-b119-5a025dedf28a
+      - 4f32fcef-3c8b-4b17-9bbf-d91d5672f684
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2237,18 +2237,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:10.6516578Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:10.6516578Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:00.9207417Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:00.9207417Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:43 GMT
+      - Sun, 29 Oct 2023 22:25:28 GMT
       etag:
-      - '"d300da3b-0000-0100-0000-6537b85c0000"'
+      - '"3c003d28-0000-0100-0000-653edacf0000"'
       expires:
       - '-1'
       pragma:
@@ -2278,10 +2278,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-24T12:32:38.175Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:42.137Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-29T22:25:22.306Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:26.937Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2292,9 +2292,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:44 GMT
+      - Sun, 29 Oct 2023 22:25:29 GMT
       mise-correlation-id:
-      - ef2c9f83-47ed-474d-bc86-2749aebc644e
+      - 73b80ad8-de70-4ddd-825e-241cf0df2183
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_app_component.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_app_component.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:12.6666047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:12.6666047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:30.9716153Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:30.9716153Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:09 GMT
+      - Mon, 09 Oct 2023 19:19:28 GMT
       etag:
-      - '"9201a1af-0000-0100-0000-6524265e0000"'
+      - '"5600ef16-0000-0100-0000-652452090000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:13:10 GMT
+      - Mon, 09 Oct 2023 19:19:29 GMT
       mise-correlation-id:
-      - bd3501c7-55a4-490c-9c9c-f543e5d8e601
+      - dfb5bacf-abb1-4709-8381-e828e3d64927
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"00081d97-e808-449d-8ae3-728cd745102e": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "b5e9700f-b93d-4671-a957-bac0156c0028":
+      {"passFailMetrics": {"edbac2db-f6a3-4803-9ac1-6d344cd7196e": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "75b13386-0b49-4125-8e94-65d3bf40c008":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "b6c0709f-63eb-4b35-98a2-986acd61a699": {"aggregate": "avg", "clientMetric":
+      "50"}, "52c44c55-9403-4c9a-baf0-87504612ca95": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:13:10.947Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:10.947Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:29.791Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:29.791Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:10 GMT
+      - Mon, 09 Oct 2023 19:19:29 GMT
       location:
-      - https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+      - https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - aa00a9d3-b892-4611-b033-e7da17d305b3
+      - f83e5c1e-46af-472a-bc86-aacb25daaee9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:11 GMT
+      - Mon, 09 Oct 2023 19:19:30 GMT
       mise-correlation-id:
-      - ac62ad42-8c1f-4eb7-bf6c-7cc4fd8f61b1
+      - f9d28bb4-a79f-4733-86fa-4c11a1fe1eba
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A11Z&sr=b&sp=r&sig=0VO7C1bLWllqp0cT7KxwTnpXASs6h9VEODrkCpFInmk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:11.8613553","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A30Z&sr=b&sp=r&sig=uE%2FSVRkH%2FpV0c3ckPJWlwCXu3AJFH3Plr2hLT68IGl8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:30.6985902","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:11 GMT
+      - Mon, 09 Oct 2023 19:19:30 GMT
       location:
-      - https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - db586886-962d-4dcd-848e-b45c7a7b2a52
+      - a5341136-0267-435e-80e5-dadab82ab48c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A12Z&sr=b&sp=r&sig=oHNQRqHNu3B73U4JljVaK%2FDvnMu1rGbtXkmIbpFHXtg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:12.1315769","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A31Z&sr=b&sp=r&sig=dqDWXQuNhirwq7LrTYH%2BydWTQxl3fhxlhEqTIUTn%2BVs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:31.063591","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '552'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:12 GMT
+      - Mon, 09 Oct 2023 19:19:31 GMT
       mise-correlation-id:
-      - e8bcd177-b310-4f55-b0bf-c3cc00aebb11
+      - 59e4ff14-5e57-4e9e-8601-62071285b3ad
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,10 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A17Z&sr=b&sp=r&sig=CvLnpEDQNfNblEd0SSYSbCX54Jf2Ylgn0rtFM7k0Vyw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:17.4054409","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A37Z&sr=b&sp=r&sig=JVPZ7FfozLbJCsrbrx9sIJzVeyAk89xDJIIpIwQU6W0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:37.1355627","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:17 GMT
+      - Mon, 09 Oct 2023 19:19:37 GMT
       mise-correlation-id:
-      - 6e142bf2-b2a3-4c3e-953e-0aabc24aae98
+      - f45ee9c3-4228-448d-8182-f58ff8e36222
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,10 +385,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A22Z&sr=b&sp=r&sig=d6zGEZ7As1UNXlzPYV1gGYIvb%2BdZlbogL7qenLJKEuE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:22.6828974","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A42Z&sr=b&sp=r&sig=51MTnLV2EhZZk6FDsXvKo%2F88x2tVtqXWbqJ6pHGrcdQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:42.4126941","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:22 GMT
+      - Mon, 09 Oct 2023 19:19:42 GMT
       mise-correlation-id:
-      - 2a8e9e51-f3f8-420d-aafa-d7691ff18bd5
+      - 0b66ff23-d3c3-453b-bbe1-d90295486431
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A27Z&sr=b&sp=r&sig=oKfIDdapVT59MYgC%2Bvb9XEhIwNCLlhVIBR9ssFDKG8c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:27.9535226","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A47Z&sr=b&sp=r&sig=8Z7scCb%2BHq0GiKEJjzbqje0ailITDLdbMH1%2BU2A%2FHU4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:47.7656298","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:27 GMT
+      - Mon, 09 Oct 2023 19:19:47 GMT
       mise-correlation-id:
-      - 3d0c0eae-655d-487f-a89c-a8429392a511
+      - 94155d3f-e005-46d4-a3ad-9a30e4b03495
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A28Z&sr=b&sp=r&sig=Q8DgHUZRXAAVWLvJ%2BF%2BG8P%2BVo8abe76a1%2BdA0nzYI8I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:28.2238328","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:13:10.947Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:25.938Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A48Z&sr=b&sp=r&sig=55v5fLJmQoSEBKUg5VJtEAlaVBM9eV8PycSXSaHqjig%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:48.0233801","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:29.791Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:43.096Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1592'
+      - '1584'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:28 GMT
+      - Mon, 09 Oct 2023 19:19:48 GMT
       mise-correlation-id:
-      - 47c591cd-cb84-43c5-a59e-72b8cd8d71b8
+      - 9f5f42ba-06f2-4f54-a7ce-cb73f53071a5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:12.6666047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:12.6666047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:30.9716153Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:30.9716153Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:29 GMT
+      - Mon, 09 Oct 2023 19:19:49 GMT
       etag:
-      - '"9201a1af-0000-0100-0000-6524265e0000"'
+      - '"5600ef16-0000-0100-0000-652452090000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A30Z&sr=b&sp=r&sig=HHaWSstnV16g06sVpdQWXRovT6j%2FyYsPO72jDX3cXH0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:30.4841021","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:13:10.947Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:25.938Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A50Z&sr=b&sp=r&sig=7MCjq9a5hlK6QYFTbFHjvZcd0S2oLjKPv9cMsCl9J2k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:50.4519711","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:29.791Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:43.096Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1598'
+      - '1596'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:30 GMT
+      - Mon, 09 Oct 2023 19:19:50 GMT
       mise-correlation-id:
-      - 9fbfaa4c-c291-412c-8947-994761031050
+      - 2445659b-0578-4dbc-b2c2-1d49ebca0abe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:12.6666047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:12.6666047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:30.9716153Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:30.9716153Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:31 GMT
+      - Mon, 09 Oct 2023 19:19:50 GMT
       etag:
-      - '"9201a1af-0000-0100-0000-6524265e0000"'
+      - '"5600ef16-0000-0100-0000-652452090000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:13:32 GMT
+      - Mon, 09 Oct 2023 19:19:52 GMT
       mise-correlation-id:
-      - ea5f3015-a0ed-4105-9be6-95dc5852e382
+      - 43081980-d7d6-41a8-af5d-9465aa649e87
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A33Z&sr=b&sp=r&sig=rtBaxXi1A8tzP93sldDFR8DNCw0D9yIgFVmgnwZnEVo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:33.5129344","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A33Z&sr=b&sp=r&sig=fPiNR4lCRDUzqmE3x0t1nL4E2oNzFIbdchvHoJPoKTw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:33.512804","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A33Z&sr=b&sp=r&sig=qWLFd6ynhK1dcUB1HPBbsHoe8BKnUAlCwLkqnlDR9lI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:33.5129619","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:33.432Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A53Z&sr=b&sp=r&sig=nujhwZsnPxnNBr10QuL%2F4T5MBTBFAJ88AZiVRQQ51Bg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:53.1235641","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A53Z&sr=b&sp=r&sig=q%2FkXVQOAPToOfORZFYx1z7iHBBCqGXiiif%2FmtS%2F4NpI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:53.123464","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A53Z&sr=b&sp=r&sig=L2VOMOVNgDSsXcMgnaeALVAqSOAKaCg1xrLZuV0UKQI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:53.1235898","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:53.041Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3182'
+      - '3189'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:33 GMT
+      - Mon, 09 Oct 2023 19:19:53 GMT
       location:
-      - https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+      - https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 1dd03fa1-bb02-4123-b0e6-fbb9d7dc6e94
+      - c17ad8af-d009-4420-96de-877d6a9169aa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,118 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A33Z&sr=b&sp=r&sig=%2FsFTELMPMUr7%2B8li9kL69k4aRwEbQfhgdlXzxo6UI%2FY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:33.946794","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A33Z&sr=b&sp=r&sig=%2BNSEy%2FJbk%2BwcbB9uqO67b33G%2F6%2BjCX3XrIb6%2Fvp8NdQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:33.946707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A33Z&sr=b&sp=r&sig=tea7Yqg1yTXu3EBzMktHIfqsKKcE1ey0eePIqQLWwuY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:33.9468092","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:33.432Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:33 GMT
-      mise-correlation-id:
-      - f5497cd3-02f9-4e80-b626-19e26c2e5032
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A39Z&sr=b&sp=r&sig=kUfFLTMc3Rnrhb6pZovnNz9Lo%2FD%2B%2B4WnOjdOUYuRGmo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:39.2193886","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A39Z&sr=b&sp=r&sig=s9NhUbe%2FtsfigOhss9qLq8n6b3jZAW7JC%2BK2aYDeRoU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:39.2193064","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A39Z&sr=b&sp=r&sig=fAi4oA0%2FfaCJIra8VPgFBSU7TaUf%2Bft41nGqEztu7E8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:39.2194056","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:34.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3244'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:39 GMT
-      mise-correlation-id:
-      - 5a4c741a-045e-4c1c-ac36-2491e0a9f32b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A44Z&sr=b&sp=r&sig=iQr%2BOVbF1thu6EL%2FBxZpdZPwdsxgmjt5Cpk%2BotqqFcY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:44.502657","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A44Z&sr=b&sp=r&sig=MY4ESn2nFpik%2FNhpg1IwkaBRdSiVv3Kjwl%2FPwPTpzuM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:44.502568","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A44Z&sr=b&sp=r&sig=B7eSXjjK8gZRSxsQhBOZO%2Fy1hHfdgkqcBbHXkKwJru0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:44.5026732","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:34.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3240'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:44 GMT
-      mise-correlation-id:
-      - 442177ad-6b7a-499f-b00c-66b4f26aec9e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A49Z&sr=b&sp=r&sig=F8HkwthzyEODQGSCcQ4DgtAT%2BMedeua5xN5y6uxNSU8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:49.784385","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A49Z&sr=b&sp=r&sig=P6cx06pcQrZnVwJs3uXUrgxgLuxEGpZNsA4oCmiloYk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:49.7842393","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A49Z&sr=b&sp=r&sig=Ku9kJNDCZk9W1ijdRMbfHNaD3YJn7NvfMe3TqQau7vs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:49.7844034","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:34.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A53Z&sr=b&sp=r&sig=%2BG0BwB9mfRlv8Sj1bhZQygXFouPfgMvBA3hf5RbU024%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:53.6951196","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A53Z&sr=b&sp=r&sig=9E7A7ql%2F0Nwxz6vRurNhaSruQBpMAmk4GJpedEalwNA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:53.6950308","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A53Z&sr=b&sp=r&sig=eN6iH2dlXopHMOrGHwqom1RbkTXycyRPCWj6fjEPljw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:53.6951345","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:53.578Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -822,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:49 GMT
+      - Mon, 09 Oct 2023 19:19:53 GMT
       mise-correlation-id:
-      - 4588efff-53bf-4106-a1f6-32718ba5b3ca
+      - 4c413631-2d51-4857-b5f8-25699223e982
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,298 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A55Z&sr=b&sp=r&sig=firMh%2BYW6WXKoBsaIOYHxl8XYpfG0wUQkDr11Ear0Pc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:55.0860402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A55Z&sr=b&sp=r&sig=vLlWUNWn6HXqec8Ase608Ti8MPbGlIqy7QWX%2FLbGnpU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:55.0859463","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A55Z&sr=b&sp=r&sig=5TJ4CJKyZRIX312p6xaAx5%2FKsLXzNEZUFEUEE1cY%2B3E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:55.0860625","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:34.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3238'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:55 GMT
-      mise-correlation-id:
-      - b113f3e6-3cc8-4332-a3fa-973d7414d517
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A00Z&sr=b&sp=r&sig=qlxf%2FGSRklqpdyvoOAItitFWdy0GjuWU%2BZG%2BRNTmdew%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:00.4052742","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A00Z&sr=b&sp=r&sig=mMnKszIaBAG2LyUeK69JLBqAeWAVk%2FsTE6eyaKFPa94%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:00.405112","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A00Z&sr=b&sp=r&sig=QEDmM0IJSCpxw%2F5JI4U7DDwI7LY9p%2Fu9Gb85Zn7qMhk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:00.4052994","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:34.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3241'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:00 GMT
-      mise-correlation-id:
-      - 1168cfe3-108e-44aa-8a1d-cef94428ea5d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A05Z&sr=b&sp=r&sig=kuLgTxjr5qqyQewhwQmdiclDoVqGpAqSHUXXsbAZtjM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:05.7108601","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A05Z&sr=b&sp=r&sig=uiJ0yAlM2dN0e1snXKqukrX3cAimcyS6e0sF7%2BVyKU0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:05.7107879","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A05Z&sr=b&sp=r&sig=Q2Rt0xUt4tS%2FZkMiZQYKEGPWo%2BXI55eKOlD2zTlUbEE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:05.7108757","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:34.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3236'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:05 GMT
-      mise-correlation-id:
-      - 0d00a7a4-6059-4562-938a-f6fd874ac9ea
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A10Z&sr=b&sp=r&sig=WTxMio4%2Ba6%2FDD4QP4qGcieKoK8etVVSMtCFUzkWz51Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:10.976076","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A10Z&sr=b&sp=r&sig=Xc%2BHlF7clDFJQQyOo8zylfs%2BSFMxyfxeeJA6Q6xJQ%2F0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:10.9759794","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A10Z&sr=b&sp=r&sig=fPJbKc5lsoJ9jSyGkMnCJ4xfPdfCQhlBaQiAxUDvRSw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:10.9760982","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:34.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3239'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:10 GMT
-      mise-correlation-id:
-      - ecd09ad1-7f7c-4a33-b96e-5ee1c904dab7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A16Z&sr=b&sp=r&sig=Ee1yM5pGQ0c3TloGkmEJxCr1M1gyCXexzocbrgtS6W4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:16.2570318","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A16Z&sr=b&sp=r&sig=EirpKcnclCmjjRVElykh0SHQsQ0YXdU3MXdV6vynq%2Fk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:16.2564661","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A16Z&sr=b&sp=r&sig=UZwRu0oumzCz5M5pr%2FuoArb882LnGmGRPQBXVyX8gD4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:16.2570558","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:34.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:16 GMT
-      mise-correlation-id:
-      - 9689e270-9aa8-4de4-836c-2b3a0dd94fa2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A21Z&sr=b&sp=r&sig=8sR0gXKBE5fj8QYUUHU71BDtgCCAwNWXosL6eZk6WVk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:21.5392251","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A21Z&sr=b&sp=r&sig=hpzniL2X2cfMeom9GTEbEIB6zAHW4h78G66M0OKKK94%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:21.5391343","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A21Z&sr=b&sp=r&sig=K9dpfAwBHFz6krRcOlUDUGfduCMImSyaExhmNzmloVc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:21.5392403","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:17.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3229'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:21 GMT
-      mise-correlation-id:
-      - e2f0380c-f046-4817-926d-ae91b3d31dee
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A26Z&sr=b&sp=r&sig=sFoXjUVG6hrL9STvGF1rheD8YMd4X0eoGVhnSQpz9Gk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:26.8194149","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A26Z&sr=b&sp=r&sig=GxBUupw%2BtUs%2FNgHjnziMWplQbUr69vHtyAeYhnf9CSo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:26.8193099","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A26Z&sr=b&sp=r&sig=QEy2O%2BgMFCVLHp%2BVUDRtk2T3JmKErn5TD6v%2FROP%2B%2BU8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:26.8194399","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3241'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:26 GMT
-      mise-correlation-id:
-      - cf9fb461-8e29-4ba6-9f6c-599f05293d2b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A32Z&sr=b&sp=r&sig=iX1%2FXtgA%2BhC%2FiGUXa4%2Bqxxf0MtoWsQB%2FJOSoYnA60ZY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:32.3658898","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A32Z&sr=b&sp=r&sig=mp0ycfus5J0JvZWI7zsqX1OPLEryQEy8Y5hz3FyYXnk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:32.3658257","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A32Z&sr=b&sp=r&sig=nccN5iKsZLPi3XYHKzTkAM%2Fyz98qyi9%2FJFkmuLM%2BYkk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:32.3659051","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3243'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:32 GMT
-      mise-correlation-id:
-      - 882468f9-be44-45b8-aa35-fbb8728b86c6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A37Z&sr=b&sp=r&sig=q1e3%2BLOfK1NXg14YEZ6izjjNNqF9hGY9E6h%2F5g1NSkA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:37.6333608","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A37Z&sr=b&sp=r&sig=vba4FJljrfe5JeOgtUvcPioDNIyv%2BpnRsLlKGNdoSPU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:37.6332887","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A37Z&sr=b&sp=r&sig=3oxRYNxv%2Fy3ZIP9WbhZn0aV1JiVmXzLqExRo%2BqRZgfs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:37.6333784","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A59Z&sr=b&sp=r&sig=HwcXCXTd%2B4mwxxGuoZTm7EBk8UJIEnseUKA6bNvzTAw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:59.0070033","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A59Z&sr=b&sp=r&sig=UDQav66cSS47WIV%2FIx3e3hrj6JnD8UDD0qlmcJQgSTE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:59.0069038","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A59Z&sr=b&sp=r&sig=m1Zwkm8LaVzJd%2FYwcFmEJgWiliVC%2Ff90M0aqYMydKCE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:59.0070241","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:54.364Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1146,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:14:37 GMT
+      - Mon, 09 Oct 2023 19:19:59 GMT
       mise-correlation-id:
-      - 242d7f64-a7d0-412f-89c8-3ddcb5471825
+      - 6b223f08-2d08-42e8-ba1b-e0c34608f0e1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1168,10 +772,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A42Z&sr=b&sp=r&sig=iXxt6CAZthx%2B4%2BWJYIVJKtPs9%2BNX91jnK3jS1iEBcd0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:42.9019698","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A42Z&sr=b&sp=r&sig=g23iZ6ez%2BG5YzgODb2ztUM7%2BlrA1Z%2Baec1xggI7FS%2Bo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:42.901871","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A42Z&sr=b&sp=r&sig=eHW0gCQdsi%2F4B7L5PKWsnBSY48KQtApaHS9m2BvoKmc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:42.9019906","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A04Z&sr=b&sp=r&sig=WNziEDo1ITWFLqzu9gUv%2B5cbPvAYbSroJZ3v7rDow60%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:04.3317753","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A04Z&sr=b&sp=r&sig=uhkf7FkSgmOxBLxl%2B5qOd%2BPa1GQpInRq5OCERPzvSm4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:04.3316946","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A04Z&sr=b&sp=r&sig=ReC0VmnubqaOOvzvTccXP9wnyd%2FfQwSmE4z27c3aV5o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:04.3317904","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:54.364Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:04 GMT
+      mise-correlation-id:
+      - b6bc9c0d-3e29-45ac-95c7-a3ef72864439
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A09Z&sr=b&sp=r&sig=iTX2jz4HGfoxfxkRwE4Mw8Xhl4rgBD5tdSW4A3A12UA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:09.5958945","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A09Z&sr=b&sp=r&sig=AjpgTh5H8kPRpQGp7Y1ypXB5KYNZL4ug5ZWUVjpPtpo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:09.5958104","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A09Z&sr=b&sp=r&sig=SWrROVXPavjbgU3twg4VVjjwS%2Bi%2BEPOUHrhdxeEZDdo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:09.5959155","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:54.364Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:09 GMT
+      mise-correlation-id:
+      - bdaba7ed-9387-4be2-93f5-b181940b5b29
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=zoajNML%2BhmPVGYzNzEpUFBG9Ki7riiB7crgkSQy65ow%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:14.8660331","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=fQSbsIMxKCOgzF%2BQIhgWJ2y351enW%2Bf9NDaYJaKhnh0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:14.8659394","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=vBc5Ws13%2Fa7nFqsbt%2BYTqHvfUszQMdZUCbrPbZRY9gc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:14.8660553","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:54.364Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3239'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:14 GMT
+      mise-correlation-id:
+      - 8f5853c1-24fc-4f00-8f3f-b364c10e6a64
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A21Z&sr=b&sp=r&sig=IEjVHpxu7sVg3Wg9MqXafJG2c6MG2GuPs3EyaqzUGK8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:21.028276","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A21Z&sr=b&sp=r&sig=AzpIuq1JE%2FICAYEE69lMiCMDB%2F9%2FrUjCzAmLK19hLEY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:21.0281955","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A21Z&sr=b&sp=r&sig=CbvM7Nbd%2BVKnYdg4FQoLAWEx%2FG%2FC9BDAKiVjJ%2FKjWHo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:21.0282937","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:54.364Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1182,9 +894,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:14:42 GMT
+      - Mon, 09 Oct 2023 19:20:21 GMT
       mise-correlation-id:
-      - 16815f05-f02f-4991-83d3-6ecf631acfeb
+      - 476f4dcd-107e-40d6-a478-1bf2243a1f67
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1204,23 +916,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A48Z&sr=b&sp=r&sig=osKbTseayos38DGCXaYaAdMIBmL%2B6nrVFPSPro70SG0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:48.1764623","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A48Z&sr=b&sp=r&sig=Ge6RobySVCVvjVvTVKHo8H9%2BbtpbaGmHEswGujit4gU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:48.1763839","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A48Z&sr=b&sp=r&sig=dv3ySvhAqm1wJIkY4BNu2Z3EBkMw5R7khIHWB74V1Ro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:48.1764775","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A26Z&sr=b&sp=r&sig=h9v8z39zZ19aruWXarasTeLk1gMV%2FeTxOcmd6WFRSlI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:26.3412173","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A26Z&sr=b&sp=r&sig=DlPXCEkwzxzAFFFyCghqB6viqcaGq6ChV5IozfFTJbw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:26.3411482","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A26Z&sr=b&sp=r&sig=a6Rk%2FkX%2FKNbcU5f1AT5LKqYfmIeUo6CrVch3DLGstwQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:26.3412328","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:54.364Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3231'
+      - '3235'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:14:48 GMT
+      - Mon, 09 Oct 2023 19:20:26 GMT
       mise-correlation-id:
-      - 44108208-ea7a-48bd-8452-5907d89cb57f
+      - 75bfb4c2-4937-4319-864b-a5634541a124
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1240,82 +952,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A53Z&sr=b&sp=r&sig=quVQtWjlOiE4yJsSaiii%2BBE7OXjpzmUGqkHEMJNwrV0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:53.4534505","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A53Z&sr=b&sp=r&sig=veRLANfpQwyL91UfrUdVpnhrB4I5VQjyelBXb24dCd0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:53.4533801","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A53Z&sr=b&sp=r&sig=EOpo2ROofMJjMGaUY36peziy3ZLdtSBtC9uhGtQ%2BPX8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:53.4534645","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3231'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:53 GMT
-      mise-correlation-id:
-      - 73bd19c8-deeb-4532-b526-8d6daeec8d33
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A58Z&sr=b&sp=r&sig=hfxraUaI1APhIGJxAAtlw%2BNXPWIV%2BjEKIbyuq1JoZgA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:58.7192775","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A58Z&sr=b&sp=r&sig=NQQXWT1qJtodY2WNVINLT5mTwpkAKRcW0YkEZAyqiIA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:58.7191773","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A58Z&sr=b&sp=r&sig=j3M7U8fBEgysPyY5LgCmJjKMek0ZiAWrqjgRzp5Tu80%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:58.7192975","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3231'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:58 GMT
-      mise-correlation-id:
-      - 4ea799d4-2c9d-449c-883d-3f91cc9c6ef4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A04Z&sr=b&sp=r&sig=lGGJSVEyIXf4rip%2FWVdwNDd0GtvVeNTDZG3x%2FuoQcLU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:04.0037224","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A04Z&sr=b&sp=r&sig=bKAmQdCv7Xw%2BChmBx%2FalvK8OdBXpcke2PWrrfgKxMWU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:04.0036531","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A04Z&sr=b&sp=r&sig=nN2rd5iwqrksQypgOV%2BqMiVn7VwYG8xhwMgYmcCHelg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:04.0037357","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A31Z&sr=b&sp=r&sig=EKazFi51op9UhtD%2BVv%2B4jyy11ApFgToKQ17np55oXLs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:31.6088106","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A31Z&sr=b&sp=r&sig=yqEKiwrtXLb9fR8FntcuYtNl6Cx238YqXfblTk49C%2BM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:31.6087247","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A31Z&sr=b&sp=r&sig=Nda%2FvPE0Q1zyo9UDMzK0DolNeZqnFTtLR8ki1jf3ot0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:31.6088317","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:54.364Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1326,9 +966,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:04 GMT
+      - Mon, 09 Oct 2023 19:20:31 GMT
       mise-correlation-id:
-      - 1f29f2dc-2128-4856-b7cc-0fad7d9e2c76
+      - bcf58a94-e2d0-4e35-b7b2-4312b0c0ae07
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1348,23 +988,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A09Z&sr=b&sp=r&sig=M6fVu6RMepQxHXj0%2Bh9KQZrNvxg0tppICSGcUYpjJEo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:09.2836914","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A09Z&sr=b&sp=r&sig=fVEw6H%2FrZU0n1H54ZdhV92RaLUSPNALgULlGMR%2FGJJg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:09.2836208","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A09Z&sr=b&sp=r&sig=Vsgr9mhhzG456afvY1WycMpskWGPXP%2FvcoBFSDys52o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:09.2837056","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A36Z&sr=b&sp=r&sig=GlNBrnm%2B1qMwRgN2GowQ4YGZNKFVEFt%2FjmydYWinaXU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:36.9058028","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A36Z&sr=b&sp=r&sig=ctAUmKK76v5iwLP0OA0kMPWaoMEVcl%2BuBWPGhCb%2FxL4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:36.9057116","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A36Z&sr=b&sp=r&sig=YpSEXZI%2BQ8UMObMiNUveRj%2BoUgXiiyLq0LuE9YGj4bs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:36.9058265","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:54.364Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3235'
+      - '3241'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:09 GMT
+      - Mon, 09 Oct 2023 19:20:36 GMT
       mise-correlation-id:
-      - bf678efa-6a1a-43a2-bce1-ac5d42d230af
+      - 46ab7807-2570-4774-a390-2e1713042544
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1384,23 +1024,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A15Z&sr=b&sp=r&sig=r7nCCwtaZwt7ydE4FEGQp7kMBBciBQEtlPQh%2BH%2B9nhI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:15.1707916","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A15Z&sr=b&sp=r&sig=vZQNwM30KYmEqF%2FHCORuFi68l3fesDjHqoPRDBKaW6U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:15.1706902","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A15Z&sr=b&sp=r&sig=X3UUaj1FsFw6Sc3bJeUMh1jh6d%2FtO6id1MOUhX09LK8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:15.1708134","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A42Z&sr=b&sp=r&sig=vT26mFPDQ3t2pxJfHQQoxvEdLiLyxXJSn%2B2EAZFkqfk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:42.2296176","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A42Z&sr=b&sp=r&sig=pNOjsA1oQ2VRwu8MSn%2FuicX7L7w%2FdBq4BfidG5PRKFw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:42.2295279","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A42Z&sr=b&sp=r&sig=yj1%2Bg%2Bmw6DcPVMYGGIwdC3S1MBs5DR0Ytcun1eZ0Q6U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:42.2296327","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:42.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3235'
+      - '3238'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:15 GMT
+      - Mon, 09 Oct 2023 19:20:42 GMT
       mise-correlation-id:
-      - 01c4c520-55f9-4d10-9d53-33c4ccf892e5
+      - c06791e3-4965-4721-a97c-670c611247b7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1420,23 +1060,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A20Z&sr=b&sp=r&sig=zvAWoDsYvQaqZ7wwDBkVPkwhJag9b0OYNsdws57PujM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:20.4434653","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A20Z&sr=b&sp=r&sig=0DZ1cqJsGUPNK0CCGSJD3IizdW8f1WsEwtJrHCdHftM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:20.4433881","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A20Z&sr=b&sp=r&sig=3i2LzCgfZIYXH8vfY3EFwSK3gwGnNeksa2r8GuUzYFw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:20.4434838","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A47Z&sr=b&sp=r&sig=TFAMspi0iIhNJjY8i1WOcEjQJkFOcbJ%2BJyJpWp1G6uI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:47.550707","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A47Z&sr=b&sp=r&sig=tj2syllMPykAnojR8F%2FW2ef2QMLvYQMCHZNyFxfNAzM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:47.5506271","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A47Z&sr=b&sp=r&sig=gtZfYa%2BECa46cMqvJHFUmOPFmcg%2FnHGeh%2F%2FdCmvWmLk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:47.5507225","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3227'
+      - '3237'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:20 GMT
+      - Mon, 09 Oct 2023 19:20:47 GMT
       mise-correlation-id:
-      - 2b226634-30ca-4c5b-bbf3-ad0e12ecd1aa
+      - 9104b53c-8266-4bf7-ab09-1d0b56cd402c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1456,23 +1096,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A25Z&sr=b&sp=r&sig=khgzgNkyc0EHHlRt%2FhI6%2ByrRpAZDWuhcXG5zI2p1bas%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:25.7160709","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A25Z&sr=b&sp=r&sig=LvoYnFO9mdtPGylPavAGeq3b5tiHmYxvCtRi28aQLjc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:25.7159479","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A25Z&sr=b&sp=r&sig=aREVLdOiEwwcKpwKrnLogT2BMx2vE7wpWD%2BDU2esGsc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:25.7160992","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A52Z&sr=b&sp=r&sig=DjpcLadT8LPtDrSyA0t%2FO43vSggEJLKtpkTGRkx1bnw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:52.8675808","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A52Z&sr=b&sp=r&sig=s3HBVEELrRXYvjodRaUQiNAl4XcfgMS%2Bxq%2BUsSofHWM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:52.8674873","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A52Z&sr=b&sp=r&sig=oA%2FjsaP6xA3HvefUH3LQlkEoF%2FJtbL5k1%2B2QsYbrTNc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:52.8676024","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3233'
+      - '3238'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:25 GMT
+      - Mon, 09 Oct 2023 19:20:52 GMT
       mise-correlation-id:
-      - 70f1d13e-8c63-4a35-9496-2392b2127be8
+      - c7651e8a-9835-4b01-87ec-f3bd701c195c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1492,10 +1132,226 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A30Z&sr=b&sp=r&sig=NqlfLQSVgYWeExzO4oaPbnB2JaHjebwwp%2Fe5laQ2jqU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:30.9824178","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A30Z&sr=b&sp=r&sig=ELWuvE6zyHFBUwEZHr0K0RMPoDVLtRiVk58YVtT1u3w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:30.9823188","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A30Z&sr=b&sp=r&sig=bR4JqS8DAzPOiy89DAHrVWST20PCS58vTQ3Q1A8kKCg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:30.9824402","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A58Z&sr=b&sp=r&sig=LuABQwvSYomOs8I2oE%2FMwIoVwCDwgA9joWGqj3Dsyco%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:58.1451772","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A58Z&sr=b&sp=r&sig=x6z%2BGtZyxLjJhr%2Fknx4XAcMfJVQFy1JLYBvXT5OmJNw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:58.1450912","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A58Z&sr=b&sp=r&sig=ZdAlUiaOlVuE8kSIYw%2BWk%2F3%2BeFoZAycgWZTRNJSJRgw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:58.1451982","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3238'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:58 GMT
+      mise-correlation-id:
+      - 68680806-803b-4c0f-9f54-a5ca836adf9b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A03Z&sr=b&sp=r&sig=l7jS4%2FrSdfAwNQ2UQqMTrygLjSt5XEsG1BBgYWO98Ik%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:03.4208756","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A03Z&sr=b&sp=r&sig=U50xLOYyczMVZV0i1wzouxU9X61gu0rPOom0nWRWLac%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:03.4207906","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A03Z&sr=b&sp=r&sig=qhSWWSVhvuWDFTzXK3eRuIe08XVPG6qKMTgDdJWMDaY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:03.4209001","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3228'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:03 GMT
+      mise-correlation-id:
+      - dd1d74c2-5281-471f-9555-bb6fa13372db
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A08Z&sr=b&sp=r&sig=xPzyd7VN3R5k4HJ6jW%2BAS5PbJ3TynxPeh8H6CSu9oWo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:08.7487732","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A08Z&sr=b&sp=r&sig=KB5%2FMkQbXA3BZeael5VG12xhETkfiV5oYTX2KLieCRs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:08.748692","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A08Z&sr=b&sp=r&sig=5NnpOwZvg9JsZhtlGpAvQzsOKrwDoIxfI%2F00aHXDB5E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:08.7487887","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:08 GMT
+      mise-correlation-id:
+      - 6a4f47e4-f7ee-45e8-b25c-fc57b520efa9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A14Z&sr=b&sp=r&sig=daaW4Fk1q4YUBJMZEJjJMh7UEfuo3GfdcuXh5Z%2Fshfo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:14.0775565","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A14Z&sr=b&sp=r&sig=5%2FtS%2FNh6uQM40nlnu58CtPjVQH2NcqUAJw6w%2Fg2D7Qw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:14.0774654","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A14Z&sr=b&sp=r&sig=owWxa6ey0WE0v0NyY2K1I4qYiBBmNZzIj2jEO9eCCcw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:14.0775712","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:14 GMT
+      mise-correlation-id:
+      - eeebf519-60cc-498e-be1b-389d3b75ebfa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A19Z&sr=b&sp=r&sig=7Ygy8BtOqXoxVBCJIYfaapLRHV3VmhmG4A3jflkfnDA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:19.4121623","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A19Z&sr=b&sp=r&sig=gWs4MAW1zKIWL%2F7UOcQq3Udgl4ya6YAhuOE8GBjfG1Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:19.4120812","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A19Z&sr=b&sp=r&sig=ytZKToATVC%2Fp4hMXS8Bshq1ZmEJJ7NQA2b%2FvXaa0qFU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:19.4121775","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:19 GMT
+      mise-correlation-id:
+      - d6f72594-e087-4bbd-b526-ed6448d4b281
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A24Z&sr=b&sp=r&sig=eU1MVFKe7%2FW9M7zMkzDimgzg0ZRz7a9xNliqBe5vIso%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:24.7221011","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A24Z&sr=b&sp=r&sig=nHmXDnTrWWYjvIO7g3JUa4e3dYYkAcUN0qz8FIJhoDY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:24.722015","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A24Z&sr=b&sp=r&sig=DuNr2R1UHr0TvXpJVmOi4Xpe90Euirwza2yPsb39pSw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:24.722123","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3226'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:24 GMT
+      mise-correlation-id:
+      - 944b2020-67a2-42ec-85b2-629fcbc4544d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A30Z&sr=b&sp=r&sig=A09ui6IKX7Ps1p9XZqsVAgKn6vs1IyHLcBjO1Cgspwk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:30.031415","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A30Z&sr=b&sp=r&sig=kXKZt73fDxnPvAWk%2FTo8BhtWr766nucKZv5eupzO86s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:30.0313229","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A30Z&sr=b&sp=r&sig=RJ3cneInil9bUp2gvIk6hCwgWPFjIosco3s%2F7ENSaM0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:30.0314392","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1506,9 +1362,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:30 GMT
+      - Mon, 09 Oct 2023 19:21:30 GMT
       mise-correlation-id:
-      - f3412dc7-dc06-4d37-87f3-0d4bf9c698dd
+      - 9da0e665-e444-41c8-b9ed-a03dbe38b1cd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1528,23 +1384,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A36Z&sr=b&sp=r&sig=xR0QGlQXQpu5pi3ZWx665oZi27AtQY5%2BxM4Yg2dUI38%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:36.2637363","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A36Z&sr=b&sp=r&sig=tyoJ1ZGKc0ycwhzWGoOjz3o5xiYcpMA8AbvneewXGMY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:36.2636446","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A36Z&sr=b&sp=r&sig=Ue7%2Fu1uVVyc1SCI49DamhPkn0YaP%2FoPiHQSjRYL52o8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:36.2637536","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A36Z&sr=b&sp=r&sig=SOHk9UY3%2FdF4s6mofm9SiTySqEQTSZ%2F3BnOVUfTiodc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:36.3455087","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A36Z&sr=b&sp=r&sig=NQy3%2BW2TQ0sgZxWTmHt458nqPFJ4KPSQd6h%2B3g57F48%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:36.3454234","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A36Z&sr=b&sp=r&sig=Pq%2FocKvYpTK4PAumn6oWB06Hd255e%2BVJ7ZHodasBSUg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:36.3455231","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3233'
+      - '3238'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:36 GMT
+      - Mon, 09 Oct 2023 19:21:36 GMT
       mise-correlation-id:
-      - cabf334d-4e7e-47d2-b59a-ec87354519f6
+      - 08f89206-5a3c-4fd9-a55d-565b7060dde7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,23 +1420,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A41Z&sr=b&sp=r&sig=pPDyJ4XtX0V%2BOw%2BmSMa%2BZvVZEZphUFPrubhPXKqaLic%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:41.5289693","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A41Z&sr=b&sp=r&sig=Ptm8ICgpd8b61Tx6ckrCCN1hkMMwSsbfEQzwKGwwpkg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:41.5288971","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A41Z&sr=b&sp=r&sig=ieATPYND5KUIYGY3SLUoZRIzUno4Kb1We8Y7JBPSZEk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:41.528985","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A41Z&sr=b&sp=r&sig=yUEubmM0NwAAO%2FjNgXdJGD3rPTpr0V0S3H3qhDA0iVY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:41.7036693","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A41Z&sr=b&sp=r&sig=kkUH9x6DOBhuGBe5Lv9nObYM5Y%2BzTvK%2FrK22fg%2BYSX8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:41.7035769","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A41Z&sr=b&sp=r&sig=1WZajK9%2FuF%2F3mVyj6nZeovJTQfW0gwH90kVtjI9cjWc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:41.7036898","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3232'
+      - '3238'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:41 GMT
+      - Mon, 09 Oct 2023 19:21:41 GMT
       mise-correlation-id:
-      - f9704e6e-e60d-49e8-bd22-be928125028b
+      - a9df65b7-ee53-49d3-8aba-79960287619f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,23 +1456,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A46Z&sr=b&sp=r&sig=zsKRVbXJwjApOGwxwWaQK4P8mdLLpsge%2BFwPnwmWHbE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:46.8184519","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A46Z&sr=b&sp=r&sig=pJU%2BEe20kHRmZOLTbyjj7f770%2FR4NfeSYVh%2FB5fdoJ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:46.8183698","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A46Z&sr=b&sp=r&sig=FerYL2lO9yPiI9PKBxLhcI%2FxNdScYs6MaKKT6Vka%2Bi0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:46.8184681","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A47Z&sr=b&sp=r&sig=sP3LcGW3gM0515pYhqAAz21oMB5mcaciREQUju71cJw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:47.0525085","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A47Z&sr=b&sp=r&sig=OYj1OrSd6dUxOTx5tAGkrFruJIxPpuH2wMzAXN6VVck%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:47.0524326","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A47Z&sr=b&sp=r&sig=SETeA3qaRYPlP59R3o%2B%2FUP5oiELOnqLV9okL3FPpjPo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:47.0525265","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3239'
+      - '3230'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:46 GMT
+      - Mon, 09 Oct 2023 19:21:47 GMT
       mise-correlation-id:
-      - 7fb7fc95-0aed-42eb-b405-5f761bd92a75
+      - 06dd70e1-e772-4a16-b833-9c5985718a66
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,23 +1492,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A52Z&sr=b&sp=r&sig=Bi8EBS%2Be7PpLieqHZLlGSBiSnSl49EA10zZi%2Bb7jnJE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:52.0780052","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A52Z&sr=b&sp=r&sig=hlYZSQUPKIxJ1Bk7V%2BxpRI2bdzJfLaTDYbWqUVuzN54%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:52.077934","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A52Z&sr=b&sp=r&sig=kpXBx6F8ADqvgOsMHUcFUuDUswCitQVhUVcLyCcTWS8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:52.0780212","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A52Z&sr=b&sp=r&sig=Y1ytmf2cycgm9t6YHihmzDUFQ5ixy2vmOO9gY1mH08I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:52.3051837","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A52Z&sr=b&sp=r&sig=WfZNSkEtCliBGVW0OoMM3rwVKJKWNV9nC%2FDbkfzJA8c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:52.3050973","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A52Z&sr=b&sp=r&sig=prfI7nMJZqHda8Z%2Bvp7yYg%2BbT%2B176tNAZRSSCpAx4Aw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:52.3052048","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3232'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:52 GMT
+      - Mon, 09 Oct 2023 19:21:52 GMT
       mise-correlation-id:
-      - f5ee6c2f-8895-4d65-96fd-04a77f41790b
+      - 4776181d-efbc-4475-98bc-26b70483c6ae
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,23 +1528,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A57Z&sr=b&sp=r&sig=lh5Nq%2FNFM%2Bwr4uJhn6pFBBINk%2BBuJQQyS5FxPurRxRw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:57.3690945","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A57Z&sr=b&sp=r&sig=Ihx%2BvAmEOR9u3XYPRj5XikGyO3XBlb1n8Wt%2BZ9NcG3k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:57.3689935","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A57Z&sr=b&sp=r&sig=DcXimQ39dpMHHfExy3d5XD6U0VpMeEWXRqy5%2B8uDQU8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:57.3691189","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A57Z&sr=b&sp=r&sig=xiYNfu5260jPUZiDR36DGBBFC5zMt3s67vfhr5Yif08%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:57.5777906","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A57Z&sr=b&sp=r&sig=iQ6N12wkHpJ3EObQQ0dTQ84ySaKealZVNjDldeh8ojg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:57.5776743","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A57Z&sr=b&sp=r&sig=GR%2B5CpStV0vlMDSlisYVcwCLRDTbomeEQVKXcahXCsw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:57.5778172","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3239'
+      - '3228'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:57 GMT
+      - Mon, 09 Oct 2023 19:21:57 GMT
       mise-correlation-id:
-      - a4f1ec99-937e-44a0-94c8-e81b503332e8
+      - eb490280-2158-427b-9232-1e1f5d97f863
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,10 +1564,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A02Z&sr=b&sp=r&sig=VD04nXhfzz2Sk3LmRhDdeKaPUfgWYFqo3E5YSOeGGtU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:02.6556155","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A02Z&sr=b&sp=r&sig=Tjc9Iat6zIpRBWiaXkQUvSeHiGB7JuUcoDjgxdg8r38%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:02.6555288","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A02Z&sr=b&sp=r&sig=uwXcUWQfSl06Fy0xypkQIDC3TvhfJQKYdi7z4PlJ02w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:02.6556377","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A02Z&sr=b&sp=r&sig=XNjQBkyHzP8NNulDt1Fi4HUaeAigmkRzgVq8TBQosG8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:02.9054523","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A02Z&sr=b&sp=r&sig=20NIF6soigU2cYX9WS8mysXgOLE7MkUXZiYs8AkUim4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:02.9053578","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A02Z&sr=b&sp=r&sig=2o83m2merxBAHC41GfZURRp17cpCEIqfA%2FmwR0i3m0k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:02.905475","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1722,9 +1578,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:02 GMT
+      - Mon, 09 Oct 2023 19:22:02 GMT
       mise-correlation-id:
-      - 1affd881-6594-4259-8626-ee1fbf652363
+      - 3e989473-7b98-4e3a-8f33-5a47de56988b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,23 +1600,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A08Z&sr=b&sp=r&sig=et5%2BFSyRlkI2bdbCaM%2FXoIiaMXUB%2BcLfQPqnA74%2FXIo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:08.0156018","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A08Z&sr=b&sp=r&sig=8OwDNPiUjSmulPfoAXm5SfDJwarfk96J89uBJ%2BGsMOI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:08.0155353","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A08Z&sr=b&sp=r&sig=kmtTjvNrWKD651Zz%2FFie3qyTUbiuckI3juopYEtRVFE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:08.0156185","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A08Z&sr=b&sp=r&sig=gghHZgROhedLNVRUZDghaWkGDKwL%2FNClNPd1aYBJ9Lw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:08.2175385","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A08Z&sr=b&sp=r&sig=yP7qtXS8uwPGk773C%2FWsh1BNPVo6ucN9DMVPdEGERTQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:08.217457","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A08Z&sr=b&sp=r&sig=5kDzVQVtwQfhENg1Crec8L%2Bo3XyfXKTGB%2BXuIU1HSks%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:08.2175597","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3239'
+      - '3233'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:08 GMT
+      - Mon, 09 Oct 2023 19:22:08 GMT
       mise-correlation-id:
-      - e7d8c284-078f-42c1-a94a-5dafa1085c12
+      - 934eb167-54f4-44ae-8bf3-81b296ad94b1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,24 +1636,204 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A13Z&sr=b&sp=r&sig=mAW%2Bk8WDVLhuAajaTKVQk5e7KE1RvZYGm2QMNfKMrWk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:13.2983378","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A13Z&sr=b&sp=r&sig=JQhy8SMg4v8NAMu6nxXekyX975RgScyI4nz42nrirEw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:13.2982439","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A13Z&sr=b&sp=r&sig=VBKpWLRSJV42f6sdr7zCvuNRr75rU0a5swFTfcafrPk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:13.2983604","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-09T16:13:34.509Z","endDateTime":"2023-10-09T16:16:11.959Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:12.04Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A13Z&sr=b&sp=r&sig=BvrAbNZ%2FBgsDOGeYsLGZK8%2B1N%2FrTaWEB4uygvh7ksVQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:13.4846083","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A13Z&sr=b&sp=r&sig=j1%2B8%2BxBxVp0snsGbEv19CgQt3j%2FuXnU7k%2FCzpR5C49Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:13.4845131","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A13Z&sr=b&sp=r&sig=PiBBFPFEfItsjtYJKnsthVsviOaX8gyQbDddjBsi7fI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:13.4846288","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3363'
+      - '3240'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:13 GMT
+      - Mon, 09 Oct 2023 19:22:13 GMT
       mise-correlation-id:
-      - 0a727938-4d42-4118-82b1-df453759765f
+      - a17013fd-e45a-4a38-85b0-6a693c5439c4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A18Z&sr=b&sp=r&sig=1xC2laXoFEzrRwShsI8alb8XzzTRYAMz1SlylLRZx0Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:18.7481895","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A18Z&sr=b&sp=r&sig=hBYc4hBFLKpFhvcfoKN%2BhrKKR4fgOP2WHe4q07Rt81w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:18.7480605","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A18Z&sr=b&sp=r&sig=%2B9jdV6TIqh4Hy5nm2TR9VrKYHXQ2jycproqMP0VHoyg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:18.7482124","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3230'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:18 GMT
+      mise-correlation-id:
+      - cf868a99-d34d-472f-b170-3f718c3bc7e1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A24Z&sr=b&sp=r&sig=2epy5F8t5vJ7ie%2BlAU%2FpYoZLL0mXxqRJzEqoPV6b2iM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:24.0430906","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A24Z&sr=b&sp=r&sig=mL%2BWdgE2%2FN7eTBbi0sAz95PAyuyFIk%2F0ga%2BW%2Bo1Y2Yk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:24.0429513","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A24Z&sr=b&sp=r&sig=ThJwD8mmFaxFEoqORfg%2FnX2HtS%2BkixazhkyzxiQHHFY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:24.0431117","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3244'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:24 GMT
+      mise-correlation-id:
+      - a71822fc-988f-45cd-8179-e67786501e27
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A29Z&sr=b&sp=r&sig=FO9NtA6Cy0Bi8o%2BcwdLJGAOYoIdiJnIgwEeMTnL5ONY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:29.4026895","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A29Z&sr=b&sp=r&sig=IHc%2BHp5jgt0fyaHtLHZc3cU%2Ba87Xoe1RRR4v%2FvIjYi4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:29.4025872","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A29Z&sr=b&sp=r&sig=TNI1YYWbvE6GDaT%2F9Q1GR3CuJCtyk0HN40XUy4MOuAU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:29.4027123","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:29 GMT
+      mise-correlation-id:
+      - db6994cc-8e78-4bbd-bba3-e50bac69eba2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A34Z&sr=b&sp=r&sig=qSNIon9vmlKXx9vUc2CDuKOiMlS22kkERhE36VVPFwU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:34.661683","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A34Z&sr=b&sp=r&sig=xSBl2MKKL2T863EprrLI6MiPbwin7D9E%2BRP6FDxUMFo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:34.6615548","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A34Z&sr=b&sp=r&sig=B1EBlSeV99vdFiUtsKbB8284p33XTMgkCoW%2Fu8DMJ%2Bo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:34.6617112","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:19:53.578Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:47.039Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:34 GMT
+      mise-correlation-id:
+      - 7caee6a0-cf38-465a-b592-6b6099e02875
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A39Z&sr=b&sp=r&sig=ut7XpDZFDbX2qgLkgwkreR5aytj7%2BGzX9sw2Q2O6rJ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:39.9692748","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A39Z&sr=b&sp=r&sig=nu56Djwv1MS55hvHEkmiTOVw7YV2FnUcLnzjgCtV%2BM0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:39.9692007","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A39Z&sr=b&sp=r&sig=9rGHVf4rq3qbiMmm2Jyi7jbmTF69n47%2BzirKJdHC2UM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:39.9692969","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-09T19:19:53.578Z","endDateTime":"2023-10-09T19:22:39.859Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:39.938Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3367'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:39 GMT
+      mise-correlation-id:
+      - a87bbe19-f203-440c-befc-741a0b514d22
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,7 +1856,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:12.6666047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:12.6666047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:30.9716153Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:30.9716153Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1829,9 +1865,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:13 GMT
+      - Mon, 09 Oct 2023 19:22:41 GMT
       etag:
-      - '"9201a1af-0000-0100-0000-6524265e0000"'
+      - '"5600ef16-0000-0100-0000-652452090000"'
       expires:
       - '-1'
       pragma:
@@ -1861,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=app-component-test-case&api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=app-component-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A14Z&sr=b&sp=r&sig=r6G1zOFXP358pyq8bQYKNe60%2BnY4ABN2Rx%2B0CP6%2F4xY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:14.8450505","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A14Z&sr=b&sp=r&sig=wErZFvqQQ2qR98F%2B4IwonaeeIWldEOrVomsjsaDpPqM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:14.8449845","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A14Z&sr=b&sp=r&sig=uSsfQJab77sWUg03a13YbfzSo1TrVUgl3kti9Fmg9Pk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:14.8450647","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-09T16:13:34.509Z","endDateTime":"2023-10-09T16:16:11.959Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:12.04Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"edbac2db-f6a3-4803-9ac1-6d344cd7196e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75b13386-0b49-4125-8e94-65d3bf40c008":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"52c44c55-9403-4c9a-baf0-87504612ca95":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/6ed54c91-3d61-4057-a691-97d3dd233294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A42Z&sr=b&sp=r&sig=JS1YUTn0vK6kJcc1vdgsf%2BHFCb6TnpnCytzicMjCBw8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:42.245244","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/823efb20-33f3-49ba-9239-7ba52433ee34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A42Z&sr=b&sp=r&sig=DX3ImZ7mIWLBqxXwyN3PxkGY9WYX4MYfi%2Bvvt1vGGIg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:42.245171","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bc037ecf-9068-40f0-9b38-802132342cbd/d557c779-2094-4f05-93d6-55dd9268b419?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A42Z&sr=b&sp=r&sig=aDjitIv6lo1409xwDvNREM8d7LlsEjThMm2TLMPx0EE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:42.2452614","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-09T19:19:53.578Z","endDateTime":"2023-10-09T19:22:39.859Z","executedDateTime":"2023-10-09T19:19:52.78Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T19:19:53.041Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:39.938Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3381'
+      - '3375'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:14 GMT
+      - Mon, 09 Oct 2023 19:22:42 GMT
       mise-correlation-id:
-      - 5dcff09f-03f4-415c-a01d-4999af763f6a
+      - d5548e24-4c7b-4c3e-a8e0-afc7d4e63a5f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1905,7 +1941,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-09T16:12:47.3253639Z","key2":"2023-10-09T16:12:47.3253639Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T16:12:47.3253639Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T16:12:47.3253639Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-09T16:12:47.1535497Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-09T19:19:06.2113337Z","key2":"2023-10-09T19:19:06.2113337Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T19:19:06.2269525Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T19:19:06.2269525Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-09T19:19:06.0238654Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -1914,7 +1950,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:16:25 GMT
+      - Mon, 09 Oct 2023 19:22:52 GMT
       expires:
       - '-1'
       pragma:
@@ -1947,7 +1983,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:12.6666047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:12.6666047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:30.9716153Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:30.9716153Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1956,9 +1992,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:26 GMT
+      - Mon, 09 Oct 2023 19:22:53 GMT
       etag:
-      - '"9201a1af-0000-0100-0000-6524265e0000"'
+      - '"5600ef16-0000-0100-0000-652452090000"'
       expires:
       - '-1'
       pragma:
@@ -1977,9 +2013,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-nbvjxnmoj3xym5hjv/providers/Microsoft.Storage/storageAccounts/clitestloadw4qcwvheu":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-nbvjxnmoj3xym5hjv/providers/Microsoft.Storage/storageAccounts/clitestloadw4qcwvheu",
-      "resourceName": "clitestloadw4qcwvheu", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ydnn7ff3t3qwkq5td/providers/Microsoft.Storage/storageAccounts/clitestloadxggg3gf52":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ydnn7ff3t3qwkq5td/providers/Microsoft.Storage/storageAccounts/clitestloadxggg3gf52",
+      "resourceName": "clitestloadxggg3gf52", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -1995,10 +2031,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-09T16:16:27.855Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:27.855Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-09T19:22:55.664Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:55.664Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2009,11 +2045,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:27 GMT
+      - Mon, 09 Oct 2023 19:22:55 GMT
       location:
-      - https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+      - https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - c0459ab9-2f72-4f2f-80b5-c5694e5dfc13
+      - 190966ff-a484-45a0-b457-195286a9232e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2036,7 +2072,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:12.6666047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:12.6666047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:30.9716153Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:30.9716153Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2045,9 +2081,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:29 GMT
+      - Mon, 09 Oct 2023 19:22:56 GMT
       etag:
-      - '"9201a1af-0000-0100-0000-6524265e0000"'
+      - '"5600ef16-0000-0100-0000-652452090000"'
       expires:
       - '-1'
       pragma:
@@ -2077,10 +2113,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-09T16:16:27.855Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:27.855Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-09T19:22:55.664Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:55.664Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2091,9 +2127,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:30 GMT
+      - Mon, 09 Oct 2023 19:22:58 GMT
       mise-correlation-id:
-      - d2da2e58-30e6-4758-9c5c-6502911f0b3e
+      - e2bc9fc5-765a-46dc-be1c-517060b0e9d9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2116,7 +2152,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:12.6666047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:12.6666047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:30.9716153Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:30.9716153Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2125,9 +2161,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:30 GMT
+      - Mon, 09 Oct 2023 19:22:59 GMT
       etag:
-      - '"9201a1af-0000-0100-0000-6524265e0000"'
+      - '"5600ef16-0000-0100-0000-652452090000"'
       expires:
       - '-1'
       pragma:
@@ -2146,7 +2182,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-nbvjxnmoj3xym5hjv/providers/Microsoft.Storage/storageAccounts/clitestloadw4qcwvheu":
+    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ydnn7ff3t3qwkq5td/providers/Microsoft.Storage/storageAccounts/clitestloadxggg3gf52":
       null}}'
     headers:
       Accept:
@@ -2162,10 +2198,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-09T16:16:27.855Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:31.674Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-09T19:22:55.664Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:00.474Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2176,9 +2212,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:31 GMT
+      - Mon, 09 Oct 2023 19:23:00 GMT
       mise-correlation-id:
-      - 355778e6-6c9b-442a-a44f-70e40fa93ac3
+      - a0256f52-cab8-4aa3-b018-c313b7da7b50
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2201,7 +2237,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:12.6666047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:12.6666047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:30.9716153Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:30.9716153Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2210,9 +2246,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:32 GMT
+      - Mon, 09 Oct 2023 19:23:01 GMT
       etag:
-      - '"9201a1af-0000-0100-0000-6524265e0000"'
+      - '"5600ef16-0000-0100-0000-652452090000"'
       expires:
       - '-1'
       pragma:
@@ -2242,10 +2278,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://ea8b2a8f-9db3-411e-ae11-3df7138ec7db.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-09T16:16:27.855Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:31.674Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-09T19:22:55.664Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:00.474Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2256,9 +2292,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:34 GMT
+      - Mon, 09 Oct 2023 19:23:02 GMT
       mise-correlation-id:
-      - 411ce6c7-1567-4ad1-8266-0ac02fa25806
+      - 2a6b2745-e6a5-4954-a650-370b1cc6e06a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_app_component.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_app_component.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:00.9207417Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:00.9207417Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:07.3353753Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:07.3353753Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:58 GMT
+      - Mon, 30 Oct 2023 07:22:04 GMT
       etag:
-      - '"3c003d28-0000-0100-0000-653edacf0000"'
+      - '"3f00ab6a-0000-0100-0000-653f59650000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:21:59 GMT
+      - Mon, 30 Oct 2023 07:22:05 GMT
       mise-correlation-id:
-      - 9d1c2648-1cb3-4034-8a56-bde0e59a3093
+      - 1419ddfa-b09d-4084-8ecd-07b2bdf3bd07
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"3641458f-9f86-4d48-b54d-2afc955e4211": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "d7c5c239-9478-425e-8312-559c57b34fda":
+      {"passFailMetrics": {"d1fede50-4b32-409d-9c17-5aab55c44e92": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "a7d644dc-1c94-4580-9833-5b86499a8906":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "505a1c97-3b9e-42ff-a88b-d7b9547cfaf7": {"aggregate": "avg", "clientMetric":
+      "50"}, "61a79b8d-faea-43a3-a574-75a87ec406df": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:22:00.266Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:00.266Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:22:06.369Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:06.369Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:00 GMT
+      - Mon, 30 Oct 2023 07:22:06 GMT
       location:
-      - https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+      - https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 28a8f7a1-59db-4530-8769-1419c710942c
+      - 80046539-5314-497b-95c2-dbfc98381948
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:00 GMT
+      - Mon, 30 Oct 2023 07:22:06 GMT
       mise-correlation-id:
-      - 56880678-bcae-4433-a2f5-252e54b7b047
+      - 3e393484-162b-4039-a557-cbd5dfe8fbd3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A01Z&sr=b&sp=r&sig=ocOUgiBGt0h5drwJ0iPK1S%2BZSmbjMZSHym8gtKc1%2BUk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:01.7741128","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A32%3A07Z&sr=b&sp=r&sig=kCWsaCcNV3VsDStZCx6izo66NINvQY80L3TCFlkMsIM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:32:07.3146774","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:01 GMT
+      - Mon, 30 Oct 2023 07:22:07 GMT
       location:
-      - https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 03f25aa0-f3b6-40aa-b51d-5974cc0d1d09
+      - 92911eda-f29d-436d-a716-b33ad69d2e3e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A02Z&sr=b&sp=r&sig=0DWX%2BujSv0K8q6fRuQ%2BGo084q4A2Huuj9D34yds0j28%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:02.0113781","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:22:02 GMT
-      mise-correlation-id:
-      - b39c23fb-40c6-4aaa-b9df-40456852060d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A07Z&sr=b&sp=r&sig=unaIAtgtEKlKsnB3%2Fo%2FMatbxavTg8J1sE6Yb2Ubwy7M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:07.3391233","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:22:07 GMT
-      mise-correlation-id:
-      - 265e8ad5-4f6a-4a89-9dda-0d961d2ec96c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A12Z&sr=b&sp=r&sig=T1HD9%2BJqJU1129HPGA43ccRSFglL5Q2iGLmC4P54670%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:12.6114642","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A32%3A07Z&sr=b&sp=r&sig=1acmrOjFSjFc%2BZ9v08L4rTZCc5vzwTLBHYmpSMHvVMQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:32:07.6701644","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:12 GMT
+      - Mon, 30 Oct 2023 07:22:07 GMT
       mise-correlation-id:
-      - a4165445-3de3-4d13-b9fa-ef46dc0b9497
+      - a29e52f8-25ea-4776-99e7-7fb9f09506a6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A17Z&sr=b&sp=r&sig=Jl8EFSO77hZWeyqAkzJ5CLjhFYgRpy3eHIYrhBM20Hk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:17.8921659","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A32%3A13Z&sr=b&sp=r&sig=DlVD9xBkow4A3nM6qSRR2uM8CD0QOaZPyjheqa0Q1Fg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:32:13.000332","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '548'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:17 GMT
+      - Mon, 30 Oct 2023 07:22:13 GMT
       mise-correlation-id:
-      - 303a353e-21d3-412e-ad6d-6c40d45afb76
+      - b5f279e0-f0a0-4770-b3ed-8a248c4366f5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +385,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A18Z&sr=b&sp=r&sig=DRluhveBPObJSXlz5CYVvhlIB%2FihkQ5GvZwVrfzk%2FNc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:18.1489714","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:22:00.266Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:14.991Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A32%3A18Z&sr=b&sp=r&sig=FvfLbtblsdBMmkERre6l26buHGH9ywJz2h3wXg4yyoM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:32:18.2658479","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1588'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:18 GMT
+      - Mon, 30 Oct 2023 07:22:18 GMT
       mise-correlation-id:
-      - cba63fb4-3ce7-4600-908d-ea8c94e53c27
+      - db1b0b38-36c9-4a9a-91d4-27bf54301d8c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A32%3A23Z&sr=b&sp=r&sig=HtSOjdCZlnQRho8ZlhKuRlFzIUR79yf6HZ57cwvuzWM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:32:23.541333","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '546'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:22:23 GMT
+      mise-correlation-id:
+      - 07ac3901-695c-4881-910b-30d6ab4c3319
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A23Z&sr=b&sp=r&sig=vg%2FPoA2OytXzmhwPEyP%2BXY%2FmSJLis0s6Y07uhPkhcFY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:23.848376","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:22:06.369Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:20.434Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1589'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:22:23 GMT
+      mise-correlation-id:
+      - 6528ee8c-9563-447b-9ad4-48f5be22bdd4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:00.9207417Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:00.9207417Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:07.3353753Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:07.3353753Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:19 GMT
+      - Mon, 30 Oct 2023 07:22:25 GMT
       etag:
-      - '"3c003d28-0000-0100-0000-653edacf0000"'
+      - '"3f00ab6a-0000-0100-0000-653f59650000"'
       expires:
       - '-1'
       pragma:
@@ -538,11 +538,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A20Z&sr=b&sp=r&sig=uMbMKOEGT57mZOYHEmPy%2Fl2tfcUpaGlw3Pg5kuJnGJg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:20.3827162","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:22:00.266Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:14.991Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A26Z&sr=b&sp=r&sig=Mv3L3U7i3GYa07bV93bviiwcf%2FZDay347qBMUBbh918%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:26.3695298","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:22:06.369Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:20.434Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:20 GMT
+      - Mon, 30 Oct 2023 07:22:26 GMT
       mise-correlation-id:
-      - 6e04acd6-a486-4635-9f17-138da9df6100
+      - 56c99f3b-9a31-4a06-a668-ebc7f39f6c68
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:00.9207417Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:00.9207417Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:07.3353753Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:07.3353753Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:21 GMT
+      - Mon, 30 Oct 2023 07:22:27 GMT
       etag:
-      - '"3c003d28-0000-0100-0000-653edacf0000"'
+      - '"3f00ab6a-0000-0100-0000-653f59650000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:22:22 GMT
+      - Mon, 30 Oct 2023 07:22:28 GMT
       mise-correlation-id:
-      - 6d467318-cb88-45c5-a5c9-31ae9058243f
+      - c13e58ca-bac8-440d-ae7c-f5b1fe31276f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A23Z&sr=b&sp=r&sig=qh1mmCA8Fo%2FhIYTcamTZmakSoDLKjUib%2BhdKzDtdwGU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:23.3435431","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A23Z&sr=b&sp=r&sig=o6AHzOBX42HexqhC3HqZ3PQbMjYfa1S3qzK%2FcDdmjHQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:23.3433685","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A23Z&sr=b&sp=r&sig=IarYgXj1FVPOEb4IYlFefeEXPJEQXyjaVkM4G7ApR2I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:23.343584","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:23.258Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A30Z&sr=b&sp=r&sig=a6TXPnWlBmzswvxmaql6uM8YAffM76EymHcaLb9kMgA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:30.2972766","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A30Z&sr=b&sp=r&sig=A4p2nuO0u%2FSfJveNoA7EHsY188ZSqJR5urHM%2FkZtu04%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:30.2970945","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A30Z&sr=b&sp=r&sig=wUt9XC0OcDkF6c3dUhqHfEfgrSBj64rorYJs3UmGVzc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:30.297307","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:30.208Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3188'
+      - '3186'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:23 GMT
+      - Mon, 30 Oct 2023 07:22:30 GMT
       location:
-      - https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+      - https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - abee526d-fce1-4848-a6be-3975b1210867
+      - 1ab8203e-b247-4402-92a1-32218e03874d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,298 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A23Z&sr=b&sp=r&sig=bBRdl3q8Ht5O0HY7YxxJWRD4oD1ouWx42KB4OGTzO8M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:23.8461707","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A23Z&sr=b&sp=r&sig=vCMhnh01LrRh4%2FZATw98KgGyH%2Fef3MOYgG9CfD7dtC0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:23.846101","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A23Z&sr=b&sp=r&sig=L3pNAPu2yT0nqU1AGGsiSavkBmpk%2FwlM6OghsANHT0s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:23.8461862","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"NOTSTARTED","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:23.802Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3233'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:22:23 GMT
-      mise-correlation-id:
-      - 20fbd330-1946-442c-97a0-b01f9a8b7c84
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A29Z&sr=b&sp=r&sig=UtyCO1JrgY%2BeHqvlHBPK8aVTkHeW3Z1TOXS0MS4lkic%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:29.114898","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A29Z&sr=b&sp=r&sig=4lvvnkvkQSFuA0PFmi9%2FMp29El0eCgic3%2FxhQ9Y16hk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:29.1148309","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A29Z&sr=b&sp=r&sig=ASo%2FnTgqAiOXL6BDeZBsNjwP049GMlVxEfWdLAqyTwo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:29.1149119","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:24.005Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:22:29 GMT
-      mise-correlation-id:
-      - d781e149-3230-4bda-aa9f-dea09563d20e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A34Z&sr=b&sp=r&sig=zKoc8M%2Bd39BZmyQelvczLqehdnyL3rPOSde2xGL2W48%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:34.4053167","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A34Z&sr=b&sp=r&sig=KJb2n%2B6f0uWCKoSOArTsG1%2FfXxCcsEv7SgZiypBELs8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:34.4052349","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A34Z&sr=b&sp=r&sig=b120dkfHUM5vnuKDV1UJsFcSpQDRWnhfEaga9CDlF84%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:34.4053343","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:24.005Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3236'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:22:34 GMT
-      mise-correlation-id:
-      - 0bde6c3e-1d37-42ae-bea0-c4a9b8dfc305
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A39Z&sr=b&sp=r&sig=PXOrdLgRvbnQfVIP2iRxWXIjplucANP%2BbuaOQGUnb64%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:39.6833367","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A39Z&sr=b&sp=r&sig=UYQhModZkDedCj72TpSsPAJ3Fxv8ElT6u3qNAaXolnA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:39.6832694","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A39Z&sr=b&sp=r&sig=dp%2BuqRUBH1lqfseWf95WjzxxAwWjj31VwK0UxOCrQZs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:39.6833516","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:24.005Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:22:39 GMT
-      mise-correlation-id:
-      - 9c40b77f-f0ed-44a4-a1a5-43240b0ae974
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A44Z&sr=b&sp=r&sig=iG%2BOHQOMwNCcBnugfkpZ8FHKN%2BMgHf9ZNqKUcUBi6Ks%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:44.9441296","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A44Z&sr=b&sp=r&sig=qtbcnYqatw1Sa60aIEbiIZ6a%2BiqG339LIbMghK6G6ok%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:44.9440317","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A44Z&sr=b&sp=r&sig=2JzgnJx0XJNpBqtc63%2BEtzBNEBAeySfwApQY9sYiwxQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:44.9441437","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:24.005Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3238'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:22:44 GMT
-      mise-correlation-id:
-      - 170fd92d-af42-47fe-ac7b-cd12a2536d27
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A50Z&sr=b&sp=r&sig=GSFi%2FJLPfvnQ1TIey%2B6LfNplksMFmTHzB%2FyRaBIRL04%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:50.2633424","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A50Z&sr=b&sp=r&sig=L1H7V14BHarAGP214p5NQ%2F2tZ5jcDw%2BnVtBg6OEb8dA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:50.263272","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A50Z&sr=b&sp=r&sig=6CBofTGG7G92SnpM%2BuSpvsync%2FElV2cDc3F0O4nrIz4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:50.2633565","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:24.005Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3243'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:22:50 GMT
-      mise-correlation-id:
-      - 62ac1692-5781-4235-b151-00fc3b738492
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A55Z&sr=b&sp=r&sig=S%2B6mrbcqBIYKCp%2BTw2He8QpWW0M5g6YBoURKv0OlUww%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:55.5639871","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A55Z&sr=b&sp=r&sig=k52BPAaJUf7IABwvYvgNbms8hIUWX52Xjb9oZOo6HEo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:55.5639191","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A55Z&sr=b&sp=r&sig=vcXuIox%2BpJmdcYAY%2FME0c3cC0x0kMdnohwLY9cIeY3U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:55.5640014","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:24.005Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3238'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:22:55 GMT
-      mise-correlation-id:
-      - 5ed4ac3a-ee7f-4d2f-a2f1-ad27c8df7742
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A00Z&sr=b&sp=r&sig=mD0sHKnZFZOG26qPLA0nLrTeUw65pGZdPHfT%2F%2FABtHY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:00.8944415","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A00Z&sr=b&sp=r&sig=PCSIKDSI2aFOSlqpcr4GZBo7xLcENVmUnGs%2B8KJ%2B9io%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:00.8943537","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A00Z&sr=b&sp=r&sig=mHNQQAteGEB8gyhlqRum09qx4VJa2wF4cJ6s0Vi4H%2BE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:00.8944631","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:24.005Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3240'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:00 GMT
-      mise-correlation-id:
-      - ffae8822-c7c8-44c7-b77e-632ddcbad68a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A06Z&sr=b&sp=r&sig=swezC8iKuQ691ZOnnffUaKpd%2BjfoclDJooGZn94RBS4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:06.2114389","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A06Z&sr=b&sp=r&sig=RifiuzqxFgRRmyoS7ybErKiQAYYNEfOm0vzL0NMO90Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:06.2113674","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A06Z&sr=b&sp=r&sig=S1GbRgNQMPl9NFZFg7dQsd48MvDBYhgqgShO1hVYGek%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:06.2114527","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:24.005Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A30Z&sr=b&sp=r&sig=a6TXPnWlBmzswvxmaql6uM8YAffM76EymHcaLb9kMgA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:30.8196693","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A30Z&sr=b&sp=r&sig=A4p2nuO0u%2FSfJveNoA7EHsY188ZSqJR5urHM%2FkZtu04%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:30.8195752","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A30Z&sr=b&sp=r&sig=wUt9XC0OcDkF6c3dUhqHfEfgrSBj64rorYJs3UmGVzc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:30.8196901","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"NOTSTARTED","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:30.697Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1002,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:06 GMT
+      - Mon, 30 Oct 2023 07:22:30 GMT
       mise-correlation-id:
-      - 03ea6e8a-a81d-43a0-b6cd-04f6c29242e6
+      - 5a0626e3-42f9-4dbe-aed7-5c12705e371b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1024,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A11Z&sr=b&sp=r&sig=oaK7n%2BXDOGboYHg365QHU2NPHk4Rt6o%2B1rIK4LVEXVs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:11.4627402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A11Z&sr=b&sp=r&sig=FrPDB4RPJLu5Sii2ZYSLkQA0rRJdhqNJwGeKDglxHgg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:11.4626502","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A11Z&sr=b&sp=r&sig=HLZHJT5mD5m74MSHZ9sWQyw7mWQ2mhiHK5pEXlyGhW4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:11.4627623","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"CONFIGURING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:10.709Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A36Z&sr=b&sp=r&sig=bBPkH79HWDPCrdvdotdcrWTPGdLlcGxsbnICSJ%2F47PE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:36.0902814","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A36Z&sr=b&sp=r&sig=juGOm%2FpKqk4eVD1Sk9CSeie0Ee3a0gZlBvVFn2ZIUQI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:36.0901875","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A36Z&sr=b&sp=r&sig=S82%2B4chrZvcK9UAkIo2Dpre9fY49MoPFgmfXe%2BDSL1c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:36.0903029","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:30.926Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3233'
+      - '3238'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:11 GMT
+      - Mon, 30 Oct 2023 07:22:36 GMT
       mise-correlation-id:
-      - c2c05698-d23c-4f14-823a-443019cc757e
+      - 85193ad6-6caf-4f67-9101-e257f16a64d7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A16Z&sr=b&sp=r&sig=N%2BQRGdC6gr62B2cj7d6X%2BLTzRZ%2FdV24U3MpsDZpGyVo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:16.7685896","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A16Z&sr=b&sp=r&sig=ROzqb%2F9hSIJ%2BoAQqkCtpLlCyJsqE6ywqiHmDItNkpow%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:16.7685162","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A16Z&sr=b&sp=r&sig=UHUTyR%2BmS%2B7vRp9A7oF2tLUrH8heArmIzvCfUj3Jaf8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:16.7686059","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A41Z&sr=b&sp=r&sig=wN6Fko1fhnNzxcAHgyupf8GOgNHE%2Bcr6DRKsppIXHCw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:41.3933429","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A41Z&sr=b&sp=r&sig=AxDI%2FTbBKOPQ6vRH1EzzfxRh%2B0neTYxVO71chI4dsBg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:41.3932643","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A41Z&sr=b&sp=r&sig=yVKTj%2BqKmwoiWqAkpNAvptQc7qczX0V1uIiM8nXHJ7w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:41.3933577","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:30.926Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3240'
+      - '3238'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:16 GMT
+      - Mon, 30 Oct 2023 07:22:41 GMT
       mise-correlation-id:
-      - 252ad9da-5bca-412d-a184-56d00b5f6a14
+      - 3a929b26-a3ce-4e7a-b726-8d47862b1d12
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1096,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A22Z&sr=b&sp=r&sig=IH1%2B%2BvVNAOihVIkgIZvnZLs1enTc2K6Pdd0kb7HXNmY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:22.0272983","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A22Z&sr=b&sp=r&sig=tcw8kLMXnwY1HnO4W9l3My7miPLGOGmsZN5qO6wThxU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:22.0272104","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A22Z&sr=b&sp=r&sig=%2B57iUdaQY7GM3QBKPwSj5paKTwO9iPI4gceZoN%2BESDA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:22.0273156","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A46Z&sr=b&sp=r&sig=7n6f4zWkSJYBemsfrU3TNFMJkSDCFqBzqo2TTayfDtU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:46.687361","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A46Z&sr=b&sp=r&sig=M9v1Uxr%2F%2BC7u0cu%2BRbVJ371rLlNdp8p697THMuJ5h1M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:46.6872947","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A46Z&sr=b&sp=r&sig=tnn88mHG2Iwo35go%2BrFqOhCsA%2B%2BOm4jPBzcq%2Bdt1h0s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:46.687375","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:30.926Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3234'
+      - '3242'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:22 GMT
+      - Mon, 30 Oct 2023 07:22:46 GMT
       mise-correlation-id:
-      - 01661ede-ae50-448d-b531-e8b0b9db2ba7
+      - 0e99ee5f-63f9-4454-bfd9-d02e40bd1ba3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1132,334 +844,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A27Z&sr=b&sp=r&sig=PzV0SdfRODDx1oiBYTNa5T%2BYdCGDDRujUIsdLjQuAzM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:27.2959589","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A27Z&sr=b&sp=r&sig=XEx2gcR8pfqmg7YG8DVSHNUQfz%2FuWLRfg9AwtP4AJ78%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:27.2958776","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A27Z&sr=b&sp=r&sig=aF9Cds%2Fs7ljsM8b3jGzgUAnGmL%2FVz5B8GOCxybrnC2U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:27.2959732","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:27 GMT
-      mise-correlation-id:
-      - 5dd0d4e3-b13b-488e-9591-c927184a48c6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A32Z&sr=b&sp=r&sig=ph9zB7QEyjq25wX5edbURwDNo5ocQhqYQidYy1NplOo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:32.5849402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A32Z&sr=b&sp=r&sig=l13l3SF01%2Fy6fDhRxSJ7w4wuTq%2FWZDsK%2BqQ2tYlY9es%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:32.5848511","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A32Z&sr=b&sp=r&sig=sNHEhe3h0q22xg3WGsythHQsIUXCugXgKp7F8Q44%2BD8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:32.5849557","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:32 GMT
-      mise-correlation-id:
-      - e8427e13-9961-4d29-938a-ccd127998344
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A37Z&sr=b&sp=r&sig=EvHPw%2B8St76k3ljL6M3deIgGOgUk6H2ZEs%2BO9DhvVNc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:37.8323447","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A37Z&sr=b&sp=r&sig=vEdeBWy%2BplI8WUjI2mCXlwrMA%2B3tG31%2Fk6YbBKG10bQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:37.832275","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A37Z&sr=b&sp=r&sig=wKBi%2Fam66Osvl9nHBNfYw%2Bjx%2BBMvCQSLTr1DySqIrxw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:37.8323588","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3241'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:37 GMT
-      mise-correlation-id:
-      - 00356888-1f74-4fd8-845a-3999c256ae8b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A43Z&sr=b&sp=r&sig=sOAAmjDbhrQajS9%2FWeKLrL6sRo4CXwqnidYw1zGcl5Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:43.4028054","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A43Z&sr=b&sp=r&sig=qBcPhDbWJjBQO%2FU0vPHmvlKUU9NkP41GUWnnA9tqPAU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:43.4027057","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A43Z&sr=b&sp=r&sig=iN8WZZfbeVWJD6GnQrk0X3swzkactLbQ6Pv4mnbSCVI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:43.4028262","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3230'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:43 GMT
-      mise-correlation-id:
-      - af00a301-ac49-47e4-b534-5ba62a2da1c2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A48Z&sr=b&sp=r&sig=HUWXkjUf8wzuGERHEglSaTavEQ0cyPW89xScBGMvlSE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:48.7057788","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A48Z&sr=b&sp=r&sig=RxAuLQhCulpepj2GGNgMo3vEab4c9jJpn2HNZsI%2BiVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:48.7056872","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A48Z&sr=b&sp=r&sig=oAol9ZU32PAMKdsixyu4uDrLQ5UEF6Yry9Z5Gtp%2F8Q8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:48.7057996","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3230'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:48 GMT
-      mise-correlation-id:
-      - 9724105c-0b7d-4025-ad4d-665d24480bee
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A54Z&sr=b&sp=r&sig=dx5wnm%2FLqNPXRjGtrMMX8yXQmqeg4Kev0EC9LIUyph0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:54.0562051","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A54Z&sr=b&sp=r&sig=YHPQWwW98yJZvQK%2Fg2qBJqgMhD3m%2FTGFgyomwg50TN8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:54.0561161","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A54Z&sr=b&sp=r&sig=jDnf04oUGL1%2Bb1yBjn5ROqHpY94TzuNyn%2FLaCiW0sJs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:54.0562263","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3236'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:54 GMT
-      mise-correlation-id:
-      - d0b90500-21d0-45ef-b0a9-322484a6ac6f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A59Z&sr=b&sp=r&sig=eKGdEWbBjDAh%2BkLlM1uikaOlKnABFLYbEHGjSptk1EE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:59.315162","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A59Z&sr=b&sp=r&sig=W0zdVjhVk5nJsYiCIfY3wxl%2FOsBROlQnSzAuALVPHgo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:59.3150692","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A59Z&sr=b&sp=r&sig=llxB0F1gcUGCq3RrqQEYimtDQuEDrlQ9t6RZB%2BBwBlE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:59.3151784","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3231'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:59 GMT
-      mise-correlation-id:
-      - 0af835f6-4bb6-41eb-a464-5becb82c55b1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A04Z&sr=b&sp=r&sig=kp8QT0rmV8WkvfXEFI0eiruKUIPZYmze0ktrHIEr8d8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:04.8834016","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A04Z&sr=b&sp=r&sig=LwbQ1c8Rp%2BMs6bWPMAHo24NYcP%2BBWMHYg3BNavEK19c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:04.8833145","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A04Z&sr=b&sp=r&sig=W9b%2BRaf2awb6QmsX5Oqyal4ns9vwDwM11FBMJhRzX7g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:04.8834259","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3232'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:04 GMT
-      mise-correlation-id:
-      - 20c46b43-5dc2-43bc-8d65-f90121ba8d8d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A10Z&sr=b&sp=r&sig=yXv2rwWZN1M%2FcNJ%2FibWXlTfp%2B29x68w1tPbKKqxw4Pg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:10.2157403","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A10Z&sr=b&sp=r&sig=sa6qR3%2BmGfoAGMC%2Bc1R0Yy5iNjFa3VIdgEWoYZBdWdA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:10.2156518","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A10Z&sr=b&sp=r&sig=nfaA351nBHjeduOamFmyHVjLc4eVgpg9vHcDh1IsgvI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:10.2157637","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3236'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:10 GMT
-      mise-correlation-id:
-      - fca9ab04-66aa-4153-9c52-3e8d6a0956ec
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A15Z&sr=b&sp=r&sig=NwriBTEmYzMDfWiieqe2zDE6tVNZyyuBqNOt1JOqCBk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:15.4839175","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A15Z&sr=b&sp=r&sig=Gwb6irZsoPLEiN3xlAghVMU9xaQwMzHps%2By4Xgqoerg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:15.4838491","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A15Z&sr=b&sp=r&sig=giBN2u11H0rkyqRRxIMzpjtjOnWF3cj87Vv0XP3qLD8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:15.4839314","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A52Z&sr=b&sp=r&sig=6ezVLYXNeh4CFyP7ujsbTmOZgsSNmc5u1XTQbQUwxks%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:52.00773","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A52Z&sr=b&sp=r&sig=9KcI6qCRM2xpXMc0OJ9kv8xKL9lGJoF5Y0Ln1rwWE2A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:52.0076458","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A52Z&sr=b&sp=r&sig=4qQ3E0w87IDh0NYIMBsXfO3ZXBiHKTDTfZLeDezsHUQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:52.0077521","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:30.926Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1470,9 +858,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:15 GMT
+      - Mon, 30 Oct 2023 07:22:52 GMT
       mise-correlation-id:
-      - 972bf4b6-c0cf-4fd6-8e71-47833c10a16a
+      - 4f7a8c2f-931e-4825-a7cb-a7f4c7fa09b3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1492,226 +880,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A20Z&sr=b&sp=r&sig=iaI39UsN0EZDoYoNpLd3sHF7rqIcL860IlOGqdbEhmA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:20.7316879","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A20Z&sr=b&sp=r&sig=bGtgW0ExmoBerjSRlm1c90fbKWFp%2F7y16Zty9s%2BM20Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:20.7316158","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A20Z&sr=b&sp=r&sig=fwr2Go4sFhAL9Egi11Z6gx4bXhW7WJI0BdoHyO1xmEU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:20.7317021","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3230'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:20 GMT
-      mise-correlation-id:
-      - d77d8bc1-f96a-4733-8d03-3ece15052ba2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A25Z&sr=b&sp=r&sig=ZOx60pWn7yq9ZD7uawMcbAH3l7EyGtY4vyrJmjEXiJQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:25.977562","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A25Z&sr=b&sp=r&sig=Poi8P4qVW0foB6sNQb%2F9guvHP4oiqa6UBd64L0Nq2Bk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:25.977475","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A25Z&sr=b&sp=r&sig=hekBEPFuRDVuzQ0sukkeGB9VeH4zIOKMQodYK2sO6Rg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:25.9775851","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3226'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:25 GMT
-      mise-correlation-id:
-      - fb53b47c-a3a4-4501-954e-fa69edd679e4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A31Z&sr=b&sp=r&sig=sT7T%2Fx6NK5TRncBbSOon17sJ5SUW0X9MTfEd5MRH0VE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:31.2303315","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A31Z&sr=b&sp=r&sig=A4chWD8isr4lZGCvlRVmric1SQ9%2BriPtDcLts0%2Bbq7Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:31.2302507","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A31Z&sr=b&sp=r&sig=vtGAKmC1g79W9tjTOJD7bpYgUqCGy907W54amV6AbAU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:31.23035","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3230'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:31 GMT
-      mise-correlation-id:
-      - 9cd22e45-0a51-4764-bae4-a0bcb0cac3b1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A36Z&sr=b&sp=r&sig=f3szotiAxFb70UKOfI8Ln821aymmqb%2BRO2BbqpCDzQY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:36.4927076","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A36Z&sr=b&sp=r&sig=FNjRMcP657DoMLpu5ESOGWjA0uZGiBK95n3CpJtlC70%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:36.492623","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A36Z&sr=b&sp=r&sig=NrzEhsFpD4p8Y1bSiiKU8WuEsCAWlBhJnUEQ3OX%2Fi7U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:36.4927247","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3229'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:36 GMT
-      mise-correlation-id:
-      - e47a5e59-d445-423d-b164-fc8a0c8ab710
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A41Z&sr=b&sp=r&sig=Jc02RkZwgzAZYgvZFbONnHheAeGpFmOy16DIF06zGb4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:41.75518","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A41Z&sr=b&sp=r&sig=HeTFM0NY85aPn8NVt1rgRIW2bbgS%2BBvRH9FkExVG3cs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:41.7550973","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A41Z&sr=b&sp=r&sig=iFZkZ0pjwRpVFj4zsLRwBvDU%2F%2Fa9SzlSxCrIoDzCBCc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:41.7552013","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3230'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:41 GMT
-      mise-correlation-id:
-      - 722f1a6b-da56-435a-8fb3-758f7ba14ee9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A47Z&sr=b&sp=r&sig=GJsY2IgrMxT1O0XxmRAnV2d31DhnvnC483SljUsjCc8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:47.0024942","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A47Z&sr=b&sp=r&sig=ElqZk721gfmtxlMtvuF%2FboH7WCH4Snzg9q7hLTKjSGc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:47.0024132","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A47Z&sr=b&sp=r&sig=Z2ZpkQW9RMlq3Q%2F%2BddW1WqL%2FMii3uQD8M8vUq%2FojqBk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:47.0025115","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3236'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:47 GMT
-      mise-correlation-id:
-      - d3366da9-7ecf-4573-a2f5-7db34508cd25
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A52Z&sr=b&sp=r&sig=9s9A8qLEKi9us%2F%2FWmhwOxrsGgQ61DvDh9zNZcyTD2fI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:52.2489987","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A52Z&sr=b&sp=r&sig=qka%2BUXBvTbYciRVBdrySwhT2egNPX6rMXGDuYpKsRWE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:52.2489302","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A52Z&sr=b&sp=r&sig=lGKhbcrfJ6xnkVZtAJQGoEVPXkIstmGQDucQvgi4aL0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:52.2490126","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A57Z&sr=b&sp=r&sig=sZGheW5yUeOWOsm4m9U8cG827nVrOFAtI04DJFa7PTo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:57.2951026","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A57Z&sr=b&sp=r&sig=c9zzjy986KUhPkDCrS6BCZHLARNIoFZQursXttu2FUM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:57.2949917","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A57Z&sr=b&sp=r&sig=XzBIt%2FjVAt4PvtLbdIoMH6aNvc9JEUCBtvuPhz9tnkg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:57.2951252","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:30.926Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1722,9 +894,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:52 GMT
+      - Mon, 30 Oct 2023 07:22:57 GMT
       mise-correlation-id:
-      - 630170f4-1cc3-42c8-ac8a-8abf13afb27d
+      - d5876575-fe4a-4414-aefe-86fc45afce74
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,23 +916,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A57Z&sr=b&sp=r&sig=JMTRfAqwQwSt9Ok6VomLqtxJt%2FNpdzE3GFuVuEzw4N0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:57.5223696","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A57Z&sr=b&sp=r&sig=8%2FQkwjOZdE77y%2FOG0c0v1zGKmwODUF5Srn6YKujG6h8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:57.5223016","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A57Z&sr=b&sp=r&sig=TCrQUriQlPKWmUaPvmX%2B5D%2Bx6KHGlPDj7hFc9DoRbiU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:57.5223839","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A02Z&sr=b&sp=r&sig=xdQ3oeMiekBBx13LOGWMUAmUISKtumG%2B6Ei%2FwLaNaNw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:02.5660313","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A02Z&sr=b&sp=r&sig=0Anus4NUa5xgbQ6qJLyDM6ScHEoWWz0eE5Eun7ijaek%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:02.5659452","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A02Z&sr=b&sp=r&sig=ZYET614hDfqPGrJjfXV4AbtGHdu6fGNUrDC2lpwqtnE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:02.5660454","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:30.926Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3236'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:57 GMT
+      - Mon, 30 Oct 2023 07:23:02 GMT
       mise-correlation-id:
-      - 6b50180d-ac4c-46e8-ae1f-49f358108293
+      - 6e70ee4c-2022-4628-9489-ecd3ac119146
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,23 +952,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A02Z&sr=b&sp=r&sig=V9SiIo%2BGKIogTCQ0cblaV1TjhJRb0B4ysYrdckgPOSQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:02.8056583","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A02Z&sr=b&sp=r&sig=BudvqdzPg2a8OkfAOuN9ub905raBoVmQLkmDSiFnESo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:02.8055865","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A02Z&sr=b&sp=r&sig=pacMHYXERd8IE8eBBC%2Bm4wpMXfs4whUolDjn3OKkp00%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:02.8056721","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:23.802Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:14.24Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A07Z&sr=b&sp=r&sig=idM3MtO0oBmuRYiEo5f6dT95pGBQic5Qm24IP5bW7EY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:07.881378","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A07Z&sr=b&sp=r&sig=4vie8bF257n3hKThO4Tify1g1O0ZltmekTkuLJ%2FQaQ8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:07.8812712","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A07Z&sr=b&sp=r&sig=vLCNBopCAE2tBtCVprA7KDzBYlT2wT%2FG%2FsczuaN7rq4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:07.8814067","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:30.926Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3230'
+      - '3235'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:02 GMT
+      - Mon, 30 Oct 2023 07:23:07 GMT
       mise-correlation-id:
-      - b151b4b6-5772-4128-83ca-314811d41a0f
+      - 0c8a9c1a-c2c2-4754-83da-827ed3160876
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1816,11 +988,839 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A08Z&sr=b&sp=r&sig=xZM%2FcgobqH7pwf61Ty7jfDDDMbyH9LwrkguTlpDPgoE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:08.0655236","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A08Z&sr=b&sp=r&sig=BdMomZ4GGHJMSFkALWdIi7qOJ9GWtzGFhh1f%2Fp2i7LA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:08.0654456","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A08Z&sr=b&sp=r&sig=XlVA3B3jCs5C%2B55JdIaKVTpepZ3OMWblTjFTHJ%2F4Bm4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:08.0655396","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-29T22:22:23.802Z","endDateTime":"2023-10-29T22:25:06.637Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:06.729Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A13Z&sr=b&sp=r&sig=ZXCGLxHl7Uwg%2BLsKPn0W%2BXzOPDfQGvUBt5D48%2FOqWNA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:13.2932698","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A13Z&sr=b&sp=r&sig=Tg73JU8X%2FbgjFNNExA0DiuutM3NM%2BB%2F%2B5aUnyYIa%2BN0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:13.2931896","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A13Z&sr=b&sp=r&sig=3DJq6tXzw4VM5xudVEpuzJgJpcJQshdbqF3l6VSl%2B60%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:13.2932881","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:30.926Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3248'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:13 GMT
+      mise-correlation-id:
+      - cac0e72f-627c-4bec-ab9c-c39770561bad
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A18Z&sr=b&sp=r&sig=YLhrlAaK2xjxUKi6UhplwDMGZCvUDG9wpjKeIZyBEOA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:18.5517962","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A18Z&sr=b&sp=r&sig=LgsWjBVF3mmifnzx4yrSEm9HMfYuy5OSKfNfnRYWl7c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:18.5516527","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A18Z&sr=b&sp=r&sig=m3%2FzNtHwPZYiljQy4PQOiLVdXt6Iz9xOgoArrjJtyUw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:18.5518294","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"CONFIGURING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:18.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:18 GMT
+      mise-correlation-id:
+      - c08667e8-31c8-4f73-95a9-36d556834e77
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A23Z&sr=b&sp=r&sig=IwDoppePaI0xnt5GkFhpV4a4NrZ8kPBrsnhiqTXyVPM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:23.8404924","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A23Z&sr=b&sp=r&sig=sUvALfv2AQLXuYXY9BZC0KVKixXqUcke9sRfxRPM2Mw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:23.8404093","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A23Z&sr=b&sp=r&sig=6CNozl3rPWa9UXMV56XnMHYAzgKfFuFx7%2F1KflQv3dE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:23.8405143","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3229'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:23 GMT
+      mise-correlation-id:
+      - 05013cb4-57b1-4c96-b901-5f68235d649f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A29Z&sr=b&sp=r&sig=bdb3dRmItLySvJGHP%2Bp%2BGNGa4q8jZbnSRPqQ9njXBmE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:29.1699162","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A29Z&sr=b&sp=r&sig=X%2FSLnKIZggeDR91wR2zYhuPzh7ZC%2BTDhV4H6%2BiKFeEI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:29.1698409","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A29Z&sr=b&sp=r&sig=NOv1ibKoYaWycTz5EHKSGgYRtLA5Wr6BvZpTOPgg0ug%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:29.1699308","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:29 GMT
+      mise-correlation-id:
+      - dd13e505-0c34-45cb-8731-dbb38da28b8a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A34Z&sr=b&sp=r&sig=kz3%2BK%2FqP84nFz43lXQOAYkKNzukSULLgn8vrkMGTrPI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:34.4977264","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A34Z&sr=b&sp=r&sig=uK2u3Am6I%2F2%2FVhU983%2BKdTlRCZZ03mgbbOiV9f1MGpE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:34.4976552","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A34Z&sr=b&sp=r&sig=TZNwTpYBGOcSn11OBpkhd6xBstpbNYHTzLZH6TMM7jQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:34.4977413","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:34 GMT
+      mise-correlation-id:
+      - 2a01eeb0-0be0-4dc4-8edf-9ef1e26375c7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A39Z&sr=b&sp=r&sig=aqgBBdfxuYfEzzuRH8Mv9BZnKh31AB9eUqDYd9ouFwo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:39.8104467","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A39Z&sr=b&sp=r&sig=7pKevDRRjJgRvdFIF0K2Wt9FQwt8IHjl6yBZamOrBL8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:39.8103629","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A39Z&sr=b&sp=r&sig=7WJ1tGIW9lgl99mviFb3qe%2BTnS%2B7uzBaiPnLUgFP3cc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:39.8104702","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:39 GMT
+      mise-correlation-id:
+      - 395d9320-d610-4b44-ab87-4d8f4df419ef
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A45Z&sr=b&sp=r&sig=QJNy5FU8GOSiYz416QlDjaME%2BWSt1dl5Wlp3zZKAmUs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:45.1851597","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A45Z&sr=b&sp=r&sig=H3rbFR82rkFxeZtZykLjnBl%2B5peKCfvWLrO74kH9Av4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:45.1850665","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A45Z&sr=b&sp=r&sig=LpTebPQbS7Wh9h5kaVdz%2FUtP4BqhMDdzTeoWoUqUP0A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:45.185182","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:45 GMT
+      mise-correlation-id:
+      - e719a9ac-8235-46de-8d5b-eab051e2013d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A50Z&sr=b&sp=r&sig=Ia1Tepy3DZQzHYsP7fWt4D0aRGVepMes%2Fmzz2Pidb6E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:50.4463432","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A50Z&sr=b&sp=r&sig=fKd073yQOAO3bo5MNEwjMJ5YNkNRzsZVYyeZfLXpXZY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:50.4462586","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A50Z&sr=b&sp=r&sig=%2BvzbJ6gQuqrnHQlVHdAPHZNWRatk6l7CseIM1HDIC5I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:50.4463586","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:50 GMT
+      mise-correlation-id:
+      - ca7454e3-94c8-4b9f-8eeb-2fc5d7b46b94
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A55Z&sr=b&sp=r&sig=ov%2FGymyUOsyb3rzempgGnTzA4MaBe7OWH5a5mTjPcvw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:55.7102373","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A55Z&sr=b&sp=r&sig=NRYqEdLJGPYT56q0UG2HUuqQvcyZnqV5%2FI61YXlirJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:55.7101707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A55Z&sr=b&sp=r&sig=AEtIAmE4ByaOGCCYItM8FU3B%2BbQbUiNqWlc1Ygg2aVQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:55.7102517","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:55 GMT
+      mise-correlation-id:
+      - c2656a2a-0556-4d9a-b852-b1cd0cfcee4c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A01Z&sr=b&sp=r&sig=BNKPykqUTPyDjvXMCozb9GtTW7G5ox2%2FfhyKYfei4KQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:01.0168299","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A01Z&sr=b&sp=r&sig=nBoxjoxzVlPvcGqNDDwqNFMeO%2F47NI9DoaMBb8J9bPw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:01.0167268","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A01Z&sr=b&sp=r&sig=vivMu0OSD2dm6L5cNv0LLMUFiWQTAt%2Fj70pQ5dKgJtY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:01.0168562","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:01 GMT
+      mise-correlation-id:
+      - 7daf735a-5276-434b-b8af-6a63b6f4af24
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A06Z&sr=b&sp=r&sig=sEjpj8o9Xldp0uqVNpwsHDh43WU6CPnuq3WAvhPhDjE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:06.4876965","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A06Z&sr=b&sp=r&sig=TkNcf2tCe%2FM%2FJBCdmDMNO5IW%2BUhcMymmbjSNzkAWIK0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:06.4876231","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A06Z&sr=b&sp=r&sig=mWxqgmGTi%2Fx2QSBn0oocM92U%2B4Mkw0EUBkrvb8gInic%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:06.4877116","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:06 GMT
+      mise-correlation-id:
+      - 2d2aace8-849d-4b22-b344-cdd46581642c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A11Z&sr=b&sp=r&sig=ZRtrBtk0GeSEwvt4M62XP722PQ5BRoyPPW%2FEMu%2FBoek%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:11.7527916","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A11Z&sr=b&sp=r&sig=0w8jTVGCzO6O1RZvDJWqx7HF4HSliNrPvqnM1ODsJWY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:11.7527103","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A11Z&sr=b&sp=r&sig=SpH6Rsyl0Rr7ZR231qQI3byR%2B5D0N7tIrQ8fnveL0b4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:11.7528133","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:11 GMT
+      mise-correlation-id:
+      - 7d7c2072-f001-4721-a0a2-29d247aefd27
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A17Z&sr=b&sp=r&sig=dY5YuX%2Bx%2FfMc%2BwuQePwHdPvg86Tx3DzMwRE9JMU%2F5dI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:17.1051835","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A17Z&sr=b&sp=r&sig=CtTR6v6zNJF44I9qrem9psBD9a2fcmvcxcEGovsSGEg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:17.1051168","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A17Z&sr=b&sp=r&sig=qTuTlT%2FHiaK4rcxx33yiSj59ZTpZxeOlq6X0F%2Bb1r9A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:17.1051982","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3239'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:17 GMT
+      mise-correlation-id:
+      - e9f56563-0506-4f79-acff-bae13fb12a9d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A22Z&sr=b&sp=r&sig=UjwLR4QPvZg3CjS6%2FO0ylRdZnP4i2dcq74zde99EI7Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:22.4350498","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A22Z&sr=b&sp=r&sig=FKkCRb8FjBelPAIgBCqRva8AqtvByitRtV%2FB4e6pmdE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:22.4349588","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A22Z&sr=b&sp=r&sig=3bwXulh201xuxllOWhlgpAiB%2FPRri8oxVo3kNiLvAHg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:22.4350709","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:22 GMT
+      mise-correlation-id:
+      - d879aa67-d18c-44c1-a9b3-34e473110c3c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A27Z&sr=b&sp=r&sig=5mjdVdnEFaDMOZyyULFHUYWTH6i%2BsMRCejEE2MEslFw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:27.751702","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A27Z&sr=b&sp=r&sig=tOnVJ5KqQfz%2FLMXPf%2BNdovzjQPCsYxmjvQpAyD5aAkw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:27.7516172","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A27Z&sr=b&sp=r&sig=xKUwBzZ%2FYoNcJRHDWgDMOL3dzJllW7gInPJprqZ51v8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:27.7517233","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:27 GMT
+      mise-correlation-id:
+      - fcc1dfbf-7ab9-427b-9380-1c7542e01216
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A33Z&sr=b&sp=r&sig=G00KMamrEPYvVQOun%2BT2mx4tXpZEtWmpB%2Bf6NidNGb8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:33.0896949","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A33Z&sr=b&sp=r&sig=uh3tE8V1Ct29%2FSc3bcHZRw9ljOX06L9vl5AGtDAV7MI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:33.0896271","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A33Z&sr=b&sp=r&sig=hYZp2xfMZtXg%2BE0nngnd16CdNO8P3bxlQVixA6oPe%2Bw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:33.0897091","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:33 GMT
+      mise-correlation-id:
+      - eab013e3-17de-4f47-a113-42b6ef6f89dd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A38Z&sr=b&sp=r&sig=h5NUb2fJksRppuTMKIoT%2BQlguXvu4TBj4kPAqIMhJcA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:38.4201459","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A38Z&sr=b&sp=r&sig=ijibnLaUGCjOEPqSe14tGbEDdA7OfRskRb0%2FL7b%2BOgM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:38.4200373","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A38Z&sr=b&sp=r&sig=tbHlPF6FQGvfvLcQQoQS3bMURPkhYFFmZ591Q7PBJ7U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:38.4201661","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:38 GMT
+      mise-correlation-id:
+      - 7fff12c2-33e5-4a1c-a71a-7b50799221d2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A43Z&sr=b&sp=r&sig=DFfivlAi5e9R7F8biUsC9NEtuti0GLMKzl7GOXoptpU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:43.7085515","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A43Z&sr=b&sp=r&sig=vVS18FI80uCa3tiq%2BuBZZaYpSitwGObpSNo9Jbol2us%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:43.7084685","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A43Z&sr=b&sp=r&sig=7SDo6wARmRiqAEX5m94uHoFvrpmrFbLeRaisu%2FIinf8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:43.7085731","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:43 GMT
+      mise-correlation-id:
+      - a6851744-9771-4da6-b44a-8246d001a9b4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A49Z&sr=b&sp=r&sig=QxZj%2F8Fklt57srEs06iUC8C5FROGKGK%2BoqoBbCsrL8E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:49.0989509","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A49Z&sr=b&sp=r&sig=TOD5ZQ7i1dZD%2FU7cnyuuB7vE6DxEUedXBWBOCAQ%2F2w8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:49.098882","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A49Z&sr=b&sp=r&sig=12rJzZHXb78gOJM6paTeZh8B%2BGlTzvEs6%2B%2Bi%2Fkgq%2Bfk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:49.0989661","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3244'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:49 GMT
+      mise-correlation-id:
+      - d8ec2925-6b9b-4446-90ea-e361dbc8d1a7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A54Z&sr=b&sp=r&sig=fvAMqh6%2FphAoTkurq77%2B7OQgPmd7rXgvFfpNnsL9pJk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:54.3717616","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A54Z&sr=b&sp=r&sig=uoQpdVKtH9Ff8V%2F2vRxQ%2Bv4rzClTF0nvPg86%2BaZQoVU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:54.3716883","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A54Z&sr=b&sp=r&sig=DA9z4lK%2FVbK6VFK%2FeghmfczFJq8uSeKlAwV3v17%2B4lE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:54.3717765","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3243'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:54 GMT
+      mise-correlation-id:
+      - e40d6843-826d-48ef-aa01-895ba95fb403
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A59Z&sr=b&sp=r&sig=3sgkM0AMxM0%2FRBeBM%2BtKPz6uIRvTTD3HvdpLeiklT%2B4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:59.6800893","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A59Z&sr=b&sp=r&sig=CvaQOTnskEI%2BIblc5sd%2BJkWds3XBZT13Roya4pC3l5w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:59.6800076","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A59Z&sr=b&sp=r&sig=YEgZXQnGumPYtCEBpxEtUv%2Fhe7X2uItwYd4Xl50Nr5A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:59.6801065","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3239'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:59 GMT
+      mise-correlation-id:
+      - f4d32788-71ef-44e4-b624-f41558a15651
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A05Z&sr=b&sp=r&sig=vRfISGtGRafyVzGkUd1hHIn7smd88seL52Vcv3vOuMs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:05.0201118","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A05Z&sr=b&sp=r&sig=m3HWYIhpK2UpKVkko%2BjZ04D3LgS%2BOsB84Odvr9jS%2BHE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:05.0200143","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A05Z&sr=b&sp=r&sig=3wvTqIYVk1FLPpO13cMeG3GxGSaiiSvcSmQ4ggQfTTs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:05.0201267","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:25:05 GMT
+      mise-correlation-id:
+      - 71cbd1b3-aaad-4abc-b5b1-e7844e275e61
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A10Z&sr=b&sp=r&sig=DhekfQ1E3Sqy6%2FXzYhWD8%2F8vvjLxWwd0qDBbQCTiFQY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:10.5538123","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A10Z&sr=b&sp=r&sig=x8BYrwb68ZkgWBx969e%2Flzl2iRHBkxo9n%2FLxKSBn06c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:10.5537239","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A10Z&sr=b&sp=r&sig=wQMgAGsQ0HyhFHn1uERNcYUWH6KCcIKSJyjVyg4iLek%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:10.5538331","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:30.697Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:21.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:25:10 GMT
+      mise-correlation-id:
+      - 08c033c8-ac16-4d2b-b584-c14e23fe55c6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A15Z&sr=b&sp=r&sig=Q6UN8Y7rj7dcNjM7nSv%2BbZYy2Dl%2Fs2hPK0QlIWbf9%2F0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:15.9128386","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A15Z&sr=b&sp=r&sig=qZCRlJDegpmySXNuovmuXXoTB3HYdtCvcVr8980qmDQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:15.9127671","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A15Z&sr=b&sp=r&sig=wU9A60Qj%2FpdkIJPDzltjHNBZFdqgF4GdpaNKEMS8UH4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:15.9128536","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-30T07:22:30.697Z","endDateTime":"2023-10-30T07:25:14.495Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:25:14.629Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1831,9 +1831,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:08 GMT
+      - Mon, 30 Oct 2023 07:25:15 GMT
       mise-correlation-id:
-      - 4bc2d63e-0944-48b8-bf16-10ef5026bbf9
+      - 0b6f3247-d02d-4ed7-b4b8-57c1170a59b9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1856,7 +1856,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:00.9207417Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:00.9207417Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:07.3353753Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:07.3353753Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1865,9 +1865,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:08 GMT
+      - Mon, 30 Oct 2023 07:25:17 GMT
       etag:
-      - '"3c003d28-0000-0100-0000-653edacf0000"'
+      - '"3f00ab6a-0000-0100-0000-653f59650000"'
       expires:
       - '-1'
       pragma:
@@ -1897,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=app-component-test-case&api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=app-component-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"3641458f-9f86-4d48-b54d-2afc955e4211":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d7c5c239-9478-425e-8312-559c57b34fda":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"505a1c97-3b9e-42ff-a88b-d7b9547cfaf7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/4aed3e1c-3ee2-4620-93a7-207617acea17?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A09Z&sr=b&sp=r&sig=1H5ETJZt%2F5PUHrO5OjDu901cstugthsYzNwmIMHXBIo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:09.5580613","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/61693a52-a22b-4481-b3c6-9bf90122f7b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A09Z&sr=b&sp=r&sig=6M1XEh9O%2FiH%2FNmS1lbWyCFphaWsuDFOvt8FJMVcp6xY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:09.557973","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/368f1e5b-fc43-4f3a-94fe-a6fa938cc9a4/fabe9c37-047b-46f2-b2ad-62f758324a94?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A09Z&sr=b&sp=r&sig=AQt45u33Za%2BWeayCmTWFxX4JwLbiL8Bhz%2BeTrxeWSPw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:09.5580825","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-29T22:22:23.802Z","endDateTime":"2023-10-29T22:25:06.637Z","executedDateTime":"2023-10-29T22:22:23.024Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-29T22:22:23.258Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:06.729Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d1fede50-4b32-409d-9c17-5aab55c44e92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a7d644dc-1c94-4580-9833-5b86499a8906":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"61a79b8d-faea-43a3-a574-75a87ec406df":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/3b1e9d19-0cbc-45e5-811d-43d6ff3cd220?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A18Z&sr=b&sp=r&sig=LhYM0wfuo87Daxibb2cJK859RgDwQN6Mpx0Z3kMad6E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:18.6551789","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/32b45fb8-009b-409e-b45b-bc1f3cf397e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A18Z&sr=b&sp=r&sig=BxvUsLCqtwnSqviAb5%2B34wKrBfXi1I%2FAIqv2XbCYNxQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:18.6550744","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f313e678-7b4a-488f-9a6a-195078312f19/b3b841bc-5a5c-4961-ab00-6d24edec8831?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A18Z&sr=b&sp=r&sig=5ubPsrTdhQXZIFOGgelRkFTxiJkeasWfWUBJluAr84E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:18.6552019","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-30T07:22:30.697Z","endDateTime":"2023-10-30T07:25:14.495Z","executedDateTime":"2023-10-30T07:22:29.226Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-30T07:22:30.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:25:14.629Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3383'
+      - '3378'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:09 GMT
+      - Mon, 30 Oct 2023 07:25:18 GMT
       mise-correlation-id:
-      - a7f3b0d6-381d-491c-912f-77e3a2adc040
+      - 17f3babb-9f12-49ca-911c-2ffe9b6cee85
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1936,21 +1936,21 @@ interactions:
       ParameterSetName:
       - --name --resource-group
       User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-azure-mgmt-storage/21.1.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2023-01-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-29T22:21:35.7556061Z","key2":"2023-10-29T22:21:35.7556061Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-29T22:21:35.7556061Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-29T22:21:35.7556061Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-29T22:21:35.5837216Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-30T07:21:42.5004890Z","key2":"2023-10-30T07:21:42.5004890Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-30T07:21:42.5161138Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-30T07:21:42.5161138Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-30T07:21:42.2817104Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1297'
+      - '1312'
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:25:19 GMT
+      - Mon, 30 Oct 2023 07:25:29 GMT
       expires:
       - '-1'
       pragma:
@@ -1983,7 +1983,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:00.9207417Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:00.9207417Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:07.3353753Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:07.3353753Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1992,9 +1992,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:20 GMT
+      - Mon, 30 Oct 2023 07:25:31 GMT
       etag:
-      - '"3c003d28-0000-0100-0000-653edacf0000"'
+      - '"3f00ab6a-0000-0100-0000-653f59650000"'
       expires:
       - '-1'
       pragma:
@@ -2013,9 +2013,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-estdzn7pj7eu2dksz/providers/Microsoft.Storage/storageAccounts/clitestload36zigb76n":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-estdzn7pj7eu2dksz/providers/Microsoft.Storage/storageAccounts/clitestload36zigb76n",
-      "resourceName": "clitestload36zigb76n", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-cbmppysn6cmjemqlg/providers/Microsoft.Storage/storageAccounts/clitestloadvnoa4r5a7":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-cbmppysn6cmjemqlg/providers/Microsoft.Storage/storageAccounts/clitestloadvnoa4r5a7",
+      "resourceName": "clitestloadvnoa4r5a7", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -2031,10 +2031,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-29T22:25:22.306Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:22.306Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-30T07:25:32.109Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:25:32.109Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2045,11 +2045,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:22 GMT
+      - Mon, 30 Oct 2023 07:25:32 GMT
       location:
-      - https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+      - https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - 3ac30ca5-6411-41fa-9727-bdef84e8094f
+      - b14ca5cd-1770-48ba-88a2-21d154d2bf91
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2072,7 +2072,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:00.9207417Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:00.9207417Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:07.3353753Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:07.3353753Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2081,9 +2081,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:23 GMT
+      - Mon, 30 Oct 2023 07:25:32 GMT
       etag:
-      - '"3c003d28-0000-0100-0000-653edacf0000"'
+      - '"3f00ab6a-0000-0100-0000-653f59650000"'
       expires:
       - '-1'
       pragma:
@@ -2113,10 +2113,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-29T22:25:22.306Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:22.306Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-30T07:25:32.109Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:25:32.109Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2127,9 +2127,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:24 GMT
+      - Mon, 30 Oct 2023 07:25:34 GMT
       mise-correlation-id:
-      - 5d835255-910a-4dc0-ab40-049803312b00
+      - 980c8cd3-1454-47fd-8f71-131d9b304142
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2152,7 +2152,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:00.9207417Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:00.9207417Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:07.3353753Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:07.3353753Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2161,9 +2161,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:26 GMT
+      - Mon, 30 Oct 2023 07:25:35 GMT
       etag:
-      - '"3c003d28-0000-0100-0000-653edacf0000"'
+      - '"3f00ab6a-0000-0100-0000-653f59650000"'
       expires:
       - '-1'
       pragma:
@@ -2182,7 +2182,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-estdzn7pj7eu2dksz/providers/Microsoft.Storage/storageAccounts/clitestload36zigb76n":
+    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-cbmppysn6cmjemqlg/providers/Microsoft.Storage/storageAccounts/clitestloadvnoa4r5a7":
       null}}'
     headers:
       Accept:
@@ -2198,10 +2198,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-29T22:25:22.306Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:26.937Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-30T07:25:32.109Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:25:37.181Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2212,9 +2212,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:26 GMT
+      - Mon, 30 Oct 2023 07:25:37 GMT
       mise-correlation-id:
-      - 4f32fcef-3c8b-4b17-9bbf-d91d5672f684
+      - 8aedc211-5b71-4a35-8054-62fd0d233cc7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2237,7 +2237,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:00.9207417Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:00.9207417Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:07.3353753Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:07.3353753Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2246,9 +2246,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:28 GMT
+      - Mon, 30 Oct 2023 07:25:38 GMT
       etag:
-      - '"3c003d28-0000-0100-0000-653edacf0000"'
+      - '"3f00ab6a-0000-0100-0000-653f59650000"'
       expires:
       - '-1'
       pragma:
@@ -2278,10 +2278,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25c2ce7c-4134-412e-adba-dd4663bab446.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://f51b7810-3606-41d6-8456-d6c065894c80.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-29T22:25:22.306Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:26.937Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-30T07:25:32.109Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:25:37.181Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2292,9 +2292,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:29 GMT
+      - Mon, 30 Oct 2023 07:25:39 GMT
       mise-correlation-id:
-      - 73b80ad8-de70-4ddd-825e-241cf0df2183
+      - a8ae786e-ba7b-4a80-9fcf-a026768c26ce
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_app_component.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_app_component.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:11:29.941196Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:11:29.941196Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:12.6666047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:12.6666047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:32 GMT
+      - Mon, 09 Oct 2023 16:13:09 GMT
       etag:
-      - '"1a0a12b8-0000-0100-0000-64af08f40000"'
+      - '"9201a1af-0000-0100-0000-6524265e0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:12:33 GMT
+      - Mon, 09 Oct 2023 16:13:10 GMT
       mise-correlation-id:
-      - 52104f3f-1be5-4b0e-82b7-6eae220cb02a
+      - bd3501c7-55a4-490c-9c9c-f543e5d8e601
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -85,12 +85,12 @@ interactions:
 - request:
     body: '{"displayName": "CLI-Test", "description": "Test created from az load test
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
-      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "loadTestConfiguration":
+      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"5bcd9ff5-5813-4677-99be-50856edf3d38": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "60f552d9-b3a1-42af-874d-94e5da77c41a":
+      {"passFailMetrics": {"00081d97-e808-449d-8ae3-728cd745102e": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "b5e9700f-b93d-4671-a957-bac0156c0028":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "922587f4-7b68-4671-8ab5-71a6d80d073f": {"aggregate": "avg", "clientMetric":
+      "50"}, "b6c0709f-63eb-4b35-98a2-986acd61a699": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -100,32 +100,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '768'
+      - '789'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5bcd9ff5-5813-4677-99be-50856edf3d38":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"60f552d9-b3a1-42af-874d-94e5da77c41a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"922587f4-7b68-4671-8ab5-71a6d80d073f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:12:36.79Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:12:36.79Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:13:10.947Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:10.947Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1067'
+      - '1015'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:36 GMT
+      - Mon, 09 Oct 2023 16:13:10 GMT
       location:
-      - https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+      - https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 180d7304-29cb-4266-b742-62aae5f20c95
+      - aa00a9d3-b892-4611-b033-e7da17d305b3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:37 GMT
+      - Mon, 09 Oct 2023 16:13:11 GMT
       mise-correlation-id:
-      - f0ca2615-9341-426e-84ee-717261653e67
+      - ac62ad42-8c1f-4eb7-bf6c-7cc4fd8f61b1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A22%3A37Z&sr=b&sp=r&sig=PzwYkJ8cgP9OLbS%2Fi4sy5YtCfZe9wzarhiB2%2BwqfjVI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:22:37.5119751","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A11Z&sr=b&sp=r&sig=0VO7C1bLWllqp0cT7KxwTnpXASs6h9VEODrkCpFInmk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:11.8613553","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:37 GMT
+      - Mon, 09 Oct 2023 16:13:11 GMT
       location:
-      - https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 483c74bd-cad8-46c4-b610-ef8f892690da
+      - db586886-962d-4dcd-848e-b45c7a7b2a52
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A22%3A37Z&sr=b&sp=r&sig=Iz35eov0Iw%2BVdOm206TxrnK5OHljmilF%2B0B9zac83ks%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:22:37.7959537","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A12Z&sr=b&sp=r&sig=oHNQRqHNu3B73U4JljVaK%2FDvnMu1rGbtXkmIbpFHXtg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:12.1315769","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:37 GMT
+      - Mon, 09 Oct 2023 16:13:12 GMT
       mise-correlation-id:
-      - 74306e77-4d52-4f98-a49d-34ac6f0be684
+      - e8bcd177-b310-4f55-b0bf-c3cc00aebb11
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,46 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A22%3A43Z&sr=b&sp=r&sig=8dJF07fkOqyC8fiS3Iee%2BscX424M5Cjti5r25WD1dWA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:22:43.180498","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '550'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:12:43 GMT
-      mise-correlation-id:
-      - 24340157-dad1-4241-b25d-7bc0231c6d76
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A22%3A48Z&sr=b&sp=r&sig=XXDzkf3wXxKO4dgdOfjBVmNbbHA8ZVOekwobXobjgaQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:22:48.7298487","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A17Z&sr=b&sp=r&sig=CvLnpEDQNfNblEd0SSYSbCX54Jf2Ylgn0rtFM7k0Vyw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:17.4054409","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:48 GMT
+      - Mon, 09 Oct 2023 16:13:17 GMT
       mise-correlation-id:
-      - 8905086b-af7d-4f4a-b829-9c09a9c61e18
+      - 6e142bf2-b2a3-4c3e-953e-0aabc24aae98
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A22%3A54Z&sr=b&sp=r&sig=sRjHXNuunaX%2BWBp3HZduc%2Bnz9%2B2KwxAkWoInCkcWuQo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:22:54.0898329","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A22Z&sr=b&sp=r&sig=d6zGEZ7As1UNXlzPYV1gGYIvb%2BdZlbogL7qenLJKEuE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:22.6828974","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:54 GMT
+      - Mon, 09 Oct 2023 16:13:22 GMT
       mise-correlation-id:
-      - 7a513624-cbb5-4c5c-abb8-0343eb5960ab
+      - 2a8e9e51-f3f8-420d-aafa-d7691ff18bd5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +421,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5bcd9ff5-5813-4677-99be-50856edf3d38":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"60f552d9-b3a1-42af-874d-94e5da77c41a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"922587f4-7b68-4671-8ab5-71a6d80d073f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A12%3A55Z&sr=b&sp=r&sig=nxtDBpVKqszizQOrv5l6rqN5wsHhi0hPZCq0n6OcVQU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:12:55.5473353","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:12:36.79Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:12:50.537Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A27Z&sr=b&sp=r&sig=oKfIDdapVT59MYgC%2Bvb9XEhIwNCLlhVIBR9ssFDKG8c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:27.9535226","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1637'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:55 GMT
+      - Mon, 09 Oct 2023 16:13:27 GMT
       mise-correlation-id:
-      - c1175fdc-ef9a-4471-9350-c49f92a32c69
+      - 3d0c0eae-655d-487f-a89c-a8429392a511
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A28Z&sr=b&sp=r&sig=Q8DgHUZRXAAVWLvJ%2BF%2BG8P%2BVo8abe76a1%2BdA0nzYI8I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:28.2238328","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:13:10.947Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:25.938Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1592'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:13:28 GMT
+      mise-correlation-id:
+      - 47c591cd-cb84-43c5-a59e-72b8cd8d71b8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:11:29.941196Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:11:29.941196Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:12.6666047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:12.6666047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:57 GMT
+      - Mon, 09 Oct 2023 16:13:29 GMT
       etag:
-      - '"1a0a12b8-0000-0100-0000-64af08f40000"'
+      - '"9201a1af-0000-0100-0000-6524265e0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"5bcd9ff5-5813-4677-99be-50856edf3d38":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"60f552d9-b3a1-42af-874d-94e5da77c41a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"922587f4-7b68-4671-8ab5-71a6d80d073f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A12%3A59Z&sr=b&sp=r&sig=VR3K8vTN3CDyBqVFM8mOQuqqTCOPFk9Ty7cw4kYXqtQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:12:59.3519702","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:12:36.79Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:12:50.537Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A30Z&sr=b&sp=r&sig=HHaWSstnV16g06sVpdQWXRovT6j%2FyYsPO72jDX3cXH0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:30.4841021","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:13:10.947Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:25.938Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1649'
+      - '1598'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:59 GMT
+      - Mon, 09 Oct 2023 16:13:30 GMT
       mise-correlation-id:
-      - 50fb844c-7eea-439c-a86f-9e352250ae4e
+      - 9fbfaa4c-c291-412c-8947-994761031050
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:11:29.941196Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:11:29.941196Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:12.6666047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:12.6666047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:04 GMT
+      - Mon, 09 Oct 2023 16:13:31 GMT
       etag:
-      - '"1a0a12b8-0000-0100-0000-64af08f40000"'
+      - '"9201a1af-0000-0100-0000-6524265e0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:13:05 GMT
+      - Mon, 09 Oct 2023 16:13:32 GMT
       mise-correlation-id:
-      - 0f2045fc-4640-4230-b73a-a667605f2230
+      - ea5f3015-a0ed-4105-9be6-95dc5852e382
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5bcd9ff5-5813-4677-99be-50856edf3d38":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"60f552d9-b3a1-42af-874d-94e5da77c41a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"922587f4-7b68-4671-8ab5-71a6d80d073f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/e81b2e32-4fd7-4373-921d-28b8a1552cf9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A06Z&sr=b&sp=r&sig=zMi1Caaryi37PVhfrGyRQnpxXyFY5y%2BEWKgctnqVBAI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:06.1581127","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A06Z&sr=b&sp=r&sig=mjHksv2WtJfr26XrcTd06sYIaXSTsQyZYlg43G4gUgQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:06.1579105","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/6a6b141c-074d-4f6c-b55d-1dbcf3e7dc5d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A06Z&sr=b&sp=r&sig=LTFGoV8ysjIY7IRmx4Wk0JNhvGYFwdC8El2EHuCP3Cs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:06.1581499","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-07-12T20:13:06.019Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-07-12T20:13:06.755Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:06.755Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A33Z&sr=b&sp=r&sig=rtBaxXi1A8tzP93sldDFR8DNCw0D9yIgFVmgnwZnEVo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:33.5129344","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A33Z&sr=b&sp=r&sig=fPiNR4lCRDUzqmE3x0t1nL4E2oNzFIbdchvHoJPoKTw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:33.512804","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A33Z&sr=b&sp=r&sig=qWLFd6ynhK1dcUB1HPBbsHoe8BKnUAlCwLkqnlDR9lI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:33.5129619","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:33.432Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3213'
+      - '3182'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:06 GMT
+      - Mon, 09 Oct 2023 16:13:33 GMT
       location:
-      - https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+      - https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - c277aaa5-5a1e-4e2a-92da-0273552f707b
+      - 1dd03fa1-bb02-4123-b0e6-fbb9d7dc6e94
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5bcd9ff5-5813-4677-99be-50856edf3d38":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"60f552d9-b3a1-42af-874d-94e5da77c41a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"922587f4-7b68-4671-8ab5-71a6d80d073f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/e81b2e32-4fd7-4373-921d-28b8a1552cf9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A07Z&sr=b&sp=r&sig=eaPlTiSuVEU0ngpzdQHh2jQFquQYpB6lugfMucmcwUE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:07.143728","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A07Z&sr=b&sp=r&sig=BPQL9ss5Fc3c5UYJxpkqTqPk%2F9vJUacJmsrcWYZSNTs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:07.1436646","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/6a6b141c-074d-4f6c-b55d-1dbcf3e7dc5d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A07Z&sr=b&sp=r&sig=IRkZqxFmWOyLypz7D%2B2GotS0zypaTWj6j1Ew4y7SAVw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:07.1437425","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-07-12T20:13:06.019Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-07-12T20:13:06.755Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:06.755Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A33Z&sr=b&sp=r&sig=%2FsFTELMPMUr7%2B8li9kL69k4aRwEbQfhgdlXzxo6UI%2FY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:33.946794","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A33Z&sr=b&sp=r&sig=%2BNSEy%2FJbk%2BwcbB9uqO67b33G%2F6%2BjCX3XrIb6%2Fvp8NdQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:33.946707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A33Z&sr=b&sp=r&sig=tea7Yqg1yTXu3EBzMktHIfqsKKcE1ey0eePIqQLWwuY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:33.9468092","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:33.432Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3214'
+      - '3199'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:07 GMT
+      - Mon, 09 Oct 2023 16:13:33 GMT
       mise-correlation-id:
-      - b6280d2c-2a1d-46c7-916b-cc40b3720fc4
+      - f5497cd3-02f9-4e80-b626-19e26c2e5032
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5bcd9ff5-5813-4677-99be-50856edf3d38":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"60f552d9-b3a1-42af-874d-94e5da77c41a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"922587f4-7b68-4671-8ab5-71a6d80d073f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/e81b2e32-4fd7-4373-921d-28b8a1552cf9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A18Z&sr=b&sp=r&sig=WENdQ1uFBiDmlu8%2Biw2NNgAljYTuS3koogp3bFER4es%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:18.3403671","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A18Z&sr=b&sp=r&sig=qxH1LutMQ%2BCLNOVwvIoL1Jz9cJmnNZlSMRipa3UaoSM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:18.3402768","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/6a6b141c-074d-4f6c-b55d-1dbcf3e7dc5d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A18Z&sr=b&sp=r&sig=TBlx3XmeTQlYVqcMNvPFkz0CCLE%2BRFxeZ9fUyiVOKSM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:18.3403824","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:08.584Z","executedDateTime":"2023-07-12T20:13:06.019Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-07-12T20:13:06.755Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:08.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A39Z&sr=b&sp=r&sig=kUfFLTMc3Rnrhb6pZovnNz9Lo%2FD%2B%2B4WnOjdOUYuRGmo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:39.2193886","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A39Z&sr=b&sp=r&sig=s9NhUbe%2FtsfigOhss9qLq8n6b3jZAW7JC%2BK2aYDeRoU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:39.2193064","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A39Z&sr=b&sp=r&sig=fAi4oA0%2FfaCJIra8VPgFBSU7TaUf%2Bft41nGqEztu7E8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:39.2194056","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:34.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3264'
+      - '3244'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:18 GMT
+      - Mon, 09 Oct 2023 16:13:39 GMT
       mise-correlation-id:
-      - a4bdd98f-0da6-47a2-9f1a-63a863354460
+      - 5a4c741a-045e-4c1c-ac36-2491e0a9f32b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5bcd9ff5-5813-4677-99be-50856edf3d38":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"60f552d9-b3a1-42af-874d-94e5da77c41a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"922587f4-7b68-4671-8ab5-71a6d80d073f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/e81b2e32-4fd7-4373-921d-28b8a1552cf9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A24Z&sr=b&sp=r&sig=srZh3kcBUFgQcpByTzPSjH%2BWiqR6qaas4Ok4ZiJKUIU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:24.3895207","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A24Z&sr=b&sp=r&sig=PcM8b0H%2F37qtnD78EXi%2BPmudjw3x0IxWfHkSWE7XKE4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:24.3894323","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/6a6b141c-074d-4f6c-b55d-1dbcf3e7dc5d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A24Z&sr=b&sp=r&sig=19QlpEWCMMWZCK2DWP1ieB5H%2F1tpR74YpmEejo47bLA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:24.3895381","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:08.584Z","executedDateTime":"2023-07-12T20:13:06.019Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-07-12T20:13:06.755Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:08.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A44Z&sr=b&sp=r&sig=iQr%2BOVbF1thu6EL%2FBxZpdZPwdsxgmjt5Cpk%2BotqqFcY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:44.502657","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A44Z&sr=b&sp=r&sig=MY4ESn2nFpik%2FNhpg1IwkaBRdSiVv3Kjwl%2FPwPTpzuM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:44.502568","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A44Z&sr=b&sp=r&sig=B7eSXjjK8gZRSxsQhBOZO%2Fy1hHfdgkqcBbHXkKwJru0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:44.5026732","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:34.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3266'
+      - '3240'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:24 GMT
+      - Mon, 09 Oct 2023 16:13:44 GMT
       mise-correlation-id:
-      - 6f403ace-c45a-4c8a-992c-bef4823c26ad
+      - 442177ad-6b7a-499f-b00c-66b4f26aec9e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5bcd9ff5-5813-4677-99be-50856edf3d38":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"60f552d9-b3a1-42af-874d-94e5da77c41a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"922587f4-7b68-4671-8ab5-71a6d80d073f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/e81b2e32-4fd7-4373-921d-28b8a1552cf9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A29Z&sr=b&sp=r&sig=NZCGdsJfd488%2FxmG80mrscaVwBaRfKh79lSlZk8wEk4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:29.8974677","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A29Z&sr=b&sp=r&sig=AJ7okyGIM%2FTMg7lhaVX%2BS%2FGbaA%2FIsEjTkLh4i7W7iEM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:29.897384","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/6a6b141c-074d-4f6c-b55d-1dbcf3e7dc5d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A29Z&sr=b&sp=r&sig=M7wLDRMK0oCSwFL3desg%2FXPU20Bs9aQ6bC9lxoI%2Fms0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:29.8974816","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:08.584Z","executedDateTime":"2023-07-12T20:13:06.019Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-07-12T20:13:06.755Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:08.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A49Z&sr=b&sp=r&sig=F8HkwthzyEODQGSCcQ4DgtAT%2BMedeua5xN5y6uxNSU8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:49.784385","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A49Z&sr=b&sp=r&sig=P6cx06pcQrZnVwJs3uXUrgxgLuxEGpZNsA4oCmiloYk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:49.7842393","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A49Z&sr=b&sp=r&sig=Ku9kJNDCZk9W1ijdRMbfHNaD3YJn7NvfMe3TqQau7vs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:49.7844034","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:34.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3271'
+      - '3231'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:29 GMT
+      - Mon, 09 Oct 2023 16:13:49 GMT
       mise-correlation-id:
-      - c7bb6758-3ad0-4cc6-987d-e7de58d2f12f
+      - 4588efff-53bf-4106-a1f6-32718ba5b3ca
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5bcd9ff5-5813-4677-99be-50856edf3d38":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"60f552d9-b3a1-42af-874d-94e5da77c41a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"922587f4-7b68-4671-8ab5-71a6d80d073f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/e81b2e32-4fd7-4373-921d-28b8a1552cf9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A35Z&sr=b&sp=r&sig=fIzb5XqGmoXX7LnCcmoJsv0v7vG5x8tb2CTUdkjtRp0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:35.1919809","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A35Z&sr=b&sp=r&sig=5MsU%2BWwcXElNezc1x8flu8y18dsVJFc%2B9fY9nY4blMA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:35.1918852","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/6a6b141c-074d-4f6c-b55d-1dbcf3e7dc5d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A35Z&sr=b&sp=r&sig=E9R2O7W8cEG3ehYAGLqO8ySAEk6LKqVFpO94%2FX%2Bn%2B3o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:35.1920042","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:08.584Z","executedDateTime":"2023-07-12T20:13:06.019Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-07-12T20:13:06.755Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:08.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A55Z&sr=b&sp=r&sig=firMh%2BYW6WXKoBsaIOYHxl8XYpfG0wUQkDr11Ear0Pc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:55.0860402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A55Z&sr=b&sp=r&sig=vLlWUNWn6HXqec8Ase608Ti8MPbGlIqy7QWX%2FLbGnpU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:55.0859463","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A55Z&sr=b&sp=r&sig=5TJ4CJKyZRIX312p6xaAx5%2FKsLXzNEZUFEUEE1cY%2B3E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:55.0860625","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:34.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3268'
+      - '3238'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:35 GMT
+      - Mon, 09 Oct 2023 16:13:55 GMT
       mise-correlation-id:
-      - ea293ceb-53c6-41ba-be03-d4d3246062ca
+      - b113f3e6-3cc8-4332-a3fa-973d7414d517
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -880,23 +880,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5bcd9ff5-5813-4677-99be-50856edf3d38":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"60f552d9-b3a1-42af-874d-94e5da77c41a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"922587f4-7b68-4671-8ab5-71a6d80d073f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/e81b2e32-4fd7-4373-921d-28b8a1552cf9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A40Z&sr=b&sp=r&sig=SIS6mBkATFgB9KnpuHseQkvBFMMyOTxdZyoeYY3H6Aw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:40.5399565","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A40Z&sr=b&sp=r&sig=KaBORgOcgDXUiOZQ5dwSBnr4E8xhedlB0E%2F9f9y%2B8O8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:40.5398823","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/6a6b141c-074d-4f6c-b55d-1dbcf3e7dc5d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A40Z&sr=b&sp=r&sig=B6CNmcJYLH5G%2FGK53lXXc0BqqVZVzOpIjt2m8pZwNwU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:40.5399709","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:08.584Z","executedDateTime":"2023-07-12T20:13:06.019Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-07-12T20:13:06.755Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:08.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A00Z&sr=b&sp=r&sig=qlxf%2FGSRklqpdyvoOAItitFWdy0GjuWU%2BZG%2BRNTmdew%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:00.4052742","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A00Z&sr=b&sp=r&sig=mMnKszIaBAG2LyUeK69JLBqAeWAVk%2FsTE6eyaKFPa94%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:00.405112","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A00Z&sr=b&sp=r&sig=QEDmM0IJSCpxw%2F5JI4U7DDwI7LY9p%2Fu9Gb85Zn7qMhk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:00.4052994","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:34.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3264'
+      - '3241'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:40 GMT
+      - Mon, 09 Oct 2023 16:14:00 GMT
       mise-correlation-id:
-      - 2e2ce675-d237-4644-9784-7a832832ba99
+      - 1168cfe3-108e-44aa-8a1d-cef94428ea5d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -916,23 +916,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5bcd9ff5-5813-4677-99be-50856edf3d38":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"60f552d9-b3a1-42af-874d-94e5da77c41a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"922587f4-7b68-4671-8ab5-71a6d80d073f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/e81b2e32-4fd7-4373-921d-28b8a1552cf9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A47Z&sr=b&sp=r&sig=wjKEUgehzkLz7UNmwGMFjPv4SbBxGoE70d7NluaRLbs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:47.8427416","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A47Z&sr=b&sp=r&sig=U%2B%2BLYyvd%2F9Y4FN61eDrfuY4oL1SdwbtkjmBaI0qE4Aw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:47.842666","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/6a6b141c-074d-4f6c-b55d-1dbcf3e7dc5d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A47Z&sr=b&sp=r&sig=tc8C%2BrkS9n7A6J0Q0uVYZbpjZCbueN6il7QdwidqP7Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:47.8427552","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:08.584Z","executedDateTime":"2023-07-12T20:13:06.019Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-07-12T20:13:06.755Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:08.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A05Z&sr=b&sp=r&sig=kuLgTxjr5qqyQewhwQmdiclDoVqGpAqSHUXXsbAZtjM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:05.7108601","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A05Z&sr=b&sp=r&sig=uiJ0yAlM2dN0e1snXKqukrX3cAimcyS6e0sF7%2BVyKU0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:05.7107879","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A05Z&sr=b&sp=r&sig=Q2Rt0xUt4tS%2FZkMiZQYKEGPWo%2BXI55eKOlD2zTlUbEE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:05.7108757","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:34.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3265'
+      - '3236'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:47 GMT
+      - Mon, 09 Oct 2023 16:14:05 GMT
       mise-correlation-id:
-      - a77fe001-edea-46b7-9a85-6655e8af5248
+      - 0d00a7a4-6059-4562-938a-f6fd874ac9ea
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -952,23 +952,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5bcd9ff5-5813-4677-99be-50856edf3d38":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"60f552d9-b3a1-42af-874d-94e5da77c41a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"922587f4-7b68-4671-8ab5-71a6d80d073f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/e81b2e32-4fd7-4373-921d-28b8a1552cf9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A53Z&sr=b&sp=r&sig=JzPD1dEutNz9d%2Fefa41xL4%2BrB%2FhPKa%2F%2FI33v9pQ3wxc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:53.2546394","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A53Z&sr=b&sp=r&sig=iDGq0aMHqAaYACCtFOB%2Bzw2Y7anUs6jLHHnGq5aMjTw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:53.254573","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/6a6b141c-074d-4f6c-b55d-1dbcf3e7dc5d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A53Z&sr=b&sp=r&sig=PdwiPsNsnBOqxBVPlDZcNqYJiy5qb3vwa3BU7l6iEUM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:53.2546539","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","testId":"app-component-test-case","status":"CONFIGURING","startDateTime":"2023-07-12T20:13:08.584Z","executedDateTime":"2023-07-12T20:13:06.019Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-07-12T20:13:06.755Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:51.021Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A10Z&sr=b&sp=r&sig=WTxMio4%2Ba6%2FDD4QP4qGcieKoK8etVVSMtCFUzkWz51Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:10.976076","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A10Z&sr=b&sp=r&sig=Xc%2BHlF7clDFJQQyOo8zylfs%2BSFMxyfxeeJA6Q6xJQ%2F0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:10.9759794","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A10Z&sr=b&sp=r&sig=fPJbKc5lsoJ9jSyGkMnCJ4xfPdfCQhlBaQiAxUDvRSw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:10.9760982","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:34.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3268'
+      - '3239'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:53 GMT
+      - Mon, 09 Oct 2023 16:14:10 GMT
       mise-correlation-id:
-      - 3537d656-bbd7-41fb-a8c6-6823d47252bd
+      - ecd09ad1-7f7c-4a33-b96e-5ee1c904dab7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -988,23 +988,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5bcd9ff5-5813-4677-99be-50856edf3d38":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"60f552d9-b3a1-42af-874d-94e5da77c41a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"922587f4-7b68-4671-8ab5-71a6d80d073f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/e81b2e32-4fd7-4373-921d-28b8a1552cf9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A58Z&sr=b&sp=r&sig=UnfW6dnz0Nczh64dAyvwHqd42QGnb2x4MsQZc2IUfXQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:58.5303533","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A58Z&sr=b&sp=r&sig=vrBV1prFhmIdsS4E8EVstVdR85Mxn4PDpClzIbV16PI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:58.5302824","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/6a6b141c-074d-4f6c-b55d-1dbcf3e7dc5d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A58Z&sr=b&sp=r&sig=9jfy6iKDtpXRdmVP5D5OhMY7Of4Py2f2Wl8VqGiyWM0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:58.5303667","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:13:08.584Z","executedDateTime":"2023-07-12T20:13:06.019Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-07-12T20:13:06.755Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:54.564Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A16Z&sr=b&sp=r&sig=Ee1yM5pGQ0c3TloGkmEJxCr1M1gyCXexzocbrgtS6W4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:16.2570318","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A16Z&sr=b&sp=r&sig=EirpKcnclCmjjRVElykh0SHQsQ0YXdU3MXdV6vynq%2Fk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:16.2564661","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A16Z&sr=b&sp=r&sig=UZwRu0oumzCz5M5pr%2FuoArb882LnGmGRPQBXVyX8gD4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:16.2570558","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:34.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3255'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:58 GMT
+      - Mon, 09 Oct 2023 16:14:16 GMT
       mise-correlation-id:
-      - a4b533df-a9d0-4a08-964e-c6e81f8d88c2
+      - 9689e270-9aa8-4de4-836c-2b3a0dd94fa2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1024,23 +1024,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5bcd9ff5-5813-4677-99be-50856edf3d38":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"60f552d9-b3a1-42af-874d-94e5da77c41a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"922587f4-7b68-4671-8ab5-71a6d80d073f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/e81b2e32-4fd7-4373-921d-28b8a1552cf9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A04Z&sr=b&sp=r&sig=WeSIXruGvJVPPuMAY5t6W7Z8oNpek7sVdafdEclTYGQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:04.3833531","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A04Z&sr=b&sp=r&sig=oRRdfcn1MXMZ3ccT8eb4cN0ZPhEYXaM2rm4qStTJ9hQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:04.3832788","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/6a6b141c-074d-4f6c-b55d-1dbcf3e7dc5d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A04Z&sr=b&sp=r&sig=Qv6Psvmb8vLSioJv4XP6pbr1XdjnprpJslMfbm3IuZc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:04.3833664","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:13:08.584Z","executedDateTime":"2023-07-12T20:13:06.019Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-07-12T20:13:06.755Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:54.564Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A21Z&sr=b&sp=r&sig=8sR0gXKBE5fj8QYUUHU71BDtgCCAwNWXosL6eZk6WVk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:21.5392251","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A21Z&sr=b&sp=r&sig=hpzniL2X2cfMeom9GTEbEIB6zAHW4h78G66M0OKKK94%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:21.5391343","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A21Z&sr=b&sp=r&sig=K9dpfAwBHFz6krRcOlUDUGfduCMImSyaExhmNzmloVc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:21.5392403","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:17.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3255'
+      - '3229'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:04 GMT
+      - Mon, 09 Oct 2023 16:14:21 GMT
       mise-correlation-id:
-      - 42af461e-8f90-4a5d-9c70-05fca42a3a20
+      - e2f0380c-f046-4817-926d-ae91b3d31dee
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,24 +1060,744 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5bcd9ff5-5813-4677-99be-50856edf3d38":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"60f552d9-b3a1-42af-874d-94e5da77c41a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"922587f4-7b68-4671-8ab5-71a6d80d073f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/e81b2e32-4fd7-4373-921d-28b8a1552cf9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A10Z&sr=b&sp=r&sig=xpE2By9rDwMnsWVrWIcrQUCngI%2BsF2Un46ONpCfg1Xc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:10.0203022","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A10Z&sr=b&sp=r&sig=%2FNgP57EWoY8YqBhv6zOdB%2FuZQQcggmC8lI3MUjAw3ns%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:10.0202294","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/6a6b141c-074d-4f6c-b55d-1dbcf3e7dc5d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A10Z&sr=b&sp=r&sig=bmJA4b5Xe9MtWVN5P8hPLAMwMpozmDlfmHXTf%2BKYCHs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:10.0203166","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-07-12T20:13:08.584Z","endDateTime":"2023-07-12T20:14:04.965Z","executedDateTime":"2023-07-12T20:13:06.019Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-07-12T20:13:06.755Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:09.262Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A26Z&sr=b&sp=r&sig=sFoXjUVG6hrL9STvGF1rheD8YMd4X0eoGVhnSQpz9Gk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:26.8194149","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A26Z&sr=b&sp=r&sig=GxBUupw%2BtUs%2FNgHjnziMWplQbUr69vHtyAeYhnf9CSo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:26.8193099","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A26Z&sr=b&sp=r&sig=QEy2O%2BgMFCVLHp%2BVUDRtk2T3JmKErn5TD6v%2FROP%2B%2BU8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:26.8194399","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3398'
+      - '3241'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:10 GMT
+      - Mon, 09 Oct 2023 16:14:26 GMT
       mise-correlation-id:
-      - 7965a28e-c411-4e21-9868-516d84529045
+      - cf9fb461-8e29-4ba6-9f6c-599f05293d2b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A32Z&sr=b&sp=r&sig=iX1%2FXtgA%2BhC%2FiGUXa4%2Bqxxf0MtoWsQB%2FJOSoYnA60ZY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:32.3658898","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A32Z&sr=b&sp=r&sig=mp0ycfus5J0JvZWI7zsqX1OPLEryQEy8Y5hz3FyYXnk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:32.3658257","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A32Z&sr=b&sp=r&sig=nccN5iKsZLPi3XYHKzTkAM%2Fyz98qyi9%2FJFkmuLM%2BYkk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:32.3659051","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3243'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:32 GMT
+      mise-correlation-id:
+      - 882468f9-be44-45b8-aa35-fbb8728b86c6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A37Z&sr=b&sp=r&sig=q1e3%2BLOfK1NXg14YEZ6izjjNNqF9hGY9E6h%2F5g1NSkA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:37.6333608","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A37Z&sr=b&sp=r&sig=vba4FJljrfe5JeOgtUvcPioDNIyv%2BpnRsLlKGNdoSPU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:37.6332887","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A37Z&sr=b&sp=r&sig=3oxRYNxv%2Fy3ZIP9WbhZn0aV1JiVmXzLqExRo%2BqRZgfs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:37.6333784","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:37 GMT
+      mise-correlation-id:
+      - 242d7f64-a7d0-412f-89c8-3ddcb5471825
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A42Z&sr=b&sp=r&sig=iXxt6CAZthx%2B4%2BWJYIVJKtPs9%2BNX91jnK3jS1iEBcd0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:42.9019698","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A42Z&sr=b&sp=r&sig=g23iZ6ez%2BG5YzgODb2ztUM7%2BlrA1Z%2Baec1xggI7FS%2Bo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:42.901871","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A42Z&sr=b&sp=r&sig=eHW0gCQdsi%2F4B7L5PKWsnBSY48KQtApaHS9m2BvoKmc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:42.9019906","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3242'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:42 GMT
+      mise-correlation-id:
+      - 16815f05-f02f-4991-83d3-6ecf631acfeb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A48Z&sr=b&sp=r&sig=osKbTseayos38DGCXaYaAdMIBmL%2B6nrVFPSPro70SG0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:48.1764623","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A48Z&sr=b&sp=r&sig=Ge6RobySVCVvjVvTVKHo8H9%2BbtpbaGmHEswGujit4gU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:48.1763839","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A48Z&sr=b&sp=r&sig=dv3ySvhAqm1wJIkY4BNu2Z3EBkMw5R7khIHWB74V1Ro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:48.1764775","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:48 GMT
+      mise-correlation-id:
+      - 44108208-ea7a-48bd-8452-5907d89cb57f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A53Z&sr=b&sp=r&sig=quVQtWjlOiE4yJsSaiii%2BBE7OXjpzmUGqkHEMJNwrV0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:53.4534505","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A53Z&sr=b&sp=r&sig=veRLANfpQwyL91UfrUdVpnhrB4I5VQjyelBXb24dCd0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:53.4533801","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A53Z&sr=b&sp=r&sig=EOpo2ROofMJjMGaUY36peziy3ZLdtSBtC9uhGtQ%2BPX8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:53.4534645","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:53 GMT
+      mise-correlation-id:
+      - 73bd19c8-deeb-4532-b526-8d6daeec8d33
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A58Z&sr=b&sp=r&sig=hfxraUaI1APhIGJxAAtlw%2BNXPWIV%2BjEKIbyuq1JoZgA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:58.7192775","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A58Z&sr=b&sp=r&sig=NQQXWT1qJtodY2WNVINLT5mTwpkAKRcW0YkEZAyqiIA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:58.7191773","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A58Z&sr=b&sp=r&sig=j3M7U8fBEgysPyY5LgCmJjKMek0ZiAWrqjgRzp5Tu80%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:58.7192975","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:58 GMT
+      mise-correlation-id:
+      - 4ea799d4-2c9d-449c-883d-3f91cc9c6ef4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A04Z&sr=b&sp=r&sig=lGGJSVEyIXf4rip%2FWVdwNDd0GtvVeNTDZG3x%2FuoQcLU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:04.0037224","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A04Z&sr=b&sp=r&sig=bKAmQdCv7Xw%2BChmBx%2FalvK8OdBXpcke2PWrrfgKxMWU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:04.0036531","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A04Z&sr=b&sp=r&sig=nN2rd5iwqrksQypgOV%2BqMiVn7VwYG8xhwMgYmcCHelg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:04.0037357","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:04 GMT
+      mise-correlation-id:
+      - 1f29f2dc-2128-4856-b7cc-0fad7d9e2c76
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A09Z&sr=b&sp=r&sig=M6fVu6RMepQxHXj0%2Bh9KQZrNvxg0tppICSGcUYpjJEo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:09.2836914","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A09Z&sr=b&sp=r&sig=fVEw6H%2FrZU0n1H54ZdhV92RaLUSPNALgULlGMR%2FGJJg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:09.2836208","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A09Z&sr=b&sp=r&sig=Vsgr9mhhzG456afvY1WycMpskWGPXP%2FvcoBFSDys52o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:09.2837056","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:09 GMT
+      mise-correlation-id:
+      - bf678efa-6a1a-43a2-bce1-ac5d42d230af
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A15Z&sr=b&sp=r&sig=r7nCCwtaZwt7ydE4FEGQp7kMBBciBQEtlPQh%2BH%2B9nhI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:15.1707916","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A15Z&sr=b&sp=r&sig=vZQNwM30KYmEqF%2FHCORuFi68l3fesDjHqoPRDBKaW6U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:15.1706902","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A15Z&sr=b&sp=r&sig=X3UUaj1FsFw6Sc3bJeUMh1jh6d%2FtO6id1MOUhX09LK8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:15.1708134","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:15 GMT
+      mise-correlation-id:
+      - 01c4c520-55f9-4d10-9d53-33c4ccf892e5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A20Z&sr=b&sp=r&sig=zvAWoDsYvQaqZ7wwDBkVPkwhJag9b0OYNsdws57PujM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:20.4434653","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A20Z&sr=b&sp=r&sig=0DZ1cqJsGUPNK0CCGSJD3IizdW8f1WsEwtJrHCdHftM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:20.4433881","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A20Z&sr=b&sp=r&sig=3i2LzCgfZIYXH8vfY3EFwSK3gwGnNeksa2r8GuUzYFw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:20.4434838","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3227'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:20 GMT
+      mise-correlation-id:
+      - 2b226634-30ca-4c5b-bbf3-ad0e12ecd1aa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A25Z&sr=b&sp=r&sig=khgzgNkyc0EHHlRt%2FhI6%2ByrRpAZDWuhcXG5zI2p1bas%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:25.7160709","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A25Z&sr=b&sp=r&sig=LvoYnFO9mdtPGylPavAGeq3b5tiHmYxvCtRi28aQLjc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:25.7159479","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A25Z&sr=b&sp=r&sig=aREVLdOiEwwcKpwKrnLogT2BMx2vE7wpWD%2BDU2esGsc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:25.7160992","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:25 GMT
+      mise-correlation-id:
+      - 70f1d13e-8c63-4a35-9496-2392b2127be8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A30Z&sr=b&sp=r&sig=NqlfLQSVgYWeExzO4oaPbnB2JaHjebwwp%2Fe5laQ2jqU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:30.9824178","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A30Z&sr=b&sp=r&sig=ELWuvE6zyHFBUwEZHr0K0RMPoDVLtRiVk58YVtT1u3w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:30.9823188","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A30Z&sr=b&sp=r&sig=bR4JqS8DAzPOiy89DAHrVWST20PCS58vTQ3Q1A8kKCg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:30.9824402","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3229'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:30 GMT
+      mise-correlation-id:
+      - f3412dc7-dc06-4d37-87f3-0d4bf9c698dd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A36Z&sr=b&sp=r&sig=xR0QGlQXQpu5pi3ZWx665oZi27AtQY5%2BxM4Yg2dUI38%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:36.2637363","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A36Z&sr=b&sp=r&sig=tyoJ1ZGKc0ycwhzWGoOjz3o5xiYcpMA8AbvneewXGMY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:36.2636446","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A36Z&sr=b&sp=r&sig=Ue7%2Fu1uVVyc1SCI49DamhPkn0YaP%2FoPiHQSjRYL52o8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:36.2637536","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:36 GMT
+      mise-correlation-id:
+      - cabf334d-4e7e-47d2-b59a-ec87354519f6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A41Z&sr=b&sp=r&sig=pPDyJ4XtX0V%2BOw%2BmSMa%2BZvVZEZphUFPrubhPXKqaLic%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:41.5289693","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A41Z&sr=b&sp=r&sig=Ptm8ICgpd8b61Tx6ckrCCN1hkMMwSsbfEQzwKGwwpkg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:41.5288971","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A41Z&sr=b&sp=r&sig=ieATPYND5KUIYGY3SLUoZRIzUno4Kb1We8Y7JBPSZEk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:41.528985","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:41 GMT
+      mise-correlation-id:
+      - f9704e6e-e60d-49e8-bd22-be928125028b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A46Z&sr=b&sp=r&sig=zsKRVbXJwjApOGwxwWaQK4P8mdLLpsge%2BFwPnwmWHbE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:46.8184519","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A46Z&sr=b&sp=r&sig=pJU%2BEe20kHRmZOLTbyjj7f770%2FR4NfeSYVh%2FB5fdoJ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:46.8183698","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A46Z&sr=b&sp=r&sig=FerYL2lO9yPiI9PKBxLhcI%2FxNdScYs6MaKKT6Vka%2Bi0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:46.8184681","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3239'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:46 GMT
+      mise-correlation-id:
+      - 7fb7fc95-0aed-42eb-b405-5f761bd92a75
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A52Z&sr=b&sp=r&sig=Bi8EBS%2Be7PpLieqHZLlGSBiSnSl49EA10zZi%2Bb7jnJE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:52.0780052","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A52Z&sr=b&sp=r&sig=hlYZSQUPKIxJ1Bk7V%2BxpRI2bdzJfLaTDYbWqUVuzN54%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:52.077934","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A52Z&sr=b&sp=r&sig=kpXBx6F8ADqvgOsMHUcFUuDUswCitQVhUVcLyCcTWS8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:52.0780212","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:52 GMT
+      mise-correlation-id:
+      - f5ee6c2f-8895-4d65-96fd-04a77f41790b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A57Z&sr=b&sp=r&sig=lh5Nq%2FNFM%2Bwr4uJhn6pFBBINk%2BBuJQQyS5FxPurRxRw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:57.3690945","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A57Z&sr=b&sp=r&sig=Ihx%2BvAmEOR9u3XYPRj5XikGyO3XBlb1n8Wt%2BZ9NcG3k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:57.3689935","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A57Z&sr=b&sp=r&sig=DcXimQ39dpMHHfExy3d5XD6U0VpMeEWXRqy5%2B8uDQU8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:57.3691189","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3239'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:57 GMT
+      mise-correlation-id:
+      - a4f1ec99-937e-44a0-94c8-e81b503332e8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A02Z&sr=b&sp=r&sig=VD04nXhfzz2Sk3LmRhDdeKaPUfgWYFqo3E5YSOeGGtU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:02.6556155","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A02Z&sr=b&sp=r&sig=Tjc9Iat6zIpRBWiaXkQUvSeHiGB7JuUcoDjgxdg8r38%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:02.6555288","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A02Z&sr=b&sp=r&sig=uwXcUWQfSl06Fy0xypkQIDC3TvhfJQKYdi7z4PlJ02w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:02.6556377","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3227'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:16:02 GMT
+      mise-correlation-id:
+      - 1affd881-6594-4259-8626-ee1fbf652363
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A08Z&sr=b&sp=r&sig=et5%2BFSyRlkI2bdbCaM%2FXoIiaMXUB%2BcLfQPqnA74%2FXIo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:08.0156018","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A08Z&sr=b&sp=r&sig=8OwDNPiUjSmulPfoAXm5SfDJwarfk96J89uBJ%2BGsMOI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:08.0155353","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A08Z&sr=b&sp=r&sig=kmtTjvNrWKD651Zz%2FFie3qyTUbiuckI3juopYEtRVFE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:08.0156185","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:34.509Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:22.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3239'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:16:08 GMT
+      mise-correlation-id:
+      - e7d8c284-078f-42c1-a94a-5dafa1085c12
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A13Z&sr=b&sp=r&sig=mAW%2Bk8WDVLhuAajaTKVQk5e7KE1RvZYGm2QMNfKMrWk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:13.2983378","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A13Z&sr=b&sp=r&sig=JQhy8SMg4v8NAMu6nxXekyX975RgScyI4nz42nrirEw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:13.2982439","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A13Z&sr=b&sp=r&sig=VBKpWLRSJV42f6sdr7zCvuNRr75rU0a5swFTfcafrPk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:13.2983604","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-09T16:13:34.509Z","endDateTime":"2023-10-09T16:16:11.959Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:12.04Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3363'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:16:13 GMT
+      mise-correlation-id:
+      - 0a727938-4d42-4118-82b1-df453759765f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1100,18 +1820,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:11:29.941196Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:11:29.941196Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:12.6666047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:12.6666047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:11 GMT
+      - Mon, 09 Oct 2023 16:16:13 GMT
       etag:
-      - '"1a0a12b8-0000-0100-0000-64af08f40000"'
+      - '"9201a1af-0000-0100-0000-6524265e0000"'
       expires:
       - '-1'
       pragma:
@@ -1141,24 +1861,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=app-component-test-case&api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=app-component-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"5bcd9ff5-5813-4677-99be-50856edf3d38":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"60f552d9-b3a1-42af-874d-94e5da77c41a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"922587f4-7b68-4671-8ab5-71a6d80d073f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/e81b2e32-4fd7-4373-921d-28b8a1552cf9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A14Z&sr=b&sp=r&sig=aTJMvlkxvDnf9tITtAScw1vTQPSNfZEAzidO1D6fsBg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:14.519452","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/1d411a3c-96ec-49d8-954c-8b6eb2c548c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A14Z&sr=b&sp=r&sig=hW%2BEHDzYZ1VUAT6yeHS9Urq9JlIM9kEnpX2AHnA7IR8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:14.5193633","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c238f7fc-5d69-42b8-89c1-6e5932e2f8d7/6a6b141c-074d-4f6c-b55d-1dbcf3e7dc5d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A14Z&sr=b&sp=r&sig=bIXGwSxT7zSgTXTWblayUkSNlhiMPQ9iQ6zF8KUPM2k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:14.519471","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-07-12T20:13:08.584Z","endDateTime":"2023-07-12T20:14:04.965Z","executedDateTime":"2023-07-12T20:13:06.019Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-07-12T20:13:06.755Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:09.262Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"00081d97-e808-449d-8ae3-728cd745102e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"b5e9700f-b93d-4671-a957-bac0156c0028":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b6c0709f-63eb-4b35-98a2-986acd61a699":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/92443c28-dfb7-4dc8-8481-751b396607c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A14Z&sr=b&sp=r&sig=r6G1zOFXP358pyq8bQYKNe60%2BnY4ABN2Rx%2B0CP6%2F4xY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:14.8450505","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/d938e8d8-995c-46c6-b412-5b87fa48a770?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A14Z&sr=b&sp=r&sig=wErZFvqQQ2qR98F%2B4IwonaeeIWldEOrVomsjsaDpPqM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:14.8449845","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/37a94037-728a-40cc-b0b5-359eeb485c28/b246c224-6e2c-44aa-b29e-c9db4f8ab14b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A14Z&sr=b&sp=r&sig=uSsfQJab77sWUg03a13YbfzSo1TrVUgl3kti9Fmg9Pk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:14.8450647","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-09T16:13:34.509Z","endDateTime":"2023-10-09T16:16:11.959Z","executedDateTime":"2023-10-09T16:13:32.602Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-09T16:13:33.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:12.04Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3402'
+      - '3381'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:14 GMT
+      - Mon, 09 Oct 2023 16:16:14 GMT
       mise-correlation-id:
-      - 4f2c1fc2-6099-4bf9-b2c3-ad557a715b68
+      - 5dcff09f-03f4-415c-a01d-4999af763f6a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1185,7 +1905,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-07-12T20:12:10.6957223Z","key2":"2023-07-12T20:12:10.6957223Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-07-12T20:12:10.7113152Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-07-12T20:12:10.7113152Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-07-12T20:12:10.5081915Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-09T16:12:47.3253639Z","key2":"2023-10-09T16:12:47.3253639Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T16:12:47.3253639Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T16:12:47.3253639Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-09T16:12:47.1535497Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -1194,7 +1914,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:14:24 GMT
+      - Mon, 09 Oct 2023 16:16:25 GMT
       expires:
       - '-1'
       pragma:
@@ -1227,18 +1947,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:11:29.941196Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:11:29.941196Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:12.6666047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:12.6666047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:25 GMT
+      - Mon, 09 Oct 2023 16:16:26 GMT
       etag:
-      - '"1a0a12b8-0000-0100-0000-64af08f40000"'
+      - '"9201a1af-0000-0100-0000-6524265e0000"'
       expires:
       - '-1'
       pragma:
@@ -1257,9 +1977,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-eehr3vmuvakwj65qr/providers/Microsoft.Storage/storageAccounts/clitestload5gpyorbjj":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-eehr3vmuvakwj65qr/providers/Microsoft.Storage/storageAccounts/clitestload5gpyorbjj",
-      "resourceName": "clitestload5gpyorbjj", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-nbvjxnmoj3xym5hjv/providers/Microsoft.Storage/storageAccounts/clitestloadw4qcwvheu":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-nbvjxnmoj3xym5hjv/providers/Microsoft.Storage/storageAccounts/clitestloadw4qcwvheu",
+      "resourceName": "clitestloadw4qcwvheu", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -1275,10 +1995,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-07-12T20:14:27.315Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:27.315Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-09T16:16:27.855Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:27.855Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1289,11 +2009,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:27 GMT
+      - Mon, 09 Oct 2023 16:16:27 GMT
       location:
-      - https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+      - https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - 58ae70ae-7a30-4596-92dd-68b87ad36a66
+      - c0459ab9-2f72-4f2f-80b5-c5694e5dfc13
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1316,18 +2036,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:11:29.941196Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:11:29.941196Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:12.6666047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:12.6666047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:28 GMT
+      - Mon, 09 Oct 2023 16:16:29 GMT
       etag:
-      - '"1a0a12b8-0000-0100-0000-64af08f40000"'
+      - '"9201a1af-0000-0100-0000-6524265e0000"'
       expires:
       - '-1'
       pragma:
@@ -1357,10 +2077,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-07-12T20:14:27.315Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:27.315Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-09T16:16:27.855Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:27.855Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1371,9 +2091,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:29 GMT
+      - Mon, 09 Oct 2023 16:16:30 GMT
       mise-correlation-id:
-      - 6e4dff49-567a-435c-9f49-27e73ec7bd28
+      - d2da2e58-30e6-4758-9c5c-6502911f0b3e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1396,18 +2116,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:11:29.941196Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:11:29.941196Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:12.6666047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:12.6666047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:31 GMT
+      - Mon, 09 Oct 2023 16:16:30 GMT
       etag:
-      - '"1a0a12b8-0000-0100-0000-64af08f40000"'
+      - '"9201a1af-0000-0100-0000-6524265e0000"'
       expires:
       - '-1'
       pragma:
@@ -1426,7 +2146,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-eehr3vmuvakwj65qr/providers/Microsoft.Storage/storageAccounts/clitestload5gpyorbjj":
+    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-nbvjxnmoj3xym5hjv/providers/Microsoft.Storage/storageAccounts/clitestloadw4qcwvheu":
       null}}'
     headers:
       Accept:
@@ -1442,10 +2162,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-07-12T20:14:27.315Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:32.413Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-09T16:16:27.855Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:31.674Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1456,9 +2176,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:32 GMT
+      - Mon, 09 Oct 2023 16:16:31 GMT
       mise-correlation-id:
-      - 800bed30-d6d3-4446-8134-453d194d4206
+      - 355778e6-6c9b-442a-a44f-70e40fa93ac3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1481,18 +2201,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:11:29.941196Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:11:29.941196Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:12.6666047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:12.6666047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:34 GMT
+      - Mon, 09 Oct 2023 16:16:32 GMT
       etag:
-      - '"1a0a12b8-0000-0100-0000-64af08f40000"'
+      - '"9201a1af-0000-0100-0000-6524265e0000"'
       expires:
       - '-1'
       pragma:
@@ -1522,10 +2242,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://63017d22-ee40-4eec-9f81-f05f3a112266.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://8cff7b24-df6f-407a-8f18-4deb6d60a512.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-07-12T20:14:27.315Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:32.413Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-09T16:16:27.855Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:31.674Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1536,9 +2256,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:37 GMT
+      - Mon, 09 Oct 2023 16:16:34 GMT
       mise-correlation-id:
-      - 61d05a44-9cad-4188-aa2e-e3f962ecea00
+      - 411ce6c7-1567-4ad1-8266-0ac02fa25806
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_app_component.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_app_component.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:28.2169395Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:28.2169395Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:10.6516578Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:10.6516578Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:23 GMT
+      - Tue, 24 Oct 2023 12:29:08 GMT
       etag:
-      - '"75005e4d-0000-0100-0000-653045510000"'
+      - '"d300da3b-0000-0100-0000-6537b85c0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:52:25 GMT
+      - Tue, 24 Oct 2023 12:29:08 GMT
       mise-correlation-id:
-      - dfe9fcb9-6367-4359-a124-92861af11091
+      - 427328f3-72cc-4b1f-b520-5ba87eed3c44
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"31ad3a4f-8712-4ddf-ad8f-15b5105c3361": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "0f16e512-990f-4caf-8c5e-39e040ec0e27":
+      {"passFailMetrics": {"0823c9ca-c379-4eea-a06d-d21fd6ec75db": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "043cecbc-0424-42a7-bf14-76f36fa3c56c":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "57a98ded-236c-415f-9ad5-d16cafcafc93": {"aggregate": "avg", "clientMetric":
+      "50"}, "9dffc865-f428-47fd-bac0-fc382d724331": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:52:25.693Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:25.693Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:29:10.005Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:10.005Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:25 GMT
+      - Tue, 24 Oct 2023 12:29:10 GMT
       location:
-      - https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+      - https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - b10d7756-b4e3-4515-b3ba-926b37ac1077
+      - 21247209-cd46-48c1-a4fe-7a58a520761f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:26 GMT
+      - Tue, 24 Oct 2023 12:29:10 GMT
       mise-correlation-id:
-      - e839cd3f-ffd1-4899-aa90-a1d9ed43eb5b
+      - 5e0a33d7-a39b-4997-9911-88d1d27ef95f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A27Z&sr=b&sp=r&sig=QguXEqEClfynN0ifLqzWUwusGryXhWRXUDDa8RUFqWE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:27.4694908","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A12Z&sr=b&sp=r&sig=Sgt6Du%2F4qVUje9a9iyrRWeDsomU7xodJD7vJuoY8Xi8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:12.1012494","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:27 GMT
+      - Tue, 24 Oct 2023 12:29:12 GMT
       location:
-      - https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 7af8220f-b75d-4723-addd-29e7e942aac5
+      - ced1d77f-26da-4be6-9dd6-2d673e54053b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,118 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A27Z&sr=b&sp=r&sig=zlNvNCZg81%2F5tOFZdoRDGccZ5%2F2F8%2Bc%2FC037s%2F7SKkQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:27.7254367","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '559'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:52:27 GMT
-      mise-correlation-id:
-      - 0cda6d72-69c4-4d98-9247-7a617993d3d3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A32Z&sr=b&sp=r&sig=PrOFxGY2tKb7%2BB7URBYHMJF%2Bg6%2FMyUc3JBE1d0g4Yf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:32.9922908","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:52:32 GMT
-      mise-correlation-id:
-      - d1d0368f-76dc-4fd6-890b-5096da8db762
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A38Z&sr=b&sp=r&sig=zMtmzj3QsCihbS7mVbUdKM1VV%2FjJCvrslaYCNNolYZU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:38.2488445","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:52:38 GMT
-      mise-correlation-id:
-      - 69cb39d8-eef8-4872-a382-856a8c088a24
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A43Z&sr=b&sp=r&sig=cs9fG6TEDp4Hg3jmg7aM4Mtw6Ko8wJLjGSxE%2Fh8ZGC0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:43.5310639","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A12Z&sr=b&sp=r&sig=GVOHtmWwAG8MoAZbs6xBc6GTwLdd2734FM7kxDZBTIo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:12.3567529","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:43 GMT
+      - Tue, 24 Oct 2023 12:29:12 GMT
       mise-correlation-id:
-      - 4953835a-28db-44a5-8ac4-677221b2933d
+      - b6e20f72-b7c8-4686-b64e-2f471f4601ab
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +349,132 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A43Z&sr=b&sp=r&sig=gyRWdvK48124nB2qsQjOA9hRoRLMXnvAqTU5E8q4wK0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:43.8243025","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:52:25.693Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.793Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A17Z&sr=b&sp=r&sig=kmRgvM6vS%2Bcki%2Fcq%2BpxY6JgBlvf87HLV6i59TZREML4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:17.8410868","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1584'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:43 GMT
+      - Tue, 24 Oct 2023 12:29:17 GMT
       mise-correlation-id:
-      - 3c8d1f7f-1afa-492d-8b7b-fa06ce9590fc
+      - a267fbfc-a846-43a2-a1d9-911f5e4d0e9d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A23Z&sr=b&sp=r&sig=xLUsZcqBJILe2SVGB6Xswhby0W1AUsx8CavuA%2FeNL%2Fg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:23.2009324","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:29:23 GMT
+      mise-correlation-id:
+      - f072a659-4f65-4b24-868d-3465cd445da8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A28Z&sr=b&sp=r&sig=za2bCpVOrDA2GsicqnUVIM0IOODrzEkHgt9uGHA3WkA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:28.5518454","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '547'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:29:28 GMT
+      mise-correlation-id:
+      - 2b948903-d161-46b8-8479-800646ce7d52
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A28Z&sr=b&sp=r&sig=%2BhN2iyefiWNxK0ri4IwhoLxFM36Uh9VU0Uk18THoGqE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:28.8428059","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:29:10.005Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:27.201Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1586'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:29:28 GMT
+      mise-correlation-id:
+      - 3c386574-ec11-4eea-b52f-6c42c4d52f7e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:28.2169395Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:28.2169395Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:10.6516578Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:10.6516578Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:44 GMT
+      - Tue, 24 Oct 2023 12:29:30 GMT
       etag:
-      - '"75005e4d-0000-0100-0000-653045510000"'
+      - '"d300da3b-0000-0100-0000-6537b85c0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A46Z&sr=b&sp=r&sig=kJxEoqOmKzmOBx%2FTHV%2BIqC2%2BPFGnjbObT4iB4Oy1lFo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:46.179303","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:52:25.693Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.793Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A31Z&sr=b&sp=r&sig=NGULBEmzbwrUS8jmopVO0tnKVfM%2B3C7Ij7zIYkP70wY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:31.295437","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:29:10.005Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:27.201Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1601'
+      - '1597'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:46 GMT
+      - Tue, 24 Oct 2023 12:29:31 GMT
       mise-correlation-id:
-      - ff949646-8b2a-432a-a0f9-90e625fdb7ef
+      - 9ec0262a-840a-41db-a0fa-b204e78fb0ae
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:28.2169395Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:28.2169395Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:10.6516578Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:10.6516578Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:47 GMT
+      - Tue, 24 Oct 2023 12:29:31 GMT
       etag:
-      - '"75005e4d-0000-0100-0000-653045510000"'
+      - '"d300da3b-0000-0100-0000-6537b85c0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:52:48 GMT
+      - Tue, 24 Oct 2023 12:29:33 GMT
       mise-correlation-id:
-      - d5883ba3-a62f-4dc1-b4e5-c20c86d7ce4f
+      - c3333af2-b6f0-4139-8fe8-fb540c35cbb8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A50Z&sr=b&sp=r&sig=wF2TOd%2F2qGVQ0xCcD9f%2BcQtqfg6ckLsIOGYVt%2FdpGeY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:50.0441471","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A50Z&sr=b&sp=r&sig=UgfNs4iA%2BJaNOX5PKmVMUFXPf9658fR3zDEsKo%2FwHUM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:50.0440355","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A50Z&sr=b&sp=r&sig=AxkF3ybLX8ZnnfjRW%2FYe1kQjxiZPraKpLDxBDK4MKqM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:50.0441811","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:49.978Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A34Z&sr=b&sp=r&sig=wf56qSk3CQLV84iPsRulllDmnAI9HL8CLv4l7XJMYdI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:34.8145835","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A34Z&sr=b&sp=r&sig=WHYQAiFB%2Buuy2tb5YCpGWDFx681J47P8gcin942CvC8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:34.8144366","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A34Z&sr=b&sp=r&sig=F%2BYgZfnw7Tvo6jpjNrxaaQIDZic2NPIC0BmmyvNXFXw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:34.8146107","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:34.741Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3195'
+      - '3187'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:50 GMT
+      - Tue, 24 Oct 2023 12:29:35 GMT
       location:
-      - https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+      - https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 0fd6ea20-51ba-47c4-bd31-983434ea6bb3
+      - 654107fd-4164-4c32-a3b7-039de4e040f9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,658 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A50Z&sr=b&sp=r&sig=Qdj%2FBFieIV%2FRpp1WNP8hWUb3MnN%2FGRNLuqugBk9Tofo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:50.4821015","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A50Z&sr=b&sp=r&sig=qwDHo4pSh5hZ3uqK52s0lQd0dyUDYsp%2F%2B1N%2FQA%2FP3CI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:50.4819848","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A50Z&sr=b&sp=r&sig=vDr928vl6ztEdFswjKBDub4Mt3hn3VsQkyK%2Bm%2FQyVnk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:50.4821269","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"NOTSTARTED","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:50.372Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3246'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:52:50 GMT
-      mise-correlation-id:
-      - 338d9580-6b7c-4cac-863b-8d09335e8d4d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A55Z&sr=b&sp=r&sig=JgmALIz9JwdBINXTKg4wZCtDpYljoL1a2h0HTrCsyYo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:55.7889425","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A55Z&sr=b&sp=r&sig=4YpPXb0VVqrFveQO3k1u3bkaXlwW2fwrsWW2RecTOsE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:55.7888492","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A55Z&sr=b&sp=r&sig=EdlYXUbuwcBBFEVltp0M55ZwozuH4dW%2FoB8Mw5WnZnU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:55.7889667","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:50.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3232'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:52:55 GMT
-      mise-correlation-id:
-      - d049be7c-1b4e-4f81-847c-47247837ba05
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A01Z&sr=b&sp=r&sig=9l6v5ZfJ97iD2unY7C9zIjYgb5kIOEaE4IsHeU68RuI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:01.1198965","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A01Z&sr=b&sp=r&sig=zvVBzi3LwM8RIqUCLxP6GCtSkO2Hw0OLdc8u%2FAFyLLM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:01.1198281","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A01Z&sr=b&sp=r&sig=7wtDNkPF5Otj7D5Y91VSzxj6nAoP7FNSTL5RYfHxJr4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:01.1199126","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:50.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3232'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:01 GMT
-      mise-correlation-id:
-      - f1d8e080-8815-4ee1-a695-8768c25f39ab
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A06Z&sr=b&sp=r&sig=lYIsvHjGj2hNVNqW3rZ%2Fd73rSEu04zdEwV%2F80LFSeRU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:06.3935792","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A06Z&sr=b&sp=r&sig=ar2CC3MWB3VWQAYsB2KAWFETvMlBAy7Z8olcgRtOC04%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:06.3935084","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A06Z&sr=b&sp=r&sig=y5RFfsUhgDo%2BZEtaBAMXMY8Fq9P4rFhe%2B5xNMF8TddI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:06.3935938","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:50.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3238'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:06 GMT
-      mise-correlation-id:
-      - 72af5562-39a6-4816-b9df-e07d1d072ce4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A11Z&sr=b&sp=r&sig=fas0XAUZXNB4Nb7m6UUS7vxPYwdycEMcjLXxIbH%2BoJs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:11.6843526","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A11Z&sr=b&sp=r&sig=Y7lGSABk7Fk49TrRmWGARvZvrGBc0sURJvyICeBJA2w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:11.6842771","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A11Z&sr=b&sp=r&sig=I1QFfo8ZA3u30nkDU7xtGFRAMTSzxMrhJ4k2pf0Aquw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:11.6843675","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:50.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3232'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:11 GMT
-      mise-correlation-id:
-      - be2e2b03-3f06-409f-a2f2-8b24a9548f62
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A17Z&sr=b&sp=r&sig=DOp%2FsF6Oda1%2FV2QFVYtfQ89tjGlTe%2Frn0kF80Rl9Ses%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:17.0107188","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A17Z&sr=b&sp=r&sig=XI%2FmSB5ytVdClfADZ2tBbAZbY1WLQv8vwiGVxc40sF0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:17.0106437","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A17Z&sr=b&sp=r&sig=MPcno5wMxzQxYEYnpu9ytL3j0LvM72Mm%2B9lidPZ6XcA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:17.0107336","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:50.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3240'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:17 GMT
-      mise-correlation-id:
-      - 0a056b4e-2712-4852-aee2-6311f11afbba
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A22Z&sr=b&sp=r&sig=3lRi8hZ51O9jpN92Y9nSSLhxEqgvRGRU9ey9NBSScQM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:22.3346174","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A22Z&sr=b&sp=r&sig=clxgPw2qb6h%2FCaJSBU%2BYPf6a%2F%2B9l0%2Blb5NvYtKu0NQ0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:22.3345395","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A22Z&sr=b&sp=r&sig=VVE1lCwUAUvYjYoRhnYRRza5IZJ5TTMkQOXQYUmedlA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:22.3346326","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:50.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3240'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:22 GMT
-      mise-correlation-id:
-      - 5a1dea3c-1b42-4a64-bbf9-dc4ff7e85fd8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A27Z&sr=b&sp=r&sig=aKePusCcaI%2FjtzFKOFLkU8bBQVEvWQIc16BwTOt0rp0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:27.6312709","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A27Z&sr=b&sp=r&sig=O4lmlV3vBbBNrvBqHFSJOLQtF1Vs%2FMuAb7sYcU3MBlk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:27.6311725","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A27Z&sr=b&sp=r&sig=eJgTNGCtkzKAbay392pU9sT%2BuGt2nkrA2e8YObZxHbg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:27.6312906","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:50.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3236'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:27 GMT
-      mise-correlation-id:
-      - 37663d6e-6c7e-4df6-a835-b13e2047151a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A32Z&sr=b&sp=r&sig=FswCuSYLFxHlO8vS6GYftvXdl2Op5E7r5TFghTfWwbo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:32.9607652","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A32Z&sr=b&sp=r&sig=BLLcuiMLEvdC4ZWdd1ir56CnuDKeyxwMzhrgSvdKsnY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:32.9606879","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A32Z&sr=b&sp=r&sig=PcM8%2FItS5kFbc7seRMVt0ynqfbP3TCkM8aT39TJfsZI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:32.9607794","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:50.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3232'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:32 GMT
-      mise-correlation-id:
-      - f8fac27a-55ea-4eff-abae-630416bb5ba0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A38Z&sr=b&sp=r&sig=5T2WxbEbfQN4idrwa3KeL60r6NCt5XFCifNRODdOKZI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:38.2951967","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A38Z&sr=b&sp=r&sig=PKYJYTk2l3iQNl1PPQqhAvrzFDHWvOVqeHsOfubncc0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:38.2951055","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A38Z&sr=b&sp=r&sig=xaioWyKuIrQqUqtQAbyOqjrEIq%2BLZ7MvOVNQ5Ma2CDM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:38.2952174","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3229'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:38 GMT
-      mise-correlation-id:
-      - c39847e4-4612-45fb-99bd-626f8e9ff4e7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A43Z&sr=b&sp=r&sig=wbDLZ77aZbVIyFBMOeDRvnwjZOOCDJpMI2aYeEVfSW8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:43.6367102","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A43Z&sr=b&sp=r&sig=VGmVT9q1IBoHi2evE9iGEcg0fOBzSD%2FFIpZpWVo3BP4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:43.6366129","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A43Z&sr=b&sp=r&sig=5FDzTrUtqc9WEG2PuHPx4l68QvhtrxHPSouMnWFMRgE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:43.6367316","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3229'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:43 GMT
-      mise-correlation-id:
-      - 0a72e8ee-f0d4-4d9e-8316-be8e991e6a54
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A48Z&sr=b&sp=r&sig=I0HhLyU7IQGB9c%2Ble0%2BwW5LoKhZZNOhtTuVkr%2FhS8AE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:48.9081694","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A48Z&sr=b&sp=r&sig=173SrAjTRWOHn1orWtoKlM9HXt%2B8Jipu3qEHH6xsKlk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:48.9080932","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A48Z&sr=b&sp=r&sig=Nah6y1udo0taC0kZrkyUbOxzAy3x7ElBC%2FVfYuN4M30%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:48.9081833","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:48 GMT
-      mise-correlation-id:
-      - a5fcdc79-6eb6-4428-aafe-1e41792d5646
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A54Z&sr=b&sp=r&sig=ge%2F1VSPSA3iBuPJJPYQJci0KWFvw6BfUvbxshnaxfM8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:54.1761916","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A54Z&sr=b&sp=r&sig=ECeAcMpBVJMTFAGkYwkt1lm1qwjhfJoJ4wW7RRiO7M4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:54.1760989","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A54Z&sr=b&sp=r&sig=jSv%2FKvReObFDEs5VN0Y1%2FL62395eNYC%2BMsO8ts4X5yM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:54.1762141","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:54 GMT
-      mise-correlation-id:
-      - ab9471ca-54df-45f5-876c-03a54fee770a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A59Z&sr=b&sp=r&sig=oldR7wOGpl9Pps3YRdiS2AAKldxcbpT4t5dLyg24CV8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:59.5240187","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A59Z&sr=b&sp=r&sig=9EB6tSPRVAYP0Csl2v31UMC90huLn3iQTwG4oS%2FD%2Fbc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:59.5239427","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A59Z&sr=b&sp=r&sig=%2BObUicDZdXFykLehq9BOmqnbYcTCNgrjbIVuWHl0Fig%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:59.5240324","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3233'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:59 GMT
-      mise-correlation-id:
-      - 323ad84f-0600-4d2d-8a03-673f4f0d8f40
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A04Z&sr=b&sp=r&sig=mieBbdMhD1%2BUAMmCbqu03WlpPdYqKtj1owYQzjbNiQ0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:04.8450344","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A04Z&sr=b&sp=r&sig=1Qj%2B0DZlLVGJij9v8F9G2uZaVVGmkeXEoFbjwpGt%2F%2F0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:04.8449633","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A04Z&sr=b&sp=r&sig=qJvU6%2F31x5%2BJil6CklwJJEMJmKUzZL0YDUVkBfWc8vk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:04.8450488","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3239'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:04 GMT
-      mise-correlation-id:
-      - 1b9583ab-ce5f-456c-85f5-61a2e1a35a41
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A10Z&sr=b&sp=r&sig=KFZtA7%2F8zBU92Hay7kYJK9H8crWxg66LA2ho1BR6GQE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:10.1494642","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A10Z&sr=b&sp=r&sig=hMiEGIrXet1BC5YF9V3e8Xp7u9jOORNnhC0%2FOpXWrDk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:10.1493681","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A10Z&sr=b&sp=r&sig=3QWVaxq74%2BpbBYXqeVMrGrSM0xRPs%2BBaRUN1vlOsUOk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:10.1494879","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:10 GMT
-      mise-correlation-id:
-      - 21391e23-ef10-475d-8165-4d7a1d0bccc4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A15Z&sr=b&sp=r&sig=9A1HTOJKECGq0gakZIijHA%2FWD5r3dvf21zQjWrGaWEA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:15.4349354","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A15Z&sr=b&sp=r&sig=F8b9xDlU805IzJm9gZ8jANME5WU6HEMMrhX%2FEEqx0tw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:15.4348496","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A15Z&sr=b&sp=r&sig=DJhGzfBQ3XssOZIwPThOCDnccrCO1%2FvvLK6fTGyYq30%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:15.4349503","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3233'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:15 GMT
-      mise-correlation-id:
-      - 42dc2958-2caa-44bd-a696-1d9271165b19
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A20Z&sr=b&sp=r&sig=cZMPSXLP2MY%2FUE1P%2BancNSHte4xbG1oJ1A4ohKAf0ME%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:20.7218845","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A20Z&sr=b&sp=r&sig=VmSue4MSbUeWERh5yv2K8OeHtYEiUBUUnnBkfSWUEQU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:20.7217478","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A20Z&sr=b&sp=r&sig=oi3m5vAQlNIvznkGFNxqQvJXq8LT3IPLvmexAgbtdkM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:20.721915","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3230'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:20 GMT
-      mise-correlation-id:
-      - 122e13f0-a791-438b-8ff5-d176c505de33
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A26Z&sr=b&sp=r&sig=1Pu70gsN8tV4%2BaobonWkXkPuMWE0Lv3zU1IEGH%2BEcCs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:26.0279096","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A26Z&sr=b&sp=r&sig=QcuUzvFa38pT5FVHsxqQkCH0s2HwaI8Weg3ufJKouMk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:26.0278363","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A26Z&sr=b&sp=r&sig=4EqqmqOsfYT3%2FAY1scMy4jwbIQjLsBsez0yZd%2BzimL0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:26.027925","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A35Z&sr=b&sp=r&sig=AP2n2zdwVuPl%2F0LUohfVLnZkEgwzwg4prk%2BCUF0c%2BBY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:35.4376147","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A35Z&sr=b&sp=r&sig=AQli09uoW2aQaFuMUlW3fs8H9gMz5yw6HyGiVxNdtpQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:35.4375456","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A35Z&sr=b&sp=r&sig=Kd4JUuFdXuxtiA5RyKqkPqFOM64fcEFVUECcCOOdfbc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:35.4376299","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"NOTSTARTED","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:35.295Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1362,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:26 GMT
+      - Tue, 24 Oct 2023 12:29:35 GMT
       mise-correlation-id:
-      - 7541ffae-970d-4b70-bf7b-197c928139bc
+      - 6a484bcb-851e-4a0c-92df-7e5c76e1b47b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1384,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A31Z&sr=b&sp=r&sig=cGc4p14Cv8q6EYr2TgkExESywwAdjm%2FAhLkDwZcnX7I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:31.3527255","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A31Z&sr=b&sp=r&sig=PPlYA0qkEnv4tYR3zbjfL3wscDwkp0JxQ9Tb%2Bqy6zMg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:31.3526488","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A31Z&sr=b&sp=r&sig=RNYj0t4kJ0ocSwpFmOb4sBgzSQuLwZXAbwWC1w2prjY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:31.3527398","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A40Z&sr=b&sp=r&sig=pw4ZPYbBVA0R54V07SeW3RVznRhQ9n5eTcShZ0Ax%2Fpc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:40.7305292","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A40Z&sr=b&sp=r&sig=CEGVsJlKQsMsYS25Mlj2L6rpOzxj0DLCjHGqWAyq5rU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:40.7304506","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A40Z&sr=b&sp=r&sig=8qiu569A1pP%2F5D0hbBn%2FnFUlMXlQC2LizW01tB7k05Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:40.7305458","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:36.396Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3231'
+      - '3236'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:31 GMT
+      - Tue, 24 Oct 2023 12:29:40 GMT
       mise-correlation-id:
-      - f342daea-c9a6-41f1-8b42-7e6569929e8b
+      - 99f20c7d-c413-4760-a31b-984d0f4b890d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1420,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A36Z&sr=b&sp=r&sig=X%2FxVpuaOyh4%2BSuHifpa4v%2F3n7hG0d8BQ%2FNzD2TzUOxw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:36.682347","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A36Z&sr=b&sp=r&sig=2fc4T6%2F95fMhwe%2F%2BHEvLE7uIpEcB%2BVeUbDZq7s8Raso%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:36.6822528","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A36Z&sr=b&sp=r&sig=LvN8GbweTudceOLsjMEj%2FZ3A5nV%2BIhQky9TUwmoc62c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:36.6823626","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A46Z&sr=b&sp=r&sig=8KsRrMSycYqReqt%2BpIc9P2I6%2B%2BmuYuh4IAz6H43reZQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:46.408717","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A46Z&sr=b&sp=r&sig=kJqHnIC47aIeqlQT2FgjKhLMSEzyYN30%2F2leVeIxikE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:46.4086479","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A46Z&sr=b&sp=r&sig=UhpP8twagTq4Hdr9McgtlSNNVjgRhaL9SYZSZ%2F%2BZS3E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:46.4087317","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:36.396Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3246'
+      - '3241'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:36 GMT
+      - Tue, 24 Oct 2023 12:29:46 GMT
       mise-correlation-id:
-      - 0bf48d03-62ab-4199-aa3a-85d58f60d634
+      - 92e66421-f8fe-4d28-b31a-71485c1fdfcb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1456,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A42Z&sr=b&sp=r&sig=Ym1jmu1cKQ2zbWjJRAlOd0MOaaqx4zkL8oA%2Fn7npcxs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:42.0124238","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A42Z&sr=b&sp=r&sig=X%2FxFoHzY92m0EGEgeevr8yfRZCh69QYOzQtc%2FdjfV60%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:42.0123243","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A42Z&sr=b&sp=r&sig=aznmP2WO2t2QEPxbGs9IefFTIYpqYhwCJfF6DkGnCMk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:42.012447","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A51Z&sr=b&sp=r&sig=X2ehByjE%2FCls0T7bxspODbKfgwZa57EJJiuj3TmCMgk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:51.9075159","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A51Z&sr=b&sp=r&sig=38bLaJ2%2FMD0%2B89R34EzutlA4FVZ2xQoJisDT6RXTSfA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:51.9074625","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A51Z&sr=b&sp=r&sig=URpgHYdwD0UbXRv67MaaIFzo9y%2FO7svQnFlW%2Bw843SQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:51.9075299","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:36.396Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3232'
+      - '3240'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:42 GMT
+      - Tue, 24 Oct 2023 12:29:51 GMT
       mise-correlation-id:
-      - fa367ac3-2933-44c2-b7b2-c0ae8cd81084
+      - d426b95c-0e67-4fac-81c7-4d5e5a05e2cd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1492,154 +844,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A47Z&sr=b&sp=r&sig=lLvfZb3PTUx87KhmTlkC3shAu64W1eFDxVRmFN6x4Is%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:47.3372258","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A47Z&sr=b&sp=r&sig=Ol9sLcXPBXvY5p%2BphTMaJMJc%2FiKjU7hUWQxOaeh8ZbE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:47.3371396","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A47Z&sr=b&sp=r&sig=cVsSTvXPyBNaTsUBLTTjbhB%2BLTXuq%2BxKg3I5VPciyc4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:47.3372475","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:47 GMT
-      mise-correlation-id:
-      - 6dfff755-e11e-4ff2-b6e1-bd9f02ee74d1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A52Z&sr=b&sp=r&sig=NGPaffqiFLET8aqEEoAFqzTVc9ok4EwM1oIqyipNBds%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:52.6616687","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A52Z&sr=b&sp=r&sig=pokxLQFzdDl6FL9FsHWKUC07fVzPZEVW45ZqeVQG%2FK4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:52.6615903","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A52Z&sr=b&sp=r&sig=NnytxFdrGwqIP9KrVWRMRf%2FnCpyQLL4ceKJJ7%2B24vzc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:52.661685","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3232'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:52 GMT
-      mise-correlation-id:
-      - 809c9f75-25f9-49ce-b62d-bdcc7f57a205
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A57Z&sr=b&sp=r&sig=8keSXUxMPajZ1CVFNw0Qb5cjhwumGf8Xe%2BigrEcUeNE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:57.9688559","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A57Z&sr=b&sp=r&sig=EgFYCHo7oQG5WXWeB8WgacrgyPXJwh2UOiqTauOYJi4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:57.968757","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A57Z&sr=b&sp=r&sig=6tkzWOXgKURHwMjNUr9ZVoX6GsQR5mkO%2FWE5KOqc%2B9E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:57.968881","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3231'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:57 GMT
-      mise-correlation-id:
-      - 2613a444-dfd6-4a5b-93bd-9193fa534fd1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A03Z&sr=b&sp=r&sig=GKrjWPGPOr%2FtlvyU3VPTZP2fq5TOd6h3Ua1voeCqG5s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:03.284446","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A03Z&sr=b&sp=r&sig=YMvtqNhD2D5SV%2F0%2Fpe6yMqT8E3AEvd88KD4kr%2FXATEM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:03.284374","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A03Z&sr=b&sp=r&sig=HqW5UyPaLuVtenE4gIsR7B%2BTjQMOXy3h5VCPS9N%2Fvqo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:03.2844615","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:55:03 GMT
-      mise-correlation-id:
-      - 29549b3f-dfeb-4e89-9e10-ad165fd54483
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A08Z&sr=b&sp=r&sig=XUDZsyyVqw9tq8FRlU0nB5DZY7y8ir40b4QPS%2FM6yEo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:08.5462372","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A08Z&sr=b&sp=r&sig=3yULhL8zAN0%2Bst%2Bra8nfF8glJkMHYhBEAdSCNy2H88E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:08.5461376","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A08Z&sr=b&sp=r&sig=i%2F3lZfPm%2FtZLXgbj%2Fjnjfimy%2Bv0VoJtLeky%2FkQ2R6fM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:08.5462605","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A57Z&sr=b&sp=r&sig=e%2BFvcDFg0T9FxMx%2FDJORQpiTQwD%2Fu9DVzsLpULM9eQ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:57.786014","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A57Z&sr=b&sp=r&sig=qMqGGfN55K7x%2BCxiNQn1iZu9ZPbf79T25pkN9mpp9zk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:57.7859416","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A57Z&sr=b&sp=r&sig=At%2BP3WxKEUZAtAwXXjPpOlo4VOaDpjeJ%2FZdoedW%2BGr0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:57.7860301","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:36.396Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1650,9 +858,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:08 GMT
+      - Tue, 24 Oct 2023 12:29:57 GMT
       mise-correlation-id:
-      - 8cd443a6-1d23-442c-a087-6ba035679744
+      - 978d2daf-ccb2-479e-8abf-88763894a4e0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,10 +880,190 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A13Z&sr=b&sp=r&sig=dtSOAKC4l3jdp6yr6yrytELOcKIJfej1jVh%2ByvbnqkA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:13.8347912","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A13Z&sr=b&sp=r&sig=UqmL4gShQ20RM2oKybzVSONUXKVHgJO%2BbO765hda4iE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:13.8347256","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A13Z&sr=b&sp=r&sig=CAYdpH%2Ftjb%2F7gcFf6B8bNtqIUST06jII0VEz1iNDPVQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:13.8348071","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A03Z&sr=b&sp=r&sig=YRKhafweqjbL%2BDe4ZPrO71xAmC0BcCW0Y6qekLdcnNI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:03.1397166","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A03Z&sr=b&sp=r&sig=fao16lb1FfinrXhk0g7JNBKVDTxDe8D7nxM%2BEM2Vfuk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:03.1396247","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A03Z&sr=b&sp=r&sig=9uYEXpoU%2F6UDLQlB8EdOATY5ajf1X5nzZWcMUIlFOro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:03.1397376","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:36.396Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:03 GMT
+      mise-correlation-id:
+      - cb1b3bb2-fa48-4c8d-8441-edaa257e06a8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A08Z&sr=b&sp=r&sig=G7Bfz4HbSGH71Bp7ALCYU1cx1D%2BqJgHUN%2BAKZt8Nv%2Bk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:08.8212255","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A08Z&sr=b&sp=r&sig=o%2F7mKxK5crlq8BTf4UhoK2tvGmg%2FVFHpbaYYTY0LdO4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:08.8211366","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A08Z&sr=b&sp=r&sig=kvehxPdxUropeRoPkS6VAf8MGb4LiAAlJHBFb7VZFX8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:08.8212472","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:36.396Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3240'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:08 GMT
+      mise-correlation-id:
+      - 6f833f3b-397d-4441-bd9c-6319662fdeec
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A14Z&sr=b&sp=r&sig=rjSHeaTiFQqcAd1TIEr5w1gZi347e0bh6wyCsB9fFtQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:14.1173519","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A14Z&sr=b&sp=r&sig=qPdkgIcFam9DEcbBR%2B4WY4%2BTKnI0o6W4Wgi%2BSmHwEc8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:14.1172835","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A14Z&sr=b&sp=r&sig=D3mlLVvh6c2SQxbIaR9XjrXjexiJMi5eBPLnXs4%2BGFw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:14.1173663","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:36.396Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3238'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:14 GMT
+      mise-correlation-id:
+      - 78b30813-10d3-40e1-bffc-e592e82abc36
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A19Z&sr=b&sp=r&sig=jWtLh1QagpEABfN6Ot0SGvEsEQ44OlRa%2BUC9RM6EQFM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:19.4406261","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A19Z&sr=b&sp=r&sig=ul0VnfpxnjQd95a0UsAf0iM3waoAp9sdRmd85hxSuKg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:19.4405501","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A19Z&sr=b&sp=r&sig=CQZo%2BzyYNLxpxTr0m7oc2ZLFycf7od%2Ft3MyStvsiCdU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:19.4406399","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:36.396Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:19 GMT
+      mise-correlation-id:
+      - e86aefe8-8ee8-4be5-8faa-31104a916000
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A24Z&sr=b&sp=r&sig=NDA26kFhekPKpRqJyfLZ1E2yDJKcBP%2FhGrFaaAOuvn8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:24.7322768","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A24Z&sr=b&sp=r&sig=REc5hZ3dlxdX61nrGE8c0oFTSYuCt5w0G96ydL9QhNc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:24.732189","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A24Z&sr=b&sp=r&sig=fTRPOYgE9CwaozLzd1lq2hBU8CC%2BvY%2BWDM7sXBRxojc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:24.7322978","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"CONFIGURING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:21.715Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:24 GMT
+      mise-correlation-id:
+      - 9c37791b-3f5c-4f49-be1c-382574d183cc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A30Z&sr=b&sp=r&sig=fMBSapx72JvM%2BY8L0vIZSDp7x2U1BLAq5il3dX7OJJY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:30.0761298","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A30Z&sr=b&sp=r&sig=he1TIjhNAyKWZhOxS1yDvI%2B%2BlGS3eJKQAH5kHaXQNoE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:30.0760552","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A30Z&sr=b&sp=r&sig=r43zOxRvKwTZDi83HvGtTMIiW%2BmHzkjXrK6s3NNGzKE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:30.0761443","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1686,9 +1074,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:13 GMT
+      - Tue, 24 Oct 2023 12:30:30 GMT
       mise-correlation-id:
-      - 71ce69fa-76c0-4238-90d1-323a5c894ecf
+      - f57fd59c-455f-4fcf-b575-84b0e791f590
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,23 +1096,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A19Z&sr=b&sp=r&sig=SB0RtHrhDKai41z%2B4%2Bnb%2Ba1qdMVHeslidaSNm9V%2FlMw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:19.152459","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A19Z&sr=b&sp=r&sig=Xag%2FVa18CIMzf4nSofZCqeRHswFO0NXknN4Emrqu%2Btc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:19.1523945","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A19Z&sr=b&sp=r&sig=Btz2jTDxruwvI%2BqHmVA%2F7f6tSy7RkENPMaJ4X2KmiPk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:19.1524737","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A35Z&sr=b&sp=r&sig=OnqUXiurAv7hsEOLO2ptv%2FuBVaAFK%2F02UMWibKcc5fM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:35.3927648","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A35Z&sr=b&sp=r&sig=sqeVZ2KwQ9rrf6kQCWq%2FJzDsBFniDcYC9qcvyisSVIs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:35.3926522","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A35Z&sr=b&sp=r&sig=p5wS%2BWeiDsmuDwt2BIjfLkYQMsGRox52KxrVnkZuf70%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:35.3927921","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3242'
+      - '3235'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:19 GMT
+      - Tue, 24 Oct 2023 12:30:35 GMT
       mise-correlation-id:
-      - 851ee872-8962-4480-8adc-f5d68f1ec075
+      - 061e36b0-0a76-4336-91f4-2cedc1b69a8c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,23 +1132,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A24Z&sr=b&sp=r&sig=wRg0TLpVpmixV6X2OGG1VeIF2rH%2B4tg8Cc%2F3oUDqqx4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:24.4989765","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A24Z&sr=b&sp=r&sig=varCFcms8iYYZ0B90bJRWqr8x%2BwC83YYq0REf%2FFCDA4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:24.4988761","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A24Z&sr=b&sp=r&sig=iIKRPfcb%2BHrw0tuo4Yj1DvzTkYONXICiK0ftJVWlLJc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:24.4990011","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A40Z&sr=b&sp=r&sig=hFBRuENFL9YIWrpFmAa3SGv8%2FVuRfgDX9T37g4BXVow%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:40.7281405","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A40Z&sr=b&sp=r&sig=43W0czN81nHk1bCyE8q0Y85HtQJxQXdXCpAyr8RfcDk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:40.7280626","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A40Z&sr=b&sp=r&sig=yNwiQSmPckB2MRwp8rlbyu6zjiR9URLK73Kbe%2BiAblU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:40.7281552","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3237'
+      - '3231'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:24 GMT
+      - Tue, 24 Oct 2023 12:30:40 GMT
       mise-correlation-id:
-      - 28644e65-eb34-4087-b962-66a82eee1fb5
+      - 11587441-0317-4b2c-aa59-7516084da2f8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,10 +1168,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A29Z&sr=b&sp=r&sig=qEWKjzemQ1v%2FQjCRFxMYC9I1zOtLNjpQJ8kIcCZn1fQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:29.7597269","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A29Z&sr=b&sp=r&sig=Fj5wGXbxo2gLIZex22xTrUo5%2B8AnXuWubUPzHLkOp1M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:29.7595982","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A29Z&sr=b&sp=r&sig=zxh46ZCEwI3%2F%2BCwZodYOLonPXPX5VxIZKgsP4VOuYks%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:29.75975","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:50.372Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:37.165Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A46Z&sr=b&sp=r&sig=a8vCOl1M%2BtullfBj7Xif856qQyy86OpercFR2vkOtxg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:46.053909","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A46Z&sr=b&sp=r&sig=C8l71Dfsj8ECAXujRxi2%2FDc7NjZOko0aXPRuCqqXQYU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:46.0538405","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A46Z&sr=b&sp=r&sig=noBHjXLWQZjyxn0SC5KDZHMUjDlfJf69%2FongM%2FJ0ZDU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:46.0539233","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:46 GMT
+      mise-correlation-id:
+      - c2f1cbf8-49e1-419f-9b28-6896a8b6f775
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A51Z&sr=b&sp=r&sig=TyS7d2tXoQWLowv0pa852%2BcQ4P%2B7XaLbZEXvELHPzaM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:51.3312914","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A51Z&sr=b&sp=r&sig=kZ8h3SeXMq%2Bvspv44rwmro9SyyudqnRrQVIIs0ZKTOE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:51.3312068","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A51Z&sr=b&sp=r&sig=tkUzxOk4I084B4IaFkCDQvJh%2F79lV7GNngYs3qESpN8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:51.3313148","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:51 GMT
+      mise-correlation-id:
+      - 38542fec-d1e8-4281-b077-f255d47567eb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A56Z&sr=b&sp=r&sig=Xe7fFnMRjCYDTkENfypi4qx2TJ3UnM8bsHRc9E6Yg8k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:56.7111367","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A56Z&sr=b&sp=r&sig=xuZCNZxQFfpW5cAAKvZez5T2PIH8HQpmjhjvcCgMhQA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:56.7110667","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A56Z&sr=b&sp=r&sig=QqTB2v7Ex7Bt%2B5XYetY0EfyTR7f7BL2Ys4s%2B9DTfTRk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:56.7111517","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:56 GMT
+      mise-correlation-id:
+      - c56381dd-2ec5-4c8e-a632-8504544a4917
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A02Z&sr=b&sp=r&sig=yiYJAvxC7dRiltpVQQoSSYBCQe55d0vFX2k1haLazbk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:02.0277399","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A02Z&sr=b&sp=r&sig=iP8AumF3XFLsyFEofuU%2BvuYcgzmMN7i6pvvhr%2Bb2vL8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:02.0276579","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A02Z&sr=b&sp=r&sig=TB93qjVKU9yVQr6qezdRuneOdL%2Fh1qGFG94wF94r5aI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:02.0277554","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1794,9 +1290,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:29 GMT
+      - Tue, 24 Oct 2023 12:31:02 GMT
       mise-correlation-id:
-      - a3228e35-7953-4158-9b79-4c47ede4d7e7
+      - e1886490-23a8-4dbc-a1e7-d0b2580ebe62
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1816,24 +1312,528 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A35Z&sr=b&sp=r&sig=kF6t%2BPkTaGq2iYvuuPmTeBWv0wKXmpKIcReBOp%2BDD9s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:35.0117063","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A35Z&sr=b&sp=r&sig=jtIKxvY37oX1pAJZlpRVWu0HS%2FonqdP8vP0kAGuAnZo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:35.0116356","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A35Z&sr=b&sp=r&sig=rnzddUn75ofXopRp%2FPD3c9YT7r6EzyxFNt2GBFf59rA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:35.0117204","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-18T20:52:50.372Z","endDateTime":"2023-10-18T20:55:30.069Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:31.699Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A07Z&sr=b&sp=r&sig=wEQlmofS7BYYKHV8ZxL8mct7kMZQ6UxbnAaW2VQRDSU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:07.6943663","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A07Z&sr=b&sp=r&sig=e7JQT5ZPSP7COq9QEq9kGqZU%2FOPTyvg%2F99nSIDJYTYw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:07.6942968","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A07Z&sr=b&sp=r&sig=lgCGdx9hpHRQ0G7jYr3SagLR578KGghQPVM4kOPx17E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:07.694382","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3370'
+      - '3230'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:35 GMT
+      - Tue, 24 Oct 2023 12:31:07 GMT
       mise-correlation-id:
-      - c2b8fb44-14bb-49ed-a585-fbcc1bca72c0
+      - a6d625bd-1efc-49b4-b0a6-2f859f395238
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A12Z&sr=b&sp=r&sig=%2BMMScx%2FL4HEq85bcJ7TlqGzfp3xIUlJkXW3IooxtpHM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:12.9788771","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A12Z&sr=b&sp=r&sig=ArH8jZNs%2BeNoHV1MW%2BM2SpKps5b5kWLhymUuTBm054A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:12.9787931","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A12Z&sr=b&sp=r&sig=RUEozae3mapqectJJzfaNTXDi%2Fa7Qls1AZuZjWSaQJA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:12.9788985","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:12 GMT
+      mise-correlation-id:
+      - 7751f073-e3a7-4e98-8ca9-63a5ea225c21
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A18Z&sr=b&sp=r&sig=OGZxTgUKPnT27darJl2ZzVCaiGxMidoJImOyoCFclpE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:18.2541667","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A18Z&sr=b&sp=r&sig=fk4M6gdpPQdUOtiw%2Bezx5ZDNz6HkNpfWCZL3vYhhyag%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:18.2540787","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A18Z&sr=b&sp=r&sig=7CqgPxs77KYZ07HJ2PhuQqvwb9CNunBQm%2FsCb1DGfX8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:18.2541865","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:18 GMT
+      mise-correlation-id:
+      - 09abab3e-2baa-493d-9eee-374f617a2380
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A23Z&sr=b&sp=r&sig=1EVbLWUTQDAwqetoZACu%2B71NfwpHXQJRoI%2BXO62EzUc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:23.5379053","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A23Z&sr=b&sp=r&sig=853BAyMQjDmLfUl1y4by0RTjpCdvYHr77tK1yRqRur4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:23.537815","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A23Z&sr=b&sp=r&sig=1s15Lq2Ipli6ODndAyf50uCiTor7o7Mo%2F17y7I9diUw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:23.5379392","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:23 GMT
+      mise-correlation-id:
+      - 59ea4c7e-54c8-4814-ad75-270eaf969e0c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A28Z&sr=b&sp=r&sig=2cb6Sfnwga0%2Bq4zldZvStbFuWLS2Iuvf9bgydp%2Fk3i0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:28.861725","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A28Z&sr=b&sp=r&sig=VB7QZvTuNVcL0RHYfES4HwYCbJ0ATfPKoa9Pi0mCzLg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:28.8616452","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A28Z&sr=b&sp=r&sig=jDlkVYq78SKRzWRaJPG3%2BerNVHCbHh7uUI0qVr3nCLc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:28.8617397","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:28 GMT
+      mise-correlation-id:
+      - 3fb11208-0981-4195-a73f-d5c9934ebdbd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A34Z&sr=b&sp=r&sig=zB%2FnQ%2BZ1EkYbguHzRpskfO2yq5i2%2BYYYN8M19f6nkLY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:34.1827606","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A34Z&sr=b&sp=r&sig=38HbcdUhNEn0J9iU9aqQ1LNxpEabZgnvExVK9PkxOas%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:34.1826669","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A34Z&sr=b&sp=r&sig=l4XrM6ZtO%2BVap0tgnEpOes6SJ%2FVAdKtkeIeZ%2F7VRmFw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:34.1827758","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3239'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:34 GMT
+      mise-correlation-id:
+      - 1684d51a-e083-4a96-8e61-eedccbb85480
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A39Z&sr=b&sp=r&sig=tOtExo4SVLUCYvyocKNIYyIZ5WeH9mJ0aURxrgW%2BlzI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:39.4612862","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A39Z&sr=b&sp=r&sig=CettTF%2FTcMgqq0%2FGEWjt3wpBhsvGYpJiom%2FurxcLqjE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:39.4612075","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A39Z&sr=b&sp=r&sig=GG6V6d0%2FtXCDFW2IkJe2U75Gg%2FVcAOa8E5B7HD14L3Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:39.4613007","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3239'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:39 GMT
+      mise-correlation-id:
+      - 3716a896-7968-4ee5-aeed-37090588e5b4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A44Z&sr=b&sp=r&sig=Ht1MpmDN505A77Q40F2jliOtkFWjIf%2Bjf37cupLSZQM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:44.7315468","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A44Z&sr=b&sp=r&sig=UEzvM1wj%2FnmAWEo6jkTz80WoKTtESWblkJxWzw4mPCc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:44.7314708","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A44Z&sr=b&sp=r&sig=1zUpUcJKuRw92mZb8oX%2F4QO8h6ft5YiH6OsFMNMk%2BfI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:44.7315613","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:44 GMT
+      mise-correlation-id:
+      - b58dc670-77d4-4e88-9343-b5de7320fd04
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A50Z&sr=b&sp=r&sig=Rpg2albfT%2Fe5nzpDPOxIb8nmfEIPpki2AniyhIBuhpo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:50.0674488","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A50Z&sr=b&sp=r&sig=OX2wg8qkD7fAU1cWaZYp%2FStuAdng6sfpyUxYEY7fN4E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:50.0673798","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A50Z&sr=b&sp=r&sig=S93PQSLUte8s10fGeH95KUE%2F9NqLjydb1E02jKIDn4E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:50.067463","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:50 GMT
+      mise-correlation-id:
+      - f69df66d-4ea4-4615-8b23-ce25c27f6872
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A55Z&sr=b&sp=r&sig=s%2B7viMy4OMOE3bdkviudrsCvaorMSiVIfVO%2FaNpZdi0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:55.3424925","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A55Z&sr=b&sp=r&sig=%2FKvLxHc1mh%2BYHm9PsNsUoea04r7oDwjLT%2B5IXvCJ6y4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:55.3424118","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A55Z&sr=b&sp=r&sig=4c%2B%2BBWKLzSfjF%2BJvPDnGncetNRS3xKlKJir%2BEy051sQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:55.342514","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3244'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:55 GMT
+      mise-correlation-id:
+      - 056cbafc-213d-401c-8e39-08897acc00d7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A00Z&sr=b&sp=r&sig=6Xt4M1Pu%2F3i8L9OqnDNMX22AKfh4frU883k1mfzAaOQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:00.7185657","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A00Z&sr=b&sp=r&sig=I6sc7b%2BZNAp1vMA7FcZv1DGT61muzEgGc9t5oJE5QoE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:00.7184962","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A00Z&sr=b&sp=r&sig=M2A%2BVg95B0%2BMd%2Bra6IU7pdPUA7z4GtPH%2F5VrcmKkC58%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:00.7185799","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3239'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:32:00 GMT
+      mise-correlation-id:
+      - 54b71713-ea45-47c0-81e4-7aab9454ab8f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A05Z&sr=b&sp=r&sig=DpOT6Zqk7TZdbmg0we33EqugnisEd0CIDDixtyPA7S8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:05.9995312","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A05Z&sr=b&sp=r&sig=ABI22fc0pqDSC9egtP5dXPpEDIeBmjahMzDCSRRjesw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:05.999461","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A05Z&sr=b&sp=r&sig=wiUT72FxBvhDRp6d13Rycl1GY9EdAEjyGRbXFkgU%2Fno%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:05.9995462","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3228'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:32:06 GMT
+      mise-correlation-id:
+      - 758e87f8-9e07-4e4a-998b-1da2e147b411
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A11Z&sr=b&sp=r&sig=Y75wLA7PwS56KUqU0woz1Lo185RPnRfvY80T4LRPj%2FA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:11.3470169","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A11Z&sr=b&sp=r&sig=SLrMBUner%2BdY4Uxk2tedPDLsHIdxW5fnLYoM8TUIWys%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:11.3469305","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A11Z&sr=b&sp=r&sig=5B%2B7jxm%2FP3h1bD8pnxKixm8jtEwkYBioIiAb3qLlnG0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:11.3470313","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:32:11 GMT
+      mise-correlation-id:
+      - a92a3efe-09ec-46f7-81b2-d8d6b477a1e4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A16Z&sr=b&sp=r&sig=ivQA7bXvrVlUALSk8V2LyY%2BDtafKheesfVIjIDeiipU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:16.6023343","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A16Z&sr=b&sp=r&sig=eNQJzZtaMsoDGzFmqkIuQixGrDNpp9dwIEJ1myBo8bs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:16.6022638","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A16Z&sr=b&sp=r&sig=tE%2F%2FexIpQPErSwsGVadX9JmZXXPs%2FP41wIM%2Bbp4XMjQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:16.602351","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:35.295Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:25.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:32:16 GMT
+      mise-correlation-id:
+      - 1d72b52f-62b4-4603-aba7-098a61939aff
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A21Z&sr=b&sp=r&sig=GkZxQhY%2BqvrpY1BP%2BSNX%2BjTc4rNSDRWp%2BApR2pEWl%2BA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:21.8943718","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A21Z&sr=b&sp=r&sig=B5KDQab8OSqQTNDIxqPeUcR1AP8yXtUhTxa7RITmpSA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:21.8943037","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A21Z&sr=b&sp=r&sig=gqyKhG0W6YWCphNC1EvzoPP7ioi2Ft7AqARfEZOsvNs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:21.8943855","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-24T12:29:35.295Z","endDateTime":"2023-10-24T12:32:19.175Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:19.247Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3372'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:32:21 GMT
+      mise-correlation-id:
+      - 5f66abb1-cd4f-4dab-abef-a11a013f356c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1856,7 +1856,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:28.2169395Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:28.2169395Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:10.6516578Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:10.6516578Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1865,9 +1865,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:35 GMT
+      - Tue, 24 Oct 2023 12:32:23 GMT
       etag:
-      - '"75005e4d-0000-0100-0000-653045510000"'
+      - '"d300da3b-0000-0100-0000-6537b85c0000"'
       expires:
       - '-1'
       pragma:
@@ -1897,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=app-component-test-case&api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=app-component-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"31ad3a4f-8712-4ddf-ad8f-15b5105c3361":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0f16e512-990f-4caf-8c5e-39e040ec0e27":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57a98ded-236c-415f-9ad5-d16cafcafc93":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/4a6b41fa-e888-4e25-b6ed-20a3798176c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A37Z&sr=b&sp=r&sig=JbgpvdStcaiMdXRvV495wCKMr%2BupVQKugyBsQotS38s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:37.2862365","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/22f3da01-541f-4909-8743-32ed1f7cc9c1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A37Z&sr=b&sp=r&sig=yi7s92wNwDhtzPqL%2FGjS5fPppVbhIBKVba%2BNYom5kTE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:37.286167","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b80f5112-f27c-4bd8-8594-ae272b7c67db/3dedef44-d686-4b99-a7b7-4223fb8827d3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A37Z&sr=b&sp=r&sig=YEF2D0BASRftJQjY4GE6xZq9f17yovR5sKFnlGATs74%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:37.2862517","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-18T20:52:50.372Z","endDateTime":"2023-10-18T20:55:30.069Z","executedDateTime":"2023-10-18T20:52:48.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-18T20:52:49.978Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:31.699Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0823c9ca-c379-4eea-a06d-d21fd6ec75db":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"043cecbc-0424-42a7-bf14-76f36fa3c56c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9dffc865-f428-47fd-bac0-fc382d724331":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/c5581ae5-aa0c-49d2-887b-c90ad037e184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A25Z&sr=b&sp=r&sig=lWirbw2BkTV8PLg28K4wg4NfAkrkGjime7tri5p4t0g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:25.0695275","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/4ec13dfc-d081-4a8c-8915-e29b48ea919e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A25Z&sr=b&sp=r&sig=dc057dxVTfPcmFeUAKTIqtbfj6byirn48U00i2w97hg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:25.0694276","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9fe3b058-ea7d-4a0d-9692-64ed9f2932bf/bdb06388-f068-4445-9a51-71126f6bc941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A25Z&sr=b&sp=r&sig=B0%2F1Crtid8DSJN%2BlvRLO75iDkowLDhhjUvC%2FRnYkYnY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:25.0695505","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"app-component-test-run-case","displayName":"app-component-test-run-case","testId":"app-component-test-case","status":"FAILED","startDateTime":"2023-10-24T12:29:35.295Z","endDateTime":"2023-10-24T12:32:19.175Z","executedDateTime":"2023-10-24T12:29:33.692Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/app-component-test-case/testRunId/app-component-test-run-case","createdDateTime":"2023-10-24T12:29:34.741Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:19.247Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3379'
+      - '3380'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:37 GMT
+      - Tue, 24 Oct 2023 12:32:25 GMT
       mise-correlation-id:
-      - bf414ae2-41f8-4574-b5a6-fafb2ff76441
+      - f5b86518-a708-4f0e-8142-8d6d982174b0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1941,7 +1941,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-18T20:52:02.3537236Z","key2":"2023-10-18T20:52:02.3537236Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-18T20:52:02.3693170Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-18T20:52:02.3693170Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-18T20:52:02.1661927Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-24T12:28:46.5429960Z","key2":"2023-10-24T12:28:46.5429960Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-24T12:28:46.5585938Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-24T12:28:46.5585938Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-24T12:28:46.3554736Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -1950,7 +1950,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:55:47 GMT
+      - Tue, 24 Oct 2023 12:32:35 GMT
       expires:
       - '-1'
       pragma:
@@ -1983,7 +1983,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:28.2169395Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:28.2169395Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:10.6516578Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:10.6516578Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1992,9 +1992,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:48 GMT
+      - Tue, 24 Oct 2023 12:32:36 GMT
       etag:
-      - '"75005e4d-0000-0100-0000-653045510000"'
+      - '"d300da3b-0000-0100-0000-6537b85c0000"'
       expires:
       - '-1'
       pragma:
@@ -2013,9 +2013,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-xfqy55dmgr7cp5zjy/providers/Microsoft.Storage/storageAccounts/clitestloadhrktmktjb":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-xfqy55dmgr7cp5zjy/providers/Microsoft.Storage/storageAccounts/clitestloadhrktmktjb",
-      "resourceName": "clitestloadhrktmktjb", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-2tcg3hznsh4th4b4v/providers/Microsoft.Storage/storageAccounts/clitestloadua7e5w3yq":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-2tcg3hznsh4th4b4v/providers/Microsoft.Storage/storageAccounts/clitestloadua7e5w3yq",
+      "resourceName": "clitestloadua7e5w3yq", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -2031,10 +2031,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-18T20:55:50.392Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:50.392Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-24T12:32:38.175Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:38.175Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2045,11 +2045,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:50 GMT
+      - Tue, 24 Oct 2023 12:32:38 GMT
       location:
-      - https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+      - https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - 6e698bcd-29d7-4d6c-afcb-2b8ac0d2b65a
+      - 2ea55b75-1bea-497a-aaa0-f68a66c47edb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2072,7 +2072,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:28.2169395Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:28.2169395Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:10.6516578Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:10.6516578Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2081,9 +2081,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:51 GMT
+      - Tue, 24 Oct 2023 12:32:39 GMT
       etag:
-      - '"75005e4d-0000-0100-0000-653045510000"'
+      - '"d300da3b-0000-0100-0000-6537b85c0000"'
       expires:
       - '-1'
       pragma:
@@ -2113,10 +2113,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-18T20:55:50.392Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:50.392Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-24T12:32:38.175Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:38.175Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2127,9 +2127,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:53 GMT
+      - Tue, 24 Oct 2023 12:32:40 GMT
       mise-correlation-id:
-      - 8b84c357-6658-49c5-ac71-f6a18c7b7260
+      - 38c6a32b-d161-481b-bd28-838182bfb2ca
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2152,7 +2152,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:28.2169395Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:28.2169395Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:10.6516578Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:10.6516578Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2161,9 +2161,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:53 GMT
+      - Tue, 24 Oct 2023 12:32:41 GMT
       etag:
-      - '"75005e4d-0000-0100-0000-653045510000"'
+      - '"d300da3b-0000-0100-0000-6537b85c0000"'
       expires:
       - '-1'
       pragma:
@@ -2182,7 +2182,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-xfqy55dmgr7cp5zjy/providers/Microsoft.Storage/storageAccounts/clitestloadhrktmktjb":
+    body: '{"testRunId": "app-component-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-2tcg3hznsh4th4b4v/providers/Microsoft.Storage/storageAccounts/clitestloadua7e5w3yq":
       null}}'
     headers:
       Accept:
@@ -2198,10 +2198,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-18T20:55:50.392Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:54.941Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-24T12:32:38.175Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:42.137Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2212,9 +2212,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:54 GMT
+      - Tue, 24 Oct 2023 12:32:42 GMT
       mise-correlation-id:
-      - 286309f0-1699-4cdc-b40a-2477cd64d6ca
+      - ad048e11-d585-4062-b119-5a025dedf28a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2237,7 +2237,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:28.2169395Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:28.2169395Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:10.6516578Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:10.6516578Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2246,9 +2246,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:55 GMT
+      - Tue, 24 Oct 2023 12:32:43 GMT
       etag:
-      - '"75005e4d-0000-0100-0000-653045510000"'
+      - '"d300da3b-0000-0100-0000-6537b85c0000"'
       expires:
       - '-1'
       pragma:
@@ -2278,10 +2278,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6bdd3f66-d31c-4b40-b319-5713b80687b6.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
+    uri: https://3e982efa-812b-4b3c-ac40-58003b9c26a0.eastus.cnt-prod.loadtesting.azure.com/test-runs/app-component-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-18T20:55:50.392Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:54.941Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testRunId":"app-component-test-run-case","createdDateTime":"2023-10-24T12:32:38.175Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:42.137Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2292,9 +2292,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:57 GMT
+      - Tue, 24 Oct 2023 12:32:44 GMT
       mise-correlation-id:
-      - dd3fe8f8-4567-408d-9b10-bc32962461fc
+      - ef2c9f83-47ed-474d-bc86-2749aebc644e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_app_component.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_app_component.yaml
@@ -18,7 +18,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-18T20:48:41.2443722Z","key2":"2023-10-18T20:48:41.2443722Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-18T20:48:41.2599692Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-18T20:48:41.2599692Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-18T20:48:41.0256006Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-24T12:25:18.7621539Z","key2":"2023-10-24T12:25:18.7621539Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-24T12:25:18.7779663Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-24T12:25:18.7779663Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-24T12:25:18.5746371Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:49:02 GMT
+      - Tue, 24 Oct 2023 12:25:40 GMT
       expires:
       - '-1'
       pragma:
@@ -60,7 +60,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.3865267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.3865267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1189356Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1189356Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -69,9 +69,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:03 GMT
+      - Tue, 24 Oct 2023 12:25:41 GMT
       etag:
-      - '"75000d3a-0000-0100-0000-653044870000"'
+      - '"d300fa31-0000-0100-0000-6537b78c0000"'
       expires:
       - '-1'
       pragma:
@@ -101,7 +101,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -114,9 +114,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:49:05 GMT
+      - Tue, 24 Oct 2023 12:25:42 GMT
       mise-correlation-id:
-      - 6dea7ba4-6d69-4660-a8c3-14fe725a4c6e
+      - c853633c-1e41-46ef-8cee-f3d26ac2f5ca
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -133,10 +133,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"65e04f17-9ceb-4a04-aa67-ebf448672ae7": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "124b30cb-8d75-40f1-af14-a94fb7962b31":
+      {"passFailMetrics": {"d6acffe8-d95c-4a5a-85bb-7fcf988b3a94": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "76fef6ec-dd6f-44e7-be72-b923c51a5401":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "5e18501b-c274-4d11-b266-ee6da60a8cb6": {"aggregate": "avg", "clientMetric":
+      "50"}, "c13a6ed4-a028-406c-9857-ddf8f992b608": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -152,11 +152,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"65e04f17-9ceb-4a04-aa67-ebf448672ae7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"124b30cb-8d75-40f1-af14-a94fb7962b31":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"5e18501b-c274-4d11-b266-ee6da60a8cb6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:49:05.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:49:05.772Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d6acffe8-d95c-4a5a-85bb-7fcf988b3a94":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"76fef6ec-dd6f-44e7-be72-b923c51a5401":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c13a6ed4-a028-406c-9857-ddf8f992b608":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:42.972Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:42.972Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -167,11 +167,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:05 GMT
+      - Tue, 24 Oct 2023 12:25:43 GMT
       location:
-      - https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+      - https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 932b29e1-e36e-4475-8cc0-9dcceddbd6e0
+      - 7b914414-d099-4897-936a-618c933c55b5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -191,7 +191,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
+    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -205,9 +205,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:06 GMT
+      - Tue, 24 Oct 2023 12:25:43 GMT
       mise-correlation-id:
-      - 02536277-ff17-4785-b470-07dc050e3a93
+      - bde73fad-f7b3-4534-acae-d3c453f8b71e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -321,25 +321,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2daaf99d-dc39-487d-845f-f5bddff92336/fa4df137-a473-4edf-8f16-61bdf54ecf27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A07Z&sr=b&sp=r&sig=tRI4SQk%2F5%2FOIlGuVz8CKbmXxQ6Qdvin%2FyRm6oAe9WKs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:07.2361478","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/95f981ad-ec63-49b7-90dd-f404f37d3f89/ae17b9ca-31ce-4b2f-864e-5b7ca027e4a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A44Z&sr=b&sp=r&sig=yy6tu2p3Qr92eorTkEUogrMBr0s2W0ywbwImqSsfzIU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:44.8164423","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:07 GMT
+      - Tue, 24 Oct 2023 12:25:44 GMT
       location:
-      - https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 904343e3-1c79-4013-85b7-f0653e5980fe
+      - d7a4d922-3897-4e86-b7ac-f3eede518c61
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -359,46 +359,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2daaf99d-dc39-487d-845f-f5bddff92336/fa4df137-a473-4edf-8f16-61bdf54ecf27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A07Z&sr=b&sp=r&sig=f6BsyHliBgZZBZnygYYtVBeKufnJk4mAIR7l06oahqs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:07.5274541","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:49:07 GMT
-      mise-correlation-id:
-      - dcdf5209-d08c-4e08-b246-db48fc6fba0c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2daaf99d-dc39-487d-845f-f5bddff92336/fa4df137-a473-4edf-8f16-61bdf54ecf27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A12Z&sr=b&sp=r&sig=YIujv0d3BuHnl306VONbhqB%2FP%2B8oUIHAc1XZeYe4Jp0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:12.8511493","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/95f981ad-ec63-49b7-90dd-f404f37d3f89/ae17b9ca-31ce-4b2f-864e-5b7ca027e4a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A45Z&sr=b&sp=r&sig=p5DkK1ZYtv%2FNu9nA6A5xY8EB%2BH4GbHbbbpTqLxD6CU8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:45.0808864","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -409,9 +373,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:12 GMT
+      - Tue, 24 Oct 2023 12:25:45 GMT
       mise-correlation-id:
-      - bf19bb1e-d225-4f76-b9fa-a5a50cfde382
+      - 02db8a09-98bd-4afa-aa7f-a460ac6c8c84
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -431,46 +395,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2daaf99d-dc39-487d-845f-f5bddff92336/fa4df137-a473-4edf-8f16-61bdf54ecf27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A18Z&sr=b&sp=r&sig=%2FbDtF7aklD%2F%2F9SfIi8IZv1h3Xv790BdmC7MBmoe3r4Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:18.2120936","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:49:18 GMT
-      mise-correlation-id:
-      - 84f49944-9e03-4cb1-be47-e692942398b8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2daaf99d-dc39-487d-845f-f5bddff92336/fa4df137-a473-4edf-8f16-61bdf54ecf27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A23Z&sr=b&sp=r&sig=xvpM9C4MDw1ep%2BP6NzSak7NW0fS2bUxeCyaaZ02MBYI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:23.4735282","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/95f981ad-ec63-49b7-90dd-f404f37d3f89/ae17b9ca-31ce-4b2f-864e-5b7ca027e4a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A50Z&sr=b&sp=r&sig=Yo6dXDjUal2kP2AP349HmkNDDRdRD84QfeeVD0q8ihw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:50.3349501","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -481,9 +409,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:23 GMT
+      - Tue, 24 Oct 2023 12:25:50 GMT
       mise-correlation-id:
-      - 6b280004-48d6-459a-b806-f1b39c0f29c9
+      - a12b96d8-c053-4052-9f3a-600413005da0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -503,24 +431,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"65e04f17-9ceb-4a04-aa67-ebf448672ae7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"124b30cb-8d75-40f1-af14-a94fb7962b31":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"5e18501b-c274-4d11-b266-ee6da60a8cb6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2daaf99d-dc39-487d-845f-f5bddff92336/fa4df137-a473-4edf-8f16-61bdf54ecf27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A49%3A24Z&sr=b&sp=r&sig=aAvvy%2FroCWnDyqJWo1WWel3MI88xB5W%2Fyocc7ucmfmY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:49:24.4144934","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:49:05.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:49:19.766Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/95f981ad-ec63-49b7-90dd-f404f37d3f89/ae17b9ca-31ce-4b2f-864e-5b7ca027e4a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A55Z&sr=b&sp=r&sig=6bUQwf5tsFmuqaCdLNd1zPmcF%2BOKPxyYyD%2BPFL1Kfh4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:55.6397401","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1588'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:24 GMT
+      - Tue, 24 Oct 2023 12:25:55 GMT
       mise-correlation-id:
-      - 1d68daea-5d23-4a36-92ab-7269526cd272
+      - 48027ffe-fda6-4bff-b306-00d8cbb78620
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/95f981ad-ec63-49b7-90dd-f404f37d3f89/ae17b9ca-31ce-4b2f-864e-5b7ca027e4a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A00Z&sr=b&sp=r&sig=higk6XTWhZ8w1NiWHlnWZIFyh44nJo%2BQ3OkgFkBFoRo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:00.9110788","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:26:00 GMT
+      mise-correlation-id:
+      - 4dccd423-dbe5-49f7-9b5c-c59ecab0a9af
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d6acffe8-d95c-4a5a-85bb-7fcf988b3a94":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"76fef6ec-dd6f-44e7-be72-b923c51a5401":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c13a6ed4-a028-406c-9857-ddf8f992b608":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/95f981ad-ec63-49b7-90dd-f404f37d3f89/ae17b9ca-31ce-4b2f-864e-5b7ca027e4a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A26%3A01Z&sr=b&sp=r&sig=T4rQrFT29vmOATMj4KrYFwYLxbvZg%2F9z2SrQvxusoIw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:26:01.1938365","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:42.972Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:59.929Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1586'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:26:01 GMT
+      mise-correlation-id:
+      - cb37c6fc-ea95-413a-b1d8-956409799d0b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -543,7 +543,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.3865267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.3865267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1189356Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1189356Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -552,9 +552,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:25 GMT
+      - Tue, 24 Oct 2023 12:26:02 GMT
       etag:
-      - '"75000d3a-0000-0100-0000-653044870000"'
+      - '"d300fa31-0000-0100-0000-6537b78c0000"'
       expires:
       - '-1'
       pragma:
@@ -584,24 +584,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"65e04f17-9ceb-4a04-aa67-ebf448672ae7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"124b30cb-8d75-40f1-af14-a94fb7962b31":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"5e18501b-c274-4d11-b266-ee6da60a8cb6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2daaf99d-dc39-487d-845f-f5bddff92336/fa4df137-a473-4edf-8f16-61bdf54ecf27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A49%3A26Z&sr=b&sp=r&sig=jFiyLfeDUlfj9beTWlQadTmt3Xqohuyo5zk7xo71DRE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:49:26.6607951","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:49:05.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:49:19.766Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d6acffe8-d95c-4a5a-85bb-7fcf988b3a94":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"76fef6ec-dd6f-44e7-be72-b923c51a5401":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c13a6ed4-a028-406c-9857-ddf8f992b608":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/95f981ad-ec63-49b7-90dd-f404f37d3f89/ae17b9ca-31ce-4b2f-864e-5b7ca027e4a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A26%3A03Z&sr=b&sp=r&sig=u5Q1T%2BGPORSEnU10dATqz2236iofk64Rctimsa2IgJo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:26:03.6898057","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:42.972Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:59.929Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1596'
+      - '1598'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:26 GMT
+      - Tue, 24 Oct 2023 12:26:03 GMT
       mise-correlation-id:
-      - 19c5ebeb-8578-4981-92f8-b4a7aaaf28e4
+      - 5353bace-6bdc-4bc6-9460-a63f03309c02
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -624,7 +624,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.3865267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.3865267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1189356Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1189356Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -633,9 +633,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:27 GMT
+      - Tue, 24 Oct 2023 12:26:03 GMT
       etag:
-      - '"75000d3a-0000-0100-0000-653044870000"'
+      - '"d300fa31-0000-0100-0000-6537b78c0000"'
       expires:
       - '-1'
       pragma:
@@ -654,9 +654,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-m6qsywrvk2vtat63s/providers/Microsoft.Storage/storageAccounts/clitestloadfcmoug4rx":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-m6qsywrvk2vtat63s/providers/Microsoft.Storage/storageAccounts/clitestloadfcmoug4rx",
-      "resourceName": "clitestloadfcmoug4rx", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-6z3mcxscziz5klhcn/providers/Microsoft.Storage/storageAccounts/clitestloadofdcgxjju":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-6z3mcxscziz5klhcn/providers/Microsoft.Storage/storageAccounts/clitestloadofdcgxjju",
+      "resourceName": "clitestloadofdcgxjju", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -672,25 +672,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-18T20:49:28.85Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:49:28.85Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-24T12:26:05.471Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:05.471Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '733'
+      - '735'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:28 GMT
+      - Tue, 24 Oct 2023 12:26:05 GMT
       location:
-      - https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+      - https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - 3bfd772f-0acd-4d9e-a220-d95cfc259f86
+      - 775b689a-1a28-48b3-a35c-40691c5433bb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -713,7 +713,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.3865267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.3865267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1189356Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1189356Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -722,9 +722,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:29 GMT
+      - Tue, 24 Oct 2023 12:26:06 GMT
       etag:
-      - '"75000d3a-0000-0100-0000-653044870000"'
+      - '"d300fa31-0000-0100-0000-6537b78c0000"'
       expires:
       - '-1'
       pragma:
@@ -754,23 +754,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-18T20:49:28.85Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:49:28.85Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-24T12:26:05.471Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:05.471Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '733'
+      - '735'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:30 GMT
+      - Tue, 24 Oct 2023 12:26:07 GMT
       mise-correlation-id:
-      - c226eb50-f36d-4ccc-8903-65dbc5562e34
+      - f1f5d94c-6e24-4c30-84fc-3d97d3cf88eb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -793,7 +793,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.3865267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.3865267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1189356Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1189356Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -802,9 +802,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:31 GMT
+      - Tue, 24 Oct 2023 12:26:08 GMT
       etag:
-      - '"75000d3a-0000-0100-0000-653044870000"'
+      - '"d300fa31-0000-0100-0000-6537b78c0000"'
       expires:
       - '-1'
       pragma:
@@ -823,7 +823,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-m6qsywrvk2vtat63s/providers/Microsoft.Storage/storageAccounts/clitestloadfcmoug4rx":
+    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-6z3mcxscziz5klhcn/providers/Microsoft.Storage/storageAccounts/clitestloadofdcgxjju":
       null}}'
     headers:
       Accept:
@@ -839,23 +839,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-18T20:49:28.85Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:49:33.045Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-24T12:26:05.471Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:09.935Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '221'
+      - '222'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:33 GMT
+      - Tue, 24 Oct 2023 12:26:09 GMT
       mise-correlation-id:
-      - e59d4e78-8a4a-438c-baf0-d19258eb3fdd
+      - d79ee6fa-4c4a-4cfc-8507-686a00b607e6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -878,7 +878,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.3865267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.3865267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1189356Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1189356Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -887,9 +887,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:33 GMT
+      - Tue, 24 Oct 2023 12:26:11 GMT
       etag:
-      - '"75000d3a-0000-0100-0000-653044870000"'
+      - '"d300fa31-0000-0100-0000-6537b78c0000"'
       expires:
       - '-1'
       pragma:
@@ -919,23 +919,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-18T20:49:28.85Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:49:33.045Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-24T12:26:05.471Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:09.935Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '221'
+      - '222'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:34 GMT
+      - Tue, 24 Oct 2023 12:26:12 GMT
       mise-correlation-id:
-      - b234abbe-3ef7-4d55-8743-3b9846687a5c
+      - 012355ef-29c5-4766-936d-88ba887f8c99
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_app_component.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_app_component.yaml
@@ -18,7 +18,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-09T16:09:10.2007337Z","key2":"2023-10-09T16:09:10.2007337Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T16:09:10.2007337Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T16:09:10.2007337Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-09T16:09:10.0132468Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-09T19:15:30.7117533Z","key2":"2023-10-09T19:15:30.7117533Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T19:15:30.7273825Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T19:15:30.7273825Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-09T19:15:30.5086596Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:09:32 GMT
+      - Mon, 09 Oct 2023 19:15:52 GMT
       expires:
       - '-1'
       pragma:
@@ -60,7 +60,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5600354Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5600354Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:54.5220216Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:54.5220216Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -69,9 +69,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:34 GMT
+      - Mon, 09 Oct 2023 19:15:53 GMT
       etag:
-      - '"92017289-0000-0100-0000-652425840000"'
+      - '"5500ada4-0000-0100-0000-652451300000"'
       expires:
       - '-1'
       pragma:
@@ -101,7 +101,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -114,9 +114,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:09:35 GMT
+      - Mon, 09 Oct 2023 19:15:55 GMT
       mise-correlation-id:
-      - 6eaf783c-3204-4b5e-9c39-ffddc6ffa302
+      - a3c64dc6-8596-4c8d-abf2-35813bd8e864
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -133,10 +133,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"3758ea94-6b12-4947-baa7-e537f9456a2d": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "2d8671fa-3cbd-4cd4-801b-6a06f61871e6":
+      {"passFailMetrics": {"94a6a302-97dd-40f5-b13e-f6eb1f1d28ea": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "7f7ffe8e-4325-4172-9c02-890246eab5e0":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "e533f9e1-882e-4d7c-a27f-005c434fbdf2": {"aggregate": "avg", "clientMetric":
+      "50"}, "53ce0bb7-f524-4059-9c06-74a025786b62": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -152,26 +152,26 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3758ea94-6b12-4947-baa7-e537f9456a2d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2d8671fa-3cbd-4cd4-801b-6a06f61871e6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e533f9e1-882e-4d7c-a27f-005c434fbdf2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:35.99Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:35.99Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"94a6a302-97dd-40f5-b13e-f6eb1f1d28ea":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7f7ffe8e-4325-4172-9c02-890246eab5e0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"53ce0bb7-f524-4059-9c06-74a025786b62":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:55.717Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:55.717Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1013'
+      - '1015'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:36 GMT
+      - Mon, 09 Oct 2023 19:15:55 GMT
       location:
-      - https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+      - https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - b4f19628-e46e-462a-a205-6f73eb9a998c
+      - 14e49c9a-5857-4a23-8ea0-718c811773d4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -191,7 +191,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
+    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -205,9 +205,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:36 GMT
+      - Mon, 09 Oct 2023 19:15:56 GMT
       mise-correlation-id:
-      - 7c7eadb2-4d3b-43ea-958b-47f55c2b6a10
+      - 11b93eb6-74cc-4b0d-b2a2-239088ce5c82
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -321,25 +321,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83f8c227-7b85-48ec-a3a0-42f001f95710/e8408f8e-d9af-4c60-a48b-ab5e673fc34c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A38Z&sr=b&sp=r&sig=0IMO3IZnrDQ2r%2FnXlAzu2ZMAfRBYTPjEJx%2FoOqL2Esc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:38.2942612","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/205fcd6c-1bef-4125-8102-300100ff5521/de1b1bed-eb12-45b1-8a9b-fa2551280a69?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A56Z&sr=b&sp=r&sig=kJrOE%2FkX33%2F8MxE4SLNjZJwIAX9iuBobCQTmpw%2BlbcQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:56.4793926","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:38 GMT
+      - Mon, 09 Oct 2023 19:15:56 GMT
       location:
-      - https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 468c72a8-5223-4ee9-846e-e8cb7f0cd72d
+      - 8f24df9f-0cc5-4a30-a322-afdf4bd1b5bc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -359,10 +359,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83f8c227-7b85-48ec-a3a0-42f001f95710/e8408f8e-d9af-4c60-a48b-ab5e673fc34c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A38Z&sr=b&sp=r&sig=IJ0f15tVD7KS%2FK4ZCR%2Fq1IZqE2u8VCVavwnlfruG634%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:38.5646794","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/205fcd6c-1bef-4125-8102-300100ff5521/de1b1bed-eb12-45b1-8a9b-fa2551280a69?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A56Z&sr=b&sp=r&sig=5EJladhwdGuKH4Tsv4nRUAfcDj4ZW3SLlEE%2F%2FCmclWc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:56.7336866","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -373,9 +373,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:38 GMT
+      - Mon, 09 Oct 2023 19:15:56 GMT
       mise-correlation-id:
-      - cb104c7f-c667-482f-9412-5c70e0631e68
+      - 6ea8ad6e-e90c-436c-87de-0276eda343e8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -395,46 +395,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83f8c227-7b85-48ec-a3a0-42f001f95710/e8408f8e-d9af-4c60-a48b-ab5e673fc34c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A43Z&sr=b&sp=r&sig=NXhq%2BXAI1zAbaMYJzhxA2TnKzM0%2F7eo1DG2qfT7jLPE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:43.849901","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '552'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:09:43 GMT
-      mise-correlation-id:
-      - 4345d3df-518e-4d20-bf81-ce72f142b23f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83f8c227-7b85-48ec-a3a0-42f001f95710/e8408f8e-d9af-4c60-a48b-ab5e673fc34c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A49Z&sr=b&sp=r&sig=wtHMDgZ0J4z4qAqH%2FMdskBOSUIfo3wNpyQPqqU1ZqxE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:49.1993297","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/205fcd6c-1bef-4125-8102-300100ff5521/de1b1bed-eb12-45b1-8a9b-fa2551280a69?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A01Z&sr=b&sp=r&sig=0c0F7SNIinye87RNZtnyqI2bXLdR5%2FzomlxvUAjDb6Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:01.9943445","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -445,9 +409,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:49 GMT
+      - Mon, 09 Oct 2023 19:16:01 GMT
       mise-correlation-id:
-      - d083b087-888e-404e-9a36-cf23dfebcfb2
+      - 214ade9e-d586-47b1-baa4-34d8761fb389
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -467,23 +431,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83f8c227-7b85-48ec-a3a0-42f001f95710/e8408f8e-d9af-4c60-a48b-ab5e673fc34c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A54Z&sr=b&sp=r&sig=YecQXxzwVBXmInzqmDAq0a7cf%2FSQrag%2BXs27IgHxu34%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:54.5269338","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/205fcd6c-1bef-4125-8102-300100ff5521/de1b1bed-eb12-45b1-8a9b-fa2551280a69?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A07Z&sr=b&sp=r&sig=nRvAc%2BpLiEl16OJdHnHDOUqIyRarYWC6D6qqWM6J3nI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:07.258605","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:54 GMT
+      - Mon, 09 Oct 2023 19:16:07 GMT
       mise-correlation-id:
-      - 5794e67d-eee7-448e-be4a-b9ab0f28d838
+      - 4b16c94a-be41-4478-9b76-3e0fc162fd6f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -503,24 +467,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3758ea94-6b12-4947-baa7-e537f9456a2d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2d8671fa-3cbd-4cd4-801b-6a06f61871e6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e533f9e1-882e-4d7c-a27f-005c434fbdf2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83f8c227-7b85-48ec-a3a0-42f001f95710/e8408f8e-d9af-4c60-a48b-ab5e673fc34c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A09%3A54Z&sr=b&sp=r&sig=XQPYjxNhs4e04frudL1L2ajPuI0fEsAlLx1cAKyQRac%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:09:54.7916558","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:35.99Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:51.168Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/205fcd6c-1bef-4125-8102-300100ff5521/de1b1bed-eb12-45b1-8a9b-fa2551280a69?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A12Z&sr=b&sp=r&sig=%2B7hbPRMscJoHtlcGePNc0p49wEwOJSthzHtnNZxeQ1A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:12.5285438","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1583'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:54 GMT
+      - Mon, 09 Oct 2023 19:16:12 GMT
       mise-correlation-id:
-      - 422cd1a0-becf-4361-b1dc-9ee0ffb9ddbb
+      - b3847774-964e-46c7-937b-784448aea6e3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"94a6a302-97dd-40f5-b13e-f6eb1f1d28ea":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7f7ffe8e-4325-4172-9c02-890246eab5e0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"53ce0bb7-f524-4059-9c06-74a025786b62":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/205fcd6c-1bef-4125-8102-300100ff5521/de1b1bed-eb12-45b1-8a9b-fa2551280a69?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A16%3A12Z&sr=b&sp=r&sig=e82gKTNjectjRwJDURvkYZOnNl5I%2Bz0Fqa6a7aWOhk8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:16:12.8062921","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:55.717Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:09.717Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1586'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:16:12 GMT
+      mise-correlation-id:
+      - f8fdfec1-f57a-43a3-ba77-2ba53c055ce8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -543,7 +543,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5600354Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5600354Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:54.5220216Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:54.5220216Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -552,9 +552,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:55 GMT
+      - Mon, 09 Oct 2023 19:16:14 GMT
       etag:
-      - '"92017289-0000-0100-0000-652425840000"'
+      - '"5500ada4-0000-0100-0000-652451300000"'
       expires:
       - '-1'
       pragma:
@@ -584,24 +584,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"3758ea94-6b12-4947-baa7-e537f9456a2d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2d8671fa-3cbd-4cd4-801b-6a06f61871e6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e533f9e1-882e-4d7c-a27f-005c434fbdf2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83f8c227-7b85-48ec-a3a0-42f001f95710/e8408f8e-d9af-4c60-a48b-ab5e673fc34c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A09%3A57Z&sr=b&sp=r&sig=AHVOJ8azRoWCONikplqgwrnXgsNphGOa8D%2F7HLKN5DE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:09:57.0883366","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:35.99Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:51.168Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"94a6a302-97dd-40f5-b13e-f6eb1f1d28ea":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7f7ffe8e-4325-4172-9c02-890246eab5e0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"53ce0bb7-f524-4059-9c06-74a025786b62":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/205fcd6c-1bef-4125-8102-300100ff5521/de1b1bed-eb12-45b1-8a9b-fa2551280a69?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A16%3A15Z&sr=b&sp=r&sig=%2FkEnWwP5uE7iUT1A1Z%2FCJ5tn7JAHHN5JCcwe%2Brhtw%2BE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:16:15.2750751","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:55.717Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:09.717Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1597'
+      - '1604'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:57 GMT
+      - Mon, 09 Oct 2023 19:16:15 GMT
       mise-correlation-id:
-      - 8757d6c6-f548-4b11-b3ec-1417d3242185
+      - 3c7db09a-04e2-493e-bfa1-9b4cd9b33d3f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -624,7 +624,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5600354Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5600354Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:54.5220216Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:54.5220216Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -633,9 +633,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:58 GMT
+      - Mon, 09 Oct 2023 19:16:16 GMT
       etag:
-      - '"92017289-0000-0100-0000-652425840000"'
+      - '"5500ada4-0000-0100-0000-652451300000"'
       expires:
       - '-1'
       pragma:
@@ -654,9 +654,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-3addzxwzlm7tklw67/providers/Microsoft.Storage/storageAccounts/clitestloadyjnlvpiop":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-3addzxwzlm7tklw67/providers/Microsoft.Storage/storageAccounts/clitestloadyjnlvpiop",
-      "resourceName": "clitestloadyjnlvpiop", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-dsz4uoglif2nvveix/providers/Microsoft.Storage/storageAccounts/clitestloadra2ybcest":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-dsz4uoglif2nvveix/providers/Microsoft.Storage/storageAccounts/clitestloadra2ybcest",
+      "resourceName": "clitestloadra2ybcest", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -672,25 +672,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-09T16:09:59.46Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:59.46Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-09T19:16:17.723Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:17.723Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '733'
+      - '735'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:59 GMT
+      - Mon, 09 Oct 2023 19:16:17 GMT
       location:
-      - https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+      - https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - 5b803308-9a37-489b-8bc4-bd6aa11851c2
+      - 5f0d514c-fa69-47a4-9809-17b735285f86
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -713,7 +713,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5600354Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5600354Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:54.5220216Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:54.5220216Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -722,9 +722,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:00 GMT
+      - Mon, 09 Oct 2023 19:16:18 GMT
       etag:
-      - '"92017289-0000-0100-0000-652425840000"'
+      - '"5500ada4-0000-0100-0000-652451300000"'
       expires:
       - '-1'
       pragma:
@@ -754,23 +754,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-09T16:09:59.46Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:59.46Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-09T19:16:17.723Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:17.723Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '733'
+      - '735'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:01 GMT
+      - Mon, 09 Oct 2023 19:16:19 GMT
       mise-correlation-id:
-      - a13d7dae-91e1-424f-a75c-ba9e6cb65338
+      - 24cda7e1-d7b7-4f1e-b3f1-cabe7be17e42
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -793,7 +793,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5600354Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5600354Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:54.5220216Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:54.5220216Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -802,9 +802,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:02 GMT
+      - Mon, 09 Oct 2023 19:16:20 GMT
       etag:
-      - '"92017289-0000-0100-0000-652425840000"'
+      - '"5500ada4-0000-0100-0000-652451300000"'
       expires:
       - '-1'
       pragma:
@@ -823,7 +823,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-3addzxwzlm7tklw67/providers/Microsoft.Storage/storageAccounts/clitestloadyjnlvpiop":
+    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-dsz4uoglif2nvveix/providers/Microsoft.Storage/storageAccounts/clitestloadra2ybcest":
       null}}'
     headers:
       Accept:
@@ -839,23 +839,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-09T16:09:59.46Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:03.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-09T19:16:17.723Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:22.228Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '221'
+      - '222'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:03 GMT
+      - Mon, 09 Oct 2023 19:16:22 GMT
       mise-correlation-id:
-      - 4ad1c571-0a87-4a50-bbdb-33aa009ac257
+      - 8c8fd8d9-39b6-4d80-b634-c56f07774d98
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -878,7 +878,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5600354Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5600354Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:54.5220216Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:54.5220216Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -887,9 +887,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:04 GMT
+      - Mon, 09 Oct 2023 19:16:23 GMT
       etag:
-      - '"92017289-0000-0100-0000-652425840000"'
+      - '"5500ada4-0000-0100-0000-652451300000"'
       expires:
       - '-1'
       pragma:
@@ -919,23 +919,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-09T16:09:59.46Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:03.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-09T19:16:17.723Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:22.228Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '221'
+      - '222'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:06 GMT
+      - Mon, 09 Oct 2023 19:16:24 GMT
       mise-correlation-id:
-      - 344e4382-5fe2-49a8-8211-c2f23a6e481f
+      - 0fdd1eb4-4335-4c8c-b66e-8cb86fb2be8f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_app_component.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_app_component.yaml
@@ -13,12 +13,12 @@ interactions:
       ParameterSetName:
       - --name --resource-group
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-09T19:15:30.7117533Z","key2":"2023-10-09T19:15:30.7117533Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T19:15:30.7273825Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T19:15:30.7273825Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-09T19:15:30.5086596Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-13T13:48:32.4011907Z","key2":"2023-10-13T13:48:32.4011907Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-13T13:48:32.4168075Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-13T13:48:32.4168075Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-13T13:48:32.2293047Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:15:52 GMT
+      - Fri, 13 Oct 2023 13:48:56 GMT
       expires:
       - '-1'
       pragma:
@@ -60,18 +60,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:54.5220216Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:54.5220216Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.986501Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.986501Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:53 GMT
+      - Fri, 13 Oct 2023 13:48:57 GMT
       etag:
-      - '"5500ada4-0000-0100-0000-652451300000"'
+      - '"d801eaa4-0000-0100-0000-65294a8d0000"'
       expires:
       - '-1'
       pragma:
@@ -99,9 +99,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -114,9 +114,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:15:55 GMT
+      - Fri, 13 Oct 2023 13:48:58 GMT
       mise-correlation-id:
-      - a3c64dc6-8596-4c8d-abf2-35813bd8e864
+      - 090b7e61-54f8-467c-8e2b-6cc81a4bc03b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -133,10 +133,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"94a6a302-97dd-40f5-b13e-f6eb1f1d28ea": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "7f7ffe8e-4325-4172-9c02-890246eab5e0":
+      {"passFailMetrics": {"0b28c2ae-d62a-49ab-829a-9719b42be9ea": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "7a3f3232-ecfc-4ff7-935e-9e74672f06b0":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "53ce0bb7-f524-4059-9c06-74a025786b62": {"aggregate": "avg", "clientMetric":
+      "50"}, "ce9d4f98-426c-47a0-b816-b9ea30729b6e": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -150,13 +150,13 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"94a6a302-97dd-40f5-b13e-f6eb1f1d28ea":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7f7ffe8e-4325-4172-9c02-890246eab5e0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"53ce0bb7-f524-4059-9c06-74a025786b62":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:55.717Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:55.717Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0b28c2ae-d62a-49ab-829a-9719b42be9ea":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7a3f3232-ecfc-4ff7-935e-9e74672f06b0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ce9d4f98-426c-47a0-b816-b9ea30729b6e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:59.424Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:59.424Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -167,11 +167,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:55 GMT
+      - Fri, 13 Oct 2023 13:48:59 GMT
       location:
-      - https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+      - https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 14e49c9a-5857-4a23-8ea0-718c811773d4
+      - a1c41253-551e-4d90-83f0-c88cb888c6fe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -189,9 +189,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
+    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -205,9 +205,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:56 GMT
+      - Fri, 13 Oct 2023 13:48:59 GMT
       mise-correlation-id:
-      - 11b93eb6-74cc-4b0d-b2a2-239088ce5c82
+      - f88cf783-24ff-4cfd-9663-042db8e78bf3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -319,27 +319,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/205fcd6c-1bef-4125-8102-300100ff5521/de1b1bed-eb12-45b1-8a9b-fa2551280a69?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A56Z&sr=b&sp=r&sig=kJrOE%2FkX33%2F8MxE4SLNjZJwIAX9iuBobCQTmpw%2BlbcQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:56.4793926","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0a8d8d77-460d-4f1d-b4ab-d1e9895ee03d/0948bcdd-cbf4-44e5-b76a-d34c7dd05319?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A01Z&sr=b&sp=r&sig=kkn8YOsEpjoVoFZVrF%2BnFrYplRhxfxW9i7VclkqPxeI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:01.9173711","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:56 GMT
+      - Fri, 13 Oct 2023 13:49:01 GMT
       location:
-      - https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 8f24df9f-0cc5-4a30-a322-afdf4bd1b5bc
+      - f612deaa-b5aa-4b0f-a1d6-9f5961d3e099
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -357,120 +357,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/205fcd6c-1bef-4125-8102-300100ff5521/de1b1bed-eb12-45b1-8a9b-fa2551280a69?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A56Z&sr=b&sp=r&sig=5EJladhwdGuKH4Tsv4nRUAfcDj4ZW3SLlEE%2F%2FCmclWc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:56.7336866","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:15:56 GMT
-      mise-correlation-id:
-      - 6ea8ad6e-e90c-436c-87de-0276eda343e8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/205fcd6c-1bef-4125-8102-300100ff5521/de1b1bed-eb12-45b1-8a9b-fa2551280a69?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A01Z&sr=b&sp=r&sig=0c0F7SNIinye87RNZtnyqI2bXLdR5%2FzomlxvUAjDb6Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:01.9943445","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:16:01 GMT
-      mise-correlation-id:
-      - 214ade9e-d586-47b1-baa4-34d8761fb389
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/205fcd6c-1bef-4125-8102-300100ff5521/de1b1bed-eb12-45b1-8a9b-fa2551280a69?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A07Z&sr=b&sp=r&sig=nRvAc%2BpLiEl16OJdHnHDOUqIyRarYWC6D6qqWM6J3nI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:07.258605","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '550'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:16:07 GMT
-      mise-correlation-id:
-      - 4b16c94a-be41-4478-9b76-3e0fc162fd6f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/205fcd6c-1bef-4125-8102-300100ff5521/de1b1bed-eb12-45b1-8a9b-fa2551280a69?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A12Z&sr=b&sp=r&sig=%2B7hbPRMscJoHtlcGePNc0p49wEwOJSthzHtnNZxeQ1A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:12.5285438","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0a8d8d77-460d-4f1d-b4ab-d1e9895ee03d/0948bcdd-cbf4-44e5-b76a-d34c7dd05319?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A02Z&sr=b&sp=r&sig=ReeJXpXuhU5GquXceMegVwi8F5UL9t47rCHJdHDsXoM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:02.1516922","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -481,9 +373,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:12 GMT
+      - Fri, 13 Oct 2023 13:49:02 GMT
       mise-correlation-id:
-      - b3847774-964e-46c7-937b-784448aea6e3
+      - 2e1fb48a-8765-4b48-a001-54815d86414b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -501,26 +393,134 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"94a6a302-97dd-40f5-b13e-f6eb1f1d28ea":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7f7ffe8e-4325-4172-9c02-890246eab5e0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"53ce0bb7-f524-4059-9c06-74a025786b62":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/205fcd6c-1bef-4125-8102-300100ff5521/de1b1bed-eb12-45b1-8a9b-fa2551280a69?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A16%3A12Z&sr=b&sp=r&sig=e82gKTNjectjRwJDURvkYZOnNl5I%2Bz0Fqa6a7aWOhk8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:16:12.8062921","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:55.717Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:09.717Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0a8d8d77-460d-4f1d-b4ab-d1e9895ee03d/0948bcdd-cbf4-44e5-b76a-d34c7dd05319?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A07Z&sr=b&sp=r&sig=2ua6o9sezIZRvvzqwY4iX79jR8tEdgZsK0OKHTDsL5w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:07.3964486","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1586'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:12 GMT
+      - Fri, 13 Oct 2023 13:49:07 GMT
       mise-correlation-id:
-      - f8fdfec1-f57a-43a3-ba77-2ba53c055ce8
+      - 97ea0689-3152-495b-b93f-a0197b0d3451
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0a8d8d77-460d-4f1d-b4ab-d1e9895ee03d/0948bcdd-cbf4-44e5-b76a-d34c7dd05319?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A12Z&sr=b&sp=r&sig=ba6bJjo28xq0S6gpjFELL91R7Oj4%2Bt7oX7tGsLwvk%2Fk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:12.6586763","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:49:12 GMT
+      mise-correlation-id:
+      - fe9b62c9-23bc-4237-8392-d7811b7ec17a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0a8d8d77-460d-4f1d-b4ab-d1e9895ee03d/0948bcdd-cbf4-44e5-b76a-d34c7dd05319?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A17Z&sr=b&sp=r&sig=06QYPw2e6gNwNdclfGmHxDKFM3sBcDPydOM1Q35EBLo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:17.8998242","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '547'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:49:17 GMT
+      mise-correlation-id:
+      - b870689f-1d15-44ae-9db7-94edf2bcd20a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0b28c2ae-d62a-49ab-829a-9719b42be9ea":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7a3f3232-ecfc-4ff7-935e-9e74672f06b0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ce9d4f98-426c-47a0-b816-b9ea30729b6e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0a8d8d77-460d-4f1d-b4ab-d1e9895ee03d/0948bcdd-cbf4-44e5-b76a-d34c7dd05319?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A49%3A18Z&sr=b&sp=r&sig=aWaykg%2BZb4%2BGvVQQDjUvx2rmSqqOSih5XtvgSqQ8XO4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:49:18.1316572","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:59.424Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:15.341Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1588'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:49:18 GMT
+      mise-correlation-id:
+      - bc388c45-f7bb-405e-8892-4bf89a1309bc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -543,18 +543,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:54.5220216Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:54.5220216Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.986501Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.986501Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:14 GMT
+      - Fri, 13 Oct 2023 13:49:19 GMT
       etag:
-      - '"5500ada4-0000-0100-0000-652451300000"'
+      - '"d801eaa4-0000-0100-0000-65294a8d0000"'
       expires:
       - '-1'
       pragma:
@@ -582,26 +582,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"94a6a302-97dd-40f5-b13e-f6eb1f1d28ea":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7f7ffe8e-4325-4172-9c02-890246eab5e0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"53ce0bb7-f524-4059-9c06-74a025786b62":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/205fcd6c-1bef-4125-8102-300100ff5521/de1b1bed-eb12-45b1-8a9b-fa2551280a69?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A16%3A15Z&sr=b&sp=r&sig=%2FkEnWwP5uE7iUT1A1Z%2FCJ5tn7JAHHN5JCcwe%2Brhtw%2BE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:16:15.2750751","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:55.717Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:09.717Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0b28c2ae-d62a-49ab-829a-9719b42be9ea":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7a3f3232-ecfc-4ff7-935e-9e74672f06b0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ce9d4f98-426c-47a0-b816-b9ea30729b6e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0a8d8d77-460d-4f1d-b4ab-d1e9895ee03d/0948bcdd-cbf4-44e5-b76a-d34c7dd05319?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A49%3A20Z&sr=b&sp=r&sig=yj7hXk1s8BLEWEOKdH0rKeHPNpsckfpcZ06ZYSoJ%2B64%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:49:20.5465032","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:59.424Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:15.341Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1604'
+      - '1598'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:15 GMT
+      - Fri, 13 Oct 2023 13:49:20 GMT
       mise-correlation-id:
-      - 3c7db09a-04e2-493e-bfa1-9b4cd9b33d3f
+      - 187ba5b7-df7a-4bc0-945b-3115112c9952
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -624,18 +624,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:54.5220216Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:54.5220216Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.986501Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.986501Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:16 GMT
+      - Fri, 13 Oct 2023 13:49:21 GMT
       etag:
-      - '"5500ada4-0000-0100-0000-652451300000"'
+      - '"d801eaa4-0000-0100-0000-65294a8d0000"'
       expires:
       - '-1'
       pragma:
@@ -654,9 +654,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-dsz4uoglif2nvveix/providers/Microsoft.Storage/storageAccounts/clitestloadra2ybcest":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-dsz4uoglif2nvveix/providers/Microsoft.Storage/storageAccounts/clitestloadra2ybcest",
-      "resourceName": "clitestloadra2ybcest", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-2hn4ud63knbeenno4/providers/Microsoft.Storage/storageAccounts/clitestloadir3yuxdh5":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-2hn4ud63knbeenno4/providers/Microsoft.Storage/storageAccounts/clitestloadir3yuxdh5",
+      "resourceName": "clitestloadir3yuxdh5", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -670,12 +670,12 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-09T19:16:17.723Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:17.723Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-13T13:49:23.058Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:23.058Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -686,11 +686,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:17 GMT
+      - Fri, 13 Oct 2023 13:49:23 GMT
       location:
-      - https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+      - https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - 5f0d514c-fa69-47a4-9809-17b735285f86
+      - e3fa0120-1afa-4789-a6e9-efac2fde5cb8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -713,18 +713,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:54.5220216Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:54.5220216Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.986501Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.986501Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:18 GMT
+      - Fri, 13 Oct 2023 13:49:23 GMT
       etag:
-      - '"5500ada4-0000-0100-0000-652451300000"'
+      - '"d801eaa4-0000-0100-0000-65294a8d0000"'
       expires:
       - '-1'
       pragma:
@@ -752,12 +752,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-09T19:16:17.723Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:17.723Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-13T13:49:23.058Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:23.058Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -768,9 +768,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:19 GMT
+      - Fri, 13 Oct 2023 13:49:24 GMT
       mise-correlation-id:
-      - 24cda7e1-d7b7-4f1e-b3f1-cabe7be17e42
+      - c52fd9ff-328d-4bef-916a-42d30398314e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -793,18 +793,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:54.5220216Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:54.5220216Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.986501Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.986501Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:20 GMT
+      - Fri, 13 Oct 2023 13:49:26 GMT
       etag:
-      - '"5500ada4-0000-0100-0000-652451300000"'
+      - '"d801eaa4-0000-0100-0000-65294a8d0000"'
       expires:
       - '-1'
       pragma:
@@ -823,7 +823,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-dsz4uoglif2nvveix/providers/Microsoft.Storage/storageAccounts/clitestloadra2ybcest":
+    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-2hn4ud63knbeenno4/providers/Microsoft.Storage/storageAccounts/clitestloadir3yuxdh5":
       null}}'
     headers:
       Accept:
@@ -837,12 +837,12 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-09T19:16:17.723Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:22.228Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-13T13:49:23.058Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:27.704Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -853,9 +853,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:22 GMT
+      - Fri, 13 Oct 2023 13:49:27 GMT
       mise-correlation-id:
-      - 8c8fd8d9-39b6-4d80-b634-c56f07774d98
+      - 105ffec7-9669-48fb-9758-e3eab62df7bf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -878,18 +878,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:54.5220216Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:54.5220216Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.986501Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.986501Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:23 GMT
+      - Fri, 13 Oct 2023 13:49:29 GMT
       etag:
-      - '"5500ada4-0000-0100-0000-652451300000"'
+      - '"d801eaa4-0000-0100-0000-65294a8d0000"'
       expires:
       - '-1'
       pragma:
@@ -917,12 +917,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7306c705-6195-4f74-a632-a3a03d7b05e5.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-09T19:16:17.723Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:22.228Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-13T13:49:23.058Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:27.704Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -933,9 +933,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:24 GMT
+      - Fri, 13 Oct 2023 13:49:30 GMT
       mise-correlation-id:
-      - 0fdd1eb4-4335-4c8c-b66e-8cb86fb2be8f
+      - 4e56e1a8-649c-4740-8c55-055703115259
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_app_component.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_app_component.yaml
@@ -18,7 +18,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-24T12:25:18.7621539Z","key2":"2023-10-24T12:25:18.7621539Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-24T12:25:18.7779663Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-24T12:25:18.7779663Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-24T12:25:18.5746371Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-29T22:18:14.1622465Z","key2":"2023-10-29T22:18:14.1622465Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-29T22:18:14.1778696Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-29T22:18:14.1778696Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-29T22:18:13.9903714Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:25:40 GMT
+      - Sun, 29 Oct 2023 22:18:36 GMT
       expires:
       - '-1'
       pragma:
@@ -60,18 +60,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1189356Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1189356Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:37.7857696Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:37.7857696Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:41 GMT
+      - Sun, 29 Oct 2023 22:18:36 GMT
       etag:
-      - '"d300fa31-0000-0100-0000-6537b78c0000"'
+      - '"3c00e221-0000-0100-0000-653eda030000"'
       expires:
       - '-1'
       pragma:
@@ -101,7 +101,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -114,9 +114,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:25:42 GMT
+      - Sun, 29 Oct 2023 22:18:38 GMT
       mise-correlation-id:
-      - c853633c-1e41-46ef-8cee-f3d26ac2f5ca
+      - 65c2afc6-2bcb-4133-8eef-66da86f616ec
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -133,10 +133,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"d6acffe8-d95c-4a5a-85bb-7fcf988b3a94": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "76fef6ec-dd6f-44e7-be72-b923c51a5401":
+      {"passFailMetrics": {"ac2a25e1-6585-4a02-937a-11d574853dc3": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "f71fa5ca-32bb-4c75-a512-a8b59af17e55":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "c13a6ed4-a028-406c-9857-ddf8f992b608": {"aggregate": "avg", "clientMetric":
+      "50"}, "17eac847-d539-44b2-97d4-6d91028a4738": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -152,11 +152,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d6acffe8-d95c-4a5a-85bb-7fcf988b3a94":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"76fef6ec-dd6f-44e7-be72-b923c51a5401":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c13a6ed4-a028-406c-9857-ddf8f992b608":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:42.972Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:42.972Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ac2a25e1-6585-4a02-937a-11d574853dc3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f71fa5ca-32bb-4c75-a512-a8b59af17e55":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17eac847-d539-44b2-97d4-6d91028a4738":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:38.905Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:38.905Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -167,11 +167,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:43 GMT
+      - Sun, 29 Oct 2023 22:18:38 GMT
       location:
-      - https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+      - https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 7b914414-d099-4897-936a-618c933c55b5
+      - ac3cc842-12e9-490c-93e3-c130c8ae3661
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -191,7 +191,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
+    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -205,9 +205,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:43 GMT
+      - Sun, 29 Oct 2023 22:18:39 GMT
       mise-correlation-id:
-      - bde73fad-f7b3-4534-acae-d3c453f8b71e
+      - 8d1b99ef-fcb4-4ba5-9df2-6fb8e651106d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -321,10 +321,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/95f981ad-ec63-49b7-90dd-f404f37d3f89/ae17b9ca-31ce-4b2f-864e-5b7ca027e4a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A44Z&sr=b&sp=r&sig=yy6tu2p3Qr92eorTkEUogrMBr0s2W0ywbwImqSsfzIU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:44.8164423","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/abb5893e-48ef-4af9-83cf-9e97b2ff1048/d109dfbe-2c1f-4d4e-a7a0-d53ce484bf48?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A40Z&sr=b&sp=r&sig=wrEFytNJ9TXIYxGrtaOOWiEXsR47clWy2JvfsUWArlU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:40.3016419","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -335,11 +335,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:44 GMT
+      - Sun, 29 Oct 2023 22:18:40 GMT
       location:
-      - https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - d7a4d922-3897-4e86-b7ac-f3eede518c61
+      - 089c59b5-9024-4193-937f-74b7356bef8a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -359,23 +359,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/95f981ad-ec63-49b7-90dd-f404f37d3f89/ae17b9ca-31ce-4b2f-864e-5b7ca027e4a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A45Z&sr=b&sp=r&sig=p5DkK1ZYtv%2FNu9nA6A5xY8EB%2BH4GbHbbbpTqLxD6CU8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:45.0808864","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/abb5893e-48ef-4af9-83cf-9e97b2ff1048/d109dfbe-2c1f-4d4e-a7a0-d53ce484bf48?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A40Z&sr=b&sp=r&sig=eUTAJwIPt92Sw7An3vhqtGFqU3FJmnASaQm1qnOX6%2B8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:40.5482105","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:45 GMT
+      - Sun, 29 Oct 2023 22:18:40 GMT
       mise-correlation-id:
-      - 02db8a09-98bd-4afa-aa7f-a460ac6c8c84
+      - 35e90705-a425-416f-baad-5ec6f2324b50
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -395,10 +395,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/95f981ad-ec63-49b7-90dd-f404f37d3f89/ae17b9ca-31ce-4b2f-864e-5b7ca027e4a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A50Z&sr=b&sp=r&sig=Yo6dXDjUal2kP2AP349HmkNDDRdRD84QfeeVD0q8ihw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:50.3349501","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/abb5893e-48ef-4af9-83cf-9e97b2ff1048/d109dfbe-2c1f-4d4e-a7a0-d53ce484bf48?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A45Z&sr=b&sp=r&sig=%2B1%2B%2BfKrqTLWiwFOY2VwETWi1ND75NVkR592n%2F4o8ryg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:45.7982458","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '557'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:18:45 GMT
+      mise-correlation-id:
+      - 22c80568-fb3a-4f19-b985-612af9ebf843
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/abb5893e-48ef-4af9-83cf-9e97b2ff1048/d109dfbe-2c1f-4d4e-a7a0-d53ce484bf48?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A51Z&sr=b&sp=r&sig=dn%2FRr0uk0lMAjE7%2FhhyWyiJag%2B%2FCN2rIrbEy38H0auU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:51.0467574","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '557'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:18:51 GMT
+      mise-correlation-id:
+      - 72ba1089-4be2-42e0-bae0-f8ecfbeee8f4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/abb5893e-48ef-4af9-83cf-9e97b2ff1048/d109dfbe-2c1f-4d4e-a7a0-d53ce484bf48?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A56Z&sr=b&sp=r&sig=tAmHDvv3YtyumJEtf9mWsm91pDelPMASymx2UYG%2BVNA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:56.2940203","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -409,9 +481,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:50 GMT
+      - Sun, 29 Oct 2023 22:18:56 GMT
       mise-correlation-id:
-      - a12b96d8-c053-4052-9f3a-600413005da0
+      - ca7b80f3-67de-4bd5-b89f-cb3e61f9917e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -431,83 +503,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/95f981ad-ec63-49b7-90dd-f404f37d3f89/ae17b9ca-31ce-4b2f-864e-5b7ca027e4a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A55Z&sr=b&sp=r&sig=6bUQwf5tsFmuqaCdLNd1zPmcF%2BOKPxyYyD%2BPFL1Kfh4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:55.6397401","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:25:55 GMT
-      mise-correlation-id:
-      - 48027ffe-fda6-4bff-b306-00d8cbb78620
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/95f981ad-ec63-49b7-90dd-f404f37d3f89/ae17b9ca-31ce-4b2f-864e-5b7ca027e4a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A00Z&sr=b&sp=r&sig=higk6XTWhZ8w1NiWHlnWZIFyh44nJo%2BQ3OkgFkBFoRo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:00.9110788","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:26:00 GMT
-      mise-correlation-id:
-      - 4dccd423-dbe5-49f7-9b5c-c59ecab0a9af
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d6acffe8-d95c-4a5a-85bb-7fcf988b3a94":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"76fef6ec-dd6f-44e7-be72-b923c51a5401":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c13a6ed4-a028-406c-9857-ddf8f992b608":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/95f981ad-ec63-49b7-90dd-f404f37d3f89/ae17b9ca-31ce-4b2f-864e-5b7ca027e4a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A26%3A01Z&sr=b&sp=r&sig=T4rQrFT29vmOATMj4KrYFwYLxbvZg%2F9z2SrQvxusoIw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:26:01.1938365","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:42.972Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:59.929Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ac2a25e1-6585-4a02-937a-11d574853dc3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f71fa5ca-32bb-4c75-a512-a8b59af17e55":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17eac847-d539-44b2-97d4-6d91028a4738":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/abb5893e-48ef-4af9-83cf-9e97b2ff1048/d109dfbe-2c1f-4d4e-a7a0-d53ce484bf48?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A18%3A56Z&sr=b&sp=r&sig=h0DGlZ7dO53m7KADJO0BlfaxZofQOEUhoMXMNA8r%2FP0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:18:56.8191127","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:38.905Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:53.009Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -518,9 +518,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:01 GMT
+      - Sun, 29 Oct 2023 22:18:56 GMT
       mise-correlation-id:
-      - cb37c6fc-ea95-413a-b1d8-956409799d0b
+      - 7ff33ad9-224d-404f-a59d-f0bea4ae1b88
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -543,18 +543,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1189356Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1189356Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:37.7857696Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:37.7857696Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:02 GMT
+      - Sun, 29 Oct 2023 22:18:57 GMT
       etag:
-      - '"d300fa31-0000-0100-0000-6537b78c0000"'
+      - '"3c00e221-0000-0100-0000-653eda030000"'
       expires:
       - '-1'
       pragma:
@@ -584,24 +584,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d6acffe8-d95c-4a5a-85bb-7fcf988b3a94":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"76fef6ec-dd6f-44e7-be72-b923c51a5401":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c13a6ed4-a028-406c-9857-ddf8f992b608":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/95f981ad-ec63-49b7-90dd-f404f37d3f89/ae17b9ca-31ce-4b2f-864e-5b7ca027e4a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A26%3A03Z&sr=b&sp=r&sig=u5Q1T%2BGPORSEnU10dATqz2236iofk64Rctimsa2IgJo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:26:03.6898057","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:42.972Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:59.929Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ac2a25e1-6585-4a02-937a-11d574853dc3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f71fa5ca-32bb-4c75-a512-a8b59af17e55":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17eac847-d539-44b2-97d4-6d91028a4738":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/abb5893e-48ef-4af9-83cf-9e97b2ff1048/d109dfbe-2c1f-4d4e-a7a0-d53ce484bf48?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A18%3A58Z&sr=b&sp=r&sig=xSs7e9eorPB5DDJvMeDj3lkFI%2BnKNpdQwzR9Q%2FcIbAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:18:58.3081939","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:38.905Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:53.009Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1598'
+      - '1600'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:03 GMT
+      - Sun, 29 Oct 2023 22:18:58 GMT
       mise-correlation-id:
-      - 5353bace-6bdc-4bc6-9460-a63f03309c02
+      - 095ea0a1-a4d3-4a6b-bbca-5ddfd2001bcb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -624,18 +624,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1189356Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1189356Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:37.7857696Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:37.7857696Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:03 GMT
+      - Sun, 29 Oct 2023 22:18:58 GMT
       etag:
-      - '"d300fa31-0000-0100-0000-6537b78c0000"'
+      - '"3c00e221-0000-0100-0000-653eda030000"'
       expires:
       - '-1'
       pragma:
@@ -654,9 +654,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-6z3mcxscziz5klhcn/providers/Microsoft.Storage/storageAccounts/clitestloadofdcgxjju":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-6z3mcxscziz5klhcn/providers/Microsoft.Storage/storageAccounts/clitestloadofdcgxjju",
-      "resourceName": "clitestloadofdcgxjju", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-7slfevordeq3clkul/providers/Microsoft.Storage/storageAccounts/clitestload4qnr3fjsi":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-7slfevordeq3clkul/providers/Microsoft.Storage/storageAccounts/clitestload4qnr3fjsi",
+      "resourceName": "clitestload4qnr3fjsi", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -672,10 +672,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-24T12:26:05.471Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:05.471Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-29T22:18:59.831Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:59.831Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -686,11 +686,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:05 GMT
+      - Sun, 29 Oct 2023 22:18:59 GMT
       location:
-      - https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+      - https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - 775b689a-1a28-48b3-a35c-40691c5433bb
+      - 9d8e60f9-bf26-434a-9bd7-bbc8e3f4dd89
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -713,18 +713,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1189356Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1189356Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:37.7857696Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:37.7857696Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:06 GMT
+      - Sun, 29 Oct 2023 22:19:01 GMT
       etag:
-      - '"d300fa31-0000-0100-0000-6537b78c0000"'
+      - '"3c00e221-0000-0100-0000-653eda030000"'
       expires:
       - '-1'
       pragma:
@@ -754,10 +754,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-24T12:26:05.471Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:05.471Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-29T22:18:59.831Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:59.831Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -768,9 +768,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:07 GMT
+      - Sun, 29 Oct 2023 22:19:02 GMT
       mise-correlation-id:
-      - f1f5d94c-6e24-4c30-84fc-3d97d3cf88eb
+      - ca6bb0f3-4c34-4506-84af-fae8f7ecfc38
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -793,18 +793,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1189356Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1189356Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:37.7857696Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:37.7857696Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:08 GMT
+      - Sun, 29 Oct 2023 22:19:03 GMT
       etag:
-      - '"d300fa31-0000-0100-0000-6537b78c0000"'
+      - '"3c00e221-0000-0100-0000-653eda030000"'
       expires:
       - '-1'
       pragma:
@@ -823,7 +823,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-6z3mcxscziz5klhcn/providers/Microsoft.Storage/storageAccounts/clitestloadofdcgxjju":
+    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-7slfevordeq3clkul/providers/Microsoft.Storage/storageAccounts/clitestload4qnr3fjsi":
       null}}'
     headers:
       Accept:
@@ -839,10 +839,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-24T12:26:05.471Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:09.935Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-29T22:18:59.831Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:19:04.447Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -853,9 +853,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:09 GMT
+      - Sun, 29 Oct 2023 22:19:04 GMT
       mise-correlation-id:
-      - d79ee6fa-4c4a-4cfc-8507-686a00b607e6
+      - 5f7125da-b46b-4cdd-a4e8-f9f6e600630c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -878,18 +878,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1189356Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1189356Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:37.7857696Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:37.7857696Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:11 GMT
+      - Sun, 29 Oct 2023 22:19:06 GMT
       etag:
-      - '"d300fa31-0000-0100-0000-6537b78c0000"'
+      - '"3c00e221-0000-0100-0000-653eda030000"'
       expires:
       - '-1'
       pragma:
@@ -919,10 +919,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c5286f7d-c588-435b-a749-03420ebfea13.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-24T12:26:05.471Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:09.935Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-29T22:18:59.831Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:19:04.447Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -933,9 +933,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:12 GMT
+      - Sun, 29 Oct 2023 22:19:06 GMT
       mise-correlation-id:
-      - 012355ef-29c5-4766-936d-88ba887f8c99
+      - 37e7b3ad-e314-4e90-b831-29b3d8e68e41
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_app_component.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_app_component.yaml
@@ -18,7 +18,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-07-12T20:08:58.9771780Z","key2":"2023-07-12T20:08:58.9771780Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-07-12T20:08:58.9928015Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-07-12T20:08:58.9928015Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-07-12T20:08:58.8053540Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-09T16:09:10.2007337Z","key2":"2023-10-09T16:09:10.2007337Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T16:09:10.2007337Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T16:09:10.2007337Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-09T16:09:10.0132468Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:09:20 GMT
+      - Mon, 09 Oct 2023 16:09:32 GMT
       expires:
       - '-1'
       pragma:
@@ -60,7 +60,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:08:18.1085713Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:08:18.1085713Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5600354Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5600354Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -69,9 +69,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:22 GMT
+      - Mon, 09 Oct 2023 16:09:34 GMT
       etag:
-      - '"1a0a7c97-0000-0100-0000-64af08340000"'
+      - '"92017289-0000-0100-0000-652425840000"'
       expires:
       - '-1'
       pragma:
@@ -101,7 +101,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -114,9 +114,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:09:23 GMT
+      - Mon, 09 Oct 2023 16:09:35 GMT
       mise-correlation-id:
-      - a8227070-5b28-4f54-8811-b935a0283396
+      - 6eaf783c-3204-4b5e-9c39-ffddc6ffa302
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -131,12 +131,12 @@ interactions:
 - request:
     body: '{"displayName": "CLI-Test", "description": "Test created from az load test
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
-      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "loadTestConfiguration":
+      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"ec9ea542-963b-4463-86ce-cf114c504a85": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "5617ab68-0d7e-4223-8390-14b9e02c8424":
+      {"passFailMetrics": {"3758ea94-6b12-4947-baa7-e537f9456a2d": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "2d8671fa-3cbd-4cd4-801b-6a06f61871e6":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "d4921467-e295-4068-965c-1db9daf5a8bc": {"aggregate": "avg", "clientMetric":
+      "50"}, "e533f9e1-882e-4d7c-a27f-005c434fbdf2": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -146,32 +146,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '768'
+      - '789'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ec9ea542-963b-4463-86ce-cf114c504a85":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"5617ab68-0d7e-4223-8390-14b9e02c8424":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"d4921467-e295-4068-965c-1db9daf5a8bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:09:24.685Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:09:24.685Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3758ea94-6b12-4947-baa7-e537f9456a2d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2d8671fa-3cbd-4cd4-801b-6a06f61871e6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e533f9e1-882e-4d7c-a27f-005c434fbdf2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:35.99Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:35.99Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1069'
+      - '1013'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:24 GMT
+      - Mon, 09 Oct 2023 16:09:36 GMT
       location:
-      - https://b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+      - https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - e81f9cb6-0bff-492f-bba3-9710d7b45e15
+      - b4f19628-e46e-462a-a205-6f73eb9a998c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -191,7 +191,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
+    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -205,9 +205,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:24 GMT
+      - Mon, 09 Oct 2023 16:09:36 GMT
       mise-correlation-id:
-      - e7d1df89-031c-4524-ba75-b8bf1bfae0ee
+      - 7c7eadb2-4d3b-43ea-958b-47f55c2b6a10
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -321,25 +321,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1ceb4fd2-cb6f-4039-884d-8a04ca626331/93045077-2000-40c5-9f49-993f572272a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A19%3A25Z&sr=b&sp=r&sig=ghIhYnTRSI9tk9hWUpTGVizXM0nf88REETv6ZvJNYoA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:19:25.6315678","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83f8c227-7b85-48ec-a3a0-42f001f95710/e8408f8e-d9af-4c60-a48b-ab5e673fc34c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A38Z&sr=b&sp=r&sig=0IMO3IZnrDQ2r%2FnXlAzu2ZMAfRBYTPjEJx%2FoOqL2Esc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:38.2942612","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:25 GMT
+      - Mon, 09 Oct 2023 16:09:38 GMT
       location:
-      - https://b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 82fbce6c-6c05-4090-8f55-4ef26f7244a1
+      - 468c72a8-5223-4ee9-846e-e8cb7f0cd72d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -359,118 +359,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1ceb4fd2-cb6f-4039-884d-8a04ca626331/93045077-2000-40c5-9f49-993f572272a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A19%3A26Z&sr=b&sp=r&sig=kW4qCbCwSr%2FMkUaaeAgw73Twj4HA%2B7%2Fgr6b2UFcZ3rE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:19:26.2084351","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:09:26 GMT
-      mise-correlation-id:
-      - de17beac-619e-47cf-9532-d13af5373d1f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1ceb4fd2-cb6f-4039-884d-8a04ca626331/93045077-2000-40c5-9f49-993f572272a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A19%3A31Z&sr=b&sp=r&sig=KOpuOs4r38KXCP3bs0Yy26Cj5yzadlg4KxaqX91NjwU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:19:31.4697419","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:09:31 GMT
-      mise-correlation-id:
-      - df913714-3fdb-4e3a-9aea-4b763a74959b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1ceb4fd2-cb6f-4039-884d-8a04ca626331/93045077-2000-40c5-9f49-993f572272a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A19%3A36Z&sr=b&sp=r&sig=8LceQ63%2FW7lFoYNWv4bk1deTXSesZE%2FV1OBn%2B86EsAE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:19:36.7980099","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:09:36 GMT
-      mise-correlation-id:
-      - 5db0ae0d-f4f2-4093-ba99-1bcdd32a7d6c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1ceb4fd2-cb6f-4039-884d-8a04ca626331/93045077-2000-40c5-9f49-993f572272a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A19%3A42Z&sr=b&sp=r&sig=kr%2BJIAZ%2FPL70Jyp6F1EQLIDncMkxGFB2xKpB6%2FY9g20%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:19:42.0655458","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83f8c227-7b85-48ec-a3a0-42f001f95710/e8408f8e-d9af-4c60-a48b-ab5e673fc34c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A38Z&sr=b&sp=r&sig=IJ0f15tVD7KS%2FK4ZCR%2Fq1IZqE2u8VCVavwnlfruG634%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:38.5646794","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -481,9 +373,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:42 GMT
+      - Mon, 09 Oct 2023 16:09:38 GMT
       mise-correlation-id:
-      - 085f4cc9-34aa-4065-8d7a-7cd1325394cd
+      - cb104c7f-c667-482f-9412-5c70e0631e68
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -503,24 +395,132 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ec9ea542-963b-4463-86ce-cf114c504a85":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"5617ab68-0d7e-4223-8390-14b9e02c8424":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"d4921467-e295-4068-965c-1db9daf5a8bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1ceb4fd2-cb6f-4039-884d-8a04ca626331/93045077-2000-40c5-9f49-993f572272a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A09%3A42Z&sr=b&sp=r&sig=7hjGUZ%2BMN7aO2WXLZfRezgbpsB6c430JWA2dVlk%2Br1c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:09:42.3371448","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:09:24.685Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:09:37.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83f8c227-7b85-48ec-a3a0-42f001f95710/e8408f8e-d9af-4c60-a48b-ab5e673fc34c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A43Z&sr=b&sp=r&sig=NXhq%2BXAI1zAbaMYJzhxA2TnKzM0%2F7eo1DG2qfT7jLPE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:43.849901","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1642'
+      - '552'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:42 GMT
+      - Mon, 09 Oct 2023 16:09:43 GMT
       mise-correlation-id:
-      - ac62e6e4-78ed-4cdb-963e-c24719054d8a
+      - 4345d3df-518e-4d20-bf81-ce72f142b23f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83f8c227-7b85-48ec-a3a0-42f001f95710/e8408f8e-d9af-4c60-a48b-ab5e673fc34c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A49Z&sr=b&sp=r&sig=wtHMDgZ0J4z4qAqH%2FMdskBOSUIfo3wNpyQPqqU1ZqxE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:49.1993297","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:09:49 GMT
+      mise-correlation-id:
+      - d083b087-888e-404e-9a36-cf23dfebcfb2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83f8c227-7b85-48ec-a3a0-42f001f95710/e8408f8e-d9af-4c60-a48b-ab5e673fc34c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A54Z&sr=b&sp=r&sig=YecQXxzwVBXmInzqmDAq0a7cf%2FSQrag%2BXs27IgHxu34%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:54.5269338","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:09:54 GMT
+      mise-correlation-id:
+      - 5794e67d-eee7-448e-be4a-b9ab0f28d838
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3758ea94-6b12-4947-baa7-e537f9456a2d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2d8671fa-3cbd-4cd4-801b-6a06f61871e6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e533f9e1-882e-4d7c-a27f-005c434fbdf2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83f8c227-7b85-48ec-a3a0-42f001f95710/e8408f8e-d9af-4c60-a48b-ab5e673fc34c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A09%3A54Z&sr=b&sp=r&sig=XQPYjxNhs4e04frudL1L2ajPuI0fEsAlLx1cAKyQRac%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:09:54.7916558","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:35.99Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:51.168Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1583'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:09:54 GMT
+      mise-correlation-id:
+      - 422cd1a0-becf-4361-b1dc-9ee0ffb9ddbb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -543,7 +543,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:08:18.1085713Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:08:18.1085713Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5600354Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5600354Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -552,9 +552,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:43 GMT
+      - Mon, 09 Oct 2023 16:09:55 GMT
       etag:
-      - '"1a0a7c97-0000-0100-0000-64af08340000"'
+      - '"92017289-0000-0100-0000-652425840000"'
       expires:
       - '-1'
       pragma:
@@ -584,24 +584,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ec9ea542-963b-4463-86ce-cf114c504a85":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"5617ab68-0d7e-4223-8390-14b9e02c8424":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"d4921467-e295-4068-965c-1db9daf5a8bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1ceb4fd2-cb6f-4039-884d-8a04ca626331/93045077-2000-40c5-9f49-993f572272a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A09%3A44Z&sr=b&sp=r&sig=FwUcWd9nMWZg7tu6SYTySrt%2BjxGOYHSuuVFQfooTkFg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:09:44.845339","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:09:24.685Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:09:37.792Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"3758ea94-6b12-4947-baa7-e537f9456a2d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2d8671fa-3cbd-4cd4-801b-6a06f61871e6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e533f9e1-882e-4d7c-a27f-005c434fbdf2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83f8c227-7b85-48ec-a3a0-42f001f95710/e8408f8e-d9af-4c60-a48b-ab5e673fc34c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A09%3A57Z&sr=b&sp=r&sig=AHVOJ8azRoWCONikplqgwrnXgsNphGOa8D%2F7HLKN5DE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:09:57.0883366","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:35.99Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:51.168Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1651'
+      - '1597'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:44 GMT
+      - Mon, 09 Oct 2023 16:09:57 GMT
       mise-correlation-id:
-      - d572c2c3-c5fe-450c-a71e-755a37337ff4
+      - 8757d6c6-f548-4b11-b3ec-1417d3242185
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -624,7 +624,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:08:18.1085713Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:08:18.1085713Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5600354Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5600354Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -633,9 +633,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:45 GMT
+      - Mon, 09 Oct 2023 16:09:58 GMT
       etag:
-      - '"1a0a7c97-0000-0100-0000-64af08340000"'
+      - '"92017289-0000-0100-0000-652425840000"'
       expires:
       - '-1'
       pragma:
@@ -654,9 +654,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-glsbbxg2wjfbqro3s/providers/Microsoft.Storage/storageAccounts/clitestloadf5g3dcpn3":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-glsbbxg2wjfbqro3s/providers/Microsoft.Storage/storageAccounts/clitestloadf5g3dcpn3",
-      "resourceName": "clitestloadf5g3dcpn3", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-3addzxwzlm7tklw67/providers/Microsoft.Storage/storageAccounts/clitestloadyjnlvpiop":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-3addzxwzlm7tklw67/providers/Microsoft.Storage/storageAccounts/clitestloadyjnlvpiop",
+      "resourceName": "clitestloadyjnlvpiop", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -672,25 +672,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-07-12T20:09:47.465Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:09:47.465Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-09T16:09:59.46Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:59.46Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '735'
+      - '733'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:47 GMT
+      - Mon, 09 Oct 2023 16:09:59 GMT
       location:
-      - https://b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+      - https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - 1f3124d3-a213-4f59-97de-398d231929cb
+      - 5b803308-9a37-489b-8bc4-bd6aa11851c2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -713,7 +713,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:08:18.1085713Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:08:18.1085713Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5600354Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5600354Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -722,9 +722,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:48 GMT
+      - Mon, 09 Oct 2023 16:10:00 GMT
       etag:
-      - '"1a0a7c97-0000-0100-0000-64af08340000"'
+      - '"92017289-0000-0100-0000-652425840000"'
       expires:
       - '-1'
       pragma:
@@ -754,23 +754,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-07-12T20:09:47.465Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:09:47.465Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-09T16:09:59.46Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:59.46Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '735'
+      - '733'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:49 GMT
+      - Mon, 09 Oct 2023 16:10:01 GMT
       mise-correlation-id:
-      - 7c3b8fd7-a177-4386-b0c0-cc4ecb3781ce
+      - a13d7dae-91e1-424f-a75c-ba9e6cb65338
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -793,7 +793,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:08:18.1085713Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:08:18.1085713Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5600354Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5600354Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -802,9 +802,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:51 GMT
+      - Mon, 09 Oct 2023 16:10:02 GMT
       etag:
-      - '"1a0a7c97-0000-0100-0000-64af08340000"'
+      - '"92017289-0000-0100-0000-652425840000"'
       expires:
       - '-1'
       pragma:
@@ -823,7 +823,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-glsbbxg2wjfbqro3s/providers/Microsoft.Storage/storageAccounts/clitestloadf5g3dcpn3":
+    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-3addzxwzlm7tklw67/providers/Microsoft.Storage/storageAccounts/clitestloadyjnlvpiop":
       null}}'
     headers:
       Accept:
@@ -839,23 +839,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-07-12T20:09:47.465Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:09:52.718Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-09T16:09:59.46Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:03.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '222'
+      - '221'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:52 GMT
+      - Mon, 09 Oct 2023 16:10:03 GMT
       mise-correlation-id:
-      - 0ec05cc7-4fd4-4b19-9e7d-de267df76caa
+      - 4ad1c571-0a87-4a50-bbdb-33aa009ac257
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -878,7 +878,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:08:18.1085713Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:08:18.1085713Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5600354Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5600354Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -887,9 +887,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:54 GMT
+      - Mon, 09 Oct 2023 16:10:04 GMT
       etag:
-      - '"1a0a7c97-0000-0100-0000-64af08340000"'
+      - '"92017289-0000-0100-0000-652425840000"'
       expires:
       - '-1'
       pragma:
@@ -919,23 +919,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b387898c-fefd-4ca9-8e75-905f1187b764.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://a6de9ab6-23a9-44c6-b9ec-a084f84be17a.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-07-12T20:09:47.465Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:09:52.718Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-09T16:09:59.46Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:03.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '222'
+      - '221'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:55 GMT
+      - Mon, 09 Oct 2023 16:10:06 GMT
       mise-correlation-id:
-      - f1982641-0e90-4c1d-81d2-ba9d20eba31a
+      - 344e4382-5fe2-49a8-8211-c2f23a6e481f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_app_component.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_app_component.yaml
@@ -18,7 +18,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-13T13:48:32.4011907Z","key2":"2023-10-13T13:48:32.4011907Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-13T13:48:32.4168075Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-13T13:48:32.4168075Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-13T13:48:32.2293047Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-18T20:48:41.2443722Z","key2":"2023-10-18T20:48:41.2443722Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-18T20:48:41.2599692Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-18T20:48:41.2599692Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-18T20:48:41.0256006Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:48:56 GMT
+      - Wed, 18 Oct 2023 20:49:02 GMT
       expires:
       - '-1'
       pragma:
@@ -60,18 +60,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.986501Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.986501Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.3865267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.3865267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:57 GMT
+      - Wed, 18 Oct 2023 20:49:03 GMT
       etag:
-      - '"d801eaa4-0000-0100-0000-65294a8d0000"'
+      - '"75000d3a-0000-0100-0000-653044870000"'
       expires:
       - '-1'
       pragma:
@@ -101,7 +101,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -114,9 +114,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:48:58 GMT
+      - Wed, 18 Oct 2023 20:49:05 GMT
       mise-correlation-id:
-      - 090b7e61-54f8-467c-8e2b-6cc81a4bc03b
+      - 6dea7ba4-6d69-4660-a8c3-14fe725a4c6e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -133,10 +133,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"0b28c2ae-d62a-49ab-829a-9719b42be9ea": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "7a3f3232-ecfc-4ff7-935e-9e74672f06b0":
+      {"passFailMetrics": {"65e04f17-9ceb-4a04-aa67-ebf448672ae7": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "124b30cb-8d75-40f1-af14-a94fb7962b31":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "ce9d4f98-426c-47a0-b816-b9ea30729b6e": {"aggregate": "avg", "clientMetric":
+      "50"}, "5e18501b-c274-4d11-b266-ee6da60a8cb6": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -152,11 +152,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0b28c2ae-d62a-49ab-829a-9719b42be9ea":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7a3f3232-ecfc-4ff7-935e-9e74672f06b0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ce9d4f98-426c-47a0-b816-b9ea30729b6e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:59.424Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:59.424Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"65e04f17-9ceb-4a04-aa67-ebf448672ae7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"124b30cb-8d75-40f1-af14-a94fb7962b31":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"5e18501b-c274-4d11-b266-ee6da60a8cb6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:49:05.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:49:05.772Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -167,11 +167,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:59 GMT
+      - Wed, 18 Oct 2023 20:49:05 GMT
       location:
-      - https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+      - https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - a1c41253-551e-4d90-83f0-c88cb888c6fe
+      - 932b29e1-e36e-4475-8cc0-9dcceddbd6e0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -191,7 +191,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
+    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -205,9 +205,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:59 GMT
+      - Wed, 18 Oct 2023 20:49:06 GMT
       mise-correlation-id:
-      - f88cf783-24ff-4cfd-9663-042db8e78bf3
+      - 02536277-ff17-4785-b470-07dc050e3a93
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -321,25 +321,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0a8d8d77-460d-4f1d-b4ab-d1e9895ee03d/0948bcdd-cbf4-44e5-b76a-d34c7dd05319?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A01Z&sr=b&sp=r&sig=kkn8YOsEpjoVoFZVrF%2BnFrYplRhxfxW9i7VclkqPxeI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:01.9173711","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2daaf99d-dc39-487d-845f-f5bddff92336/fa4df137-a473-4edf-8f16-61bdf54ecf27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A07Z&sr=b&sp=r&sig=tRI4SQk%2F5%2FOIlGuVz8CKbmXxQ6Qdvin%2FyRm6oAe9WKs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:07.2361478","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:01 GMT
+      - Wed, 18 Oct 2023 20:49:07 GMT
       location:
-      - https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - f612deaa-b5aa-4b0f-a1d6-9f5961d3e099
+      - 904343e3-1c79-4013-85b7-f0653e5980fe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -359,10 +359,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0a8d8d77-460d-4f1d-b4ab-d1e9895ee03d/0948bcdd-cbf4-44e5-b76a-d34c7dd05319?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A02Z&sr=b&sp=r&sig=ReeJXpXuhU5GquXceMegVwi8F5UL9t47rCHJdHDsXoM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:02.1516922","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2daaf99d-dc39-487d-845f-f5bddff92336/fa4df137-a473-4edf-8f16-61bdf54ecf27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A07Z&sr=b&sp=r&sig=f6BsyHliBgZZBZnygYYtVBeKufnJk4mAIR7l06oahqs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:07.5274541","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -373,9 +373,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:02 GMT
+      - Wed, 18 Oct 2023 20:49:07 GMT
       mise-correlation-id:
-      - 2e1fb48a-8765-4b48-a001-54815d86414b
+      - dcdf5209-d08c-4e08-b246-db48fc6fba0c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -395,46 +395,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0a8d8d77-460d-4f1d-b4ab-d1e9895ee03d/0948bcdd-cbf4-44e5-b76a-d34c7dd05319?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A07Z&sr=b&sp=r&sig=2ua6o9sezIZRvvzqwY4iX79jR8tEdgZsK0OKHTDsL5w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:07.3964486","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:49:07 GMT
-      mise-correlation-id:
-      - 97ea0689-3152-495b-b93f-a0197b0d3451
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0a8d8d77-460d-4f1d-b4ab-d1e9895ee03d/0948bcdd-cbf4-44e5-b76a-d34c7dd05319?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A12Z&sr=b&sp=r&sig=ba6bJjo28xq0S6gpjFELL91R7Oj4%2Bt7oX7tGsLwvk%2Fk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:12.6586763","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2daaf99d-dc39-487d-845f-f5bddff92336/fa4df137-a473-4edf-8f16-61bdf54ecf27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A12Z&sr=b&sp=r&sig=YIujv0d3BuHnl306VONbhqB%2FP%2B8oUIHAc1XZeYe4Jp0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:12.8511493","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -445,9 +409,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:12 GMT
+      - Wed, 18 Oct 2023 20:49:12 GMT
       mise-correlation-id:
-      - fe9b62c9-23bc-4237-8392-d7811b7ec17a
+      - bf19bb1e-d225-4f76-b9fa-a5a50cfde382
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -467,23 +431,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0a8d8d77-460d-4f1d-b4ab-d1e9895ee03d/0948bcdd-cbf4-44e5-b76a-d34c7dd05319?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A17Z&sr=b&sp=r&sig=06QYPw2e6gNwNdclfGmHxDKFM3sBcDPydOM1Q35EBLo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:17.8998242","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2daaf99d-dc39-487d-845f-f5bddff92336/fa4df137-a473-4edf-8f16-61bdf54ecf27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A18Z&sr=b&sp=r&sig=%2FbDtF7aklD%2F%2F9SfIi8IZv1h3Xv790BdmC7MBmoe3r4Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:18.2120936","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:17 GMT
+      - Wed, 18 Oct 2023 20:49:18 GMT
       mise-correlation-id:
-      - b870689f-1d15-44ae-9db7-94edf2bcd20a
+      - 84f49944-9e03-4cb1-be47-e692942398b8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -503,11 +467,47 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0b28c2ae-d62a-49ab-829a-9719b42be9ea":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7a3f3232-ecfc-4ff7-935e-9e74672f06b0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ce9d4f98-426c-47a0-b816-b9ea30729b6e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0a8d8d77-460d-4f1d-b4ab-d1e9895ee03d/0948bcdd-cbf4-44e5-b76a-d34c7dd05319?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A49%3A18Z&sr=b&sp=r&sig=aWaykg%2BZb4%2BGvVQQDjUvx2rmSqqOSih5XtvgSqQ8XO4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:49:18.1316572","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:59.424Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:15.341Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2daaf99d-dc39-487d-845f-f5bddff92336/fa4df137-a473-4edf-8f16-61bdf54ecf27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A23Z&sr=b&sp=r&sig=xvpM9C4MDw1ep%2BP6NzSak7NW0fS2bUxeCyaaZ02MBYI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:23.4735282","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:49:23 GMT
+      mise-correlation-id:
+      - 6b280004-48d6-459a-b806-f1b39c0f29c9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"65e04f17-9ceb-4a04-aa67-ebf448672ae7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"124b30cb-8d75-40f1-af14-a94fb7962b31":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"5e18501b-c274-4d11-b266-ee6da60a8cb6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2daaf99d-dc39-487d-845f-f5bddff92336/fa4df137-a473-4edf-8f16-61bdf54ecf27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A49%3A24Z&sr=b&sp=r&sig=aAvvy%2FroCWnDyqJWo1WWel3MI88xB5W%2Fyocc7ucmfmY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:49:24.4144934","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:49:05.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:49:19.766Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -518,9 +518,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:18 GMT
+      - Wed, 18 Oct 2023 20:49:24 GMT
       mise-correlation-id:
-      - bc388c45-f7bb-405e-8892-4bf89a1309bc
+      - 1d68daea-5d23-4a36-92ab-7269526cd272
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -543,18 +543,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.986501Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.986501Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.3865267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.3865267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:19 GMT
+      - Wed, 18 Oct 2023 20:49:25 GMT
       etag:
-      - '"d801eaa4-0000-0100-0000-65294a8d0000"'
+      - '"75000d3a-0000-0100-0000-653044870000"'
       expires:
       - '-1'
       pragma:
@@ -584,24 +584,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0b28c2ae-d62a-49ab-829a-9719b42be9ea":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7a3f3232-ecfc-4ff7-935e-9e74672f06b0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ce9d4f98-426c-47a0-b816-b9ea30729b6e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0a8d8d77-460d-4f1d-b4ab-d1e9895ee03d/0948bcdd-cbf4-44e5-b76a-d34c7dd05319?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A49%3A20Z&sr=b&sp=r&sig=yj7hXk1s8BLEWEOKdH0rKeHPNpsckfpcZ06ZYSoJ%2B64%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:49:20.5465032","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:59.424Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:15.341Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"65e04f17-9ceb-4a04-aa67-ebf448672ae7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"124b30cb-8d75-40f1-af14-a94fb7962b31":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"5e18501b-c274-4d11-b266-ee6da60a8cb6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2daaf99d-dc39-487d-845f-f5bddff92336/fa4df137-a473-4edf-8f16-61bdf54ecf27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A49%3A26Z&sr=b&sp=r&sig=jFiyLfeDUlfj9beTWlQadTmt3Xqohuyo5zk7xo71DRE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:49:26.6607951","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:49:05.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:49:19.766Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1598'
+      - '1596'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:20 GMT
+      - Wed, 18 Oct 2023 20:49:26 GMT
       mise-correlation-id:
-      - 187ba5b7-df7a-4bc0-945b-3115112c9952
+      - 19c5ebeb-8578-4981-92f8-b4a7aaaf28e4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -624,18 +624,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.986501Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.986501Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.3865267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.3865267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:21 GMT
+      - Wed, 18 Oct 2023 20:49:27 GMT
       etag:
-      - '"d801eaa4-0000-0100-0000-65294a8d0000"'
+      - '"75000d3a-0000-0100-0000-653044870000"'
       expires:
       - '-1'
       pragma:
@@ -654,9 +654,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-2hn4ud63knbeenno4/providers/Microsoft.Storage/storageAccounts/clitestloadir3yuxdh5":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-2hn4ud63knbeenno4/providers/Microsoft.Storage/storageAccounts/clitestloadir3yuxdh5",
-      "resourceName": "clitestloadir3yuxdh5", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-m6qsywrvk2vtat63s/providers/Microsoft.Storage/storageAccounts/clitestloadfcmoug4rx":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-m6qsywrvk2vtat63s/providers/Microsoft.Storage/storageAccounts/clitestloadfcmoug4rx",
+      "resourceName": "clitestloadfcmoug4rx", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -672,25 +672,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-13T13:49:23.058Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:23.058Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-18T20:49:28.85Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:49:28.85Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '735'
+      - '733'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:23 GMT
+      - Wed, 18 Oct 2023 20:49:28 GMT
       location:
-      - https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+      - https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - e3fa0120-1afa-4789-a6e9-efac2fde5cb8
+      - 3bfd772f-0acd-4d9e-a220-d95cfc259f86
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -713,18 +713,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.986501Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.986501Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.3865267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.3865267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:23 GMT
+      - Wed, 18 Oct 2023 20:49:29 GMT
       etag:
-      - '"d801eaa4-0000-0100-0000-65294a8d0000"'
+      - '"75000d3a-0000-0100-0000-653044870000"'
       expires:
       - '-1'
       pragma:
@@ -754,23 +754,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-13T13:49:23.058Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:23.058Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-18T20:49:28.85Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:49:28.85Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '735'
+      - '733'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:24 GMT
+      - Wed, 18 Oct 2023 20:49:30 GMT
       mise-correlation-id:
-      - c52fd9ff-328d-4bef-916a-42d30398314e
+      - c226eb50-f36d-4ccc-8903-65dbc5562e34
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -793,18 +793,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.986501Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.986501Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.3865267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.3865267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:26 GMT
+      - Wed, 18 Oct 2023 20:49:31 GMT
       etag:
-      - '"d801eaa4-0000-0100-0000-65294a8d0000"'
+      - '"75000d3a-0000-0100-0000-653044870000"'
       expires:
       - '-1'
       pragma:
@@ -823,7 +823,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-2hn4ud63knbeenno4/providers/Microsoft.Storage/storageAccounts/clitestloadir3yuxdh5":
+    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-m6qsywrvk2vtat63s/providers/Microsoft.Storage/storageAccounts/clitestloadfcmoug4rx":
       null}}'
     headers:
       Accept:
@@ -839,23 +839,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-13T13:49:23.058Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:27.704Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-18T20:49:28.85Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:49:33.045Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '222'
+      - '221'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:27 GMT
+      - Wed, 18 Oct 2023 20:49:33 GMT
       mise-correlation-id:
-      - 105ffec7-9669-48fb-9758-e3eab62df7bf
+      - e59d4e78-8a4a-438c-baf0-d19258eb3fdd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -878,18 +878,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.986501Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.986501Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.3865267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.3865267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:29 GMT
+      - Wed, 18 Oct 2023 20:49:33 GMT
       etag:
-      - '"d801eaa4-0000-0100-0000-65294a8d0000"'
+      - '"75000d3a-0000-0100-0000-653044870000"'
       expires:
       - '-1'
       pragma:
@@ -919,23 +919,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://471d0db3-d0db-45d7-9872-a3c780f3c821.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://ba1098cd-a5e4-4837-817f-c41c467cafd1.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-13T13:49:23.058Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:27.704Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-18T20:49:28.85Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:49:33.045Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '222'
+      - '221'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:30 GMT
+      - Wed, 18 Oct 2023 20:49:34 GMT
       mise-correlation-id:
-      - 4e56e1a8-649c-4740-8c55-055703115259
+      - b234abbe-3ef7-4d55-8743-3b9846687a5c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_app_component.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_app_component.yaml
@@ -13,21 +13,21 @@ interactions:
       ParameterSetName:
       - --name --resource-group
       User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-azure-mgmt-storage/21.1.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2023-01-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-29T22:18:14.1622465Z","key2":"2023-10-29T22:18:14.1622465Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-29T22:18:14.1778696Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-29T22:18:14.1778696Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-29T22:18:13.9903714Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-30T07:17:59.2977891Z","key2":"2023-10-30T07:17:59.2977891Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-30T07:17:59.2977891Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-30T07:17:59.2977891Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-30T07:17:59.1102941Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1297'
+      - '1312'
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:18:36 GMT
+      - Mon, 30 Oct 2023 07:18:21 GMT
       expires:
       - '-1'
       pragma:
@@ -60,18 +60,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:37.7857696Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:37.7857696Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:17:21.323558Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:17:21.323558Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '653'
+      - '651'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:36 GMT
+      - Mon, 30 Oct 2023 07:18:23 GMT
       etag:
-      - '"3c00e221-0000-0100-0000-653eda030000"'
+      - '"3f00b865-0000-0100-0000-653f58840000"'
       expires:
       - '-1'
       pragma:
@@ -101,7 +101,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -114,9 +114,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:18:38 GMT
+      - Mon, 30 Oct 2023 07:18:24 GMT
       mise-correlation-id:
-      - 65c2afc6-2bcb-4133-8eef-66da86f616ec
+      - b2220b3a-025f-414b-ad74-09e972806f85
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -133,10 +133,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"ac2a25e1-6585-4a02-937a-11d574853dc3": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "f71fa5ca-32bb-4c75-a512-a8b59af17e55":
+      {"passFailMetrics": {"12a6ecb2-27ee-41e0-80ee-282b2fe59f0e": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "9119d70b-8d85-45a3-9c45-20f7ecadcfde":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "17eac847-d539-44b2-97d4-6d91028a4738": {"aggregate": "avg", "clientMetric":
+      "50"}, "bfff03c9-f9d0-49b5-9cd0-d15e370dc905": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -152,11 +152,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ac2a25e1-6585-4a02-937a-11d574853dc3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f71fa5ca-32bb-4c75-a512-a8b59af17e55":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17eac847-d539-44b2-97d4-6d91028a4738":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:38.905Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:38.905Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"12a6ecb2-27ee-41e0-80ee-282b2fe59f0e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9119d70b-8d85-45a3-9c45-20f7ecadcfde":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bfff03c9-f9d0-49b5-9cd0-d15e370dc905":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:18:24.674Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:18:24.674Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -167,11 +167,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:38 GMT
+      - Mon, 30 Oct 2023 07:18:24 GMT
       location:
-      - https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+      - https://56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - ac3cc842-12e9-490c-93e3-c130c8ae3661
+      - 4d4dcf35-a548-494d-a1c5-192d84ae97fd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -191,7 +191,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
+    uri: https://56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -205,9 +205,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:39 GMT
+      - Mon, 30 Oct 2023 07:18:25 GMT
       mise-correlation-id:
-      - 8d1b99ef-fcb4-4ba5-9df2-6fb8e651106d
+      - 15a56231-0cd9-49f5-a359-4e1cda357dad
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -321,25 +321,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/abb5893e-48ef-4af9-83cf-9e97b2ff1048/d109dfbe-2c1f-4d4e-a7a0-d53ce484bf48?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A40Z&sr=b&sp=r&sig=wrEFytNJ9TXIYxGrtaOOWiEXsR47clWy2JvfsUWArlU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:40.3016419","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e806228c-53d5-4bb2-a7d8-dfbfeead720f/6200b0bb-506c-42fd-b97b-5bb98720143f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A26Z&sr=b&sp=r&sig=8FkTmWBcn7tQVxT3OmzxOXVdcoC61YWXxK%2BhINUzejI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:26.560713","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:40 GMT
+      - Mon, 30 Oct 2023 07:18:26 GMT
       location:
-      - https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 089c59b5-9024-4193-937f-74b7356bef8a
+      - 61833399-36b8-482e-909c-7a61bfbd6c32
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -359,118 +359,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/abb5893e-48ef-4af9-83cf-9e97b2ff1048/d109dfbe-2c1f-4d4e-a7a0-d53ce484bf48?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A40Z&sr=b&sp=r&sig=eUTAJwIPt92Sw7An3vhqtGFqU3FJmnASaQm1qnOX6%2B8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:40.5482105","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:18:40 GMT
-      mise-correlation-id:
-      - 35e90705-a425-416f-baad-5ec6f2324b50
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/abb5893e-48ef-4af9-83cf-9e97b2ff1048/d109dfbe-2c1f-4d4e-a7a0-d53ce484bf48?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A45Z&sr=b&sp=r&sig=%2B1%2B%2BfKrqTLWiwFOY2VwETWi1ND75NVkR592n%2F4o8ryg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:45.7982458","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '557'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:18:45 GMT
-      mise-correlation-id:
-      - 22c80568-fb3a-4f19-b985-612af9ebf843
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/abb5893e-48ef-4af9-83cf-9e97b2ff1048/d109dfbe-2c1f-4d4e-a7a0-d53ce484bf48?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A51Z&sr=b&sp=r&sig=dn%2FRr0uk0lMAjE7%2FhhyWyiJag%2B%2FCN2rIrbEy38H0auU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:51.0467574","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '557'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:18:51 GMT
-      mise-correlation-id:
-      - 72ba1089-4be2-42e0-bae0-f8ecfbeee8f4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/abb5893e-48ef-4af9-83cf-9e97b2ff1048/d109dfbe-2c1f-4d4e-a7a0-d53ce484bf48?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A56Z&sr=b&sp=r&sig=tAmHDvv3YtyumJEtf9mWsm91pDelPMASymx2UYG%2BVNA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:56.2940203","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e806228c-53d5-4bb2-a7d8-dfbfeead720f/6200b0bb-506c-42fd-b97b-5bb98720143f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A27Z&sr=b&sp=r&sig=RCrJCbTvFc30RrWb6epQjnCQqjhKB5UCarhI4Ix6rpI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:27.2321563","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -481,9 +373,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:56 GMT
+      - Mon, 30 Oct 2023 07:18:27 GMT
       mise-correlation-id:
-      - ca7b80f3-67de-4bd5-b89f-cb3e61f9917e
+      - a81b611e-9617-446e-bddb-882f4d003230
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -503,24 +395,132 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+    uri: https://56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ac2a25e1-6585-4a02-937a-11d574853dc3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f71fa5ca-32bb-4c75-a512-a8b59af17e55":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17eac847-d539-44b2-97d4-6d91028a4738":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/abb5893e-48ef-4af9-83cf-9e97b2ff1048/d109dfbe-2c1f-4d4e-a7a0-d53ce484bf48?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A18%3A56Z&sr=b&sp=r&sig=h0DGlZ7dO53m7KADJO0BlfaxZofQOEUhoMXMNA8r%2FP0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:18:56.8191127","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:38.905Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:53.009Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e806228c-53d5-4bb2-a7d8-dfbfeead720f/6200b0bb-506c-42fd-b97b-5bb98720143f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A32Z&sr=b&sp=r&sig=2vZCSiNRehMZmXzhT0aIxfwrN%2Fm3klHNJebEe1BZT%2Bk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:32.5069724","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1586'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:56 GMT
+      - Mon, 30 Oct 2023 07:18:32 GMT
       mise-correlation-id:
-      - 7ff33ad9-224d-404f-a59d-f0bea4ae1b88
+      - 5988533c-7e51-40dd-aa79-b409f85b98b8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e806228c-53d5-4bb2-a7d8-dfbfeead720f/6200b0bb-506c-42fd-b97b-5bb98720143f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A37Z&sr=b&sp=r&sig=M8jHHF7IziNjZiLc9wqu74XrCOLT3mgoHtR6riv%2BD%2BM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:37.7559617","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:18:37 GMT
+      mise-correlation-id:
+      - d39c7f2a-517e-43f5-919a-6264692c2345
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e806228c-53d5-4bb2-a7d8-dfbfeead720f/6200b0bb-506c-42fd-b97b-5bb98720143f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A43Z&sr=b&sp=r&sig=VpA8oMKSZVTAQb34lIolti%2FU4gB7I2Vs%2FHpv4oRwMOQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:43.0694389","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:18:43 GMT
+      mise-correlation-id:
+      - e430ec1a-321d-4648-bdb4-6020e67ef968
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"12a6ecb2-27ee-41e0-80ee-282b2fe59f0e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9119d70b-8d85-45a3-9c45-20f7ecadcfde":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bfff03c9-f9d0-49b5-9cd0-d15e370dc905":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e806228c-53d5-4bb2-a7d8-dfbfeead720f/6200b0bb-506c-42fd-b97b-5bb98720143f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A18%3A43Z&sr=b&sp=r&sig=RVqm%2F0pB39A%2BIi1nDG3rESB8LbjU2ANT8nS8ARH0WFQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:18:43.3667548","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:18:24.674Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:18:39.377Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1588'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:18:43 GMT
+      mise-correlation-id:
+      - 864be136-1c11-469b-9df3-7531799c9637
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -543,18 +543,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:37.7857696Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:37.7857696Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:17:21.323558Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:17:21.323558Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '653'
+      - '651'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:57 GMT
+      - Mon, 30 Oct 2023 07:18:45 GMT
       etag:
-      - '"3c00e221-0000-0100-0000-653eda030000"'
+      - '"3f00b865-0000-0100-0000-653f58840000"'
       expires:
       - '-1'
       pragma:
@@ -584,11 +584,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ac2a25e1-6585-4a02-937a-11d574853dc3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f71fa5ca-32bb-4c75-a512-a8b59af17e55":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17eac847-d539-44b2-97d4-6d91028a4738":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/abb5893e-48ef-4af9-83cf-9e97b2ff1048/d109dfbe-2c1f-4d4e-a7a0-d53ce484bf48?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A18%3A58Z&sr=b&sp=r&sig=xSs7e9eorPB5DDJvMeDj3lkFI%2BnKNpdQwzR9Q%2FcIbAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:18:58.3081939","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:38.905Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:53.009Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"12a6ecb2-27ee-41e0-80ee-282b2fe59f0e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9119d70b-8d85-45a3-9c45-20f7ecadcfde":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bfff03c9-f9d0-49b5-9cd0-d15e370dc905":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e806228c-53d5-4bb2-a7d8-dfbfeead720f/6200b0bb-506c-42fd-b97b-5bb98720143f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A18%3A45Z&sr=b&sp=r&sig=vx4AAHeLU3V6ajv47P3na%2Be7MTbJ5ogR7%2B3GURk4T4U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:18:45.8584625","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"app-component-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:18:24.674Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:18:39.377Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -599,9 +599,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:58 GMT
+      - Mon, 30 Oct 2023 07:18:45 GMT
       mise-correlation-id:
-      - 095ea0a1-a4d3-4a6b-bbca-5ddfd2001bcb
+      - c7931dc3-caf1-4609-8069-cde75c42e2c9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -624,18 +624,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:37.7857696Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:37.7857696Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:17:21.323558Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:17:21.323558Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '653'
+      - '651'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:58 GMT
+      - Mon, 30 Oct 2023 07:18:47 GMT
       etag:
-      - '"3c00e221-0000-0100-0000-653eda030000"'
+      - '"3f00b865-0000-0100-0000-653f58840000"'
       expires:
       - '-1'
       pragma:
@@ -654,9 +654,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-7slfevordeq3clkul/providers/Microsoft.Storage/storageAccounts/clitestload4qnr3fjsi":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-7slfevordeq3clkul/providers/Microsoft.Storage/storageAccounts/clitestload4qnr3fjsi",
-      "resourceName": "clitestload4qnr3fjsi", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-u7fy4srobhk2tx7cb/providers/Microsoft.Storage/storageAccounts/clitestloadgibyucy25":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-u7fy4srobhk2tx7cb/providers/Microsoft.Storage/storageAccounts/clitestloadgibyucy25",
+      "resourceName": "clitestloadgibyucy25", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -672,10 +672,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-29T22:18:59.831Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:59.831Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-30T07:18:48.384Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:18:48.384Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -686,11 +686,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:59 GMT
+      - Mon, 30 Oct 2023 07:18:48 GMT
       location:
-      - https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+      - https://56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - 9d8e60f9-bf26-434a-9bd7-bbc8e3f4dd89
+      - 002b5a1d-f80e-4c98-b135-cfd4340ad7d9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -713,18 +713,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:37.7857696Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:37.7857696Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:17:21.323558Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:17:21.323558Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '653'
+      - '651'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:01 GMT
+      - Mon, 30 Oct 2023 07:18:50 GMT
       etag:
-      - '"3c00e221-0000-0100-0000-653eda030000"'
+      - '"3f00b865-0000-0100-0000-653f58840000"'
       expires:
       - '-1'
       pragma:
@@ -754,10 +754,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-29T22:18:59.831Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:59.831Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"app-component-test-case","createdDateTime":"2023-10-30T07:18:48.384Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:18:48.384Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -768,9 +768,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:02 GMT
+      - Mon, 30 Oct 2023 07:18:51 GMT
       mise-correlation-id:
-      - ca6bb0f3-4c34-4506-84af-fae8f7ecfc38
+      - f0cce09b-e3bf-452f-8cb2-f54eba088612
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -793,18 +793,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:37.7857696Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:37.7857696Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:17:21.323558Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:17:21.323558Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '653'
+      - '651'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:03 GMT
+      - Mon, 30 Oct 2023 07:18:52 GMT
       etag:
-      - '"3c00e221-0000-0100-0000-653eda030000"'
+      - '"3f00b865-0000-0100-0000-653f58840000"'
       expires:
       - '-1'
       pragma:
@@ -823,7 +823,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-7slfevordeq3clkul/providers/Microsoft.Storage/storageAccounts/clitestload4qnr3fjsi":
+    body: '{"testId": "app-component-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-u7fy4srobhk2tx7cb/providers/Microsoft.Storage/storageAccounts/clitestloadgibyucy25":
       null}}'
     headers:
       Accept:
@@ -839,10 +839,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-29T22:18:59.831Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:19:04.447Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-30T07:18:48.384Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:18:54.251Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -853,9 +853,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:04 GMT
+      - Mon, 30 Oct 2023 07:18:54 GMT
       mise-correlation-id:
-      - 5f7125da-b46b-4cdd-a4e8-f9f6e600630c
+      - 29fd9ba6-5008-44ef-82dc-febbf24f22af
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -878,18 +878,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:37.7857696Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:37.7857696Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:17:21.323558Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:17:21.323558Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '653'
+      - '651'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:06 GMT
+      - Mon, 30 Oct 2023 07:18:55 GMT
       etag:
-      - '"3c00e221-0000-0100-0000-653eda030000"'
+      - '"3f00b865-0000-0100-0000-653f58840000"'
       expires:
       - '-1'
       pragma:
@@ -919,10 +919,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0b5e19a8-7c35-4fc7-99b1-447891fe41c0.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
+    uri: https://56218bea-fa63-426b-a514-5ce7dfe6aefa.eastus.cnt-prod.loadtesting.azure.com/tests/app-component-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-29T22:18:59.831Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:19:04.447Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{},"testId":"app-component-test-case","createdDateTime":"2023-10-30T07:18:48.384Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:18:54.251Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -933,9 +933,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:06 GMT
+      - Mon, 30 Oct 2023 07:18:56 GMT
       mise-correlation-id:
-      - 37e7b3ad-e314-4e90-b831-29b3d8e68e41
+      - 08ed2f7c-be85-46c9-a4a7-522d501ef4c2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_create.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_create.yaml
@@ -18,7 +18,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets?api-version=2023-05-01
   response:
     body:
-      string: '{"value":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","etag":"W/\"752b0457-6909-4146-aae7-35127323ef3a\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}]}'
+      string: '{"value":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","etag":"W/\"e8f60ce0-97b2-49ce-bf09-3077e586fb69\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}]}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:48 GMT
+      - Wed, 18 Oct 2023 20:50:48 GMT
       expires:
       - '-1'
       pragma:
@@ -44,7 +44,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - cc699cf0-e8c9-4ce4-8d0a-ce3498070542
+      - fd0f920f-7c82-4e73-bc7c-2028d4e19b3d
     status:
       code: 200
       message: OK
@@ -63,7 +63,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:44.0484484Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:44.0484484Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:47.3557741Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:47.3557741Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -72,9 +72,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:50 GMT
+      - Wed, 18 Oct 2023 20:50:50 GMT
       etag:
-      - '"d8015cc4-0000-0100-0000-65294af90000"'
+      - '"75004843-0000-0100-0000-653044ec0000"'
       expires:
       - '-1'
       pragma:
@@ -104,7 +104,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -117,9 +117,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:50:51 GMT
+      - Wed, 18 Oct 2023 20:50:51 GMT
       mise-correlation-id:
-      - 0c2cfc95-4716-4a1b-b59e-7a339cab0e35
+      - bade2067-4bd6-4243-b687-1fef40c8b891
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -134,17 +134,17 @@ interactions:
 - request:
     body: '{"displayName": "Sample_test_display_name", "description": "Sample_test_description",
       "keyvaultReferenceIdentityType": "UserAssigned", "keyvaultReferenceIdentityId":
-      "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi",
-      "subnetId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-sauc4rv3nmmxpsoeo/providers/Microsoft.Network/virtualNetworks/clitest-load-iok7ieogs37pti3xy/subnets/default",
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi",
+      "subnetId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-itknerb26srwup62n/providers/Microsoft.Network/virtualNetworks/clitest-load-vsd5e2ekqvnktdtla/subnets/default",
       "environmentVariables": {"rps": "10"}, "secrets": {"secret_name1": {"type":
       "AKV_SECRET_URI", "value": "https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757"},
       "secret_name2": {"type": "AKV_SECRET_URI", "value": "https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757"}},
       "certificate": {"name": "cert", "type": "AKV_CERT_URI", "value": "https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc"},
       "loadTestConfiguration": {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs":
-      true}, "passFailCriteria": {"passFailMetrics": {"34bb4a2f-fdef-451d-bed5-68458dcc4d51":
+      true}, "passFailCriteria": {"passFailMetrics": {"f88a774a-4925-40da-8d90-3f0a292571a0":
       {"aggregate": "avg", "clientMetric": "requests_per_sec", "condition": ">", "value":
-      "78"}, "7aca474e-0326-4b19-a482-3cbd7a34b800": {"aggregate": "percentage", "clientMetric":
-      "error", "condition": ">", "value": "50"}, "f574ac4c-d895-4837-9df8-c18a82df36bd":
+      "78"}, "8bc94b90-2230-4087-b11d-1b667b4af62c": {"aggregate": "percentage", "clientMetric":
+      "error", "condition": ">", "value": "50"}, "1ea670fb-8965-4d36-99e4-ba5ef70d8b2b":
       {"aggregate": "avg", "clientMetric": "latency", "condition": ">", "value": "200",
       "requestName": "GetCustomerDetails"}}}}'
     headers:
@@ -161,10 +161,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"34bb4a2f-fdef-451d-bed5-68458dcc4d51":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7aca474e-0326-4b19-a482-3cbd7a34b800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f574ac4c-d895-4837-9df8-c18a82df36bd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-13T13:50:53.397Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:53.397Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f88a774a-4925-40da-8d90-3f0a292571a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8bc94b90-2230-4087-b11d-1b667b4af62c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1ea670fb-8965-4d36-99e4-ba5ef70d8b2b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-18T20:50:54.012Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:54.012Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -175,11 +175,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:53 GMT
+      - Wed, 18 Oct 2023 20:50:54 GMT
       location:
-      - https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+      - https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 6b417d9b-2eac-4a86-8cb6-07620267c7ca
+      - f95df97b-74d9-4404-849d-889024de877b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -199,7 +199,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
+    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -213,9 +213,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:53 GMT
+      - Wed, 18 Oct 2023 20:50:54 GMT
       mise-correlation-id:
-      - cfcd2908-4ff9-45e0-b28d-9e0957bd22c3
+      - 6274824c-6f5e-442a-a64f-7e776732ceba
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -329,25 +329,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bd8bc747-283c-410c-a894-ffb9a505191a/96b7d9d5-ee00-45e6-a208-6167e4952535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A54Z&sr=b&sp=r&sig=1dSCMFH%2FrgSDJ6RZqOXEb%2FWKvvf%2Bryit%2BVjGmMe%2FmY0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:54.1657959","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1877326-c865-4ad8-86e4-b53abc9a0ab3/737c0330-fe9d-4de9-8587-d65852f1ccd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A54Z&sr=b&sp=r&sig=CqWKRdQiHwqcJohIxxDVQUmincUSi1hf1YJ1i1xlxbk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:54.8408466","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '559'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:54 GMT
+      - Wed, 18 Oct 2023 20:50:54 GMT
       location:
-      - https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 85e998f9-a2c4-453e-b262-12b5e7b466fe
+      - 9caf60da-8be1-4967-8ef0-0c563133b0fa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -367,23 +367,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bd8bc747-283c-410c-a894-ffb9a505191a/96b7d9d5-ee00-45e6-a208-6167e4952535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A54Z&sr=b&sp=r&sig=FPmixNcGI%2B5SF1PRRwhmYBbjFBXR08Rzrd%2BkJLPn2z0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:54.4288298","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1877326-c865-4ad8-86e4-b53abc9a0ab3/737c0330-fe9d-4de9-8587-d65852f1ccd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A55Z&sr=b&sp=r&sig=ugY4kMlUnayPmUmpli%2FXZd1fktqJXkXWwUJg6qEGDxA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:55.08859","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:54 GMT
+      - Wed, 18 Oct 2023 20:50:55 GMT
       mise-correlation-id:
-      - 86f33240-ba75-4a7c-a3d0-a1845c227602
+      - e5a3e911-63c6-4d18-aea2-ed0bd08d54ed
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -403,10 +403,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bd8bc747-283c-410c-a894-ffb9a505191a/96b7d9d5-ee00-45e6-a208-6167e4952535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A59Z&sr=b&sp=r&sig=H9FsAOgm4nR4uqJr0R4Lgthm7PN%2F5wHODblRxJiVLSU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:59.6997726","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1877326-c865-4ad8-86e4-b53abc9a0ab3/737c0330-fe9d-4de9-8587-d65852f1ccd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A00Z&sr=b&sp=r&sig=dnG1JkXLaq7eeRBNwVU4L2pMRvefpgynHs%2FjW5dVHNk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:00.3532504","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -417,9 +417,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:59 GMT
+      - Wed, 18 Oct 2023 20:51:00 GMT
       mise-correlation-id:
-      - e3771c22-0e0e-4644-a92b-c69055417fbe
+      - 00d1fb76-4473-403f-9344-ecc69029a6e5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -439,10 +439,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bd8bc747-283c-410c-a894-ffb9a505191a/96b7d9d5-ee00-45e6-a208-6167e4952535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A04Z&sr=b&sp=r&sig=qO6bgsdjvWiwZ9nOeglnLNk5jr4tXE2fwn%2BNkvkOjS8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:04.9861252","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1877326-c865-4ad8-86e4-b53abc9a0ab3/737c0330-fe9d-4de9-8587-d65852f1ccd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A05Z&sr=b&sp=r&sig=22kkcgTR41fCR01s0daJbAHEg%2F1CA3C7FYgZyhFf944%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:05.6184728","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -453,9 +453,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:04 GMT
+      - Wed, 18 Oct 2023 20:51:05 GMT
       mise-correlation-id:
-      - 964ff47f-127e-4121-b19f-e3220e77509c
+      - dd47eb2d-dc59-488c-b70f-47b75eba67b9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -475,23 +475,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bd8bc747-283c-410c-a894-ffb9a505191a/96b7d9d5-ee00-45e6-a208-6167e4952535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A10Z&sr=b&sp=r&sig=wSoHNeh7ChcHUyPhKT51%2BQ6DyPgVPurMQ%2FWOk5gPKYc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:10.3238316","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1877326-c865-4ad8-86e4-b53abc9a0ab3/737c0330-fe9d-4de9-8587-d65852f1ccd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A10Z&sr=b&sp=r&sig=hhXCJZJAeoAPvzgRVAyupjtnMTdTC6IPULDYu4k%2BZuY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:10.8747647","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:10 GMT
+      - Wed, 18 Oct 2023 20:51:10 GMT
       mise-correlation-id:
-      - 0133887c-66d9-4098-a874-a1d521f2ebe8
+      - 60caf697-0578-48ed-8f59-ead82e799623
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -511,23 +511,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"34bb4a2f-fdef-451d-bed5-68458dcc4d51":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7aca474e-0326-4b19-a482-3cbd7a34b800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f574ac4c-d895-4837-9df8-c18a82df36bd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bd8bc747-283c-410c-a894-ffb9a505191a/96b7d9d5-ee00-45e6-a208-6167e4952535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A10Z&sr=b&sp=r&sig=3wNSOKi5GyS3fudNCwJZiNE6w%2FIKlhxBLSWhqkjxvCQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:10.5671659","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-13T13:50:53.397Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:06.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f88a774a-4925-40da-8d90-3f0a292571a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8bc94b90-2230-4087-b11d-1b667b4af62c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1ea670fb-8965-4d36-99e4-ba5ef70d8b2b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1877326-c865-4ad8-86e4-b53abc9a0ab3/737c0330-fe9d-4de9-8587-d65852f1ccd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A11Z&sr=b&sp=r&sig=t9bzAgDpthIkF3NGW%2FrKtGLbDR6B0I%2BUFXw79ao9%2F%2FQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:11.1239007","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-18T20:50:54.012Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:08.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2356'
+      - '2362'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:10 GMT
+      - Wed, 18 Oct 2023 20:51:11 GMT
       mise-correlation-id:
-      - 9019ebfa-cde5-4a8d-95bf-b78829b8065c
+      - 4c46dca6-342d-4e37-84c3-ff8611c5c852
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -550,7 +550,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:44.0484484Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:44.0484484Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:47.3557741Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:47.3557741Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -559,9 +559,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:11 GMT
+      - Wed, 18 Oct 2023 20:51:12 GMT
       etag:
-      - '"d8015cc4-0000-0100-0000-65294af90000"'
+      - '"75004843-0000-0100-0000-653044ec0000"'
       expires:
       - '-1'
       pragma:
@@ -591,23 +591,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"34bb4a2f-fdef-451d-bed5-68458dcc4d51":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7aca474e-0326-4b19-a482-3cbd7a34b800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f574ac4c-d895-4837-9df8-c18a82df36bd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bd8bc747-283c-410c-a894-ffb9a505191a/96b7d9d5-ee00-45e6-a208-6167e4952535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A12Z&sr=b&sp=r&sig=ZBw%2B7riQYh9nQ7kijBl6x1vVOlt9gNO%2FkCLTUv05ieQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:12.9572836","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-13T13:50:53.397Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:06.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f88a774a-4925-40da-8d90-3f0a292571a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8bc94b90-2230-4087-b11d-1b667b4af62c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1ea670fb-8965-4d36-99e4-ba5ef70d8b2b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1877326-c865-4ad8-86e4-b53abc9a0ab3/737c0330-fe9d-4de9-8587-d65852f1ccd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A13Z&sr=b&sp=r&sig=0zkiSK7R8nsYdHO6PFjVrjIe8ZiLnC9ixYMYljAzW3c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:13.2276443","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-18T20:50:54.012Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:08.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2358'
+      - '2354'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:12 GMT
+      - Wed, 18 Oct 2023 20:51:13 GMT
       mise-correlation-id:
-      - e59e466c-6a82-4b5a-b42c-4d20865b2f7e
+      - 8a27c995-a676-4762-b3a3-72e5d3054811
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -630,7 +630,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:44.0484484Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:44.0484484Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:47.3557741Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:47.3557741Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -639,9 +639,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:16 GMT
+      - Wed, 18 Oct 2023 20:51:15 GMT
       etag:
-      - '"d8015cc4-0000-0100-0000-65294af90000"'
+      - '"75004843-0000-0100-0000-653044ec0000"'
       expires:
       - '-1'
       pragma:
@@ -671,7 +671,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-pf-test-case?api-version=2022-11-01
+    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-pf-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -684,9 +684,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:51:17 GMT
+      - Wed, 18 Oct 2023 20:51:16 GMT
       mise-correlation-id:
-      - c07a8dd1-a7ff-4a22-b2d9-fcf58c20d3f1
+      - dded0cc8-b19e-48f3-89fc-4fac076fd034
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_create.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_create.yaml
@@ -13,28 +13,21 @@ interactions:
       ParameterSetName:
       - --resource-group --vnet-name
       User-Agent:
-      - AZURECLI/2.46.0 (AAZ) azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 (AAZ) azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets?api-version=2022-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets?api-version=2023-05-01
   response:
     body:
-      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"default\",\r\n      \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default\",\r\n
-        \     \"etag\": \"W/\\\"2e49f423-be94-4901-8ec6-44c35ecd4ffe\\\"\",\r\n      \"properties\":
-        {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"addressPrefix\":
-        \"10.0.0.0/24\",\r\n        \"delegations\": [],\r\n        \"privateEndpointNetworkPolicies\":
-        \"Disabled\",\r\n        \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
-        \     },\r\n      \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
-        \   }\r\n  ]\r\n}"
+      string: '{"value":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","etag":"W/\"752b0457-6909-4146-aae7-35127323ef3a\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '622'
+      - '491'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:42 GMT
+      - Fri, 13 Oct 2023 13:50:48 GMT
       expires:
       - '-1'
       pragma:
@@ -51,7 +44,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 45c1739a-9fad-4335-a9aa-8dfc88b0b737
+      - cc699cf0-e8c9-4ce4-8d0a-ce3498070542
     status:
       code: 200
       message: OK
@@ -70,7 +63,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:35.3177746Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:35.3177746Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:44.0484484Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:44.0484484Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -79,9 +72,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:44 GMT
+      - Fri, 13 Oct 2023 13:50:50 GMT
       etag:
-      - '"550004d8-0000-0100-0000-652451950000"'
+      - '"d8015cc4-0000-0100-0000-65294af90000"'
       expires:
       - '-1'
       pragma:
@@ -109,9 +102,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -124,9 +117,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:17:44 GMT
+      - Fri, 13 Oct 2023 13:50:51 GMT
       mise-correlation-id:
-      - 91f3ad1e-dfbb-40c4-8c02-032fcb851ccf
+      - 0c2cfc95-4716-4a1b-b59e-7a339cab0e35
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -142,16 +135,16 @@ interactions:
     body: '{"displayName": "Sample_test_display_name", "description": "Sample_test_description",
       "keyvaultReferenceIdentityType": "UserAssigned", "keyvaultReferenceIdentityId":
       "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi",
-      "subnetId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-qs52bdu5hka3kkcu6/providers/Microsoft.Network/virtualNetworks/clitest-load-fshclswir63ufsl43/subnets/default",
+      "subnetId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-sauc4rv3nmmxpsoeo/providers/Microsoft.Network/virtualNetworks/clitest-load-iok7ieogs37pti3xy/subnets/default",
       "environmentVariables": {"rps": "10"}, "secrets": {"secret_name1": {"type":
       "AKV_SECRET_URI", "value": "https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757"},
       "secret_name2": {"type": "AKV_SECRET_URI", "value": "https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757"}},
       "certificate": {"name": "cert", "type": "AKV_CERT_URI", "value": "https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc"},
       "loadTestConfiguration": {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs":
-      true}, "passFailCriteria": {"passFailMetrics": {"244f71bf-bd7d-4524-a81b-1a250929298c":
+      true}, "passFailCriteria": {"passFailMetrics": {"34bb4a2f-fdef-451d-bed5-68458dcc4d51":
       {"aggregate": "avg", "clientMetric": "requests_per_sec", "condition": ">", "value":
-      "78"}, "2fa97893-203b-4312-8336-6d6c35a5cf2f": {"aggregate": "percentage", "clientMetric":
-      "error", "condition": ">", "value": "50"}, "7c1dc945-46eb-4204-bd64-382b2285afde":
+      "78"}, "7aca474e-0326-4b19-a482-3cbd7a34b800": {"aggregate": "percentage", "clientMetric":
+      "error", "condition": ">", "value": "50"}, "f574ac4c-d895-4837-9df8-c18a82df36bd":
       {"aggregate": "avg", "clientMetric": "latency", "condition": ">", "value": "200",
       "requestName": "GetCustomerDetails"}}}}'
     headers:
@@ -166,12 +159,12 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"244f71bf-bd7d-4524-a81b-1a250929298c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2fa97893-203b-4312-8336-6d6c35a5cf2f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7c1dc945-46eb-4204-bd64-382b2285afde":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-09T19:17:47.256Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:47.256Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"34bb4a2f-fdef-451d-bed5-68458dcc4d51":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7aca474e-0326-4b19-a482-3cbd7a34b800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f574ac4c-d895-4837-9df8-c18a82df36bd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-13T13:50:53.397Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:53.397Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -182,11 +175,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:47 GMT
+      - Fri, 13 Oct 2023 13:50:53 GMT
       location:
-      - https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+      - https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 62dd0a05-83a1-4be0-8a2d-20178ed4a15e
+      - 6b417d9b-2eac-4a86-8cb6-07620267c7ca
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -204,9 +197,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
+    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -220,9 +213,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:47 GMT
+      - Fri, 13 Oct 2023 13:50:53 GMT
       mise-correlation-id:
-      - 15aa3f05-a34d-4fda-ad30-8972b3ba83d0
+      - cfcd2908-4ff9-45e0-b28d-9e0957bd22c3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -334,27 +327,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e903677d-01ca-4502-a2d1-4f1a33381dec/ff781c7b-b8b0-4c3b-b66d-5b96a4859ae5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A48Z&sr=b&sp=r&sig=Y7RVVyy1puMJZtz5oUaAJlWZ%2BRvcYXMfo%2F9cZlL7IzU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:48.3140316","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bd8bc747-283c-410c-a894-ffb9a505191a/96b7d9d5-ee00-45e6-a208-6167e4952535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A54Z&sr=b&sp=r&sig=1dSCMFH%2FrgSDJ6RZqOXEb%2FWKvvf%2Bryit%2BVjGmMe%2FmY0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:54.1657959","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '559'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:48 GMT
+      - Fri, 13 Oct 2023 13:50:54 GMT
       location:
-      - https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - debf9ded-14cc-421f-9845-7c538ed614c6
+      - 85e998f9-a2c4-453e-b262-12b5e7b466fe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -372,48 +365,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e903677d-01ca-4502-a2d1-4f1a33381dec/ff781c7b-b8b0-4c3b-b66d-5b96a4859ae5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A48Z&sr=b&sp=r&sig=d891x3i9KeZy3K9bSj181PtKujfiRXB38JQZmAC7Q5w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:48.6568937","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:17:48 GMT
-      mise-correlation-id:
-      - e2637ea1-3bca-4b96-8048-e559e210e9b5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e903677d-01ca-4502-a2d1-4f1a33381dec/ff781c7b-b8b0-4c3b-b66d-5b96a4859ae5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A53Z&sr=b&sp=r&sig=kql1%2F2f7IbA8NY6zBwME3C4HexZ%2FEGl6ZU0cqtLxKL4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:53.9746528","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bd8bc747-283c-410c-a894-ffb9a505191a/96b7d9d5-ee00-45e6-a208-6167e4952535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A54Z&sr=b&sp=r&sig=FPmixNcGI%2B5SF1PRRwhmYBbjFBXR08Rzrd%2BkJLPn2z0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:54.4288298","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -424,9 +381,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:53 GMT
+      - Fri, 13 Oct 2023 13:50:54 GMT
       mise-correlation-id:
-      - 2c7178ce-d671-4e9a-b473-12257dd69125
+      - 86f33240-ba75-4a7c-a3d0-a1845c227602
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -444,48 +401,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e903677d-01ca-4502-a2d1-4f1a33381dec/ff781c7b-b8b0-4c3b-b66d-5b96a4859ae5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A59Z&sr=b&sp=r&sig=0DJv0mvHFZIWKuRA%2F%2BN8HzuVO0N6MEzNvRWEO%2B7m7kk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:59.243959","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '554'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:17:59 GMT
-      mise-correlation-id:
-      - ed8698ba-c9df-4453-a38c-106b45e2d816
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e903677d-01ca-4502-a2d1-4f1a33381dec/ff781c7b-b8b0-4c3b-b66d-5b96a4859ae5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A04Z&sr=b&sp=r&sig=8ZGneLnFc%2BcrsPFmnlSfTyololW%2BwcPEoXPvzasFq88%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:04.5077021","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bd8bc747-283c-410c-a894-ffb9a505191a/96b7d9d5-ee00-45e6-a208-6167e4952535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A59Z&sr=b&sp=r&sig=H9FsAOgm4nR4uqJr0R4Lgthm7PN%2F5wHODblRxJiVLSU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:59.6997726","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -496,9 +417,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:04 GMT
+      - Fri, 13 Oct 2023 13:50:59 GMT
       mise-correlation-id:
-      - 2f92278d-b873-4559-8e88-31f008ea868b
+      - e3771c22-0e0e-4644-a92b-c69055417fbe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -516,12 +437,84 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"244f71bf-bd7d-4524-a81b-1a250929298c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2fa97893-203b-4312-8336-6d6c35a5cf2f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7c1dc945-46eb-4204-bd64-382b2285afde":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e903677d-01ca-4502-a2d1-4f1a33381dec/ff781c7b-b8b0-4c3b-b66d-5b96a4859ae5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A04Z&sr=b&sp=r&sig=c%2BUY02uC2Zzk7hhXddINbW0zfM3bFPpvxuOQceZUTDE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:04.7684705","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-09T19:17:47.256Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:03.233Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bd8bc747-283c-410c-a894-ffb9a505191a/96b7d9d5-ee00-45e6-a208-6167e4952535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A04Z&sr=b&sp=r&sig=qO6bgsdjvWiwZ9nOeglnLNk5jr4tXE2fwn%2BNkvkOjS8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:04.9861252","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:51:04 GMT
+      mise-correlation-id:
+      - 964ff47f-127e-4121-b19f-e3220e77509c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bd8bc747-283c-410c-a894-ffb9a505191a/96b7d9d5-ee00-45e6-a208-6167e4952535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A10Z&sr=b&sp=r&sig=wSoHNeh7ChcHUyPhKT51%2BQ6DyPgVPurMQ%2FWOk5gPKYc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:10.3238316","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:51:10 GMT
+      mise-correlation-id:
+      - 0133887c-66d9-4098-a874-a1d521f2ebe8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"34bb4a2f-fdef-451d-bed5-68458dcc4d51":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7aca474e-0326-4b19-a482-3cbd7a34b800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f574ac4c-d895-4837-9df8-c18a82df36bd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bd8bc747-283c-410c-a894-ffb9a505191a/96b7d9d5-ee00-45e6-a208-6167e4952535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A10Z&sr=b&sp=r&sig=3wNSOKi5GyS3fudNCwJZiNE6w%2FIKlhxBLSWhqkjxvCQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:10.5671659","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-13T13:50:53.397Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:06.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -532,9 +525,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:04 GMT
+      - Fri, 13 Oct 2023 13:51:10 GMT
       mise-correlation-id:
-      - 10fdae5e-2a55-4f9e-948d-c6277358669d
+      - 9019ebfa-cde5-4a8d-95bf-b78829b8065c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -557,7 +550,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:35.3177746Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:35.3177746Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:44.0484484Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:44.0484484Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -566,9 +559,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:05 GMT
+      - Fri, 13 Oct 2023 13:51:11 GMT
       etag:
-      - '"550004d8-0000-0100-0000-652451950000"'
+      - '"d8015cc4-0000-0100-0000-65294af90000"'
       expires:
       - '-1'
       pragma:
@@ -596,25 +589,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"244f71bf-bd7d-4524-a81b-1a250929298c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2fa97893-203b-4312-8336-6d6c35a5cf2f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7c1dc945-46eb-4204-bd64-382b2285afde":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e903677d-01ca-4502-a2d1-4f1a33381dec/ff781c7b-b8b0-4c3b-b66d-5b96a4859ae5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A07Z&sr=b&sp=r&sig=DMk1WsWYTdOI1FvxXRCF%2BdG046fvEBSOsh5pkY3oU3Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:07.2959963","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-09T19:17:47.256Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:03.233Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"34bb4a2f-fdef-451d-bed5-68458dcc4d51":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7aca474e-0326-4b19-a482-3cbd7a34b800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f574ac4c-d895-4837-9df8-c18a82df36bd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bd8bc747-283c-410c-a894-ffb9a505191a/96b7d9d5-ee00-45e6-a208-6167e4952535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A12Z&sr=b&sp=r&sig=ZBw%2B7riQYh9nQ7kijBl6x1vVOlt9gNO%2FkCLTUv05ieQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:12.9572836","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-13T13:50:53.397Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:06.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2356'
+      - '2358'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:07 GMT
+      - Fri, 13 Oct 2023 13:51:12 GMT
       mise-correlation-id:
-      - 8815375c-0910-4413-97dc-5b81956fcab9
+      - e59e466c-6a82-4b5a-b42c-4d20865b2f7e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -637,7 +630,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:35.3177746Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:35.3177746Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:44.0484484Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:44.0484484Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -646,9 +639,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:09 GMT
+      - Fri, 13 Oct 2023 13:51:16 GMT
       etag:
-      - '"550004d8-0000-0100-0000-652451950000"'
+      - '"d8015cc4-0000-0100-0000-65294af90000"'
       expires:
       - '-1'
       pragma:
@@ -676,9 +669,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-pf-test-case?api-version=2022-11-01
+    uri: https://e013270e-1f10-4e4e-8051-9109655b3bca.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-pf-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -691,9 +684,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:18:10 GMT
+      - Fri, 13 Oct 2023 13:51:17 GMT
       mise-correlation-id:
-      - 3c7d67d6-615c-42de-b6c2-261cedf7cd71
+      - c07a8dd1-a7ff-4a22-b2d9-fcf58c20d3f1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_create.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_create.yaml
@@ -20,7 +20,7 @@ interactions:
     body:
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"default\",\r\n      \"id\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default\",\r\n
-        \     \"etag\": \"W/\\\"009cb508-b316-4cc9-b8ba-e6834da903bf\\\"\",\r\n      \"properties\":
+        \     \"etag\": \"W/\\\"2e49f423-be94-4901-8ec6-44c35ecd4ffe\\\"\",\r\n      \"properties\":
         {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"addressPrefix\":
         \"10.0.0.0/24\",\r\n        \"delegations\": [],\r\n        \"privateEndpointNetworkPolicies\":
         \"Disabled\",\r\n        \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
@@ -34,7 +34,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:20 GMT
+      - Mon, 09 Oct 2023 19:17:42 GMT
       expires:
       - '-1'
       pragma:
@@ -51,7 +51,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - e68764c2-5ad4-4eb0-9529-7827619734d3
+      - 45c1739a-9fad-4335-a9aa-8dfc88b0b737
     status:
       code: 200
       message: OK
@@ -70,7 +70,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:10:15.8805824Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:10:15.8805824Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:35.3177746Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:35.3177746Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -79,9 +79,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:20 GMT
+      - Mon, 09 Oct 2023 19:17:44 GMT
       etag:
-      - '"92019a9b-0000-0100-0000-652425e90000"'
+      - '"550004d8-0000-0100-0000-652451950000"'
       expires:
       - '-1'
       pragma:
@@ -111,7 +111,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -124,9 +124,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:11:22 GMT
+      - Mon, 09 Oct 2023 19:17:44 GMT
       mise-correlation-id:
-      - 2b54924a-0899-40f0-bea0-15b5e7149160
+      - 91f3ad1e-dfbb-40c4-8c02-032fcb851ccf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -142,16 +142,16 @@ interactions:
     body: '{"displayName": "Sample_test_display_name", "description": "Sample_test_description",
       "keyvaultReferenceIdentityType": "UserAssigned", "keyvaultReferenceIdentityId":
       "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi",
-      "subnetId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ioxm3s65nobpxeoxv/providers/Microsoft.Network/virtualNetworks/clitest-load-pmv5blcdhru7wqqgn/subnets/default",
+      "subnetId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-qs52bdu5hka3kkcu6/providers/Microsoft.Network/virtualNetworks/clitest-load-fshclswir63ufsl43/subnets/default",
       "environmentVariables": {"rps": "10"}, "secrets": {"secret_name1": {"type":
       "AKV_SECRET_URI", "value": "https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757"},
       "secret_name2": {"type": "AKV_SECRET_URI", "value": "https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757"}},
       "certificate": {"name": "cert", "type": "AKV_CERT_URI", "value": "https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc"},
       "loadTestConfiguration": {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs":
-      true}, "passFailCriteria": {"passFailMetrics": {"e8621056-2746-487f-b572-3ee17c99d71d":
+      true}, "passFailCriteria": {"passFailMetrics": {"244f71bf-bd7d-4524-a81b-1a250929298c":
       {"aggregate": "avg", "clientMetric": "requests_per_sec", "condition": ">", "value":
-      "78"}, "c84c6d5a-7d88-4b5b-ad48-b7f746160320": {"aggregate": "percentage", "clientMetric":
-      "error", "condition": ">", "value": "50"}, "02aeb584-6464-48bf-a4c8-e2d9bc2be56e":
+      "78"}, "2fa97893-203b-4312-8336-6d6c35a5cf2f": {"aggregate": "percentage", "clientMetric":
+      "error", "condition": ">", "value": "50"}, "7c1dc945-46eb-4204-bd64-382b2285afde":
       {"aggregate": "avg", "clientMetric": "latency", "condition": ">", "value": "200",
       "requestName": "GetCustomerDetails"}}}}'
     headers:
@@ -168,10 +168,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"e8621056-2746-487f-b572-3ee17c99d71d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c84c6d5a-7d88-4b5b-ad48-b7f746160320":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"02aeb584-6464-48bf-a4c8-e2d9bc2be56e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-09T16:11:26.244Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:26.244Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"244f71bf-bd7d-4524-a81b-1a250929298c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2fa97893-203b-4312-8336-6d6c35a5cf2f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7c1dc945-46eb-4204-bd64-382b2285afde":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-09T19:17:47.256Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:47.256Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -182,11 +182,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:26 GMT
+      - Mon, 09 Oct 2023 19:17:47 GMT
       location:
-      - https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+      - https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 5a98ab2e-a970-4dc2-87c0-c190cecbb1b0
+      - 62dd0a05-83a1-4be0-8a2d-20178ed4a15e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -206,7 +206,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
+    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -220,9 +220,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:26 GMT
+      - Mon, 09 Oct 2023 19:17:47 GMT
       mise-correlation-id:
-      - de16798c-18a0-4def-8a98-2baa09e3af28
+      - 15aa3f05-a34d-4fda-ad30-8972b3ba83d0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -336,25 +336,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fd6fbfbe-d154-450b-b62b-cd06467cda86/37fd27dc-2f1e-4450-8338-31e7ebf1f9a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A28Z&sr=b&sp=r&sig=RzE1XGT5BIhI1gAkvjBaLSKvFn7L0yQuJ%2BZ5vwGcnpg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:28.6358354","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e903677d-01ca-4502-a2d1-4f1a33381dec/ff781c7b-b8b0-4c3b-b66d-5b96a4859ae5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A48Z&sr=b&sp=r&sig=Y7RVVyy1puMJZtz5oUaAJlWZ%2BRvcYXMfo%2F9cZlL7IzU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:48.3140316","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:28 GMT
+      - Mon, 09 Oct 2023 19:17:48 GMT
       location:
-      - https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 9a3a52ae-4eeb-49df-bf4e-316faff9f760
+      - debf9ded-14cc-421f-9845-7c538ed614c6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -374,46 +374,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fd6fbfbe-d154-450b-b62b-cd06467cda86/37fd27dc-2f1e-4450-8338-31e7ebf1f9a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A28Z&sr=b&sp=r&sig=jKGqkjUqzyNDr99WSm2V7Rrj6ojMhO4fVeHDMn%2FlqsQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:28.8973534","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:11:28 GMT
-      mise-correlation-id:
-      - 09e90d89-92c8-4bb2-ab86-6a37e0a8ed56
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fd6fbfbe-d154-450b-b62b-cd06467cda86/37fd27dc-2f1e-4450-8338-31e7ebf1f9a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A34Z&sr=b&sp=r&sig=st1UDiD3m5Ys4WKNsKxTBw9TBztXXW43tm0I3RJdVFg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:34.1827746","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e903677d-01ca-4502-a2d1-4f1a33381dec/ff781c7b-b8b0-4c3b-b66d-5b96a4859ae5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A48Z&sr=b&sp=r&sig=d891x3i9KeZy3K9bSj181PtKujfiRXB38JQZmAC7Q5w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:48.6568937","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -424,9 +388,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:34 GMT
+      - Mon, 09 Oct 2023 19:17:48 GMT
       mise-correlation-id:
-      - f5d0af76-c160-4eaf-b2f6-2ed7a01a49de
+      - e2637ea1-3bca-4b96-8048-e559e210e9b5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -446,23 +410,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fd6fbfbe-d154-450b-b62b-cd06467cda86/37fd27dc-2f1e-4450-8338-31e7ebf1f9a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A39Z&sr=b&sp=r&sig=DEU6Vn5rFrelm6EPImMU1c4W8quOm0CgHxl5aNhpg%2Bw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:39.460603","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e903677d-01ca-4502-a2d1-4f1a33381dec/ff781c7b-b8b0-4c3b-b66d-5b96a4859ae5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A53Z&sr=b&sp=r&sig=kql1%2F2f7IbA8NY6zBwME3C4HexZ%2FEGl6ZU0cqtLxKL4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:53.9746528","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:39 GMT
+      - Mon, 09 Oct 2023 19:17:53 GMT
       mise-correlation-id:
-      - 75335c3b-db33-4600-899e-ce54124d3c45
+      - 2c7178ce-d671-4e9a-b473-12257dd69125
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -482,23 +446,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fd6fbfbe-d154-450b-b62b-cd06467cda86/37fd27dc-2f1e-4450-8338-31e7ebf1f9a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A44Z&sr=b&sp=r&sig=Gi59k9wffVuJimoQJKjsZUbEuoKpycOC5dw7QFEjhf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:44.9753799","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e903677d-01ca-4502-a2d1-4f1a33381dec/ff781c7b-b8b0-4c3b-b66d-5b96a4859ae5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A59Z&sr=b&sp=r&sig=0DJv0mvHFZIWKuRA%2F%2BN8HzuVO0N6MEzNvRWEO%2B7m7kk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:59.243959","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '554'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:44 GMT
+      - Mon, 09 Oct 2023 19:17:59 GMT
       mise-correlation-id:
-      - 805ed99a-90d3-417c-ba01-a11b61c913c1
+      - ed8698ba-c9df-4453-a38c-106b45e2d816
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -518,23 +482,59 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"e8621056-2746-487f-b572-3ee17c99d71d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c84c6d5a-7d88-4b5b-ad48-b7f746160320":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"02aeb584-6464-48bf-a4c8-e2d9bc2be56e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fd6fbfbe-d154-450b-b62b-cd06467cda86/37fd27dc-2f1e-4450-8338-31e7ebf1f9a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A11%3A45Z&sr=b&sp=r&sig=R8%2FIGikT9pWwXdbhCoi0l6Tf7txvFue3XPI8lSeZ%2Bzk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:11:45.2381184","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-09T16:11:26.244Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:41.801Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e903677d-01ca-4502-a2d1-4f1a33381dec/ff781c7b-b8b0-4c3b-b66d-5b96a4859ae5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A04Z&sr=b&sp=r&sig=8ZGneLnFc%2BcrsPFmnlSfTyololW%2BwcPEoXPvzasFq88%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:04.5077021","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2358'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:45 GMT
+      - Mon, 09 Oct 2023 19:18:04 GMT
       mise-correlation-id:
-      - 10d1f0a6-9998-4be8-be71-e4d6a64fd4e8
+      - 2f92278d-b873-4559-8e88-31f008ea868b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"244f71bf-bd7d-4524-a81b-1a250929298c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2fa97893-203b-4312-8336-6d6c35a5cf2f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7c1dc945-46eb-4204-bd64-382b2285afde":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e903677d-01ca-4502-a2d1-4f1a33381dec/ff781c7b-b8b0-4c3b-b66d-5b96a4859ae5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A04Z&sr=b&sp=r&sig=c%2BUY02uC2Zzk7hhXddINbW0zfM3bFPpvxuOQceZUTDE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:04.7684705","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-09T19:17:47.256Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:03.233Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '2356'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:18:04 GMT
+      mise-correlation-id:
+      - 10fdae5e-2a55-4f9e-948d-c6277358669d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -557,7 +557,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:10:15.8805824Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:10:15.8805824Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:35.3177746Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:35.3177746Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -566,9 +566,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:45 GMT
+      - Mon, 09 Oct 2023 19:18:05 GMT
       etag:
-      - '"92019a9b-0000-0100-0000-652425e90000"'
+      - '"550004d8-0000-0100-0000-652451950000"'
       expires:
       - '-1'
       pragma:
@@ -598,23 +598,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"e8621056-2746-487f-b572-3ee17c99d71d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c84c6d5a-7d88-4b5b-ad48-b7f746160320":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"02aeb584-6464-48bf-a4c8-e2d9bc2be56e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fd6fbfbe-d154-450b-b62b-cd06467cda86/37fd27dc-2f1e-4450-8338-31e7ebf1f9a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A11%3A47Z&sr=b&sp=r&sig=DRVV9W5rshprI1svE3uQHHW85TmLUM9R3CBBiO5vR5I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:11:47.4630084","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-09T16:11:26.244Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:41.801Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"244f71bf-bd7d-4524-a81b-1a250929298c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2fa97893-203b-4312-8336-6d6c35a5cf2f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7c1dc945-46eb-4204-bd64-382b2285afde":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e903677d-01ca-4502-a2d1-4f1a33381dec/ff781c7b-b8b0-4c3b-b66d-5b96a4859ae5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A07Z&sr=b&sp=r&sig=DMk1WsWYTdOI1FvxXRCF%2BdG046fvEBSOsh5pkY3oU3Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:07.2959963","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-09T19:17:47.256Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:03.233Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2354'
+      - '2356'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:47 GMT
+      - Mon, 09 Oct 2023 19:18:07 GMT
       mise-correlation-id:
-      - 7403fba0-9570-496a-8475-c49cc999af57
+      - 8815375c-0910-4413-97dc-5b81956fcab9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -637,7 +637,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:10:15.8805824Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:10:15.8805824Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:35.3177746Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:35.3177746Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -646,9 +646,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:49 GMT
+      - Mon, 09 Oct 2023 19:18:09 GMT
       etag:
-      - '"92019a9b-0000-0100-0000-652425e90000"'
+      - '"550004d8-0000-0100-0000-652451950000"'
       expires:
       - '-1'
       pragma:
@@ -678,7 +678,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-pf-test-case?api-version=2022-11-01
+    uri: https://983a08b3-9d76-43c8-af4c-0ba3fb3d8c13.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-pf-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -691,9 +691,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:11:50 GMT
+      - Mon, 09 Oct 2023 19:18:10 GMT
       mise-correlation-id:
-      - 44392300-091a-4ce5-b742-8cb971caa3f5
+      - 3c7d67d6-615c-42de-b6c2-261cedf7cd71
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_create.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_create.yaml
@@ -18,15 +18,14 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets?api-version=2022-01-01
   response:
     body:
-      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"default\",\r\n  \
-        \    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default\"\
-        ,\r\n      \"etag\": \"W/\\\"00e6ae79-c8f9-4b50-82c3-393335832372\\\"\",\r\
-        \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
-        ,\r\n        \"addressPrefix\": \"10.0.0.0/24\",\r\n        \"delegations\"\
-        : [],\r\n        \"privateEndpointNetworkPolicies\": \"Disabled\",\r\n   \
-        \     \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n      },\r\n \
-        \     \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n    }\r\n\
-        \  ]\r\n}"
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"default\",\r\n      \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default\",\r\n
+        \     \"etag\": \"W/\\\"009cb508-b316-4cc9-b8ba-e6834da903bf\\\"\",\r\n      \"properties\":
+        {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"addressPrefix\":
+        \"10.0.0.0/24\",\r\n        \"delegations\": [],\r\n        \"privateEndpointNetworkPolicies\":
+        \"Disabled\",\r\n        \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
+        \     },\r\n      \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \   }\r\n  ]\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -35,7 +34,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:29 GMT
+      - Mon, 09 Oct 2023 16:11:20 GMT
       expires:
       - '-1'
       pragma:
@@ -52,7 +51,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 1b496ab4-dade-4efd-b3b5-94f0688865c9
+      - e68764c2-5ad4-4eb0-9529-7827619734d3
     status:
       code: 200
       message: OK
@@ -71,7 +70,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:10:10.0912782Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:10:10.0912782Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6f1f5b89-2d42-4171-90ca-6f0616b96b18.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:10:15.8805824Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:10:15.8805824Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -80,9 +79,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:30 GMT
+      - Mon, 09 Oct 2023 16:11:20 GMT
       etag:
-      - '"1a0a93aa-0000-0100-0000-64af08a40000"'
+      - '"92019a9b-0000-0100-0000-652425e90000"'
       expires:
       - '-1'
       pragma:
@@ -112,7 +111,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6f1f5b89-2d42-4171-90ca-6f0616b96b18.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -125,9 +124,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:11:32 GMT
+      - Mon, 09 Oct 2023 16:11:22 GMT
       mise-correlation-id:
-      - 506a173b-174f-406e-82f6-a68c48d4c29b
+      - 2b54924a-0899-40f0-bea0-15b5e7149160
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -142,17 +141,17 @@ interactions:
 - request:
     body: '{"displayName": "Sample_test_display_name", "description": "Sample_test_description",
       "keyvaultReferenceIdentityType": "UserAssigned", "keyvaultReferenceIdentityId":
-      "/subscriptions/{subscription_id}/resourceGroups/sample-rg/providers/Microsoft.KeyVault/vaults/sample-kv",
-      "subnetId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-3lrtjt2ynhqvu3wtp/providers/Microsoft.Network/virtualNetworks/clitest-load-a4enbgwq6vxifhmfk/subnets/default",
+      "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi",
+      "subnetId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ioxm3s65nobpxeoxv/providers/Microsoft.Network/virtualNetworks/clitest-load-pmv5blcdhru7wqqgn/subnets/default",
       "environmentVariables": {"rps": "10"}, "secrets": {"secret_name1": {"type":
       "AKV_SECRET_URI", "value": "https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757"},
       "secret_name2": {"type": "AKV_SECRET_URI", "value": "https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757"}},
       "certificate": {"name": "cert", "type": "AKV_CERT_URI", "value": "https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc"},
       "loadTestConfiguration": {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs":
-      true}, "passFailCriteria": {"passFailMetrics": {"2ae79a39-c88a-4401-9e60-840daa5bc03d":
+      true}, "passFailCriteria": {"passFailMetrics": {"e8621056-2746-487f-b572-3ee17c99d71d":
       {"aggregate": "avg", "clientMetric": "requests_per_sec", "condition": ">", "value":
-      "78"}, "eb898201-0e61-4949-ac5b-7b78fc52e67e": {"aggregate": "percentage", "clientMetric":
-      "error", "condition": ">", "value": "50"}, "4fd6d976-f06c-4d8e-bc86-45196607f7fd":
+      "78"}, "c84c6d5a-7d88-4b5b-ad48-b7f746160320": {"aggregate": "percentage", "clientMetric":
+      "error", "condition": ">", "value": "50"}, "02aeb584-6464-48bf-a4c8-e2d9bc2be56e":
       {"aggregate": "avg", "clientMetric": "latency", "condition": ">", "value": "200",
       "requestName": "GetCustomerDetails"}}}}'
     headers:
@@ -163,31 +162,31 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1532'
+      - '1574'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://6f1f5b89-2d42-4171-90ca-6f0616b96b18.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2ae79a39-c88a-4401-9e60-840daa5bc03d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"eb898201-0e61-4949-ac5b-7b78fc52e67e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"4fd6d976-f06c-4d8e-bc86-45196607f7fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/{subscription_id}/resourceGroups/sample-rg/providers/Microsoft.KeyVault/vaults/sample-kv","createdDateTime":"2023-07-12T20:11:35.451Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:11:35.451Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"e8621056-2746-487f-b572-3ee17c99d71d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c84c6d5a-7d88-4b5b-ad48-b7f746160320":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"02aeb584-6464-48bf-a4c8-e2d9bc2be56e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-09T16:11:26.244Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:26.244Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1797'
+      - '1785'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:35 GMT
+      - Mon, 09 Oct 2023 16:11:26 GMT
       location:
-      - https://6f1f5b89-2d42-4171-90ca-6f0616b96b18.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+      - https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - f04af5c2-93d2-4467-b24d-f0ec9f416501
+      - 5a98ab2e-a970-4dc2-87c0-c190cecbb1b0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -207,7 +206,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6f1f5b89-2d42-4171-90ca-6f0616b96b18.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
+    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -221,9 +220,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:35 GMT
+      - Mon, 09 Oct 2023 16:11:26 GMT
       mise-correlation-id:
-      - aee91651-aa6a-43f0-aa89-b293ee1cb0cc
+      - de16798c-18a0-4def-8a98-2baa09e3af28
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -337,25 +336,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://6f1f5b89-2d42-4171-90ca-6f0616b96b18.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec79f68d-ef87-4cf2-89af-33c450edfad4/80998d2d-34b5-4699-a8c8-b8d2bee4ea96?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A21%3A36Z&sr=b&sp=r&sig=jKM9E7fiL0%2B5zCxsZGzUXrPpuhz9XADKgl%2F66CqXwVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:21:36.2479046","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fd6fbfbe-d154-450b-b62b-cd06467cda86/37fd27dc-2f1e-4450-8338-31e7ebf1f9a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A28Z&sr=b&sp=r&sig=RzE1XGT5BIhI1gAkvjBaLSKvFn7L0yQuJ%2BZ5vwGcnpg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:28.6358354","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:36 GMT
+      - Mon, 09 Oct 2023 16:11:28 GMT
       location:
-      - https://6f1f5b89-2d42-4171-90ca-6f0616b96b18.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - d54b75e2-bc66-4e28-92e0-92bb88286d38
+      - 9a3a52ae-4eeb-49df-bf4e-316faff9f760
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -375,10 +374,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6f1f5b89-2d42-4171-90ca-6f0616b96b18.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec79f68d-ef87-4cf2-89af-33c450edfad4/80998d2d-34b5-4699-a8c8-b8d2bee4ea96?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A21%3A36Z&sr=b&sp=r&sig=rJpNqs0BE9Qp7Q9bXcxANzLVJ83txdumC9J3DDzhdOs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:21:36.8793674","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fd6fbfbe-d154-450b-b62b-cd06467cda86/37fd27dc-2f1e-4450-8338-31e7ebf1f9a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A28Z&sr=b&sp=r&sig=jKGqkjUqzyNDr99WSm2V7Rrj6ojMhO4fVeHDMn%2FlqsQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:28.8973534","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:11:28 GMT
+      mise-correlation-id:
+      - 09e90d89-92c8-4bb2-ab86-6a37e0a8ed56
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fd6fbfbe-d154-450b-b62b-cd06467cda86/37fd27dc-2f1e-4450-8338-31e7ebf1f9a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A34Z&sr=b&sp=r&sig=st1UDiD3m5Ys4WKNsKxTBw9TBztXXW43tm0I3RJdVFg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:34.1827746","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -389,9 +424,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:36 GMT
+      - Mon, 09 Oct 2023 16:11:34 GMT
       mise-correlation-id:
-      - 1919e888-e874-4413-92d7-d6258dfe9ca7
+      - f5d0af76-c160-4eaf-b2f6-2ed7a01a49de
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -411,23 +446,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6f1f5b89-2d42-4171-90ca-6f0616b96b18.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec79f68d-ef87-4cf2-89af-33c450edfad4/80998d2d-34b5-4699-a8c8-b8d2bee4ea96?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A21%3A42Z&sr=b&sp=r&sig=mLkJVfdUsRgS9zgY47O7Lq0Q%2BRTTI4lLWxibUHxb%2B0I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:21:42.6636365","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fd6fbfbe-d154-450b-b62b-cd06467cda86/37fd27dc-2f1e-4450-8338-31e7ebf1f9a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A39Z&sr=b&sp=r&sig=DEU6Vn5rFrelm6EPImMU1c4W8quOm0CgHxl5aNhpg%2Bw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:39.460603","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:42 GMT
+      - Mon, 09 Oct 2023 16:11:39 GMT
       mise-correlation-id:
-      - c1f0e286-55f2-4c24-8600-b92006f62b26
+      - 75335c3b-db33-4600-899e-ce54124d3c45
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -447,23 +482,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6f1f5b89-2d42-4171-90ca-6f0616b96b18.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec79f68d-ef87-4cf2-89af-33c450edfad4/80998d2d-34b5-4699-a8c8-b8d2bee4ea96?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A21%3A48Z&sr=b&sp=r&sig=0OkUtWzGBkurkVs2RbrR1aFnERQqZ44Bmv5N01f84kw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:21:48.3289047","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fd6fbfbe-d154-450b-b62b-cd06467cda86/37fd27dc-2f1e-4450-8338-31e7ebf1f9a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A44Z&sr=b&sp=r&sig=Gi59k9wffVuJimoQJKjsZUbEuoKpycOC5dw7QFEjhf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:44.9753799","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:48 GMT
+      - Mon, 09 Oct 2023 16:11:44 GMT
       mise-correlation-id:
-      - d84e48e5-ca99-49fc-88be-08d162c94aac
+      - 805ed99a-90d3-417c-ba01-a11b61c913c1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -483,59 +518,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6f1f5b89-2d42-4171-90ca-6f0616b96b18.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec79f68d-ef87-4cf2-89af-33c450edfad4/80998d2d-34b5-4699-a8c8-b8d2bee4ea96?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A21%3A53Z&sr=b&sp=r&sig=oTCif8CFhcvX81AgzdMtvJf84qWqGABaUkN%2Fa52NOwE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:21:53.6011806","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"e8621056-2746-487f-b572-3ee17c99d71d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c84c6d5a-7d88-4b5b-ad48-b7f746160320":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"02aeb584-6464-48bf-a4c8-e2d9bc2be56e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fd6fbfbe-d154-450b-b62b-cd06467cda86/37fd27dc-2f1e-4450-8338-31e7ebf1f9a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A11%3A45Z&sr=b&sp=r&sig=R8%2FIGikT9pWwXdbhCoi0l6Tf7txvFue3XPI8lSeZ%2Bzk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:11:45.2381184","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-09T16:11:26.244Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:41.801Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '2358'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:53 GMT
+      - Mon, 09 Oct 2023 16:11:45 GMT
       mise-correlation-id:
-      - 08a1c1ef-0b7b-4724-9088-43c45bc28c64
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6f1f5b89-2d42-4171-90ca-6f0616b96b18.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2ae79a39-c88a-4401-9e60-840daa5bc03d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"eb898201-0e61-4949-ac5b-7b78fc52e67e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"4fd6d976-f06c-4d8e-bc86-45196607f7fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec79f68d-ef87-4cf2-89af-33c450edfad4/80998d2d-34b5-4699-a8c8-b8d2bee4ea96?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A11%3A53Z&sr=b&sp=r&sig=dnz878FuQT6maBPQLCv1CRUkZroZHcLR%2FifHtpC4vQQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:11:53.9244608","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/{subscription_id}/resourceGroups/sample-rg/providers/Microsoft.KeyVault/vaults/sample-kv","createdDateTime":"2023-07-12T20:11:35.451Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:11:49.94Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '2367'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:11:53 GMT
-      mise-correlation-id:
-      - 7b284bbd-32a4-4056-9a51-d8a41b6e7a8d
+      - 10d1f0a6-9998-4be8-be71-e4d6a64fd4e8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -558,7 +557,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:10:10.0912782Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:10:10.0912782Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6f1f5b89-2d42-4171-90ca-6f0616b96b18.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:10:15.8805824Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:10:15.8805824Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -567,9 +566,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:55 GMT
+      - Mon, 09 Oct 2023 16:11:45 GMT
       etag:
-      - '"1a0a93aa-0000-0100-0000-64af08a40000"'
+      - '"92019a9b-0000-0100-0000-652425e90000"'
       expires:
       - '-1'
       pragma:
@@ -599,23 +598,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6f1f5b89-2d42-4171-90ca-6f0616b96b18.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2ae79a39-c88a-4401-9e60-840daa5bc03d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"eb898201-0e61-4949-ac5b-7b78fc52e67e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"4fd6d976-f06c-4d8e-bc86-45196607f7fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec79f68d-ef87-4cf2-89af-33c450edfad4/80998d2d-34b5-4699-a8c8-b8d2bee4ea96?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A11%3A57Z&sr=b&sp=r&sig=PrlvBFin%2F%2B8mevHu7DdObrtHWHqWPMIRvxD1GHm9Mqs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:11:57.6072697","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/{subscription_id}/resourceGroups/sample-rg/providers/Microsoft.KeyVault/vaults/sample-kv","createdDateTime":"2023-07-12T20:11:35.451Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:11:49.94Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"e8621056-2746-487f-b572-3ee17c99d71d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c84c6d5a-7d88-4b5b-ad48-b7f746160320":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"02aeb584-6464-48bf-a4c8-e2d9bc2be56e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fd6fbfbe-d154-450b-b62b-cd06467cda86/37fd27dc-2f1e-4450-8338-31e7ebf1f9a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A11%3A47Z&sr=b&sp=r&sig=DRVV9W5rshprI1svE3uQHHW85TmLUM9R3CBBiO5vR5I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:11:47.4630084","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-09T16:11:26.244Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:41.801Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2369'
+      - '2354'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:57 GMT
+      - Mon, 09 Oct 2023 16:11:47 GMT
       mise-correlation-id:
-      - 41b5d3bf-a88b-4f7c-97cb-fc4c8f4200ee
+      - 7403fba0-9570-496a-8475-c49cc999af57
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -638,7 +637,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:10:10.0912782Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:10:10.0912782Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6f1f5b89-2d42-4171-90ca-6f0616b96b18.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:10:15.8805824Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:10:15.8805824Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -647,9 +646,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:00 GMT
+      - Mon, 09 Oct 2023 16:11:49 GMT
       etag:
-      - '"1a0a93aa-0000-0100-0000-64af08a40000"'
+      - '"92019a9b-0000-0100-0000-652425e90000"'
       expires:
       - '-1'
       pragma:
@@ -679,7 +678,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6f1f5b89-2d42-4171-90ca-6f0616b96b18.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-pf-test-case?api-version=2022-11-01
+    uri: https://c83a0ef9-31ce-4281-8a95-f9748b679710.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-pf-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -692,9 +691,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:12:01 GMT
+      - Mon, 09 Oct 2023 16:11:50 GMT
       mise-correlation-id:
-      - 10a7482c-b1a1-4682-aee1-8215e247a09c
+      - 44392300-091a-4ce5-b742-8cb971caa3f5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_create.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_create.yaml
@@ -18,7 +18,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets?api-version=2023-05-01
   response:
     body:
-      string: '{"value":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","etag":"W/\"454630be-84fe-43fa-b55f-fdae31611c41\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}]}'
+      string: '{"value":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","etag":"W/\"7b842970-82ba-41d4-b8eb-78356669890b\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}]}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:28 GMT
+      - Sun, 29 Oct 2023 22:20:19 GMT
       expires:
       - '-1'
       pragma:
@@ -44,7 +44,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 832deab8-26ee-4d3a-afcd-596b619afb46
+      - da028d11-e51b-454a-b2aa-27e6262eb41b
     status:
       code: 200
       message: OK
@@ -63,18 +63,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:23.3300562Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:23.3300562Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:16.6906267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:16.6906267Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:29 GMT
+      - Sun, 29 Oct 2023 22:20:21 GMT
       etag:
-      - '"d3005036-0000-0100-0000-6537b7f10000"'
+      - '"3c00e524-0000-0100-0000-653eda660000"'
       expires:
       - '-1'
       pragma:
@@ -104,7 +104,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -117,9 +117,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:27:29 GMT
+      - Sun, 29 Oct 2023 22:20:22 GMT
       mise-correlation-id:
-      - be96d233-06fc-491e-a30f-265ff0969b80
+      - 40a6d40a-62f3-4af8-b523-9b5758880d56
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -135,16 +135,16 @@ interactions:
     body: '{"displayName": "Sample_test_display_name", "description": "Sample_test_description",
       "keyvaultReferenceIdentityType": "UserAssigned", "keyvaultReferenceIdentityId":
       "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi",
-      "subnetId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-3pmnvilyzbpgl4djj/providers/Microsoft.Network/virtualNetworks/clitest-load-3w6wmt5u63y6tqtb6/subnets/default",
+      "subnetId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-gnuf4hfntzq3t3lwd/providers/Microsoft.Network/virtualNetworks/clitest-load-j3l62zapeosqxyaku/subnets/default",
       "environmentVariables": {"rps": "10"}, "secrets": {"secret_name1": {"type":
       "AKV_SECRET_URI", "value": "https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757"},
       "secret_name2": {"type": "AKV_SECRET_URI", "value": "https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757"}},
       "certificate": {"name": "cert", "type": "AKV_CERT_URI", "value": "https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc"},
       "loadTestConfiguration": {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs":
-      true}, "passFailCriteria": {"passFailMetrics": {"ac1dff44-cfee-4a63-8615-94b940128c9a":
+      true}, "passFailCriteria": {"passFailMetrics": {"03565b54-deed-49df-b0f1-0c3db7d0ef69":
       {"aggregate": "avg", "clientMetric": "requests_per_sec", "condition": ">", "value":
-      "78"}, "70ba74c1-774a-4d9f-9cdb-3bcda8ebf017": {"aggregate": "percentage", "clientMetric":
-      "error", "condition": ">", "value": "50"}, "cb20544d-4054-4e88-b8fc-db4ba7956da3":
+      "78"}, "74b9e436-6b2e-459e-8241-e77442367a3f": {"aggregate": "percentage", "clientMetric":
+      "error", "condition": ">", "value": "50"}, "2a54d7dc-f141-4b98-800f-2c592a01a6f4":
       {"aggregate": "avg", "clientMetric": "latency", "condition": ">", "value": "200",
       "requestName": "GetCustomerDetails"}}}}'
     headers:
@@ -161,10 +161,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ac1dff44-cfee-4a63-8615-94b940128c9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"70ba74c1-774a-4d9f-9cdb-3bcda8ebf017":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"cb20544d-4054-4e88-b8fc-db4ba7956da3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-24T12:27:32.859Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:32.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"03565b54-deed-49df-b0f1-0c3db7d0ef69":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"74b9e436-6b2e-459e-8241-e77442367a3f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2a54d7dc-f141-4b98-800f-2c592a01a6f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-29T22:20:25.821Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:25.821Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -175,11 +175,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:32 GMT
+      - Sun, 29 Oct 2023 22:20:25 GMT
       location:
-      - https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+      - https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - b16cd764-f069-4327-8807-b4ffa5018e3e
+      - c811b4e1-10b3-44ee-b187-25626f87d1e8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -199,7 +199,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
+    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -213,9 +213,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:33 GMT
+      - Sun, 29 Oct 2023 22:20:26 GMT
       mise-correlation-id:
-      - 6c6db03e-227e-4739-899a-8cbe12fc25d9
+      - 89b9db2b-2a2b-4726-b5d9-991f239aef6e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -329,25 +329,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1c4f5ac7-64d2-412e-8a45-583734fb0f03/6c0946cf-4a7c-4a85-b724-3e8948ff1997?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A35Z&sr=b&sp=r&sig=Sa8j33nMqOb5TD83LRu0qFHzhlf5zEsmDO%2B6I88lZGc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:35.6455539","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/32f75083-6c22-4b0f-b569-451045a92b6c/9669fe25-e991-4ec7-86e3-83deaa50dd3f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A27Z&sr=b&sp=r&sig=JHcog4zs8VysNsrPORpSsauinF2McIAhfuuPpumjzFg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:27.3249613","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:35 GMT
+      - Sun, 29 Oct 2023 22:20:27 GMT
       location:
-      - https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 7442a355-6c2c-4c09-9a9b-843f9344bbd7
+      - 8ff02a13-ef8d-4a4d-8da3-7365ff978b60
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -367,23 +367,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1c4f5ac7-64d2-412e-8a45-583734fb0f03/6c0946cf-4a7c-4a85-b724-3e8948ff1997?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A35Z&sr=b&sp=r&sig=xi5bBLrrqoqP54%2BRgzrKdaZJujhJ2Za6hmwUnGeKInU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:35.9852082","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/32f75083-6c22-4b0f-b569-451045a92b6c/9669fe25-e991-4ec7-86e3-83deaa50dd3f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A27Z&sr=b&sp=r&sig=SfhLG5oxuqyvO1Csl0ijwknOPL6DP23qvqxTjbE4je0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:27.5639653","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:35 GMT
+      - Sun, 29 Oct 2023 22:20:27 GMT
       mise-correlation-id:
-      - f0d71a35-2a1f-4bd1-a98c-1e0f9bd809a2
+      - c97772d9-0193-4ddc-b731-eb47fdf7ca55
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -403,23 +403,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1c4f5ac7-64d2-412e-8a45-583734fb0f03/6c0946cf-4a7c-4a85-b724-3e8948ff1997?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A41Z&sr=b&sp=r&sig=ckMgldrcu31D6DNO%2BximGCVS5UmNmuQKln4dHWsKKP4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:41.3121692","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/32f75083-6c22-4b0f-b569-451045a92b6c/9669fe25-e991-4ec7-86e3-83deaa50dd3f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A32Z&sr=b&sp=r&sig=nExffvRDmsceQWEkJ8D8%2Ff31oW%2BYWmOZs1nKs6GlsFs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:32.8170767","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:41 GMT
+      - Sun, 29 Oct 2023 22:20:32 GMT
       mise-correlation-id:
-      - b8cf8462-23ab-41f5-82c4-64989af1fee3
+      - f31f0c34-cd8c-4f90-98bf-5a3daa2fc961
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -439,10 +439,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1c4f5ac7-64d2-412e-8a45-583734fb0f03/6c0946cf-4a7c-4a85-b724-3e8948ff1997?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A46Z&sr=b&sp=r&sig=rn5I%2FXVMBDFpMD5jM5BZA%2FqNf%2FQTOC%2FISG4q7vk4BMs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:46.5822267","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/32f75083-6c22-4b0f-b569-451045a92b6c/9669fe25-e991-4ec7-86e3-83deaa50dd3f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A38Z&sr=b&sp=r&sig=%2Bm3Jp%2F3pkLaJfGmmTzK4YXw4Zn%2FnwVD%2B6DCTRavc0m4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:38.3384925","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -453,9 +453,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:46 GMT
+      - Sun, 29 Oct 2023 22:20:38 GMT
       mise-correlation-id:
-      - eb35aaad-50a0-488c-9034-43854ef7869b
+      - 4d23ee2e-225a-4278-8868-d96d5c6c5b68
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -475,23 +475,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1c4f5ac7-64d2-412e-8a45-583734fb0f03/6c0946cf-4a7c-4a85-b724-3e8948ff1997?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A51Z&sr=b&sp=r&sig=90GbRnwcFt16r8dfnzDdK27182fATdQfam3RvdCMe7A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:51.8505337","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/32f75083-6c22-4b0f-b569-451045a92b6c/9669fe25-e991-4ec7-86e3-83deaa50dd3f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A43Z&sr=b&sp=r&sig=YM5l%2BUmBJLd%2BxMugMLTWBqLVibRBzdwb6beh97ThDQw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:43.9686705","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:51 GMT
+      - Sun, 29 Oct 2023 22:20:43 GMT
       mise-correlation-id:
-      - b20b4c32-bd85-46be-8dad-5f3f941a2f2a
+      - 7e7e53ea-24fe-4c9f-9e93-7585d5d0ee86
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -511,23 +511,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ac1dff44-cfee-4a63-8615-94b940128c9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"70ba74c1-774a-4d9f-9cdb-3bcda8ebf017":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"cb20544d-4054-4e88-b8fc-db4ba7956da3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1c4f5ac7-64d2-412e-8a45-583734fb0f03/6c0946cf-4a7c-4a85-b724-3e8948ff1997?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A27%3A52Z&sr=b&sp=r&sig=OnPpYGceHA422tmgPhzB9h%2FKxP0JFx8Yv23%2B00fDka8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:27:52.2672687","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-24T12:27:32.859Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:49.201Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"03565b54-deed-49df-b0f1-0c3db7d0ef69":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"74b9e436-6b2e-459e-8241-e77442367a3f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2a54d7dc-f141-4b98-800f-2c592a01a6f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/32f75083-6c22-4b0f-b569-451045a92b6c/9669fe25-e991-4ec7-86e3-83deaa50dd3f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A20%3A44Z&sr=b&sp=r&sig=1xkHOgt7QLlZsfHRlHgkSvoa%2FyZntigcR3oBOERSAf8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:20:44.2871436","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-29T22:20:25.821Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:41.003Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2358'
+      - '2356'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:52 GMT
+      - Sun, 29 Oct 2023 22:20:44 GMT
       mise-correlation-id:
-      - 6758249c-5e6d-4951-9e94-55a32cbaca3d
+      - 68f53fa8-c5a4-4966-9d67-5623ab2b189b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -550,18 +550,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:23.3300562Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:23.3300562Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:16.6906267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:16.6906267Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:52 GMT
+      - Sun, 29 Oct 2023 22:20:44 GMT
       etag:
-      - '"d3005036-0000-0100-0000-6537b7f10000"'
+      - '"3c00e524-0000-0100-0000-653eda660000"'
       expires:
       - '-1'
       pragma:
@@ -591,23 +591,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ac1dff44-cfee-4a63-8615-94b940128c9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"70ba74c1-774a-4d9f-9cdb-3bcda8ebf017":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"cb20544d-4054-4e88-b8fc-db4ba7956da3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1c4f5ac7-64d2-412e-8a45-583734fb0f03/6c0946cf-4a7c-4a85-b724-3e8948ff1997?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A27%3A53Z&sr=b&sp=r&sig=LzOfrJGxIDeT%2FgI1ty5cXHlsf0imTnlmvGbYyVp%2BifU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:27:53.8026999","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-24T12:27:32.859Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:49.201Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"03565b54-deed-49df-b0f1-0c3db7d0ef69":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"74b9e436-6b2e-459e-8241-e77442367a3f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2a54d7dc-f141-4b98-800f-2c592a01a6f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/32f75083-6c22-4b0f-b569-451045a92b6c/9669fe25-e991-4ec7-86e3-83deaa50dd3f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A20%3A45Z&sr=b&sp=r&sig=FyRy3354%2BNL8rimKU5fdy6fIUJacClGuyeCEOzWopVw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:20:45.8680222","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-29T22:20:25.821Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:41.003Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2358'
+      - '2356'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:53 GMT
+      - Sun, 29 Oct 2023 22:20:45 GMT
       mise-correlation-id:
-      - 7d569c04-8fdb-402a-8ddc-7996340e7b03
+      - 9ee97f01-8e73-4306-a841-1d316dcd541d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -630,18 +630,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:23.3300562Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:23.3300562Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:16.6906267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:16.6906267Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:56 GMT
+      - Sun, 29 Oct 2023 22:20:47 GMT
       etag:
-      - '"d3005036-0000-0100-0000-6537b7f10000"'
+      - '"3c00e524-0000-0100-0000-653eda660000"'
       expires:
       - '-1'
       pragma:
@@ -671,7 +671,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-pf-test-case?api-version=2022-11-01
+    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-pf-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -684,9 +684,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:27:57 GMT
+      - Sun, 29 Oct 2023 22:20:48 GMT
       mise-correlation-id:
-      - eb00dc50-4f9f-473d-a28d-c9c771255d7b
+      - c210b0d0-9eb1-430d-9d77-36fecf68af30
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_create.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_create.yaml
@@ -18,7 +18,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets?api-version=2023-05-01
   response:
     body:
-      string: '{"value":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","etag":"W/\"7b842970-82ba-41d4-b8eb-78356669890b\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}]}'
+      string: '{"value":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","etag":"W/\"9c37a5ea-52aa-45cd-8da2-b40eb00fab19\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}]}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:19 GMT
+      - Mon, 30 Oct 2023 07:20:17 GMT
       expires:
       - '-1'
       pragma:
@@ -44,10 +44,10 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - da028d11-e51b-454a-b2aa-27e6262eb41b
+      - d54729b4-5c86-44cd-a2c7-82e974d39bf7
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -63,7 +63,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:16.6906267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:16.6906267Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:19:09.4871816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:19:09.4871816Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1ce5bae5-be5a-4bcd-991d-ef18fa752945.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -72,9 +72,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:21 GMT
+      - Mon, 30 Oct 2023 07:20:19 GMT
       etag:
-      - '"3c00e524-0000-0100-0000-653eda660000"'
+      - '"3f00ce67-0000-0100-0000-653f58ef0000"'
       expires:
       - '-1'
       pragma:
@@ -104,7 +104,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://1ce5bae5-be5a-4bcd-991d-ef18fa752945.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -117,9 +117,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:20:22 GMT
+      - Mon, 30 Oct 2023 07:20:20 GMT
       mise-correlation-id:
-      - 40a6d40a-62f3-4af8-b523-9b5758880d56
+      - 11f9b9a9-342d-4a94-a59a-f4db0086ac30
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -135,16 +135,16 @@ interactions:
     body: '{"displayName": "Sample_test_display_name", "description": "Sample_test_description",
       "keyvaultReferenceIdentityType": "UserAssigned", "keyvaultReferenceIdentityId":
       "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi",
-      "subnetId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-gnuf4hfntzq3t3lwd/providers/Microsoft.Network/virtualNetworks/clitest-load-j3l62zapeosqxyaku/subnets/default",
+      "subnetId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-3sqislxgrwte5p2zn/providers/Microsoft.Network/virtualNetworks/clitest-load-4x5jbwlxwv4ofz3a6/subnets/default",
       "environmentVariables": {"rps": "10"}, "secrets": {"secret_name1": {"type":
       "AKV_SECRET_URI", "value": "https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757"},
       "secret_name2": {"type": "AKV_SECRET_URI", "value": "https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757"}},
       "certificate": {"name": "cert", "type": "AKV_CERT_URI", "value": "https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc"},
       "loadTestConfiguration": {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs":
-      true}, "passFailCriteria": {"passFailMetrics": {"03565b54-deed-49df-b0f1-0c3db7d0ef69":
+      true}, "passFailCriteria": {"passFailMetrics": {"a3df37a4-25dd-473f-a600-b54b53722806":
       {"aggregate": "avg", "clientMetric": "requests_per_sec", "condition": ">", "value":
-      "78"}, "74b9e436-6b2e-459e-8241-e77442367a3f": {"aggregate": "percentage", "clientMetric":
-      "error", "condition": ">", "value": "50"}, "2a54d7dc-f141-4b98-800f-2c592a01a6f4":
+      "78"}, "34f64e94-3826-45f6-afbd-2cae9dc79ee5": {"aggregate": "percentage", "clientMetric":
+      "error", "condition": ">", "value": "50"}, "c1e5300a-0edb-4c91-a168-c8db150e49ac":
       {"aggregate": "avg", "clientMetric": "latency", "condition": ">", "value": "200",
       "requestName": "GetCustomerDetails"}}}}'
     headers:
@@ -161,10 +161,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://1ce5bae5-be5a-4bcd-991d-ef18fa752945.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"03565b54-deed-49df-b0f1-0c3db7d0ef69":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"74b9e436-6b2e-459e-8241-e77442367a3f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2a54d7dc-f141-4b98-800f-2c592a01a6f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-29T22:20:25.821Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:25.821Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a3df37a4-25dd-473f-a600-b54b53722806":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"34f64e94-3826-45f6-afbd-2cae9dc79ee5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c1e5300a-0edb-4c91-a168-c8db150e49ac":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-30T07:20:23.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:20:23.026Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -175,11 +175,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:25 GMT
+      - Mon, 30 Oct 2023 07:20:23 GMT
       location:
-      - https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+      - https://1ce5bae5-be5a-4bcd-991d-ef18fa752945.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - c811b4e1-10b3-44ee-b187-25626f87d1e8
+      - 14fcc2d6-4648-44a5-bafe-0346efad5d15
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -199,7 +199,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
+    uri: https://1ce5bae5-be5a-4bcd-991d-ef18fa752945.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -213,9 +213,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:26 GMT
+      - Mon, 30 Oct 2023 07:20:23 GMT
       mise-correlation-id:
-      - 89b9db2b-2a2b-4726-b5d9-991f239aef6e
+      - ad8161c7-4991-4814-8063-38dba4f2fe0d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -329,10 +329,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://1ce5bae5-be5a-4bcd-991d-ef18fa752945.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/32f75083-6c22-4b0f-b569-451045a92b6c/9669fe25-e991-4ec7-86e3-83deaa50dd3f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A27Z&sr=b&sp=r&sig=JHcog4zs8VysNsrPORpSsauinF2McIAhfuuPpumjzFg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:27.3249613","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/35a1a253-8fa1-4e24-85aa-439f402a48dd/19b3ee8f-7e55-4a25-96a6-d35b047e9ef7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A30%3A23Z&sr=b&sp=r&sig=lxwSPoSzUMZQGayzcNOUEk5fLcs4epRCeNUq2K29Vj4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:30:23.9115624","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -343,11 +343,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:27 GMT
+      - Mon, 30 Oct 2023 07:20:23 GMT
       location:
-      - https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://1ce5bae5-be5a-4bcd-991d-ef18fa752945.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 8ff02a13-ef8d-4a4d-8da3-7365ff978b60
+      - 86232de3-ee6d-4497-b094-c27da5fee50d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -367,23 +367,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://1ce5bae5-be5a-4bcd-991d-ef18fa752945.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/32f75083-6c22-4b0f-b569-451045a92b6c/9669fe25-e991-4ec7-86e3-83deaa50dd3f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A27Z&sr=b&sp=r&sig=SfhLG5oxuqyvO1Csl0ijwknOPL6DP23qvqxTjbE4je0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:27.5639653","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/35a1a253-8fa1-4e24-85aa-439f402a48dd/19b3ee8f-7e55-4a25-96a6-d35b047e9ef7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A30%3A24Z&sr=b&sp=r&sig=u77VEG%2Fe7x0l6ctMAlcl%2FWzbqh%2FbY9B0q8nwBe6fFKM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:30:24.1636786","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:27 GMT
+      - Mon, 30 Oct 2023 07:20:24 GMT
       mise-correlation-id:
-      - c97772d9-0193-4ddc-b731-eb47fdf7ca55
+      - 625bd0f4-d63b-4289-93e0-a164ec3c212d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -403,82 +403,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://1ce5bae5-be5a-4bcd-991d-ef18fa752945.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/32f75083-6c22-4b0f-b569-451045a92b6c/9669fe25-e991-4ec7-86e3-83deaa50dd3f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A32Z&sr=b&sp=r&sig=nExffvRDmsceQWEkJ8D8%2Ff31oW%2BYWmOZs1nKs6GlsFs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:32.8170767","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:20:32 GMT
-      mise-correlation-id:
-      - f31f0c34-cd8c-4f90-98bf-5a3daa2fc961
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/32f75083-6c22-4b0f-b569-451045a92b6c/9669fe25-e991-4ec7-86e3-83deaa50dd3f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A38Z&sr=b&sp=r&sig=%2Bm3Jp%2F3pkLaJfGmmTzK4YXw4Zn%2FnwVD%2B6DCTRavc0m4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:38.3384925","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '557'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:20:38 GMT
-      mise-correlation-id:
-      - 4d23ee2e-225a-4278-8868-d96d5c6c5b68
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/32f75083-6c22-4b0f-b569-451045a92b6c/9669fe25-e991-4ec7-86e3-83deaa50dd3f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A43Z&sr=b&sp=r&sig=YM5l%2BUmBJLd%2BxMugMLTWBqLVibRBzdwb6beh97ThDQw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:43.9686705","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/35a1a253-8fa1-4e24-85aa-439f402a48dd/19b3ee8f-7e55-4a25-96a6-d35b047e9ef7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A30%3A29Z&sr=b&sp=r&sig=SjM6LfjIWZc7%2FDouj8R2svwNvCpuLgqxbkzN90JmHik%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:30:29.4204704","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -489,9 +417,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:43 GMT
+      - Mon, 30 Oct 2023 07:20:29 GMT
       mise-correlation-id:
-      - 7e7e53ea-24fe-4c9f-9e93-7585d5d0ee86
+      - 426820f5-37cb-425e-a4a1-6f54d80f9da5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -511,23 +439,95 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://1ce5bae5-be5a-4bcd-991d-ef18fa752945.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"03565b54-deed-49df-b0f1-0c3db7d0ef69":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"74b9e436-6b2e-459e-8241-e77442367a3f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2a54d7dc-f141-4b98-800f-2c592a01a6f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/32f75083-6c22-4b0f-b569-451045a92b6c/9669fe25-e991-4ec7-86e3-83deaa50dd3f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A20%3A44Z&sr=b&sp=r&sig=1xkHOgt7QLlZsfHRlHgkSvoa%2FyZntigcR3oBOERSAf8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:20:44.2871436","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-29T22:20:25.821Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:41.003Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/35a1a253-8fa1-4e24-85aa-439f402a48dd/19b3ee8f-7e55-4a25-96a6-d35b047e9ef7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A30%3A34Z&sr=b&sp=r&sig=GvPWWXwRo4rh8FD%2BYtpkOnqGYV2sHrFPcW6lJUv3A5M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:30:34.6745071","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2356'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:44 GMT
+      - Mon, 30 Oct 2023 07:20:34 GMT
       mise-correlation-id:
-      - 68f53fa8-c5a4-4966-9d67-5623ab2b189b
+      - 93d26664-30b6-4385-bb37-2142fcd80de1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1ce5bae5-be5a-4bcd-991d-ef18fa752945.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/35a1a253-8fa1-4e24-85aa-439f402a48dd/19b3ee8f-7e55-4a25-96a6-d35b047e9ef7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A30%3A39Z&sr=b&sp=r&sig=5uk0lQ%2B0nk%2FENC74HXZ0nbgmYxSDqywFfUna9tvQG0U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:30:39.9312736","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:20:39 GMT
+      mise-correlation-id:
+      - d7b2a454-adf2-4eae-9899-4fe7a73b8983
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1ce5bae5-be5a-4bcd-991d-ef18fa752945.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"a3df37a4-25dd-473f-a600-b54b53722806":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"34f64e94-3826-45f6-afbd-2cae9dc79ee5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c1e5300a-0edb-4c91-a168-c8db150e49ac":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/35a1a253-8fa1-4e24-85aa-439f402a48dd/19b3ee8f-7e55-4a25-96a6-d35b047e9ef7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A20%3A40Z&sr=b&sp=r&sig=nEZjNFLg7UmYhuVwtGe%2F%2BLAlACiX3XmTuksDpbuy79E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:20:40.2181553","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-30T07:20:23.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:20:36.221Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '2358'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:20:40 GMT
+      mise-correlation-id:
+      - 97343d4b-a9db-4865-8a6c-c26b703860fe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -550,7 +550,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:16.6906267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:16.6906267Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:19:09.4871816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:19:09.4871816Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1ce5bae5-be5a-4bcd-991d-ef18fa752945.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -559,9 +559,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:44 GMT
+      - Mon, 30 Oct 2023 07:20:41 GMT
       etag:
-      - '"3c00e524-0000-0100-0000-653eda660000"'
+      - '"3f00ce67-0000-0100-0000-653f58ef0000"'
       expires:
       - '-1'
       pragma:
@@ -591,10 +591,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://1ce5bae5-be5a-4bcd-991d-ef18fa752945.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"03565b54-deed-49df-b0f1-0c3db7d0ef69":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"74b9e436-6b2e-459e-8241-e77442367a3f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2a54d7dc-f141-4b98-800f-2c592a01a6f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/32f75083-6c22-4b0f-b569-451045a92b6c/9669fe25-e991-4ec7-86e3-83deaa50dd3f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A20%3A45Z&sr=b&sp=r&sig=FyRy3354%2BNL8rimKU5fdy6fIUJacClGuyeCEOzWopVw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:20:45.8680222","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-29T22:20:25.821Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:41.003Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a3df37a4-25dd-473f-a600-b54b53722806":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"34f64e94-3826-45f6-afbd-2cae9dc79ee5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c1e5300a-0edb-4c91-a168-c8db150e49ac":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/35a1a253-8fa1-4e24-85aa-439f402a48dd/19b3ee8f-7e55-4a25-96a6-d35b047e9ef7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A20%3A42Z&sr=b&sp=r&sig=h0jrjF2fXz%2Fxy6z33Cb9cZHhknNAywUqZJ0LjYHSfVo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:20:42.7727526","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-30T07:20:23.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:20:36.221Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -605,9 +605,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:45 GMT
+      - Mon, 30 Oct 2023 07:20:42 GMT
       mise-correlation-id:
-      - 9ee97f01-8e73-4306-a841-1d316dcd541d
+      - 72533908-5d10-4b63-8036-497dfdfb63d4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -630,7 +630,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:16.6906267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:16.6906267Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:19:09.4871816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:19:09.4871816Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1ce5bae5-be5a-4bcd-991d-ef18fa752945.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -639,9 +639,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:47 GMT
+      - Mon, 30 Oct 2023 07:20:46 GMT
       etag:
-      - '"3c00e524-0000-0100-0000-653eda660000"'
+      - '"3f00ce67-0000-0100-0000-653f58ef0000"'
       expires:
       - '-1'
       pragma:
@@ -671,7 +671,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb327595-b241-4646-8f19-afeb440c17b7.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-pf-test-case?api-version=2022-11-01
+    uri: https://1ce5bae5-be5a-4bcd-991d-ef18fa752945.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-pf-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -684,9 +684,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:20:48 GMT
+      - Mon, 30 Oct 2023 07:20:47 GMT
       mise-correlation-id:
-      - c210b0d0-9eb1-430d-9d77-36fecf68af30
+      - f588e011-5165-4f21-bc29-57df2517411c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_create.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_create.yaml
@@ -18,7 +18,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets?api-version=2023-05-01
   response:
     body:
-      string: '{"value":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","etag":"W/\"e8f60ce0-97b2-49ce-bf09-3077e586fb69\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}]}'
+      string: '{"value":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","etag":"W/\"454630be-84fe-43fa-b55f-fdae31611c41\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}]}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:48 GMT
+      - Tue, 24 Oct 2023 12:27:28 GMT
       expires:
       - '-1'
       pragma:
@@ -44,7 +44,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - fd0f920f-7c82-4e73-bc7c-2028d4e19b3d
+      - 832deab8-26ee-4d3a-afcd-596b619afb46
     status:
       code: 200
       message: OK
@@ -63,7 +63,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:47.3557741Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:47.3557741Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:23.3300562Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:23.3300562Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -72,9 +72,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:50 GMT
+      - Tue, 24 Oct 2023 12:27:29 GMT
       etag:
-      - '"75004843-0000-0100-0000-653044ec0000"'
+      - '"d3005036-0000-0100-0000-6537b7f10000"'
       expires:
       - '-1'
       pragma:
@@ -104,7 +104,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -117,9 +117,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:50:51 GMT
+      - Tue, 24 Oct 2023 12:27:29 GMT
       mise-correlation-id:
-      - bade2067-4bd6-4243-b687-1fef40c8b891
+      - be96d233-06fc-491e-a30f-265ff0969b80
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -135,16 +135,16 @@ interactions:
     body: '{"displayName": "Sample_test_display_name", "description": "Sample_test_description",
       "keyvaultReferenceIdentityType": "UserAssigned", "keyvaultReferenceIdentityId":
       "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi",
-      "subnetId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-itknerb26srwup62n/providers/Microsoft.Network/virtualNetworks/clitest-load-vsd5e2ekqvnktdtla/subnets/default",
+      "subnetId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-3pmnvilyzbpgl4djj/providers/Microsoft.Network/virtualNetworks/clitest-load-3w6wmt5u63y6tqtb6/subnets/default",
       "environmentVariables": {"rps": "10"}, "secrets": {"secret_name1": {"type":
       "AKV_SECRET_URI", "value": "https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757"},
       "secret_name2": {"type": "AKV_SECRET_URI", "value": "https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757"}},
       "certificate": {"name": "cert", "type": "AKV_CERT_URI", "value": "https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc"},
       "loadTestConfiguration": {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs":
-      true}, "passFailCriteria": {"passFailMetrics": {"f88a774a-4925-40da-8d90-3f0a292571a0":
+      true}, "passFailCriteria": {"passFailMetrics": {"ac1dff44-cfee-4a63-8615-94b940128c9a":
       {"aggregate": "avg", "clientMetric": "requests_per_sec", "condition": ">", "value":
-      "78"}, "8bc94b90-2230-4087-b11d-1b667b4af62c": {"aggregate": "percentage", "clientMetric":
-      "error", "condition": ">", "value": "50"}, "1ea670fb-8965-4d36-99e4-ba5ef70d8b2b":
+      "78"}, "70ba74c1-774a-4d9f-9cdb-3bcda8ebf017": {"aggregate": "percentage", "clientMetric":
+      "error", "condition": ">", "value": "50"}, "cb20544d-4054-4e88-b8fc-db4ba7956da3":
       {"aggregate": "avg", "clientMetric": "latency", "condition": ">", "value": "200",
       "requestName": "GetCustomerDetails"}}}}'
     headers:
@@ -161,10 +161,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f88a774a-4925-40da-8d90-3f0a292571a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8bc94b90-2230-4087-b11d-1b667b4af62c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1ea670fb-8965-4d36-99e4-ba5ef70d8b2b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-18T20:50:54.012Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:54.012Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ac1dff44-cfee-4a63-8615-94b940128c9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"70ba74c1-774a-4d9f-9cdb-3bcda8ebf017":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"cb20544d-4054-4e88-b8fc-db4ba7956da3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-24T12:27:32.859Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:32.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -175,11 +175,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:54 GMT
+      - Tue, 24 Oct 2023 12:27:32 GMT
       location:
-      - https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+      - https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - f95df97b-74d9-4404-849d-889024de877b
+      - b16cd764-f069-4327-8807-b4ffa5018e3e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -199,7 +199,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
+    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -213,9 +213,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:54 GMT
+      - Tue, 24 Oct 2023 12:27:33 GMT
       mise-correlation-id:
-      - 6274824c-6f5e-442a-a64f-7e776732ceba
+      - 6c6db03e-227e-4739-899a-8cbe12fc25d9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -329,25 +329,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1877326-c865-4ad8-86e4-b53abc9a0ab3/737c0330-fe9d-4de9-8587-d65852f1ccd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A54Z&sr=b&sp=r&sig=CqWKRdQiHwqcJohIxxDVQUmincUSi1hf1YJ1i1xlxbk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:54.8408466","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1c4f5ac7-64d2-412e-8a45-583734fb0f03/6c0946cf-4a7c-4a85-b724-3e8948ff1997?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A35Z&sr=b&sp=r&sig=Sa8j33nMqOb5TD83LRu0qFHzhlf5zEsmDO%2B6I88lZGc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:35.6455539","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:54 GMT
+      - Tue, 24 Oct 2023 12:27:35 GMT
       location:
-      - https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 9caf60da-8be1-4967-8ef0-0c563133b0fa
+      - 7442a355-6c2c-4c09-9a9b-843f9344bbd7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -367,46 +367,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1877326-c865-4ad8-86e4-b53abc9a0ab3/737c0330-fe9d-4de9-8587-d65852f1ccd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A55Z&sr=b&sp=r&sig=ugY4kMlUnayPmUmpli%2FXZd1fktqJXkXWwUJg6qEGDxA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:55.08859","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:50:55 GMT
-      mise-correlation-id:
-      - e5a3e911-63c6-4d18-aea2-ed0bd08d54ed
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1877326-c865-4ad8-86e4-b53abc9a0ab3/737c0330-fe9d-4de9-8587-d65852f1ccd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A00Z&sr=b&sp=r&sig=dnG1JkXLaq7eeRBNwVU4L2pMRvefpgynHs%2FjW5dVHNk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:00.3532504","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1c4f5ac7-64d2-412e-8a45-583734fb0f03/6c0946cf-4a7c-4a85-b724-3e8948ff1997?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A35Z&sr=b&sp=r&sig=xi5bBLrrqoqP54%2BRgzrKdaZJujhJ2Za6hmwUnGeKInU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:35.9852082","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -417,9 +381,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:00 GMT
+      - Tue, 24 Oct 2023 12:27:35 GMT
       mise-correlation-id:
-      - 00d1fb76-4473-403f-9344-ecc69029a6e5
+      - f0d71a35-2a1f-4bd1-a98c-1e0f9bd809a2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -439,10 +403,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1877326-c865-4ad8-86e4-b53abc9a0ab3/737c0330-fe9d-4de9-8587-d65852f1ccd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A05Z&sr=b&sp=r&sig=22kkcgTR41fCR01s0daJbAHEg%2F1CA3C7FYgZyhFf944%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:05.6184728","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1c4f5ac7-64d2-412e-8a45-583734fb0f03/6c0946cf-4a7c-4a85-b724-3e8948ff1997?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A41Z&sr=b&sp=r&sig=ckMgldrcu31D6DNO%2BximGCVS5UmNmuQKln4dHWsKKP4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:41.3121692","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -453,9 +417,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:05 GMT
+      - Tue, 24 Oct 2023 12:27:41 GMT
       mise-correlation-id:
-      - dd47eb2d-dc59-488c-b70f-47b75eba67b9
+      - b8cf8462-23ab-41f5-82c4-64989af1fee3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -475,23 +439,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1877326-c865-4ad8-86e4-b53abc9a0ab3/737c0330-fe9d-4de9-8587-d65852f1ccd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A10Z&sr=b&sp=r&sig=hhXCJZJAeoAPvzgRVAyupjtnMTdTC6IPULDYu4k%2BZuY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:10.8747647","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1c4f5ac7-64d2-412e-8a45-583734fb0f03/6c0946cf-4a7c-4a85-b724-3e8948ff1997?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A46Z&sr=b&sp=r&sig=rn5I%2FXVMBDFpMD5jM5BZA%2FqNf%2FQTOC%2FISG4q7vk4BMs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:46.5822267","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '557'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:10 GMT
+      - Tue, 24 Oct 2023 12:27:46 GMT
       mise-correlation-id:
-      - 60caf697-0578-48ed-8f59-ead82e799623
+      - eb35aaad-50a0-488c-9034-43854ef7869b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -511,23 +475,59 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f88a774a-4925-40da-8d90-3f0a292571a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8bc94b90-2230-4087-b11d-1b667b4af62c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1ea670fb-8965-4d36-99e4-ba5ef70d8b2b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1877326-c865-4ad8-86e4-b53abc9a0ab3/737c0330-fe9d-4de9-8587-d65852f1ccd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A11Z&sr=b&sp=r&sig=t9bzAgDpthIkF3NGW%2FrKtGLbDR6B0I%2BUFXw79ao9%2F%2FQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:11.1239007","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-18T20:50:54.012Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:08.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1c4f5ac7-64d2-412e-8a45-583734fb0f03/6c0946cf-4a7c-4a85-b724-3e8948ff1997?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A51Z&sr=b&sp=r&sig=90GbRnwcFt16r8dfnzDdK27182fATdQfam3RvdCMe7A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:51.8505337","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2362'
+      - '547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:11 GMT
+      - Tue, 24 Oct 2023 12:27:51 GMT
       mise-correlation-id:
-      - 4c46dca6-342d-4e37-84c3-ff8611c5c852
+      - b20b4c32-bd85-46be-8dad-5f3f941a2f2a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ac1dff44-cfee-4a63-8615-94b940128c9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"70ba74c1-774a-4d9f-9cdb-3bcda8ebf017":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"cb20544d-4054-4e88-b8fc-db4ba7956da3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1c4f5ac7-64d2-412e-8a45-583734fb0f03/6c0946cf-4a7c-4a85-b724-3e8948ff1997?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A27%3A52Z&sr=b&sp=r&sig=OnPpYGceHA422tmgPhzB9h%2FKxP0JFx8Yv23%2B00fDka8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:27:52.2672687","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-24T12:27:32.859Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:49.201Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '2358'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:27:52 GMT
+      mise-correlation-id:
+      - 6758249c-5e6d-4951-9e94-55a32cbaca3d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -550,7 +550,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:47.3557741Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:47.3557741Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:23.3300562Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:23.3300562Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -559,9 +559,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:12 GMT
+      - Tue, 24 Oct 2023 12:27:52 GMT
       etag:
-      - '"75004843-0000-0100-0000-653044ec0000"'
+      - '"d3005036-0000-0100-0000-6537b7f10000"'
       expires:
       - '-1'
       pragma:
@@ -591,23 +591,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f88a774a-4925-40da-8d90-3f0a292571a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8bc94b90-2230-4087-b11d-1b667b4af62c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1ea670fb-8965-4d36-99e4-ba5ef70d8b2b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1877326-c865-4ad8-86e4-b53abc9a0ab3/737c0330-fe9d-4de9-8587-d65852f1ccd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A13Z&sr=b&sp=r&sig=0zkiSK7R8nsYdHO6PFjVrjIe8ZiLnC9ixYMYljAzW3c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:13.2276443","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-18T20:50:54.012Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:08.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ac1dff44-cfee-4a63-8615-94b940128c9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"70ba74c1-774a-4d9f-9cdb-3bcda8ebf017":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"cb20544d-4054-4e88-b8fc-db4ba7956da3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"secrets":{"secret_name1":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name1/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"},"secret_name2":{"value":"https://sample-kv.vault.azure.net/secrets/secret-name2/8022ff4b79f04a4ca6c3ca8e3820e757","type":"AKV_SECRET_URI"}},"certificate":{"value":"https://sample-kv.vault.azure.net/certificates/cert-name/0e35fd2807ce44368cf54274dd6f35cc","type":"AKV_CERT_URI","name":"cert"},"environmentVariables":{"rps":"10"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1c4f5ac7-64d2-412e-8a45-583734fb0f03/6c0946cf-4a7c-4a85-b724-3e8948ff1997?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A27%3A53Z&sr=b&sp=r&sig=LzOfrJGxIDeT%2FgI1ty5cXHlsf0imTnlmvGbYyVp%2BifU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:27:53.8026999","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Sample_test_description","displayName":"Sample_test_display_name","subnetId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Network/virtualNetworks/clitest-load-000003/subnets/default","keyvaultReferenceIdentityType":"UserAssigned","keyvaultReferenceIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sample-rg/providers/microsoft.managedidentity/userassignedidentities/sample-mi","createdDateTime":"2023-10-24T12:27:32.859Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:49.201Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2354'
+      - '2358'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:13 GMT
+      - Tue, 24 Oct 2023 12:27:53 GMT
       mise-correlation-id:
-      - 8a27c995-a676-4762-b3a3-72e5d3054811
+      - 7d569c04-8fdb-402a-8ddc-7996340e7b03
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -630,7 +630,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:47.3557741Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:47.3557741Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:23.3300562Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:23.3300562Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -639,9 +639,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:15 GMT
+      - Tue, 24 Oct 2023 12:27:56 GMT
       etag:
-      - '"75004843-0000-0100-0000-653044ec0000"'
+      - '"d3005036-0000-0100-0000-6537b7f10000"'
       expires:
       - '-1'
       pragma:
@@ -671,7 +671,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0c6b857e-b684-4d86-b9e5-f84a68f8c8e7.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-pf-test-case?api-version=2022-11-01
+    uri: https://5e6cd946-1e57-403c-82b0-88cc9e7429ff.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-pf-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -684,9 +684,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:51:16 GMT
+      - Tue, 24 Oct 2023 12:27:57 GMT
       mise-correlation-id:
-      - dded0cc8-b19e-48f3-89fc-4fac076fd034
+      - eb00dc50-4f9f-473d-a28d-c9c771255d7b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_create_with_args.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_create_with_args.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1189356Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1189356Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:39.3741826Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:39.3741826Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:16 GMT
+      - Sun, 29 Oct 2023 22:18:13 GMT
       etag:
-      - '"d300f431-0000-0100-0000-6537b78b0000"'
+      - '"3c00f121-0000-0100-0000-653eda050000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:25:17 GMT
+      - Sun, 29 Oct 2023 22:18:15 GMT
       mise-correlation-id:
-      - 5ecc6729-16ba-486d-acb1-c146dd1dfba5
+      - 38a9ee89-36ba-49b5-a745-a30676c92ef3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -101,11 +101,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:18.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:18.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.373Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:16.373Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -116,11 +116,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:18 GMT
+      - Sun, 29 Oct 2023 22:18:16 GMT
       location:
-      - https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+      - https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 2f36b77e-8547-4221-9317-7a9227250577
+      - 892fec15-d6e0-469c-8c8a-910d31c2f988
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -140,7 +140,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files?api-version=2022-11-01
+    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -154,9 +154,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:18 GMT
+      - Sun, 29 Oct 2023 22:18:16 GMT
       mise-correlation-id:
-      - a7f95e07-dd84-4edb-a5d2-3bd6730bf331
+      - 27416d90-bd9f-49ad-8d76-9dddc3b31146
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -270,10 +270,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/81a0972b-22b5-42ea-abc5-fee24cfea2ce/3e51759a-6f9d-4978-a19b-72c25e05fe60?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A19Z&sr=b&sp=r&sig=mES8UOt24rL650S7CuWusd5G2wEE25pVH8e7qong00g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:19.4597031","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/668fdb5e-1e72-4803-83f3-8b124e9aae47/fe478b29-a9d4-459f-8e83-db511c8e3c1f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A17Z&sr=b&sp=r&sig=3VNKev0gCrbJ3keXlzZ9p4iCxpzrpECufd8J2DVzzK8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:17.3683759","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -284,11 +284,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:19 GMT
+      - Sun, 29 Oct 2023 22:18:17 GMT
       location:
-      - https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 1833de01-3e4e-4cc1-9577-e09371d46fab
+      - b3dc4507-e3f1-4075-9d65-86d698d5b1e6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -308,10 +308,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/81a0972b-22b5-42ea-abc5-fee24cfea2ce/3e51759a-6f9d-4978-a19b-72c25e05fe60?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A19Z&sr=b&sp=r&sig=NldRDJ8ije2iKl3F75gwI2CsOilGNhPlMFlpJJEkBlE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:19.6977209","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/668fdb5e-1e72-4803-83f3-8b124e9aae47/fe478b29-a9d4-459f-8e83-db511c8e3c1f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A17Z&sr=b&sp=r&sig=wnPZKI9VcpA5HnVZXns%2B0yTYYGGlQN422OKp2bcZFXA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:17.6564232","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:18:17 GMT
+      mise-correlation-id:
+      - 53356979-83c6-420e-8726-9988d918f5b0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/668fdb5e-1e72-4803-83f3-8b124e9aae47/fe478b29-a9d4-459f-8e83-db511c8e3c1f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A22Z&sr=b&sp=r&sig=fFhMvtW7YPqT3nY3QNnr9hzEJQNWulpNXvoC2oX50WA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:22.9026975","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -322,9 +358,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:19 GMT
+      - Sun, 29 Oct 2023 22:18:22 GMT
       mise-correlation-id:
-      - 87f2e10f-6257-435c-9f9a-1bec7ea0f9d8
+      - 89cb9777-9fc9-42be-b379-dd197dd2a28c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -344,46 +380,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/81a0972b-22b5-42ea-abc5-fee24cfea2ce/3e51759a-6f9d-4978-a19b-72c25e05fe60?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A25Z&sr=b&sp=r&sig=HXJ7CI2OFt4B8F6aAXbwUXeGfMGRFQi6kvUe8E%2FOxK8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:25.0057524","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:25:25 GMT
-      mise-correlation-id:
-      - 0a485278-ffdb-48be-afcd-246cfa361cf8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/81a0972b-22b5-42ea-abc5-fee24cfea2ce/3e51759a-6f9d-4978-a19b-72c25e05fe60?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A30Z&sr=b&sp=r&sig=1j%2BVLdoZ4oSsDsWXEt6f5%2FWtZfrBaDAMqL85p2Lsj1I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:30.2859795","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/668fdb5e-1e72-4803-83f3-8b124e9aae47/fe478b29-a9d4-459f-8e83-db511c8e3c1f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A28Z&sr=b&sp=r&sig=EyZOmKLyf%2F1iK7RuBlX5sqlEv%2FWW0v0V2kBEo51163o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:28.1496467","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -394,9 +394,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:30 GMT
+      - Sun, 29 Oct 2023 22:18:28 GMT
       mise-correlation-id:
-      - 36babe39-acda-4578-88e1-26efeb8a16b8
+      - 4b9f7da3-de92-4dfb-869b-248c17d528ab
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -416,23 +416,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/81a0972b-22b5-42ea-abc5-fee24cfea2ce/3e51759a-6f9d-4978-a19b-72c25e05fe60?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A35Z&sr=b&sp=r&sig=tQe%2Bu1zHla3FxsljjH0NaORLCzWBsvk%2BWHDLizG1ET4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:35.5548035","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/668fdb5e-1e72-4803-83f3-8b124e9aae47/fe478b29-a9d4-459f-8e83-db511c8e3c1f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A33Z&sr=b&sp=r&sig=XzRAfoQwO1Z6qBoUuSsWEsrWoZIYux6H%2BoohwqdjFkQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:33.3939839","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:35 GMT
+      - Sun, 29 Oct 2023 22:18:33 GMT
       mise-correlation-id:
-      - 4952c6ac-c8da-4e09-9784-f22e70fc801a
+      - 9a85764d-563f-4e79-8c90-db4c36e174eb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -452,24 +452,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/81a0972b-22b5-42ea-abc5-fee24cfea2ce/3e51759a-6f9d-4978-a19b-72c25e05fe60?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A25%3A35Z&sr=b&sp=r&sig=6%2BMiwmpVtcvUJss5rU%2FRDq84%2F9skCAwL1Oy7kstCAII%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:25:35.8631223","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:18.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:33.592Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/668fdb5e-1e72-4803-83f3-8b124e9aae47/fe478b29-a9d4-459f-8e83-db511c8e3c1f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A18%3A33Z&sr=b&sp=r&sig=DlujtAZZJj4atL%2BuNxWiKjevOlJ0J5wZ9Zx463viFrw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:18:33.6622981","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.373Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:31.657Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1104'
+      - '1100'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:35 GMT
+      - Sun, 29 Oct 2023 22:18:33 GMT
       mise-correlation-id:
-      - aca63f41-b7f4-477f-afe0-eea1cb83a077
+      - 8b48c011-3374-4701-a591-0ae8c7021493
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -492,18 +492,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1189356Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1189356Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:39.3741826Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:39.3741826Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:35 GMT
+      - Sun, 29 Oct 2023 22:18:34 GMT
       etag:
-      - '"d300f431-0000-0100-0000-6537b78b0000"'
+      - '"3c00f121-0000-0100-0000-653eda050000"'
       expires:
       - '-1'
       pragma:
@@ -533,11 +533,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/81a0972b-22b5-42ea-abc5-fee24cfea2ce/3e51759a-6f9d-4978-a19b-72c25e05fe60?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A25%3A37Z&sr=b&sp=r&sig=iKOLoa90sehGMPxGsGaJ2sv7shKJ4oKTofg5iPkIAas%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:25:37.6113834","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:18.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:33.592Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/668fdb5e-1e72-4803-83f3-8b124e9aae47/fe478b29-a9d4-459f-8e83-db511c8e3c1f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A18%3A36Z&sr=b&sp=r&sig=QZBpY9f2Y7cRUaI0fLOrl5QHgJ4DmmYu0JC16pHZo0w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:18:36.0945658","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.373Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:31.657Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -548,9 +548,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:37 GMT
+      - Sun, 29 Oct 2023 22:18:36 GMT
       mise-correlation-id:
-      - c715b314-4315-4b66-9a64-7ca106be3d40
+      - 631b3554-e732-4982-bc11-6a73d9baa4f6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_create_with_args.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_create_with_args.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:39.3741826Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:39.3741826Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:17:20.1868204Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:17:20.1868204Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"97e7491d-9ce9-4a2c-ab03-d096c01c0709.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:13 GMT
+      - Mon, 30 Oct 2023 07:17:55 GMT
       etag:
-      - '"3c00f121-0000-0100-0000-653eda050000"'
+      - '"3f00ae65-0000-0100-0000-653f58820000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://97e7491d-9ce9-4a2c-ab03-d096c01c0709.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:18:15 GMT
+      - Mon, 30 Oct 2023 07:17:57 GMT
       mise-correlation-id:
-      - 38a9ee89-36ba-49b5-a745-a30676c92ef3
+      - 38400c4e-c65a-48a7-91d3-5c88e0647516
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -101,11 +101,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://97e7491d-9ce9-4a2c-ab03-d096c01c0709.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.373Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:16.373Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:17:58.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:17:58.333Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -116,11 +116,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:16 GMT
+      - Mon, 30 Oct 2023 07:17:58 GMT
       location:
-      - https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+      - https://97e7491d-9ce9-4a2c-ab03-d096c01c0709.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 892fec15-d6e0-469c-8c8a-910d31c2f988
+      - 6921a641-86bb-4f02-aded-43384badd537
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -140,7 +140,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files?api-version=2022-11-01
+    uri: https://97e7491d-9ce9-4a2c-ab03-d096c01c0709.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -154,9 +154,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:16 GMT
+      - Mon, 30 Oct 2023 07:17:58 GMT
       mise-correlation-id:
-      - 27416d90-bd9f-49ad-8d76-9dddc3b31146
+      - 774b8f57-aa11-467d-b68e-d30b82e19f53
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -270,25 +270,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://97e7491d-9ce9-4a2c-ab03-d096c01c0709.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/668fdb5e-1e72-4803-83f3-8b124e9aae47/fe478b29-a9d4-459f-8e83-db511c8e3c1f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A17Z&sr=b&sp=r&sig=3VNKev0gCrbJ3keXlzZ9p4iCxpzrpECufd8J2DVzzK8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:17.3683759","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce7d07af-57a7-49f4-8c42-2635ae348b4f/53058d42-e506-4025-b4fe-7b42cd560f5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A27%3A59Z&sr=b&sp=r&sig=ZOVZN%2BqpXL60MibOPK7viqCgyRd3sTzEg%2BU7H3PKAck%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:27:59.5313218","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:17 GMT
+      - Mon, 30 Oct 2023 07:17:59 GMT
       location:
-      - https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://97e7491d-9ce9-4a2c-ab03-d096c01c0709.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - b3dc4507-e3f1-4075-9d65-86d698d5b1e6
+      - 574b5bc0-cfd5-4019-b1e1-f97a36d827c9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -308,10 +308,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://97e7491d-9ce9-4a2c-ab03-d096c01c0709.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/668fdb5e-1e72-4803-83f3-8b124e9aae47/fe478b29-a9d4-459f-8e83-db511c8e3c1f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A17Z&sr=b&sp=r&sig=wnPZKI9VcpA5HnVZXns%2B0yTYYGGlQN422OKp2bcZFXA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:17.6564232","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce7d07af-57a7-49f4-8c42-2635ae348b4f/53058d42-e506-4025-b4fe-7b42cd560f5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A27%3A59Z&sr=b&sp=r&sig=xXQzbIBhMwkHlAUtrd1%2By3BoxmWA1lO21s1IZi6thoU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:27:59.7811662","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -322,9 +322,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:17 GMT
+      - Mon, 30 Oct 2023 07:17:59 GMT
       mise-correlation-id:
-      - 53356979-83c6-420e-8726-9988d918f5b0
+      - 8332ba90-6b70-472d-88d7-693e8b2fabda
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -344,10 +344,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://97e7491d-9ce9-4a2c-ab03-d096c01c0709.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/668fdb5e-1e72-4803-83f3-8b124e9aae47/fe478b29-a9d4-459f-8e83-db511c8e3c1f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A22Z&sr=b&sp=r&sig=fFhMvtW7YPqT3nY3QNnr9hzEJQNWulpNXvoC2oX50WA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:22.9026975","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce7d07af-57a7-49f4-8c42-2635ae348b4f/53058d42-e506-4025-b4fe-7b42cd560f5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A05Z&sr=b&sp=r&sig=3oTCI%2BXu351bRGbfIid65AtEYyYRs31UVgCkhBu6CyI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:05.055611","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '550'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:18:05 GMT
+      mise-correlation-id:
+      - b5b06eed-fd74-4518-a645-38ec8ac55ef0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://97e7491d-9ce9-4a2c-ab03-d096c01c0709.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce7d07af-57a7-49f4-8c42-2635ae348b4f/53058d42-e506-4025-b4fe-7b42cd560f5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A10Z&sr=b&sp=r&sig=YKIzwj3BwlLVgFAjIbzBFkRin2v7qhnB5ngmIFbMtmA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:10.3865488","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -358,9 +394,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:22 GMT
+      - Mon, 30 Oct 2023 07:18:10 GMT
       mise-correlation-id:
-      - 89cb9777-9fc9-42be-b379-dd197dd2a28c
+      - 14c67217-bb6a-4bdc-affd-298f2fdecc20
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -380,23 +416,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://97e7491d-9ce9-4a2c-ab03-d096c01c0709.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/668fdb5e-1e72-4803-83f3-8b124e9aae47/fe478b29-a9d4-459f-8e83-db511c8e3c1f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A28Z&sr=b&sp=r&sig=EyZOmKLyf%2F1iK7RuBlX5sqlEv%2FWW0v0V2kBEo51163o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:28.1496467","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce7d07af-57a7-49f4-8c42-2635ae348b4f/53058d42-e506-4025-b4fe-7b42cd560f5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A15Z&sr=b&sp=r&sig=NWhVgRSFzckr4mAOWZH5l%2B2J%2BkFdXXDag6ygu3nPQFc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:15.6516913","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:28 GMT
+      - Mon, 30 Oct 2023 07:18:15 GMT
       mise-correlation-id:
-      - 4b9f7da3-de92-4dfb-869b-248c17d528ab
+      - 43c759e2-1159-469a-bc08-be67e504da6c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -416,60 +452,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://97e7491d-9ce9-4a2c-ab03-d096c01c0709.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/668fdb5e-1e72-4803-83f3-8b124e9aae47/fe478b29-a9d4-459f-8e83-db511c8e3c1f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A33Z&sr=b&sp=r&sig=XzRAfoQwO1Z6qBoUuSsWEsrWoZIYux6H%2BoohwqdjFkQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:33.3939839","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce7d07af-57a7-49f4-8c42-2635ae348b4f/53058d42-e506-4025-b4fe-7b42cd560f5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A18%3A15Z&sr=b&sp=r&sig=XPgEa3F%2BGjYDl%2FHZrD6S1AjlKyGxIsd6M2VP4PYxuTQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:18:15.9306881","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:17:58.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:18:12.757Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '1102'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:33 GMT
+      - Mon, 30 Oct 2023 07:18:15 GMT
       mise-correlation-id:
-      - 9a85764d-563f-4e79-8c90-db4c36e174eb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/668fdb5e-1e72-4803-83f3-8b124e9aae47/fe478b29-a9d4-459f-8e83-db511c8e3c1f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A18%3A33Z&sr=b&sp=r&sig=DlujtAZZJj4atL%2BuNxWiKjevOlJ0J5wZ9Zx463viFrw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:18:33.6622981","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.373Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:31.657Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1100'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:18:33 GMT
-      mise-correlation-id:
-      - 8b48c011-3374-4701-a591-0ae8c7021493
+      - 5706db7f-afc1-497c-8cdb-50b1c1d92536
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -492,7 +492,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:39.3741826Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:39.3741826Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:17:20.1868204Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:17:20.1868204Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"97e7491d-9ce9-4a2c-ab03-d096c01c0709.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -501,9 +501,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:34 GMT
+      - Mon, 30 Oct 2023 07:18:17 GMT
       etag:
-      - '"3c00f121-0000-0100-0000-653eda050000"'
+      - '"3f00ae65-0000-0100-0000-653f58820000"'
       expires:
       - '-1'
       pragma:
@@ -533,24 +533,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29234d84-46c7-4a6d-ae29-e7488d85d84d.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://97e7491d-9ce9-4a2c-ab03-d096c01c0709.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/668fdb5e-1e72-4803-83f3-8b124e9aae47/fe478b29-a9d4-459f-8e83-db511c8e3c1f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A18%3A36Z&sr=b&sp=r&sig=QZBpY9f2Y7cRUaI0fLOrl5QHgJ4DmmYu0JC16pHZo0w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:18:36.0945658","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.373Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:31.657Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce7d07af-57a7-49f4-8c42-2635ae348b4f/53058d42-e506-4025-b4fe-7b42cd560f5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A18%3A18Z&sr=b&sp=r&sig=JhXaTpv%2F6N8WnS6luYFgLmVu9%2FPGHkA4OtHkEpamoFk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:18:18.6917079","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:17:58.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:18:12.757Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1110'
+      - '1114'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:36 GMT
+      - Mon, 30 Oct 2023 07:18:18 GMT
       mise-correlation-id:
-      - 631b3554-e732-4982-bc11-6a73d9baa4f6
+      - 0889ed27-3741-48a2-a539-01a5f91b1aaf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_create_with_args.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_create_with_args.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:55.4883619Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:55.4883619Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.995962Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.995962Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:29 GMT
+      - Wed, 18 Oct 2023 20:48:39 GMT
       etag:
-      - '"d80116a5-0000-0100-0000-65294a8d0000"'
+      - '"7500263a-0000-0100-0000-653044880000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:48:31 GMT
+      - Wed, 18 Oct 2023 20:48:40 GMT
       mise-correlation-id:
-      - 9bc1fba4-6049-4878-b346-20dce96a5a6c
+      - 36d02a7f-2a9a-437f-8cf3-f52a55c9bbd1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -101,11 +101,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:31.835Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:31.835Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:42.353Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:42.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -116,11 +116,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:31 GMT
+      - Wed, 18 Oct 2023 20:48:42 GMT
       location:
-      - https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+      - https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - ce19455f-0a98-47f3-bf8e-2cc566ab977e
+      - f981cd88-a350-483a-b6a4-4cb88370e2e5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -140,7 +140,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files?api-version=2022-11-01
+    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -154,9 +154,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:32 GMT
+      - Wed, 18 Oct 2023 20:48:42 GMT
       mise-correlation-id:
-      - 4843a98a-2b6b-403c-9b0a-8fc3b00865bd
+      - 3a8c85e4-4462-4878-a51d-4000bba170db
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -270,25 +270,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ab57ea18-27b8-4cfb-913d-5e5a4ee2ffae/d1f99b8b-dfd5-47fd-9385-4161dcb1a017?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A32Z&sr=b&sp=r&sig=nzwLpMy8MxqKCOB8EzJq8pYEqzFqQqBrGwNxPKPTdac%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:32.6047595","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ffc3853f-3a1b-44dd-93e5-8140c11713cf/a1a19607-361f-4942-af4b-fcadd8e28e27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A43Z&sr=b&sp=r&sig=i%2FNWs1HcLQPGaJbigP7%2BnSRPlNBWtDlqBZXaRxLuT2U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:43.9097957","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:32 GMT
+      - Wed, 18 Oct 2023 20:48:43 GMT
       location:
-      - https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 66e589e8-169a-451c-a797-9e1fa83a60b7
+      - 7b1ed6cf-623c-4076-adc3-4dfccfc3d96b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -308,23 +308,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ab57ea18-27b8-4cfb-913d-5e5a4ee2ffae/d1f99b8b-dfd5-47fd-9385-4161dcb1a017?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A32Z&sr=b&sp=r&sig=9BpxrJfhfZvwgRh3tgoR9%2BN3yX0mdWpImcAg%2FNyenRs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:32.8396419","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ffc3853f-3a1b-44dd-93e5-8140c11713cf/a1a19607-361f-4942-af4b-fcadd8e28e27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A44Z&sr=b&sp=r&sig=7TC7798J8i8EShDi1GkWmsje0p46HT9rouRibbPfPfE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:44.226507","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '548'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:32 GMT
+      - Wed, 18 Oct 2023 20:48:44 GMT
       mise-correlation-id:
-      - 7213e4d0-2d14-4c31-963a-671478eae614
+      - ec31db99-d36f-4450-8e51-e9399b430968
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -344,46 +344,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ab57ea18-27b8-4cfb-913d-5e5a4ee2ffae/d1f99b8b-dfd5-47fd-9385-4161dcb1a017?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A38Z&sr=b&sp=r&sig=Q44wm5SvoLbwvsXXEatFr8VMVRZZuphAggzlaB0%2B%2F10%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:38.0799775","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:48:38 GMT
-      mise-correlation-id:
-      - d87fd93c-79b2-43b4-aa89-6fdcee36686c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ab57ea18-27b8-4cfb-913d-5e5a4ee2ffae/d1f99b8b-dfd5-47fd-9385-4161dcb1a017?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A43Z&sr=b&sp=r&sig=eQ5r4HH0hYBqthAov3bXTjK7aF7nnxSzU2Uzy70SG1w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:43.3498794","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ffc3853f-3a1b-44dd-93e5-8140c11713cf/a1a19607-361f-4942-af4b-fcadd8e28e27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A49Z&sr=b&sp=r&sig=Q7MkMTxGNdyAMYsibpmCNyKlS7K8pUvttfEOf%2Bdx8VE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:49.53395","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -394,9 +358,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:43 GMT
+      - Wed, 18 Oct 2023 20:48:49 GMT
       mise-correlation-id:
-      - 3572aa0a-64bb-4d60-b390-087dffb818dc
+      - 7efac867-9037-42d4-9f7a-9cc6accbb19d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -416,23 +380,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ab57ea18-27b8-4cfb-913d-5e5a4ee2ffae/d1f99b8b-dfd5-47fd-9385-4161dcb1a017?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A48Z&sr=b&sp=r&sig=RSIIcSQWdUF2k0fCE836ugbvWhqFmPY59VIb0XhJ9%2Bk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:48.6068116","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ffc3853f-3a1b-44dd-93e5-8140c11713cf/a1a19607-361f-4942-af4b-fcadd8e28e27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A54Z&sr=b&sp=r&sig=6cN1TuVXsCzGoQ4Jyr35h1T3TcwbokYWOHfh%2FiHNTkY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:54.8282114","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:48 GMT
+      - Wed, 18 Oct 2023 20:48:54 GMT
       mise-correlation-id:
-      - 98099711-ad32-4067-86da-a17488ee53d7
+      - 90a9fcca-e4be-46b1-bd09-59f3c0d108a0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -452,11 +416,47 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ab57ea18-27b8-4cfb-913d-5e5a4ee2ffae/d1f99b8b-dfd5-47fd-9385-4161dcb1a017?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A48%3A48Z&sr=b&sp=r&sig=HLXHQ0R2GRyS776j%2F3NWcvzU6yyhi2y8LPEuiXG36NA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:48:48.8475302","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:31.835Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:44.921Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ffc3853f-3a1b-44dd-93e5-8140c11713cf/a1a19607-361f-4942-af4b-fcadd8e28e27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A00Z&sr=b&sp=r&sig=mBJET3Jj7PF5gmU7XxWjIvSDNoHtP9VKZyGq6N6F7hw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:00.0932798","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '547'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:49:00 GMT
+      mise-correlation-id:
+      - 665764b5-0fb1-41d3-84ba-86d430b11cf5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ffc3853f-3a1b-44dd-93e5-8140c11713cf/a1a19607-361f-4942-af4b-fcadd8e28e27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A49%3A00Z&sr=b&sp=r&sig=YePUNDNglEo7mFtbndarM5hLcVWylfXiBx%2FB4HWLNQY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:49:00.3793094","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:42.353Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:58.296Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -467,9 +467,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:48 GMT
+      - Wed, 18 Oct 2023 20:49:00 GMT
       mise-correlation-id:
-      - 2f0a5106-a77b-44f6-925c-8071dbec3a1b
+      - b2218525-f47b-497e-9584-86cea106e2f8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -492,18 +492,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:55.4883619Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:55.4883619Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.995962Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.995962Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:50 GMT
+      - Wed, 18 Oct 2023 20:49:01 GMT
       etag:
-      - '"d80116a5-0000-0100-0000-65294a8d0000"'
+      - '"7500263a-0000-0100-0000-653044880000"'
       expires:
       - '-1'
       pragma:
@@ -533,24 +533,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ab57ea18-27b8-4cfb-913d-5e5a4ee2ffae/d1f99b8b-dfd5-47fd-9385-4161dcb1a017?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A48%3A51Z&sr=b&sp=r&sig=r0%2FgaBqbF9IZsFbHhAvBX0bn5Ng1HjqG%2BPqaVgQuSUo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:48:51.5880533","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:31.835Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:44.921Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ffc3853f-3a1b-44dd-93e5-8140c11713cf/a1a19607-361f-4942-af4b-fcadd8e28e27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A49%3A02Z&sr=b&sp=r&sig=9fQ8FkIetTqr8FtcxWg3gVgcW373Ia0YZWX7AWkzMMk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:49:02.5319855","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:42.353Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:58.296Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1114'
+      - '1110'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:51 GMT
+      - Wed, 18 Oct 2023 20:49:02 GMT
       mise-correlation-id:
-      - 91968b2e-52b6-4d9e-b464-69252c40619e
+      - 021a4dd7-8b77-4f32-98fd-942961908d33
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_create_with_args.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_create_with_args.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.995962Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.995962Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1189356Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1189356Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:39 GMT
+      - Tue, 24 Oct 2023 12:25:16 GMT
       etag:
-      - '"7500263a-0000-0100-0000-653044880000"'
+      - '"d300f431-0000-0100-0000-6537b78b0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:48:40 GMT
+      - Tue, 24 Oct 2023 12:25:17 GMT
       mise-correlation-id:
-      - 36d02a7f-2a9a-437f-8cf3-f52a55c9bbd1
+      - 5ecc6729-16ba-486d-acb1-c146dd1dfba5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -101,11 +101,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:42.353Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:42.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:18.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:18.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -116,11 +116,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:42 GMT
+      - Tue, 24 Oct 2023 12:25:18 GMT
       location:
-      - https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+      - https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - f981cd88-a350-483a-b6a4-4cb88370e2e5
+      - 2f36b77e-8547-4221-9317-7a9227250577
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -140,7 +140,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files?api-version=2022-11-01
+    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -154,9 +154,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:42 GMT
+      - Tue, 24 Oct 2023 12:25:18 GMT
       mise-correlation-id:
-      - 3a8c85e4-4462-4878-a51d-4000bba170db
+      - a7f95e07-dd84-4edb-a5d2-3bd6730bf331
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -270,25 +270,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ffc3853f-3a1b-44dd-93e5-8140c11713cf/a1a19607-361f-4942-af4b-fcadd8e28e27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A43Z&sr=b&sp=r&sig=i%2FNWs1HcLQPGaJbigP7%2BnSRPlNBWtDlqBZXaRxLuT2U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:43.9097957","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/81a0972b-22b5-42ea-abc5-fee24cfea2ce/3e51759a-6f9d-4978-a19b-72c25e05fe60?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A19Z&sr=b&sp=r&sig=mES8UOt24rL650S7CuWusd5G2wEE25pVH8e7qong00g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:19.4597031","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:43 GMT
+      - Tue, 24 Oct 2023 12:25:19 GMT
       location:
-      - https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 7b1ed6cf-623c-4076-adc3-4dfccfc3d96b
+      - 1833de01-3e4e-4cc1-9577-e09371d46fab
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -308,46 +308,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ffc3853f-3a1b-44dd-93e5-8140c11713cf/a1a19607-361f-4942-af4b-fcadd8e28e27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A44Z&sr=b&sp=r&sig=7TC7798J8i8EShDi1GkWmsje0p46HT9rouRibbPfPfE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:44.226507","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '548'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:48:44 GMT
-      mise-correlation-id:
-      - ec31db99-d36f-4450-8e51-e9399b430968
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ffc3853f-3a1b-44dd-93e5-8140c11713cf/a1a19607-361f-4942-af4b-fcadd8e28e27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A49Z&sr=b&sp=r&sig=Q7MkMTxGNdyAMYsibpmCNyKlS7K8pUvttfEOf%2Bdx8VE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:49.53395","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/81a0972b-22b5-42ea-abc5-fee24cfea2ce/3e51759a-6f9d-4978-a19b-72c25e05fe60?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A19Z&sr=b&sp=r&sig=NldRDJ8ije2iKl3F75gwI2CsOilGNhPlMFlpJJEkBlE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:19.6977209","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -358,9 +322,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:49 GMT
+      - Tue, 24 Oct 2023 12:25:19 GMT
       mise-correlation-id:
-      - 7efac867-9037-42d4-9f7a-9cc6accbb19d
+      - 87f2e10f-6257-435c-9f9a-1bec7ea0f9d8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -380,10 +344,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ffc3853f-3a1b-44dd-93e5-8140c11713cf/a1a19607-361f-4942-af4b-fcadd8e28e27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A54Z&sr=b&sp=r&sig=6cN1TuVXsCzGoQ4Jyr35h1T3TcwbokYWOHfh%2FiHNTkY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:54.8282114","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/81a0972b-22b5-42ea-abc5-fee24cfea2ce/3e51759a-6f9d-4978-a19b-72c25e05fe60?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A25Z&sr=b&sp=r&sig=HXJ7CI2OFt4B8F6aAXbwUXeGfMGRFQi6kvUe8E%2FOxK8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:25.0057524","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -394,9 +358,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:54 GMT
+      - Tue, 24 Oct 2023 12:25:25 GMT
       mise-correlation-id:
-      - 90a9fcca-e4be-46b1-bd09-59f3c0d108a0
+      - 0a485278-ffdb-48be-afcd-246cfa361cf8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -416,23 +380,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ffc3853f-3a1b-44dd-93e5-8140c11713cf/a1a19607-361f-4942-af4b-fcadd8e28e27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A00Z&sr=b&sp=r&sig=mBJET3Jj7PF5gmU7XxWjIvSDNoHtP9VKZyGq6N6F7hw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:00.0932798","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/81a0972b-22b5-42ea-abc5-fee24cfea2ce/3e51759a-6f9d-4978-a19b-72c25e05fe60?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A30Z&sr=b&sp=r&sig=1j%2BVLdoZ4oSsDsWXEt6f5%2FWtZfrBaDAMqL85p2Lsj1I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:30.2859795","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:00 GMT
+      - Tue, 24 Oct 2023 12:25:30 GMT
       mise-correlation-id:
-      - 665764b5-0fb1-41d3-84ba-86d430b11cf5
+      - 36babe39-acda-4578-88e1-26efeb8a16b8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -452,24 +416,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ffc3853f-3a1b-44dd-93e5-8140c11713cf/a1a19607-361f-4942-af4b-fcadd8e28e27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A49%3A00Z&sr=b&sp=r&sig=YePUNDNglEo7mFtbndarM5hLcVWylfXiBx%2FB4HWLNQY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:49:00.3793094","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:42.353Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:58.296Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/81a0972b-22b5-42ea-abc5-fee24cfea2ce/3e51759a-6f9d-4978-a19b-72c25e05fe60?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A35Z&sr=b&sp=r&sig=tQe%2Bu1zHla3FxsljjH0NaORLCzWBsvk%2BWHDLizG1ET4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:35.5548035","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1100'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:00 GMT
+      - Tue, 24 Oct 2023 12:25:35 GMT
       mise-correlation-id:
-      - b2218525-f47b-497e-9584-86cea106e2f8
+      - 4952c6ac-c8da-4e09-9784-f22e70fc801a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/81a0972b-22b5-42ea-abc5-fee24cfea2ce/3e51759a-6f9d-4978-a19b-72c25e05fe60?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A25%3A35Z&sr=b&sp=r&sig=6%2BMiwmpVtcvUJss5rU%2FRDq84%2F9skCAwL1Oy7kstCAII%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:25:35.8631223","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:18.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:33.592Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1104'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:25:35 GMT
+      mise-correlation-id:
+      - aca63f41-b7f4-477f-afe0-eea1cb83a077
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -492,18 +492,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.995962Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.995962Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1189356Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1189356Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:01 GMT
+      - Tue, 24 Oct 2023 12:25:35 GMT
       etag:
-      - '"7500263a-0000-0100-0000-653044880000"'
+      - '"d300f431-0000-0100-0000-6537b78b0000"'
       expires:
       - '-1'
       pragma:
@@ -533,11 +533,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://42e30f22-d068-46a2-b56f-9db8219f8b0d.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://4e925883-7c2e-4c7e-9635-6fe2c1a71dd6.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ffc3853f-3a1b-44dd-93e5-8140c11713cf/a1a19607-361f-4942-af4b-fcadd8e28e27?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A49%3A02Z&sr=b&sp=r&sig=9fQ8FkIetTqr8FtcxWg3gVgcW373Ia0YZWX7AWkzMMk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:49:02.5319855","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:42.353Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:58.296Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/81a0972b-22b5-42ea-abc5-fee24cfea2ce/3e51759a-6f9d-4978-a19b-72c25e05fe60?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A25%3A37Z&sr=b&sp=r&sig=iKOLoa90sehGMPxGsGaJ2sv7shKJ4oKTofg5iPkIAas%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:25:37.6113834","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:18.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:33.592Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -548,9 +548,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:02 GMT
+      - Tue, 24 Oct 2023 12:25:37 GMT
       mise-correlation-id:
-      - 021a4dd7-8b77-4f32-98fd-942961908d33
+      - c715b314-4315-4b66-9a64-7ca106be3d40
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_create_with_args.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_create_with_args.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:53.1800533Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:53.1800533Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:55.4883619Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:55.4883619Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:27 GMT
+      - Fri, 13 Oct 2023 13:48:29 GMT
       etag:
-      - '"550006a4-0000-0100-0000-6524512f0000"'
+      - '"d80116a5-0000-0100-0000-65294a8d0000"'
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:15:28 GMT
+      - Fri, 13 Oct 2023 13:48:31 GMT
       mise-correlation-id:
-      - cec3754b-1f27-4673-9266-390bcb8c013d
+      - 9bc1fba4-6049-4878-b346-20dce96a5a6c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -99,13 +99,13 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:29.535Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:29.535Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:31.835Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:31.835Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -116,11 +116,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:29 GMT
+      - Fri, 13 Oct 2023 13:48:31 GMT
       location:
-      - https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+      - https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 24f4c687-e544-45ed-b64d-27ee75769241
+      - ce19455f-0a98-47f3-bf8e-2cc566ab977e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -138,9 +138,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files?api-version=2022-11-01
+    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -154,9 +154,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:29 GMT
+      - Fri, 13 Oct 2023 13:48:32 GMT
       mise-correlation-id:
-      - 52abaf2d-74f4-4741-9417-f0c4595b4568
+      - 4843a98a-2b6b-403c-9b0a-8fc3b00865bd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -268,27 +268,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0855edf9-4bd1-413e-91bb-691b33c10f46/0eab8d46-f4b0-46de-b64a-f6378bd95060?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A30Z&sr=b&sp=r&sig=POyai0nTmwpQHgl72c3SP0yOnGkFb3DuID%2BAad4IXXA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:30.3094194","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ab57ea18-27b8-4cfb-913d-5e5a4ee2ffae/d1f99b8b-dfd5-47fd-9385-4161dcb1a017?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A32Z&sr=b&sp=r&sig=nzwLpMy8MxqKCOB8EzJq8pYEqzFqQqBrGwNxPKPTdac%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:32.6047595","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:30 GMT
+      - Fri, 13 Oct 2023 13:48:32 GMT
       location:
-      - https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - dd83f5b5-127a-450c-a3ba-e68095d2eb5b
+      - 66e589e8-169a-451c-a797-9e1fa83a60b7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -306,12 +306,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0855edf9-4bd1-413e-91bb-691b33c10f46/0eab8d46-f4b0-46de-b64a-f6378bd95060?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A30Z&sr=b&sp=r&sig=Sz%2FIjliZ36BB9x0lKxHwMUF%2BSPqS41QmChXKMcqSCKU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:30.6241798","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ab57ea18-27b8-4cfb-913d-5e5a4ee2ffae/d1f99b8b-dfd5-47fd-9385-4161dcb1a017?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A32Z&sr=b&sp=r&sig=9BpxrJfhfZvwgRh3tgoR9%2BN3yX0mdWpImcAg%2FNyenRs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:32.8396419","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -322,9 +322,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:30 GMT
+      - Fri, 13 Oct 2023 13:48:32 GMT
       mise-correlation-id:
-      - dee9cd7e-108b-4b72-bbe3-fd3caacf2817
+      - 7213e4d0-2d14-4c31-963a-671478eae614
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -342,12 +342,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0855edf9-4bd1-413e-91bb-691b33c10f46/0eab8d46-f4b0-46de-b64a-f6378bd95060?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A35Z&sr=b&sp=r&sig=AUozhhPrvoOB8aO6YtBZFlgrz4McMWdL%2BXoiKWeNn%2BA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:35.8892404","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ab57ea18-27b8-4cfb-913d-5e5a4ee2ffae/d1f99b8b-dfd5-47fd-9385-4161dcb1a017?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A38Z&sr=b&sp=r&sig=Q44wm5SvoLbwvsXXEatFr8VMVRZZuphAggzlaB0%2B%2F10%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:38.0799775","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -358,9 +358,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:35 GMT
+      - Fri, 13 Oct 2023 13:48:38 GMT
       mise-correlation-id:
-      - 462160c7-6040-4c30-abec-86becd147c16
+      - d87fd93c-79b2-43b4-aa89-6fdcee36686c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -378,25 +378,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0855edf9-4bd1-413e-91bb-691b33c10f46/0eab8d46-f4b0-46de-b64a-f6378bd95060?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A41Z&sr=b&sp=r&sig=ecsboN2wBP7xgzCq9AisOz8oc%2F3dCHDh40bFXjD%2FW3o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:41.152039","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ab57ea18-27b8-4cfb-913d-5e5a4ee2ffae/d1f99b8b-dfd5-47fd-9385-4161dcb1a017?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A43Z&sr=b&sp=r&sig=eQ5r4HH0hYBqthAov3bXTjK7aF7nnxSzU2Uzy70SG1w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:43.3498794","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '552'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:41 GMT
+      - Fri, 13 Oct 2023 13:48:43 GMT
       mise-correlation-id:
-      - fc520761-f2a1-47a2-baad-f14e4f191310
+      - 3572aa0a-64bb-4d60-b390-087dffb818dc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -414,25 +414,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0855edf9-4bd1-413e-91bb-691b33c10f46/0eab8d46-f4b0-46de-b64a-f6378bd95060?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A46Z&sr=b&sp=r&sig=fs%2B22NPWlmM7v7Yx19HBBMwy%2BMwM%2FZd5a6x%2FAr9Gk5Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:46.5411486","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ab57ea18-27b8-4cfb-913d-5e5a4ee2ffae/d1f99b8b-dfd5-47fd-9385-4161dcb1a017?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A48Z&sr=b&sp=r&sig=RSIIcSQWdUF2k0fCE836ugbvWhqFmPY59VIb0XhJ9%2Bk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:48.6068116","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:46 GMT
+      - Fri, 13 Oct 2023 13:48:48 GMT
       mise-correlation-id:
-      - 773b9f28-8445-4b6d-a5df-ad9c031b3f39
+      - 98099711-ad32-4067-86da-a17488ee53d7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -450,26 +450,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0855edf9-4bd1-413e-91bb-691b33c10f46/0eab8d46-f4b0-46de-b64a-f6378bd95060?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A15%3A47Z&sr=b&sp=r&sig=rYVuSccEEFG1uyqvIG4VpI7SznSmVopcYsAItdAfEOs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:15:47.1253858","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:29.535Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:44.443Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ab57ea18-27b8-4cfb-913d-5e5a4ee2ffae/d1f99b8b-dfd5-47fd-9385-4161dcb1a017?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A48%3A48Z&sr=b&sp=r&sig=HLXHQ0R2GRyS776j%2F3NWcvzU6yyhi2y8LPEuiXG36NA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:48:48.8475302","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:31.835Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:44.921Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1098'
+      - '1100'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:47 GMT
+      - Fri, 13 Oct 2023 13:48:48 GMT
       mise-correlation-id:
-      - 99bbe097-365a-4dce-81a4-224235dcd20f
+      - 2f0a5106-a77b-44f6-925c-8071dbec3a1b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -492,7 +492,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:53.1800533Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:53.1800533Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:55.4883619Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:55.4883619Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -501,9 +501,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:48 GMT
+      - Fri, 13 Oct 2023 13:48:50 GMT
       etag:
-      - '"550006a4-0000-0100-0000-6524512f0000"'
+      - '"d80116a5-0000-0100-0000-65294a8d0000"'
       expires:
       - '-1'
       pragma:
@@ -531,26 +531,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://756a5958-f089-465f-8310-e7eec68701e7.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0855edf9-4bd1-413e-91bb-691b33c10f46/0eab8d46-f4b0-46de-b64a-f6378bd95060?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A15%3A49Z&sr=b&sp=r&sig=eaFI0BesNpU17mdV4dmcwh9AOgNdUcqHsPAMsKeA91U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:15:49.7400062","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:29.535Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:44.443Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ab57ea18-27b8-4cfb-913d-5e5a4ee2ffae/d1f99b8b-dfd5-47fd-9385-4161dcb1a017?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A48%3A51Z&sr=b&sp=r&sig=r0%2FgaBqbF9IZsFbHhAvBX0bn5Ng1HjqG%2BPqaVgQuSUo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:48:51.5880533","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:31.835Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:44.921Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1110'
+      - '1114'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:49 GMT
+      - Fri, 13 Oct 2023 13:48:51 GMT
       mise-correlation-id:
-      - 197e563c-a6f1-40d8-b39f-7202f210ef21
+      - 91968b2e-52b6-4d9e-b464-69252c40619e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_create_with_args.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_create_with_args.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:08:15.7689233Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:08:15.7689233Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"084b814f-1d22-43dc-877f-8cd3c7acb3b0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5555936Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5555936Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:08:52 GMT
+      - Mon, 09 Oct 2023 16:09:06 GMT
       etag:
-      - '"1a0a1497-0000-0100-0000-64af08310000"'
+      - '"92014c89-0000-0100-0000-652425830000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://084b814f-1d22-43dc-877f-8cd3c7acb3b0.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:08:53 GMT
+      - Mon, 09 Oct 2023 16:09:08 GMT
       mise-correlation-id:
-      - c3fb7fb4-8242-4a71-ae27-68123371aa98
+      - d4a75044-a79f-46dc-a542-8dffc6912745
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -101,11 +101,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://084b814f-1d22-43dc-877f-8cd3c7acb3b0.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:08:54.455Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:08:54.455Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:08.753Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:08.753Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -116,11 +116,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:08:54 GMT
+      - Mon, 09 Oct 2023 16:09:08 GMT
       location:
-      - https://084b814f-1d22-43dc-877f-8cd3c7acb3b0.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+      - https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 72c0c448-dde2-4ca7-82a3-f54f54f86bdc
+      - 05058d9c-8ca4-4ead-9eaa-9ab4f6c13a83
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -140,7 +140,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://084b814f-1d22-43dc-877f-8cd3c7acb3b0.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files?api-version=2022-11-01
+    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -154,9 +154,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:08:54 GMT
+      - Mon, 09 Oct 2023 16:09:09 GMT
       mise-correlation-id:
-      - 1aaccbc7-6fd5-445b-a97e-68f6c0fa4c3c
+      - f9593d41-0b53-4afe-b0f2-0d3bf0941896
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -270,25 +270,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://084b814f-1d22-43dc-877f-8cd3c7acb3b0.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/edc3bd65-4d89-440e-a688-a9ad370bf77d/304a9079-9ad1-431e-b509-7706cf069e90?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A18%3A55Z&sr=b&sp=r&sig=%2BqVif4hEwxAcQ9zvHOs2fTtR9CdRih5n0aN0f7KLzLI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:18:55.2691904","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/044973e2-03e0-4640-ae05-940f17cee16a/bcd6ef3e-9a69-4305-a1bf-8f453170adf2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A09Z&sr=b&sp=r&sig=RUu7CmYRFJ5%2FPAZWRty6sSfHZaeYMo9KMhCmTEsKMzU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:09.542463","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:08:55 GMT
+      - Mon, 09 Oct 2023 16:09:09 GMT
       location:
-      - https://084b814f-1d22-43dc-877f-8cd3c7acb3b0.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 7d64c274-b79e-4294-8ec3-14d624acfe3f
+      - 7de9854c-d1b4-4377-ab02-2eb4700fd663
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -308,23 +308,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://084b814f-1d22-43dc-877f-8cd3c7acb3b0.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/edc3bd65-4d89-440e-a688-a9ad370bf77d/304a9079-9ad1-431e-b509-7706cf069e90?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A18%3A55Z&sr=b&sp=r&sig=is%2Bs0%2Byk1Y7WCBISLHKgAhfbui8S61AfOBhex%2FMq%2F%2Bo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:18:55.5304026","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/044973e2-03e0-4640-ae05-940f17cee16a/bcd6ef3e-9a69-4305-a1bf-8f453170adf2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A09Z&sr=b&sp=r&sig=fIfy25fdzUaPtcMNXD76n0RO%2Bu2AOn5CVdOpNUQ6%2BBw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:09.7978228","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '559'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:08:55 GMT
+      - Mon, 09 Oct 2023 16:09:09 GMT
       mise-correlation-id:
-      - 50ea6bfe-d81b-489d-89a5-9e88674a7f56
+      - 58940722-e3e7-4f78-b27c-5902feea952a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -344,10 +344,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://084b814f-1d22-43dc-877f-8cd3c7acb3b0.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/edc3bd65-4d89-440e-a688-a9ad370bf77d/304a9079-9ad1-431e-b509-7706cf069e90?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A19%3A00Z&sr=b&sp=r&sig=a2JMQk8NtU2Ku1%2FV7g4l8iBo6dDqZMY1kYWfNuTpvUo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:19:00.7964146","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/044973e2-03e0-4640-ae05-940f17cee16a/bcd6ef3e-9a69-4305-a1bf-8f453170adf2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A15Z&sr=b&sp=r&sig=ZyN16UCYaWY%2BmfnmWB7r6Rww5VsJIHoc0bZotrBNT9Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:15.0995364","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -358,9 +358,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:00 GMT
+      - Mon, 09 Oct 2023 16:09:15 GMT
       mise-correlation-id:
-      - 1f69f055-19dc-468b-93a3-b82b7903054a
+      - b92b1150-61c6-4e0e-b520-dcb42517b99d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -380,46 +380,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://084b814f-1d22-43dc-877f-8cd3c7acb3b0.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/edc3bd65-4d89-440e-a688-a9ad370bf77d/304a9079-9ad1-431e-b509-7706cf069e90?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A19%3A06Z&sr=b&sp=r&sig=UZJKSg5ddaEjSJnnX0dVDYrxgnLInKpvPpUq9xDYmXU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:19:06.0648816","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:09:06 GMT
-      mise-correlation-id:
-      - 0213c13b-458c-4bdd-a5e7-ff2569ec78bc
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://084b814f-1d22-43dc-877f-8cd3c7acb3b0.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/edc3bd65-4d89-440e-a688-a9ad370bf77d/304a9079-9ad1-431e-b509-7706cf069e90?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A19%3A11Z&sr=b&sp=r&sig=YPz2MzS%2FbjAXESod59%2B7NTcMLnltDXIYHmDNb8uI5mo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:19:11.3424483","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/044973e2-03e0-4640-ae05-940f17cee16a/bcd6ef3e-9a69-4305-a1bf-8f453170adf2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A20Z&sr=b&sp=r&sig=dojzT9emtHM%2BQ02vsGc2SJHz2bk0Zn7FyeeOIWMquPQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:20.4057698","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -430,9 +394,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:11 GMT
+      - Mon, 09 Oct 2023 16:09:20 GMT
       mise-correlation-id:
-      - 8d9b4f4b-2c89-4e19-96a0-20e9f67fb521
+      - 6a0a1978-ed81-470a-8221-ba32de526dd6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -452,24 +416,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://084b814f-1d22-43dc-877f-8cd3c7acb3b0.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/edc3bd65-4d89-440e-a688-a9ad370bf77d/304a9079-9ad1-431e-b509-7706cf069e90?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A09%3A11Z&sr=b&sp=r&sig=FEim7eXgf7b2fh9yauPWdXdyhvCN4QuefedXTnIesDg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:09:11.5962196","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:08:54.455Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:09:07.334Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/044973e2-03e0-4640-ae05-940f17cee16a/bcd6ef3e-9a69-4305-a1bf-8f453170adf2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A25Z&sr=b&sp=r&sig=IdW0y6Bi3lemmvqVcvZmXf2SlWM0bZdeIPeg86BI4tg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:25.6730385","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1098'
+      - '547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:11 GMT
+      - Mon, 09 Oct 2023 16:09:25 GMT
       mise-correlation-id:
-      - ebb052a1-b7d9-4955-a9d5-0054a51ac015
+      - d283d39f-c7aa-48cd-946e-a9194a259d5c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/044973e2-03e0-4640-ae05-940f17cee16a/bcd6ef3e-9a69-4305-a1bf-8f453170adf2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A09%3A25Z&sr=b&sp=r&sig=vvZJDvc%2BOlj2nH5IcEtzmpSAj5ANLUYqT1rO8uqBjHU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:09:25.939173","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:08.753Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:22.824Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1099'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:09:25 GMT
+      mise-correlation-id:
+      - c5e0151e-ad68-46c9-a806-a9febb95cdc8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -492,7 +492,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:08:15.7689233Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:08:15.7689233Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"084b814f-1d22-43dc-877f-8cd3c7acb3b0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5555936Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5555936Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -501,9 +501,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:12 GMT
+      - Mon, 09 Oct 2023 16:09:26 GMT
       etag:
-      - '"1a0a1497-0000-0100-0000-64af08310000"'
+      - '"92014c89-0000-0100-0000-652425830000"'
       expires:
       - '-1'
       pragma:
@@ -533,24 +533,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://084b814f-1d22-43dc-877f-8cd3c7acb3b0.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/edc3bd65-4d89-440e-a688-a9ad370bf77d/304a9079-9ad1-431e-b509-7706cf069e90?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A09%3A13Z&sr=b&sp=r&sig=wemu3Dv8cHq%2FomIA3O75ZUCiArxgC9wivSRqi2KqifA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:09:13.9105074","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:08:54.455Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:09:07.334Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/044973e2-03e0-4640-ae05-940f17cee16a/bcd6ef3e-9a69-4305-a1bf-8f453170adf2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A09%3A28Z&sr=b&sp=r&sig=aIplKGuwQKOnqpDTu3BRcv8OBzCePDVT4VnIXz5NjrY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:09:28.2079535","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:08.753Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:22.824Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1112'
+      - '1110'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:13 GMT
+      - Mon, 09 Oct 2023 16:09:28 GMT
       mise-correlation-id:
-      - 2202b138-65ba-4ba4-b8a4-82e219b66e7a
+      - 0166f9d0-65c1-432f-a51a-d5c70fa4d2a0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_create_with_args.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_create_with_args.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5555936Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5555936Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:53.1800533Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:53.1800533Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:06 GMT
+      - Mon, 09 Oct 2023 19:15:27 GMT
       etag:
-      - '"92014c89-0000-0100-0000-652425830000"'
+      - '"550006a4-0000-0100-0000-6524512f0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:09:08 GMT
+      - Mon, 09 Oct 2023 19:15:28 GMT
       mise-correlation-id:
-      - d4a75044-a79f-46dc-a542-8dffc6912745
+      - cec3754b-1f27-4673-9266-390bcb8c013d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -101,11 +101,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:08.753Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:08.753Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:29.535Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:29.535Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -116,11 +116,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:08 GMT
+      - Mon, 09 Oct 2023 19:15:29 GMT
       location:
-      - https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+      - https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 05058d9c-8ca4-4ead-9eaa-9ab4f6c13a83
+      - 24f4c687-e544-45ed-b64d-27ee75769241
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -140,7 +140,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files?api-version=2022-11-01
+    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -154,9 +154,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:09 GMT
+      - Mon, 09 Oct 2023 19:15:29 GMT
       mise-correlation-id:
-      - f9593d41-0b53-4afe-b0f2-0d3bf0941896
+      - 52abaf2d-74f4-4741-9417-f0c4595b4568
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -270,25 +270,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/044973e2-03e0-4640-ae05-940f17cee16a/bcd6ef3e-9a69-4305-a1bf-8f453170adf2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A09Z&sr=b&sp=r&sig=RUu7CmYRFJ5%2FPAZWRty6sSfHZaeYMo9KMhCmTEsKMzU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:09.542463","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0855edf9-4bd1-413e-91bb-691b33c10f46/0eab8d46-f4b0-46de-b64a-f6378bd95060?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A30Z&sr=b&sp=r&sig=POyai0nTmwpQHgl72c3SP0yOnGkFb3DuID%2BAad4IXXA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:30.3094194","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:09 GMT
+      - Mon, 09 Oct 2023 19:15:30 GMT
       location:
-      - https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 7de9854c-d1b4-4377-ab02-2eb4700fd663
+      - dd83f5b5-127a-450c-a3ba-e68095d2eb5b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -308,10 +308,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/044973e2-03e0-4640-ae05-940f17cee16a/bcd6ef3e-9a69-4305-a1bf-8f453170adf2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A09Z&sr=b&sp=r&sig=fIfy25fdzUaPtcMNXD76n0RO%2Bu2AOn5CVdOpNUQ6%2BBw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:09.7978228","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0855edf9-4bd1-413e-91bb-691b33c10f46/0eab8d46-f4b0-46de-b64a-f6378bd95060?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A30Z&sr=b&sp=r&sig=Sz%2FIjliZ36BB9x0lKxHwMUF%2BSPqS41QmChXKMcqSCKU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:30.6241798","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -322,9 +322,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:09 GMT
+      - Mon, 09 Oct 2023 19:15:30 GMT
       mise-correlation-id:
-      - 58940722-e3e7-4f78-b27c-5902feea952a
+      - dee9cd7e-108b-4b72-bbe3-fd3caacf2817
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -344,23 +344,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/044973e2-03e0-4640-ae05-940f17cee16a/bcd6ef3e-9a69-4305-a1bf-8f453170adf2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A15Z&sr=b&sp=r&sig=ZyN16UCYaWY%2BmfnmWB7r6Rww5VsJIHoc0bZotrBNT9Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:15.0995364","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0855edf9-4bd1-413e-91bb-691b33c10f46/0eab8d46-f4b0-46de-b64a-f6378bd95060?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A35Z&sr=b&sp=r&sig=AUozhhPrvoOB8aO6YtBZFlgrz4McMWdL%2BXoiKWeNn%2BA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:35.8892404","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:15 GMT
+      - Mon, 09 Oct 2023 19:15:35 GMT
       mise-correlation-id:
-      - b92b1150-61c6-4e0e-b520-dcb42517b99d
+      - 462160c7-6040-4c30-abec-86becd147c16
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -380,23 +380,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/044973e2-03e0-4640-ae05-940f17cee16a/bcd6ef3e-9a69-4305-a1bf-8f453170adf2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A20Z&sr=b&sp=r&sig=dojzT9emtHM%2BQ02vsGc2SJHz2bk0Zn7FyeeOIWMquPQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:20.4057698","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0855edf9-4bd1-413e-91bb-691b33c10f46/0eab8d46-f4b0-46de-b64a-f6378bd95060?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A41Z&sr=b&sp=r&sig=ecsboN2wBP7xgzCq9AisOz8oc%2F3dCHDh40bFXjD%2FW3o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:41.152039","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '552'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:20 GMT
+      - Mon, 09 Oct 2023 19:15:41 GMT
       mise-correlation-id:
-      - 6a0a1978-ed81-470a-8221-ba32de526dd6
+      - fc520761-f2a1-47a2-baad-f14e4f191310
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -416,23 +416,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/044973e2-03e0-4640-ae05-940f17cee16a/bcd6ef3e-9a69-4305-a1bf-8f453170adf2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A25Z&sr=b&sp=r&sig=IdW0y6Bi3lemmvqVcvZmXf2SlWM0bZdeIPeg86BI4tg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:25.6730385","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0855edf9-4bd1-413e-91bb-691b33c10f46/0eab8d46-f4b0-46de-b64a-f6378bd95060?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A46Z&sr=b&sp=r&sig=fs%2B22NPWlmM7v7Yx19HBBMwy%2BMwM%2FZd5a6x%2FAr9Gk5Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:46.5411486","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:25 GMT
+      - Mon, 09 Oct 2023 19:15:46 GMT
       mise-correlation-id:
-      - d283d39f-c7aa-48cd-946e-a9194a259d5c
+      - 773b9f28-8445-4b6d-a5df-ad9c031b3f39
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -452,24 +452,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
+    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests/create-with-args-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/044973e2-03e0-4640-ae05-940f17cee16a/bcd6ef3e-9a69-4305-a1bf-8f453170adf2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A09%3A25Z&sr=b&sp=r&sig=vvZJDvc%2BOlj2nH5IcEtzmpSAj5ANLUYqT1rO8uqBjHU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:09:25.939173","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:08.753Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:22.824Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0855edf9-4bd1-413e-91bb-691b33c10f46/0eab8d46-f4b0-46de-b64a-f6378bd95060?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A15%3A47Z&sr=b&sp=r&sig=rYVuSccEEFG1uyqvIG4VpI7SznSmVopcYsAItdAfEOs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:15:47.1253858","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:29.535Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:44.443Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1099'
+      - '1098'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:25 GMT
+      - Mon, 09 Oct 2023 19:15:47 GMT
       mise-correlation-id:
-      - c5e0151e-ad68-46c9-a806-a9febb95cdc8
+      - 99bbe097-365a-4dce-81a4-224235dcd20f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -492,7 +492,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5555936Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5555936Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:53.1800533Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:53.1800533Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -501,9 +501,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:26 GMT
+      - Mon, 09 Oct 2023 19:15:48 GMT
       etag:
-      - '"92014c89-0000-0100-0000-652425830000"'
+      - '"550006a4-0000-0100-0000-6524512f0000"'
       expires:
       - '-1'
       pragma:
@@ -533,11 +533,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a8181eb5-d6b0-4738-acf0-a69c05088f85.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://f58ba200-1bc3-4965-8046-2758ce056852.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/044973e2-03e0-4640-ae05-940f17cee16a/bcd6ef3e-9a69-4305-a1bf-8f453170adf2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A09%3A28Z&sr=b&sp=r&sig=aIplKGuwQKOnqpDTu3BRcv8OBzCePDVT4VnIXz5NjrY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:09:28.2079535","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:08.753Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:22.824Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0855edf9-4bd1-413e-91bb-691b33c10f46/0eab8d46-f4b0-46de-b64a-f6378bd95060?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A15%3A49Z&sr=b&sp=r&sig=eaFI0BesNpU17mdV4dmcwh9AOgNdUcqHsPAMsKeA91U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:15:49.7400062","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-with-args-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:29.535Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:44.443Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -548,9 +548,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:28 GMT
+      - Mon, 09 Oct 2023 19:15:49 GMT
       mise-correlation-id:
-      - 0166f9d0-65c1-432f-a51a-d5c70fa4d2a0
+      - 197e563c-a6f1-40d8-b39f-7202f210ef21
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_delete.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_delete.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:49.6383464Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:49.6383464Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:50.53428Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:50.53428Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '649'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:24 GMT
+      - Sun, 29 Oct 2023 22:18:53 GMT
       etag:
-      - '"d300b334-0000-0100-0000-6537b7cf0000"'
+      - '"3c001924-0000-0100-0000-653eda4b0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:26:25 GMT
+      - Sun, 29 Oct 2023 22:18:54 GMT
       mise-correlation-id:
-      - 8e6406e4-6a04-453f-890c-b97d86ed4798
+      - d5d12df7-4249-467c-a24d-7c8b5057210c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"55785ae0-aebb-48cc-9748-abecb5f3c512": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "7cf24b5a-b220-4dcc-8d36-00f8d7a845ae":
+      {"passFailMetrics": {"0b234a2a-d9a4-40b8-99bc-ff67bfd34e5d": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "295e741b-d23f-4572-948f-acd2ed7ab568":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "7f8220b6-cd7e-459b-94ef-a87ff97c036a": {"aggregate": "avg", "clientMetric":
+      "50"}, "aa117dcc-46b9-47e9-8a59-c3cf452a4410": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"55785ae0-aebb-48cc-9748-abecb5f3c512":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7cf24b5a-b220-4dcc-8d36-00f8d7a845ae":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7f8220b6-cd7e-459b-94ef-a87ff97c036a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:26:26.181Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:26.181Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0b234a2a-d9a4-40b8-99bc-ff67bfd34e5d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"295e741b-d23f-4572-948f-acd2ed7ab568":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aa117dcc-46b9-47e9-8a59-c3cf452a4410":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:54.648Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:54.648Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:26 GMT
+      - Sun, 29 Oct 2023 22:18:54 GMT
       location:
-      - https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+      - https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 1691a1f9-da50-4c85-b5da-0dab86e5ec84
+      - e334230b-686e-49e2-8fbd-c41b1773ec2f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
+    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:26 GMT
+      - Sun, 29 Oct 2023 22:18:54 GMT
       mise-correlation-id:
-      - bc98aa99-94d6-4796-9abe-de9235cdfdd6
+      - f816399c-f3c9-407f-8951-be11317303a3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27d7e199-9b76-4eb3-a2ef-6ee5127c9ade/46314fda-25dd-474d-899d-dc7ebd42a641?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A28Z&sr=b&sp=r&sig=GKRiKovsZ4TuhsewJST19EIkTHjNc9G9I0YfVJbqccY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:28.0042363","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0884bd41-3fbb-43de-afa4-37fc52ef49f3/eace4165-6d7d-4aad-8889-f21e51d742ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A55Z&sr=b&sp=r&sig=63v8cr7mMKllGzHjK8rP683ChLV%2FYzMLh7RrAXI5x1E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:55.8007539","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:28 GMT
+      - Sun, 29 Oct 2023 22:18:55 GMT
       location:
-      - https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 02190259-8dac-47f8-ada0-7ff67893899b
+      - 4e5b6f2a-7679-4164-8f65-e5c37b7d1050
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,46 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27d7e199-9b76-4eb3-a2ef-6ee5127c9ade/46314fda-25dd-474d-899d-dc7ebd42a641?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A28Z&sr=b&sp=r&sig=YDTOgjlw4iFiDnYjoYk4uFU%2FiZZa0snB90XXrZg9Ow0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:28.2724494","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:26:28 GMT
-      mise-correlation-id:
-      - a09dd3bc-5283-422f-a3ac-fe8c1ee10c09
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27d7e199-9b76-4eb3-a2ef-6ee5127c9ade/46314fda-25dd-474d-899d-dc7ebd42a641?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A33Z&sr=b&sp=r&sig=DYP4f7STCQ96czi46tmg2B98OY4eiwN9sEZz9U4f2sM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:33.5267594","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0884bd41-3fbb-43de-afa4-37fc52ef49f3/eace4165-6d7d-4aad-8889-f21e51d742ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A56Z&sr=b&sp=r&sig=3BhyGku8A8O9g0m74b2OgaC37wf6lgw2kePGYykTSnU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:56.0443237","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:33 GMT
+      - Sun, 29 Oct 2023 22:18:56 GMT
       mise-correlation-id:
-      - 84b7933f-28cd-415e-bfad-17d9115ba078
+      - ac6bb70b-ef6f-4d70-9d91-40d59970d3f0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,10 +349,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27d7e199-9b76-4eb3-a2ef-6ee5127c9ade/46314fda-25dd-474d-899d-dc7ebd42a641?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A38Z&sr=b&sp=r&sig=p21qThOemVaJEUOSvLhgToy1O%2B9OoP81odJe9EmtPdg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:38.8055212","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0884bd41-3fbb-43de-afa4-37fc52ef49f3/eace4165-6d7d-4aad-8889-f21e51d742ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A01Z&sr=b&sp=r&sig=Va%2FRDLFLLqq6V6X1pVQ6UvRsE1QzLXPL4WaI7fo0Kco%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:01.284891","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '550'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:19:01 GMT
+      mise-correlation-id:
+      - eb0764f8-1465-49dd-8c86-ed7003bd5f00
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0884bd41-3fbb-43de-afa4-37fc52ef49f3/eace4165-6d7d-4aad-8889-f21e51d742ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A06Z&sr=b&sp=r&sig=pUdXGexv5mpmuwDpKo121qsSm4ZguJIvK%2BTYxqjJPqM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:06.5235796","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:38 GMT
+      - Sun, 29 Oct 2023 22:19:06 GMT
       mise-correlation-id:
-      - e544f545-0b85-4577-8c6e-8478c2acdb05
+      - 380b85a3-eebb-4cd0-8727-970e81891edf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27d7e199-9b76-4eb3-a2ef-6ee5127c9ade/46314fda-25dd-474d-899d-dc7ebd42a641?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A44Z&sr=b&sp=r&sig=h5xPSY5wcQwHZJie%2Bi%2Fz6%2Bj%2F3YMw5QKWCwwvJ7p3pN8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:44.1714458","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0884bd41-3fbb-43de-afa4-37fc52ef49f3/eace4165-6d7d-4aad-8889-f21e51d742ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A11Z&sr=b&sp=r&sig=tFtqYDy3wVaGZN%2Bhgo6M6DjCpUavDINMlQj%2BrYSEODQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:11.8247219","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:44 GMT
+      - Sun, 29 Oct 2023 22:19:11 GMT
       mise-correlation-id:
-      - 81768715-0ea2-463f-9ad6-58d3a83ffa57
+      - b552e871-c830-459a-b431-6828db4ff059
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"55785ae0-aebb-48cc-9748-abecb5f3c512":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7cf24b5a-b220-4dcc-8d36-00f8d7a845ae":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7f8220b6-cd7e-459b-94ef-a87ff97c036a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27d7e199-9b76-4eb3-a2ef-6ee5127c9ade/46314fda-25dd-474d-899d-dc7ebd42a641?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A26%3A44Z&sr=b&sp=r&sig=do4fshK87zYS6V5HBpYHhkjxOn8vgBm0ctU%2Bevx7cYQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:26:44.5920991","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:26:26.181Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:40.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0b234a2a-d9a4-40b8-99bc-ff67bfd34e5d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"295e741b-d23f-4572-948f-acd2ed7ab568":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aa117dcc-46b9-47e9-8a59-c3cf452a4410":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0884bd41-3fbb-43de-afa4-37fc52ef49f3/eace4165-6d7d-4aad-8889-f21e51d742ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A19%3A12Z&sr=b&sp=r&sig=bkqsS2J9szaxNDvyySh7WgLcSWMknAWbwR5t9PoZff8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:19:12.0560704","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:54.648Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:19:10.436Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1579'
+      - '1577'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:44 GMT
+      - Sun, 29 Oct 2023 22:19:12 GMT
       mise-correlation-id:
-      - 8bfae95b-358c-4666-8a04-09abe2a02e88
+      - e2f087ff-ca80-40bc-ae26-a6bfb9baf83a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:49.6383464Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:49.6383464Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:50.53428Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:50.53428Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '649'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:45 GMT
+      - Sun, 29 Oct 2023 22:19:13 GMT
       etag:
-      - '"d300b334-0000-0100-0000-6537b7cf0000"'
+      - '"3c001924-0000-0100-0000-653eda4b0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"55785ae0-aebb-48cc-9748-abecb5f3c512":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7cf24b5a-b220-4dcc-8d36-00f8d7a845ae":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7f8220b6-cd7e-459b-94ef-a87ff97c036a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27d7e199-9b76-4eb3-a2ef-6ee5127c9ade/46314fda-25dd-474d-899d-dc7ebd42a641?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A26%3A46Z&sr=b&sp=r&sig=56dQ6gVmyf5DzTiGU9BcmSzpd2pASjgZ0bZQiyD1WoY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:26:46.5245377","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:26:26.181Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:40.859Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0b234a2a-d9a4-40b8-99bc-ff67bfd34e5d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"295e741b-d23f-4572-948f-acd2ed7ab568":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aa117dcc-46b9-47e9-8a59-c3cf452a4410":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0884bd41-3fbb-43de-afa4-37fc52ef49f3/eace4165-6d7d-4aad-8889-f21e51d742ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A19%3A14Z&sr=b&sp=r&sig=xheLLgHO7nFvAmL27Wxh%2BqekM01Xcwf1uI39ogl6bmY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:19:14.0694456","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:54.648Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:19:10.436Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1589'
+      - '1591'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:46 GMT
+      - Sun, 29 Oct 2023 22:19:14 GMT
       mise-correlation-id:
-      - 46604299-d8ed-413b-adcd-506414125d2e
+      - efaa104a-896c-4d46-b87f-7e0d6f5bd9e7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:49.6383464Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:49.6383464Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:50.53428Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:50.53428Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '649'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:46 GMT
+      - Sun, 29 Oct 2023 22:19:15 GMT
       etag:
-      - '"d300b334-0000-0100-0000-6537b7cf0000"'
+      - '"3c001924-0000-0100-0000-653eda4b0000"'
       expires:
       - '-1'
       pragma:
@@ -621,7 +621,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -631,9 +631,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Tue, 24 Oct 2023 12:26:48 GMT
+      - Sun, 29 Oct 2023 22:19:16 GMT
       mise-correlation-id:
-      - 7598bb18-6a91-48d2-93ed-c52890f4fa68
+      - 588230ea-63df-4d9f-af80-07e9cca6a264
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -656,18 +656,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:49.6383464Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:49.6383464Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:50.53428Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:50.53428Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '649'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:48 GMT
+      - Sun, 29 Oct 2023 22:19:17 GMT
       etag:
-      - '"d300b334-0000-0100-0000-6537b7cf0000"'
+      - '"3c001924-0000-0100-0000-653eda4b0000"'
       expires:
       - '-1'
       pragma:
@@ -697,7 +697,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -711,9 +711,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:50 GMT
+      - Sun, 29 Oct 2023 22:19:18 GMT
       mise-correlation-id:
-      - cd73b2a5-f15c-485f-8be7-c298647eb512
+      - f71d88c4-1160-4c71-b4c1-7ae7fb4068b7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,18 +736,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:49.6383464Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:49.6383464Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:50.53428Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:50.53428Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '649'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:51 GMT
+      - Sun, 29 Oct 2023 22:19:18 GMT
       etag:
-      - '"d300b334-0000-0100-0000-6537b7cf0000"'
+      - '"3c001924-0000-0100-0000-653eda4b0000"'
       expires:
       - '-1'
       pragma:
@@ -777,7 +777,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -791,9 +791,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:52 GMT
+      - Sun, 29 Oct 2023 22:19:19 GMT
       mise-correlation-id:
-      - 01306594-da6d-4551-a1d2-a0bc1be48dd8
+      - fc15b9a5-1bd3-4ab8-bfd1-c1b0268dbc95
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_delete.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_delete.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:01.5901684Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:01.5901684Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:06.3808245Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:06.3808245Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:35 GMT
+      - Fri, 13 Oct 2023 13:49:40 GMT
       etag:
-      - '"5500e3c5-0000-0100-0000-652451730000"'
+      - '"d801c3b9-0000-0100-0000-65294ad40000"'
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:16:36 GMT
+      - Fri, 13 Oct 2023 13:49:42 GMT
       mise-correlation-id:
-      - 5df870e2-8ed1-4e57-9214-43a614bd9d92
+      - 00954213-da42-49ad-be13-057dcb40b4b1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"1a7c488e-befd-4f18-b689-5d882b14d409": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "5ae6c7b3-fdf1-47b4-88e4-4772cc963474":
+      {"passFailMetrics": {"d84f7ca9-3fc7-4972-be99-d2e2147de0b2": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "2a893c2f-e4db-426d-8e65-71403081a5d5":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "bb63857d-6f26-403d-b757-5a91257b8dd7": {"aggregate": "avg", "clientMetric":
+      "50"}, "fa59caec-ec98-4887-a9e6-72845eeca39e": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -104,13 +104,13 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1a7c488e-befd-4f18-b689-5d882b14d409":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"5ae6c7b3-fdf1-47b4-88e4-4772cc963474":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bb63857d-6f26-403d-b757-5a91257b8dd7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:16:37.442Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:37.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d84f7ca9-3fc7-4972-be99-d2e2147de0b2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2a893c2f-e4db-426d-8e65-71403081a5d5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fa59caec-ec98-4887-a9e6-72845eeca39e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:49:42.464Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:42.464Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:37 GMT
+      - Fri, 13 Oct 2023 13:49:42 GMT
       location:
-      - https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+      - https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 212c6ee0-40f5-45d1-9d72-da69792563b8
+      - 531cdee9-bc87-43f2-8d35-6d4be4abb106
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -143,9 +143,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
+    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:37 GMT
+      - Fri, 13 Oct 2023 13:49:42 GMT
       mise-correlation-id:
-      - f7f17a86-5bfe-407b-87ac-b146efc59c9b
+      - e84f9569-0bd6-4710-9bd3-11bf4f548a11
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -273,27 +273,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fe5d4f80-7095-43ab-8470-bd527a1eb14e/4cb4afcd-79e4-4574-bc68-ef23919cb1b9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A39Z&sr=b&sp=r&sig=3DA8EBd8fqP1I6rsmVvu2IuP8faVEpvaX2xpXuZGrDA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:39.1933065","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fca2e7db-380a-4663-b893-94258282a72a/30f66938-34a2-4e74-81ab-537b4892dda5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A43Z&sr=b&sp=r&sig=Dj1pTm7DzHQA%2F0jGsGeXglX7CkYfhNXvqB4EMQYpwi4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:43.9808247","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:39 GMT
+      - Fri, 13 Oct 2023 13:49:43 GMT
       location:
-      - https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 47e91044-c19d-4b81-a81f-c222068b4d95
+      - 2bc1391c-a583-4c64-bb11-e971c275818b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -311,12 +311,84 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fe5d4f80-7095-43ab-8470-bd527a1eb14e/4cb4afcd-79e4-4574-bc68-ef23919cb1b9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A39Z&sr=b&sp=r&sig=aAby04rcVe9%2FB%2BbFuAqsZVRE3SoNWeVj4UlFWOvqSKw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:39.5376267","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fca2e7db-380a-4663-b893-94258282a72a/30f66938-34a2-4e74-81ab-537b4892dda5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A44Z&sr=b&sp=r&sig=t5S6LNHXUVfP4E9CGQO2OYh9l9zpbkEzVn2oWinYU4A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:44.2198972","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:49:44 GMT
+      mise-correlation-id:
+      - 8752f724-39cc-45b6-b134-8c84a0915142
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fca2e7db-380a-4663-b893-94258282a72a/30f66938-34a2-4e74-81ab-537b4892dda5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A49Z&sr=b&sp=r&sig=vnlCf93X%2F2zizuFbnQjO5V8gqs%2FQLX7v%2FLyD6B4CwI4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:49.4838195","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '555'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:49:49 GMT
+      mise-correlation-id:
+      - f4c3e052-bc29-44ad-9f46-529358f29087
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fca2e7db-380a-4663-b893-94258282a72a/30f66938-34a2-4e74-81ab-537b4892dda5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A54Z&sr=b&sp=r&sig=gykymmnE3re%2BD5DhAflqeobmjt%2BnR7KlXtNy6lez63Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:54.7327544","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:39 GMT
+      - Fri, 13 Oct 2023 13:49:54 GMT
       mise-correlation-id:
-      - 80729403-6893-45db-81fc-e955261e2aea
+      - 284030a5-4ac2-476c-bb65-c7246a40b8e8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -347,25 +419,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fe5d4f80-7095-43ab-8470-bd527a1eb14e/4cb4afcd-79e4-4574-bc68-ef23919cb1b9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A44Z&sr=b&sp=r&sig=OsrK83FcchFykgXRBa4EqO7StUUU0aak6YPiFfDcd3s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:44.8489294","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fca2e7db-380a-4663-b893-94258282a72a/30f66938-34a2-4e74-81ab-537b4892dda5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A59Z&sr=b&sp=r&sig=fiA5U4Zo41QwbywqKFJ66BgJIXBdHDC6JovxX4RpGoM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:59.9677956","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:44 GMT
+      - Fri, 13 Oct 2023 13:49:59 GMT
       mise-correlation-id:
-      - dd149580-9961-4487-9d72-eba858f23d6d
+      - b54cb389-2214-45aa-a431-95bf05800f5f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -383,98 +455,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fe5d4f80-7095-43ab-8470-bd527a1eb14e/4cb4afcd-79e4-4574-bc68-ef23919cb1b9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A50Z&sr=b&sp=r&sig=neKljQqz1fQL2Yu6ljnawE5ulElZ80YLeHtOc1QsUhM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:50.2243061","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d84f7ca9-3fc7-4972-be99-d2e2147de0b2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2a893c2f-e4db-426d-8e65-71403081a5d5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fa59caec-ec98-4887-a9e6-72845eeca39e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fca2e7db-380a-4663-b893-94258282a72a/30f66938-34a2-4e74-81ab-537b4892dda5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A50%3A00Z&sr=b&sp=r&sig=H9fCSCOZFxWtx5iA3RuYihcPtYmVrPOkVDV4GoZPHvQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:50:00.2415294","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:49:42.464Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:56.687Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '1577'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:50 GMT
+      - Fri, 13 Oct 2023 13:50:00 GMT
       mise-correlation-id:
-      - 63282489-2dee-4abf-8b15-327e680e203c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fe5d4f80-7095-43ab-8470-bd527a1eb14e/4cb4afcd-79e4-4574-bc68-ef23919cb1b9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A55Z&sr=b&sp=r&sig=69t%2Bkg4ePLsDGltqE3BsRXdTTI%2BQxU2vClKFDs06Wpk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:55.4863566","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:16:55 GMT
-      mise-correlation-id:
-      - c2e78fa5-da22-46c4-a6b3-2b24d6bbdf10
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1a7c488e-befd-4f18-b689-5d882b14d409":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"5ae6c7b3-fdf1-47b4-88e4-4772cc963474":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bb63857d-6f26-403d-b757-5a91257b8dd7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fe5d4f80-7095-43ab-8470-bd527a1eb14e/4cb4afcd-79e4-4574-bc68-ef23919cb1b9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A16%3A55Z&sr=b&sp=r&sig=X%2FdlSwRSxGVq2Xei5kF9Jm3k5cGY6bxlfMfNNViZyS8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:16:55.8207404","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:16:37.442Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:52.412Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1579'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:16:55 GMT
-      mise-correlation-id:
-      - abdbc2b6-710c-47d6-a61a-80e1ff150fcf
+      - 23640d69-df96-4fbf-8ca1-e9b77b53f80d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:01.5901684Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:01.5901684Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:06.3808245Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:06.3808245Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:57 GMT
+      - Fri, 13 Oct 2023 13:50:01 GMT
       etag:
-      - '"5500e3c5-0000-0100-0000-652451730000"'
+      - '"d801c3b9-0000-0100-0000-65294ad40000"'
       expires:
       - '-1'
       pragma:
@@ -536,26 +536,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"1a7c488e-befd-4f18-b689-5d882b14d409":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"5ae6c7b3-fdf1-47b4-88e4-4772cc963474":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bb63857d-6f26-403d-b757-5a91257b8dd7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fe5d4f80-7095-43ab-8470-bd527a1eb14e/4cb4afcd-79e4-4574-bc68-ef23919cb1b9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A16%3A58Z&sr=b&sp=r&sig=OEIw8ozgv12xx2dWGdfjuB4qIFvg6kyeUsSiUWeo9u8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:16:58.3721749","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:16:37.442Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:52.412Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d84f7ca9-3fc7-4972-be99-d2e2147de0b2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2a893c2f-e4db-426d-8e65-71403081a5d5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fa59caec-ec98-4887-a9e6-72845eeca39e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fca2e7db-380a-4663-b893-94258282a72a/30f66938-34a2-4e74-81ab-537b4892dda5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A50%3A03Z&sr=b&sp=r&sig=JCAMtpd12fE%2B8B%2F2X5wB0FKOqMu%2Bd2ALPLdLVEBZodo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:50:03.0575527","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:49:42.464Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:56.687Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1589'
+      - '1595'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:58 GMT
+      - Fri, 13 Oct 2023 13:50:03 GMT
       mise-correlation-id:
-      - 20897d40-1428-485c-891c-83ac7c1cd98f
+      - 2ad32d1c-e50d-46c9-8bf4-677cf0dac250
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:01.5901684Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:01.5901684Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:06.3808245Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:06.3808245Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:59 GMT
+      - Fri, 13 Oct 2023 13:50:05 GMT
       etag:
-      - '"5500e3c5-0000-0100-0000-652451730000"'
+      - '"d801c3b9-0000-0100-0000-65294ad40000"'
       expires:
       - '-1'
       pragma:
@@ -619,9 +619,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -631,9 +631,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Mon, 09 Oct 2023 19:17:00 GMT
+      - Fri, 13 Oct 2023 13:50:06 GMT
       mise-correlation-id:
-      - d8b225e5-cfe0-4115-a38d-c0dd7542d68a
+      - 448c882c-a663-43b4-93e4-944689ebe59c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -656,7 +656,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:01.5901684Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:01.5901684Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:06.3808245Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:06.3808245Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -665,9 +665,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:01 GMT
+      - Fri, 13 Oct 2023 13:50:07 GMT
       etag:
-      - '"5500e3c5-0000-0100-0000-652451730000"'
+      - '"d801c3b9-0000-0100-0000-65294ad40000"'
       expires:
       - '-1'
       pragma:
@@ -695,9 +695,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -711,9 +711,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:03 GMT
+      - Fri, 13 Oct 2023 13:50:08 GMT
       mise-correlation-id:
-      - a842d48f-3ae4-403d-b56a-9388985ae928
+      - 4ebdaa33-68ff-463c-9513-9a854ce4def1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,7 +736,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:01.5901684Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:01.5901684Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:06.3808245Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:06.3808245Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -745,9 +745,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:05 GMT
+      - Fri, 13 Oct 2023 13:50:10 GMT
       etag:
-      - '"5500e3c5-0000-0100-0000-652451730000"'
+      - '"d801c3b9-0000-0100-0000-65294ad40000"'
       expires:
       - '-1'
       pragma:
@@ -775,9 +775,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -791,9 +791,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:06 GMT
+      - Fri, 13 Oct 2023 13:50:10 GMT
       mise-correlation-id:
-      - dbf46154-5122-4106-b61b-9b756ec173bd
+      - 1fbe1b84-4a52-4cba-bc75-2ea44ce42cf0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_delete.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_delete.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.7927682Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.7927682Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:49.6383464Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:49.6383464Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:49 GMT
+      - Tue, 24 Oct 2023 12:26:24 GMT
       etag:
-      - '"75004940-0000-0100-0000-653044cc0000"'
+      - '"d300b334-0000-0100-0000-6537b7cf0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:49:50 GMT
+      - Tue, 24 Oct 2023 12:26:25 GMT
       mise-correlation-id:
-      - 83b587a5-a7f8-4a70-a5b3-f0ff691e589e
+      - 8e6406e4-6a04-453f-890c-b97d86ed4798
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"ec258adb-3341-4934-9447-e21de4914f05": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "6a6ea97a-827e-4457-b82b-39cd1dc38100":
+      {"passFailMetrics": {"55785ae0-aebb-48cc-9748-abecb5f3c512": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "7cf24b5a-b220-4dcc-8d36-00f8d7a845ae":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "6f13408f-8ae0-4ed6-842d-f93fa81fcdee": {"aggregate": "avg", "clientMetric":
+      "50"}, "7f8220b6-cd7e-459b-94ef-a87ff97c036a": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ec258adb-3341-4934-9447-e21de4914f05":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6ea97a-827e-4457-b82b-39cd1dc38100":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6f13408f-8ae0-4ed6-842d-f93fa81fcdee":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:49:50.729Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:49:50.729Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"55785ae0-aebb-48cc-9748-abecb5f3c512":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7cf24b5a-b220-4dcc-8d36-00f8d7a845ae":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7f8220b6-cd7e-459b-94ef-a87ff97c036a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:26:26.181Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:26.181Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:50 GMT
+      - Tue, 24 Oct 2023 12:26:26 GMT
       location:
-      - https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+      - https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - b931a801-08a5-406f-9d47-62aa6de1c4e4
+      - 1691a1f9-da50-4c85-b5da-0dab86e5ec84
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
+    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:51 GMT
+      - Tue, 24 Oct 2023 12:26:26 GMT
       mise-correlation-id:
-      - 501fef63-879f-4065-9a2d-2ec7f30c8178
+      - bc98aa99-94d6-4796-9abe-de9235cdfdd6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7b92d8ea-6114-453c-952b-fc718b80b1b8/dbbdf90d-6fb1-4f8b-96bc-ace14e4a8f71?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A51Z&sr=b&sp=r&sig=ywySAWc9iRq9aGRL%2FeohAXnrT4iLEcWMumCvVIVXW3w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:51.5306612","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27d7e199-9b76-4eb3-a2ef-6ee5127c9ade/46314fda-25dd-474d-899d-dc7ebd42a641?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A28Z&sr=b&sp=r&sig=GKRiKovsZ4TuhsewJST19EIkTHjNc9G9I0YfVJbqccY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:28.0042363","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:51 GMT
+      - Tue, 24 Oct 2023 12:26:28 GMT
       location:
-      - https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - b5d460fe-79c7-40cd-a586-4a279ceb9236
+      - 02190259-8dac-47f8-ada0-7ff67893899b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7b92d8ea-6114-453c-952b-fc718b80b1b8/dbbdf90d-6fb1-4f8b-96bc-ace14e4a8f71?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A51Z&sr=b&sp=r&sig=znJi62%2BAUM04mlsA0uC0Z2SvX33NaHzQz%2FSWz1oXNOs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:51.8803461","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27d7e199-9b76-4eb3-a2ef-6ee5127c9ade/46314fda-25dd-474d-899d-dc7ebd42a641?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A28Z&sr=b&sp=r&sig=YDTOgjlw4iFiDnYjoYk4uFU%2FiZZa0snB90XXrZg9Ow0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:28.2724494","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:51 GMT
+      - Tue, 24 Oct 2023 12:26:28 GMT
       mise-correlation-id:
-      - 7ad4753e-426b-44b5-a556-2729be91d5d5
+      - a09dd3bc-5283-422f-a3ac-fe8c1ee10c09
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7b92d8ea-6114-453c-952b-fc718b80b1b8/dbbdf90d-6fb1-4f8b-96bc-ace14e4a8f71?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A57Z&sr=b&sp=r&sig=j%2Fbl%2BrGK0ZxJUMqeRMWgcRMKKK4KfkrqfhUI6OflHHk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:57.1948703","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27d7e199-9b76-4eb3-a2ef-6ee5127c9ade/46314fda-25dd-474d-899d-dc7ebd42a641?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A33Z&sr=b&sp=r&sig=DYP4f7STCQ96czi46tmg2B98OY4eiwN9sEZz9U4f2sM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:33.5267594","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:57 GMT
+      - Tue, 24 Oct 2023 12:26:33 GMT
       mise-correlation-id:
-      - 9bec951b-b985-4e4f-a53b-dc4ba3290f64
+      - 84b7933f-28cd-415e-bfad-17d9115ba078
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7b92d8ea-6114-453c-952b-fc718b80b1b8/dbbdf90d-6fb1-4f8b-96bc-ace14e4a8f71?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A02Z&sr=b&sp=r&sig=Se2%2BMURpQVdY1R%2FmeThfzpucLXG3ai%2BUpTM%2B6oM0gwQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:02.5240992","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27d7e199-9b76-4eb3-a2ef-6ee5127c9ade/46314fda-25dd-474d-899d-dc7ebd42a641?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A38Z&sr=b&sp=r&sig=p21qThOemVaJEUOSvLhgToy1O%2B9OoP81odJe9EmtPdg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:38.8055212","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '557'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:02 GMT
+      - Tue, 24 Oct 2023 12:26:38 GMT
       mise-correlation-id:
-      - e293f1d9-54b1-42bc-8d73-b93b71bb5a46
+      - e544f545-0b85-4577-8c6e-8478c2acdb05
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7b92d8ea-6114-453c-952b-fc718b80b1b8/dbbdf90d-6fb1-4f8b-96bc-ace14e4a8f71?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A07Z&sr=b&sp=r&sig=TZy5Vd%2B4kDVEWnOIxyRPJRK3wuWAaUUuG1PyqEtB%2BkQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:07.845896","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27d7e199-9b76-4eb3-a2ef-6ee5127c9ade/46314fda-25dd-474d-899d-dc7ebd42a641?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A44Z&sr=b&sp=r&sig=h5xPSY5wcQwHZJie%2Bi%2Fz6%2Bj%2F3YMw5QKWCwwvJ7p3pN8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:44.1714458","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:07 GMT
+      - Tue, 24 Oct 2023 12:26:44 GMT
       mise-correlation-id:
-      - 5313b183-3f41-41d2-b7a1-5444e6f64319
+      - 81768715-0ea2-463f-9ad6-58d3a83ffa57
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ec258adb-3341-4934-9447-e21de4914f05":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6ea97a-827e-4457-b82b-39cd1dc38100":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6f13408f-8ae0-4ed6-842d-f93fa81fcdee":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7b92d8ea-6114-453c-952b-fc718b80b1b8/dbbdf90d-6fb1-4f8b-96bc-ace14e4a8f71?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A50%3A08Z&sr=b&sp=r&sig=ztFv5%2FZetgC4sb%2BCncX12yoSIsV10fVjj9JB0j0QjU4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:50:08.0914728","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:49:50.729Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:04.017Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"55785ae0-aebb-48cc-9748-abecb5f3c512":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7cf24b5a-b220-4dcc-8d36-00f8d7a845ae":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7f8220b6-cd7e-459b-94ef-a87ff97c036a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27d7e199-9b76-4eb3-a2ef-6ee5127c9ade/46314fda-25dd-474d-899d-dc7ebd42a641?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A26%3A44Z&sr=b&sp=r&sig=do4fshK87zYS6V5HBpYHhkjxOn8vgBm0ctU%2Bevx7cYQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:26:44.5920991","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:26:26.181Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:40.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1581'
+      - '1579'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:08 GMT
+      - Tue, 24 Oct 2023 12:26:44 GMT
       mise-correlation-id:
-      - 8d09bf25-8157-4ba3-8ed9-2060cef43c93
+      - 8bfae95b-358c-4666-8a04-09abe2a02e88
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.7927682Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.7927682Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:49.6383464Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:49.6383464Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:09 GMT
+      - Tue, 24 Oct 2023 12:26:45 GMT
       etag:
-      - '"75004940-0000-0100-0000-653044cc0000"'
+      - '"d300b334-0000-0100-0000-6537b7cf0000"'
       expires:
       - '-1'
       pragma:
@@ -538,11 +538,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ec258adb-3341-4934-9447-e21de4914f05":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6ea97a-827e-4457-b82b-39cd1dc38100":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6f13408f-8ae0-4ed6-842d-f93fa81fcdee":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7b92d8ea-6114-453c-952b-fc718b80b1b8/dbbdf90d-6fb1-4f8b-96bc-ace14e4a8f71?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A50%3A10Z&sr=b&sp=r&sig=iRS6EuWk007OTkhKLKqbIwREtS0lfBLqpUorjAUU5wA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:50:10.2795294","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:49:50.729Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:04.017Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"55785ae0-aebb-48cc-9748-abecb5f3c512":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7cf24b5a-b220-4dcc-8d36-00f8d7a845ae":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7f8220b6-cd7e-459b-94ef-a87ff97c036a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27d7e199-9b76-4eb3-a2ef-6ee5127c9ade/46314fda-25dd-474d-899d-dc7ebd42a641?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A26%3A46Z&sr=b&sp=r&sig=56dQ6gVmyf5DzTiGU9BcmSzpd2pASjgZ0bZQiyD1WoY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:26:46.5245377","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:26:26.181Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:40.859Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:10 GMT
+      - Tue, 24 Oct 2023 12:26:46 GMT
       mise-correlation-id:
-      - ecfcfc9f-8ff8-41a1-9f25-ab8cd2fcc4ca
+      - 46604299-d8ed-413b-adcd-506414125d2e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.7927682Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.7927682Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:49.6383464Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:49.6383464Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:11 GMT
+      - Tue, 24 Oct 2023 12:26:46 GMT
       etag:
-      - '"75004940-0000-0100-0000-653044cc0000"'
+      - '"d300b334-0000-0100-0000-6537b7cf0000"'
       expires:
       - '-1'
       pragma:
@@ -621,7 +621,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -631,9 +631,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Wed, 18 Oct 2023 20:50:12 GMT
+      - Tue, 24 Oct 2023 12:26:48 GMT
       mise-correlation-id:
-      - c0119e08-f719-4fae-920e-dde2773b5390
+      - 7598bb18-6a91-48d2-93ed-c52890f4fa68
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -656,7 +656,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.7927682Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.7927682Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:49.6383464Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:49.6383464Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -665,9 +665,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:13 GMT
+      - Tue, 24 Oct 2023 12:26:48 GMT
       etag:
-      - '"75004940-0000-0100-0000-653044cc0000"'
+      - '"d300b334-0000-0100-0000-6537b7cf0000"'
       expires:
       - '-1'
       pragma:
@@ -697,7 +697,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -711,9 +711,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:14 GMT
+      - Tue, 24 Oct 2023 12:26:50 GMT
       mise-correlation-id:
-      - 44249d90-aa42-4595-8b1a-76b8edee030b
+      - cd73b2a5-f15c-485f-8be7-c298647eb512
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,7 +736,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.7927682Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.7927682Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:49.6383464Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:49.6383464Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -745,9 +745,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:15 GMT
+      - Tue, 24 Oct 2023 12:26:51 GMT
       etag:
-      - '"75004940-0000-0100-0000-653044cc0000"'
+      - '"d300b334-0000-0100-0000-6537b7cf0000"'
       expires:
       - '-1'
       pragma:
@@ -777,7 +777,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://21c0b870-b729-4402-b29b-b491bb00f6f9.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -791,9 +791,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:17 GMT
+      - Tue, 24 Oct 2023 12:26:52 GMT
       mise-correlation-id:
-      - db63fdfb-54ec-4ff2-abad-9f1a40208835
+      - 01306594-da6d-4551-a1d2-a0bc1be48dd8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_delete.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_delete.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:06.3808245Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:06.3808245Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.7927682Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.7927682Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:40 GMT
+      - Wed, 18 Oct 2023 20:49:49 GMT
       etag:
-      - '"d801c3b9-0000-0100-0000-65294ad40000"'
+      - '"75004940-0000-0100-0000-653044cc0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:49:42 GMT
+      - Wed, 18 Oct 2023 20:49:50 GMT
       mise-correlation-id:
-      - 00954213-da42-49ad-be13-057dcb40b4b1
+      - 83b587a5-a7f8-4a70-a5b3-f0ff691e589e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"d84f7ca9-3fc7-4972-be99-d2e2147de0b2": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "2a893c2f-e4db-426d-8e65-71403081a5d5":
+      {"passFailMetrics": {"ec258adb-3341-4934-9447-e21de4914f05": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "6a6ea97a-827e-4457-b82b-39cd1dc38100":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "fa59caec-ec98-4887-a9e6-72845eeca39e": {"aggregate": "avg", "clientMetric":
+      "50"}, "6f13408f-8ae0-4ed6-842d-f93fa81fcdee": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d84f7ca9-3fc7-4972-be99-d2e2147de0b2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2a893c2f-e4db-426d-8e65-71403081a5d5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fa59caec-ec98-4887-a9e6-72845eeca39e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:49:42.464Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:42.464Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ec258adb-3341-4934-9447-e21de4914f05":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6ea97a-827e-4457-b82b-39cd1dc38100":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6f13408f-8ae0-4ed6-842d-f93fa81fcdee":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:49:50.729Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:49:50.729Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:42 GMT
+      - Wed, 18 Oct 2023 20:49:50 GMT
       location:
-      - https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+      - https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 531cdee9-bc87-43f2-8d35-6d4be4abb106
+      - b931a801-08a5-406f-9d47-62aa6de1c4e4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
+    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:42 GMT
+      - Wed, 18 Oct 2023 20:49:51 GMT
       mise-correlation-id:
-      - e84f9569-0bd6-4710-9bd3-11bf4f548a11
+      - 501fef63-879f-4065-9a2d-2ec7f30c8178
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,10 +275,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fca2e7db-380a-4663-b893-94258282a72a/30f66938-34a2-4e74-81ab-537b4892dda5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A43Z&sr=b&sp=r&sig=Dj1pTm7DzHQA%2F0jGsGeXglX7CkYfhNXvqB4EMQYpwi4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:43.9808247","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7b92d8ea-6114-453c-952b-fc718b80b1b8/dbbdf90d-6fb1-4f8b-96bc-ace14e4a8f71?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A51Z&sr=b&sp=r&sig=ywySAWc9iRq9aGRL%2FeohAXnrT4iLEcWMumCvVIVXW3w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:51.5306612","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -289,11 +289,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:43 GMT
+      - Wed, 18 Oct 2023 20:49:51 GMT
       location:
-      - https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 2bc1391c-a583-4c64-bb11-e971c275818b
+      - b5d460fe-79c7-40cd-a586-4a279ceb9236
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fca2e7db-380a-4663-b893-94258282a72a/30f66938-34a2-4e74-81ab-537b4892dda5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A44Z&sr=b&sp=r&sig=t5S6LNHXUVfP4E9CGQO2OYh9l9zpbkEzVn2oWinYU4A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:44.2198972","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:49:44 GMT
-      mise-correlation-id:
-      - 8752f724-39cc-45b6-b134-8c84a0915142
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fca2e7db-380a-4663-b893-94258282a72a/30f66938-34a2-4e74-81ab-537b4892dda5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A49Z&sr=b&sp=r&sig=vnlCf93X%2F2zizuFbnQjO5V8gqs%2FQLX7v%2FLyD6B4CwI4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:49.4838195","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:49:49 GMT
-      mise-correlation-id:
-      - f4c3e052-bc29-44ad-9f46-529358f29087
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fca2e7db-380a-4663-b893-94258282a72a/30f66938-34a2-4e74-81ab-537b4892dda5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A54Z&sr=b&sp=r&sig=gykymmnE3re%2BD5DhAflqeobmjt%2BnR7KlXtNy6lez63Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:54.7327544","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7b92d8ea-6114-453c-952b-fc718b80b1b8/dbbdf90d-6fb1-4f8b-96bc-ace14e4a8f71?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A51Z&sr=b&sp=r&sig=znJi62%2BAUM04mlsA0uC0Z2SvX33NaHzQz%2FSWz1oXNOs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:51.8803461","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:54 GMT
+      - Wed, 18 Oct 2023 20:49:51 GMT
       mise-correlation-id:
-      - 284030a5-4ac2-476c-bb65-c7246a40b8e8
+      - 7ad4753e-426b-44b5-a556-2729be91d5d5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fca2e7db-380a-4663-b893-94258282a72a/30f66938-34a2-4e74-81ab-537b4892dda5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A59Z&sr=b&sp=r&sig=fiA5U4Zo41QwbywqKFJ66BgJIXBdHDC6JovxX4RpGoM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:59.9677956","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7b92d8ea-6114-453c-952b-fc718b80b1b8/dbbdf90d-6fb1-4f8b-96bc-ace14e4a8f71?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A57Z&sr=b&sp=r&sig=j%2Fbl%2BrGK0ZxJUMqeRMWgcRMKKK4KfkrqfhUI6OflHHk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:57.1948703","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:59 GMT
+      - Wed, 18 Oct 2023 20:49:57 GMT
       mise-correlation-id:
-      - b54cb389-2214-45aa-a431-95bf05800f5f
+      - 9bec951b-b985-4e4f-a53b-dc4ba3290f64
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +385,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d84f7ca9-3fc7-4972-be99-d2e2147de0b2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2a893c2f-e4db-426d-8e65-71403081a5d5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fa59caec-ec98-4887-a9e6-72845eeca39e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fca2e7db-380a-4663-b893-94258282a72a/30f66938-34a2-4e74-81ab-537b4892dda5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A50%3A00Z&sr=b&sp=r&sig=H9fCSCOZFxWtx5iA3RuYihcPtYmVrPOkVDV4GoZPHvQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:50:00.2415294","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:49:42.464Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:56.687Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7b92d8ea-6114-453c-952b-fc718b80b1b8/dbbdf90d-6fb1-4f8b-96bc-ace14e4a8f71?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A02Z&sr=b&sp=r&sig=Se2%2BMURpQVdY1R%2FmeThfzpucLXG3ai%2BUpTM%2B6oM0gwQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:02.5240992","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1577'
+      - '557'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:00 GMT
+      - Wed, 18 Oct 2023 20:50:02 GMT
       mise-correlation-id:
-      - 23640d69-df96-4fbf-8ca1-e9b77b53f80d
+      - e293f1d9-54b1-42bc-8d73-b93b71bb5a46
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7b92d8ea-6114-453c-952b-fc718b80b1b8/dbbdf90d-6fb1-4f8b-96bc-ace14e4a8f71?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A07Z&sr=b&sp=r&sig=TZy5Vd%2B4kDVEWnOIxyRPJRK3wuWAaUUuG1PyqEtB%2BkQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:07.845896","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '550'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:50:07 GMT
+      mise-correlation-id:
+      - 5313b183-3f41-41d2-b7a1-5444e6f64319
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ec258adb-3341-4934-9447-e21de4914f05":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6ea97a-827e-4457-b82b-39cd1dc38100":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6f13408f-8ae0-4ed6-842d-f93fa81fcdee":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7b92d8ea-6114-453c-952b-fc718b80b1b8/dbbdf90d-6fb1-4f8b-96bc-ace14e4a8f71?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A50%3A08Z&sr=b&sp=r&sig=ztFv5%2FZetgC4sb%2BCncX12yoSIsV10fVjj9JB0j0QjU4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:50:08.0914728","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:49:50.729Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:04.017Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1581'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:50:08 GMT
+      mise-correlation-id:
+      - 8d09bf25-8157-4ba3-8ed9-2060cef43c93
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:06.3808245Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:06.3808245Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.7927682Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.7927682Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:01 GMT
+      - Wed, 18 Oct 2023 20:50:09 GMT
       etag:
-      - '"d801c3b9-0000-0100-0000-65294ad40000"'
+      - '"75004940-0000-0100-0000-653044cc0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d84f7ca9-3fc7-4972-be99-d2e2147de0b2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2a893c2f-e4db-426d-8e65-71403081a5d5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fa59caec-ec98-4887-a9e6-72845eeca39e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fca2e7db-380a-4663-b893-94258282a72a/30f66938-34a2-4e74-81ab-537b4892dda5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A50%3A03Z&sr=b&sp=r&sig=JCAMtpd12fE%2B8B%2F2X5wB0FKOqMu%2Bd2ALPLdLVEBZodo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:50:03.0575527","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:49:42.464Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:56.687Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ec258adb-3341-4934-9447-e21de4914f05":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6ea97a-827e-4457-b82b-39cd1dc38100":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6f13408f-8ae0-4ed6-842d-f93fa81fcdee":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7b92d8ea-6114-453c-952b-fc718b80b1b8/dbbdf90d-6fb1-4f8b-96bc-ace14e4a8f71?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A50%3A10Z&sr=b&sp=r&sig=iRS6EuWk007OTkhKLKqbIwREtS0lfBLqpUorjAUU5wA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:50:10.2795294","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:49:50.729Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:04.017Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1595'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:03 GMT
+      - Wed, 18 Oct 2023 20:50:10 GMT
       mise-correlation-id:
-      - 2ad32d1c-e50d-46c9-8bf4-677cf0dac250
+      - ecfcfc9f-8ff8-41a1-9f25-ab8cd2fcc4ca
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:06.3808245Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:06.3808245Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.7927682Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.7927682Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:05 GMT
+      - Wed, 18 Oct 2023 20:50:11 GMT
       etag:
-      - '"d801c3b9-0000-0100-0000-65294ad40000"'
+      - '"75004940-0000-0100-0000-653044cc0000"'
       expires:
       - '-1'
       pragma:
@@ -621,7 +621,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -631,9 +631,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Fri, 13 Oct 2023 13:50:06 GMT
+      - Wed, 18 Oct 2023 20:50:12 GMT
       mise-correlation-id:
-      - 448c882c-a663-43b4-93e4-944689ebe59c
+      - c0119e08-f719-4fae-920e-dde2773b5390
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -656,7 +656,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:06.3808245Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:06.3808245Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.7927682Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.7927682Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -665,9 +665,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:07 GMT
+      - Wed, 18 Oct 2023 20:50:13 GMT
       etag:
-      - '"d801c3b9-0000-0100-0000-65294ad40000"'
+      - '"75004940-0000-0100-0000-653044cc0000"'
       expires:
       - '-1'
       pragma:
@@ -697,7 +697,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -711,9 +711,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:08 GMT
+      - Wed, 18 Oct 2023 20:50:14 GMT
       mise-correlation-id:
-      - 4ebdaa33-68ff-463c-9513-9a854ce4def1
+      - 44249d90-aa42-4595-8b1a-76b8edee030b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,7 +736,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:06.3808245Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:06.3808245Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.7927682Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.7927682Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -745,9 +745,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:10 GMT
+      - Wed, 18 Oct 2023 20:50:15 GMT
       etag:
-      - '"d801c3b9-0000-0100-0000-65294ad40000"'
+      - '"75004940-0000-0100-0000-653044cc0000"'
       expires:
       - '-1'
       pragma:
@@ -777,7 +777,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c387e57f-6905-4161-8719-63433b117f8b.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://c1670cfe-899c-4f00-9dba-4347e4644489.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -791,9 +791,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:10 GMT
+      - Wed, 18 Oct 2023 20:50:17 GMT
       mise-correlation-id:
-      - 1fbe1b84-4a52-4cba-bc75-2ea44ce42cf0
+      - db63fdfb-54ec-4ff2-abad-9f1a40208835
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_delete.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_delete.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:09:32.5097692Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:09:32.5097692Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:36.5226838Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:36.5226838Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:08 GMT
+      - Mon, 09 Oct 2023 16:10:09 GMT
       etag:
-      - '"1a0a73a3-0000-0100-0000-64af087e0000"'
+      - '"92017292-0000-0100-0000-652425c20000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:10:09 GMT
+      - Mon, 09 Oct 2023 16:10:11 GMT
       mise-correlation-id:
-      - 01f0d1aa-2c1e-4638-8e10-2c15773e7295
+      - 8458aad3-ded9-4f91-ae13-6eb9ae41c7a4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -85,12 +85,12 @@ interactions:
 - request:
     body: '{"displayName": "CLI-Test", "description": "Test created from az load test
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
-      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "loadTestConfiguration":
+      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"2187f900-7619-46e4-a963-7dfe341ee1b3": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "582d82ad-423c-4979-a35c-224a729e25a0":
+      {"passFailMetrics": {"fd7025ef-0ed2-4109-9639-28422e4b510d": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "32117491-ad00-4e6f-bd94-85172f8a8de2":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "eb8227b8-9df9-4c89-b566-62e1fe2609d9": {"aggregate": "avg", "clientMetric":
+      "50"}, "82549f1a-575e-437e-8b9c-762afa2ccf8b": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -100,32 +100,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '768'
+      - '789'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2187f900-7619-46e4-a963-7dfe341ee1b3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"582d82ad-423c-4979-a35c-224a729e25a0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"eb8227b8-9df9-4c89-b566-62e1fe2609d9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:10:10.458Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:10:10.458Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"fd7025ef-0ed2-4109-9639-28422e4b510d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"32117491-ad00-4e6f-bd94-85172f8a8de2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"82549f1a-575e-437e-8b9c-762afa2ccf8b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:10:11.816Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:11.816Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1062'
+      - '1008'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:10 GMT
+      - Mon, 09 Oct 2023 16:10:11 GMT
       location:
-      - https://534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+      - https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 912cf478-f393-4750-8b6c-d8be82e594c1
+      - 1fdf3c5a-9dd4-41f1-9bde-b741c5748336
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
+    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:10 GMT
+      - Mon, 09 Oct 2023 16:10:12 GMT
       mise-correlation-id:
-      - 8cb538ad-4ca8-48de-9835-9ce217f67b0a
+      - 40661ba5-ac1d-4055-b762-0df27ad2da00
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41ed9dda-0a2b-4cad-9138-e19eed98d469/2705d3bc-2b8b-40a1-86fd-b66c7f7ce352?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A20%3A11Z&sr=b&sp=r&sig=u%2FHZSzu8izOvOhjOcqCeMTljsNhfkdEJbIYWXhvl4cU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:20:11.2482919","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/94f0c583-b512-44aa-bfdf-3d9865b2d4b5/571f1380-0d0c-474e-ac62-363e35af0079?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A13Z&sr=b&sp=r&sig=tMef%2FnELlE0gGOyvPH0byVrN%2Fvqh%2B1yUutuwozvfDQI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:13.4179191","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:11 GMT
+      - Mon, 09 Oct 2023 16:10:13 GMT
       location:
-      - https://534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - c4fa2755-0879-468e-b026-26afd8a69752
+      - c0709fa4-c3b0-4a5e-98aa-cbaf1a23c172
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,46 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41ed9dda-0a2b-4cad-9138-e19eed98d469/2705d3bc-2b8b-40a1-86fd-b66c7f7ce352?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A20%3A11Z&sr=b&sp=r&sig=5Y%2F0vehp1oWyn%2BvsY9AGIJ5dDtvBmvNVmp3bzScC5k8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:20:11.6221653","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:10:11 GMT
-      mise-correlation-id:
-      - 4664be4f-88cc-4e50-b288-353e335143a2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41ed9dda-0a2b-4cad-9138-e19eed98d469/2705d3bc-2b8b-40a1-86fd-b66c7f7ce352?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A20%3A16Z&sr=b&sp=r&sig=PsQ1w7lCw8hj9Mchqh%2FsFBTTApmLYsC2YCRHYxawxN8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:20:16.8953332","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/94f0c583-b512-44aa-bfdf-3d9865b2d4b5/571f1380-0d0c-474e-ac62-363e35af0079?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A13Z&sr=b&sp=r&sig=zvp69kgdRSoUvAvxL4uIBuZGm7rhIsj%2F5WFBLArtdys%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:13.6749509","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:16 GMT
+      - Mon, 09 Oct 2023 16:10:13 GMT
       mise-correlation-id:
-      - c22d4ba4-0821-4804-8ba7-7669c68c7d84
+      - cba4c52c-2f53-4368-ae5c-a9271f6db86f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,82 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41ed9dda-0a2b-4cad-9138-e19eed98d469/2705d3bc-2b8b-40a1-86fd-b66c7f7ce352?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A20%3A22Z&sr=b&sp=r&sig=eu%2FrxhAAd%2BF9CxxRckWZFlcXtJ6RoW0HqUWp12UhF8E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:20:22.1820389","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:10:22 GMT
-      mise-correlation-id:
-      - f4b5d435-ff51-4a7c-bbe0-5fc7203425ef
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41ed9dda-0a2b-4cad-9138-e19eed98d469/2705d3bc-2b8b-40a1-86fd-b66c7f7ce352?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A20%3A27Z&sr=b&sp=r&sig=19y6qh52SQedDLv3vTfXFfFUxrtu%2Fe%2F1U7TeJJMEJUI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:20:27.5040436","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:10:27 GMT
-      mise-correlation-id:
-      - bc33323c-0d4f-4a4f-9cce-d8f05b41b73a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41ed9dda-0a2b-4cad-9138-e19eed98d469/2705d3bc-2b8b-40a1-86fd-b66c7f7ce352?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A20%3A32Z&sr=b&sp=r&sig=UF57Drh6KVdqS2zTy1MdRxQqh42IjKMGXq%2Bm1Z9mhQk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:20:32.8338329","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/94f0c583-b512-44aa-bfdf-3d9865b2d4b5/571f1380-0d0c-474e-ac62-363e35af0079?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A18Z&sr=b&sp=r&sig=qEUJCiM5M8aAb9T8IrlWQrD2xDP5puuO6NhO3sfw1IA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:18.9428116","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -471,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:32 GMT
+      - Mon, 09 Oct 2023 16:10:18 GMT
       mise-correlation-id:
-      - 847fe170-e7c8-44b7-8e8c-346ae0f88d5d
+      - 4b9e2213-1240-41c2-a87b-c87efcdd86ba
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -493,24 +385,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2187f900-7619-46e4-a963-7dfe341ee1b3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"582d82ad-423c-4979-a35c-224a729e25a0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"eb8227b8-9df9-4c89-b566-62e1fe2609d9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41ed9dda-0a2b-4cad-9138-e19eed98d469/2705d3bc-2b8b-40a1-86fd-b66c7f7ce352?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A10%3A33Z&sr=b&sp=r&sig=Z0e%2FOgNt3hiXOaR00cuKFi8ce6e%2BTsJumrwU0v4DnPk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:10:33.1416982","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:10:10.458Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:10:27.763Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/94f0c583-b512-44aa-bfdf-3d9865b2d4b5/571f1380-0d0c-474e-ac62-363e35af0079?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A24Z&sr=b&sp=r&sig=Ou3Yc9GaTaajIaVz9K1q6zzLLxuw15qDFgp%2FtVWvogY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:24.2249928","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1635'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:33 GMT
+      - Mon, 09 Oct 2023 16:10:24 GMT
       mise-correlation-id:
-      - 504daea5-6b88-47d2-a7cd-498303879bd3
+      - f8f51dbf-8634-466c-a95e-66885d649cb6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/94f0c583-b512-44aa-bfdf-3d9865b2d4b5/571f1380-0d0c-474e-ac62-363e35af0079?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A29Z&sr=b&sp=r&sig=PGNMHNp%2B47ZrA9q39fY%2FpJx%2FSvB70wIgLqbpCJhaAx0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:29.5599532","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:10:29 GMT
+      mise-correlation-id:
+      - 44cc6902-e5ab-4896-9056-aae31cfb6232
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"fd7025ef-0ed2-4109-9639-28422e4b510d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"32117491-ad00-4e6f-bd94-85172f8a8de2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"82549f1a-575e-437e-8b9c-762afa2ccf8b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/94f0c583-b512-44aa-bfdf-3d9865b2d4b5/571f1380-0d0c-474e-ac62-363e35af0079?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A10%3A29Z&sr=b&sp=r&sig=ILdG5%2BB%2F8ftt5bBJSoPBEKCRFLdzEAMaQc26JJhUFTc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:10:29.8627112","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:10:11.816Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:27.129Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1581'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:10:29 GMT
+      mise-correlation-id:
+      - 7333ed4a-7072-4837-8e66-e5546377901f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -533,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:09:32.5097692Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:09:32.5097692Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:36.5226838Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:36.5226838Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -542,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:34 GMT
+      - Mon, 09 Oct 2023 16:10:30 GMT
       etag:
-      - '"1a0a73a3-0000-0100-0000-64af087e0000"'
+      - '"92017292-0000-0100-0000-652425c20000"'
       expires:
       - '-1'
       pragma:
@@ -574,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"2187f900-7619-46e4-a963-7dfe341ee1b3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"582d82ad-423c-4979-a35c-224a729e25a0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"eb8227b8-9df9-4c89-b566-62e1fe2609d9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41ed9dda-0a2b-4cad-9138-e19eed98d469/2705d3bc-2b8b-40a1-86fd-b66c7f7ce352?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A10%3A35Z&sr=b&sp=r&sig=VGfJrYp9I%2Bg%2FdfPRuYw67wZhkgacdqziL5dnzuylteI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:10:35.6741985","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:10:10.458Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:10:27.763Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"fd7025ef-0ed2-4109-9639-28422e4b510d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"32117491-ad00-4e6f-bd94-85172f8a8de2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"82549f1a-575e-437e-8b9c-762afa2ccf8b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/94f0c583-b512-44aa-bfdf-3d9865b2d4b5/571f1380-0d0c-474e-ac62-363e35af0079?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A10%3A32Z&sr=b&sp=r&sig=EZ745E4CrL4NVX%2B4F%2Bzbi4RUVVPNJRF1dVf38g8a96g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:10:32.9000286","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:10:11.816Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:27.129Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1647'
+      - '1593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:35 GMT
+      - Mon, 09 Oct 2023 16:10:32 GMT
       mise-correlation-id:
-      - 8e7b396b-d66b-498d-8cc6-819f42afce44
+      - fd6ebb67-6bee-4861-98aa-d8d081be41a1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -614,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:09:32.5097692Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:09:32.5097692Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:36.5226838Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:36.5226838Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -623,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:36 GMT
+      - Mon, 09 Oct 2023 16:10:33 GMT
       etag:
-      - '"1a0a73a3-0000-0100-0000-64af087e0000"'
+      - '"92017292-0000-0100-0000-652425c20000"'
       expires:
       - '-1'
       pragma:
@@ -657,7 +621,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -667,9 +631,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Wed, 12 Jul 2023 20:10:39 GMT
+      - Mon, 09 Oct 2023 16:10:35 GMT
       mise-correlation-id:
-      - bc4ee1ad-235b-4b55-952c-9b0f46ac6e10
+      - 91b3dbb0-cb8b-4b87-b8d0-7beb9b3851e8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -692,7 +656,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:09:32.5097692Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:09:32.5097692Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:36.5226838Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:36.5226838Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -701,9 +665,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:39 GMT
+      - Mon, 09 Oct 2023 16:10:36 GMT
       etag:
-      - '"1a0a73a3-0000-0100-0000-64af087e0000"'
+      - '"92017292-0000-0100-0000-652425c20000"'
       expires:
       - '-1'
       pragma:
@@ -733,7 +697,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -747,9 +711,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:41 GMT
+      - Mon, 09 Oct 2023 16:10:37 GMT
       mise-correlation-id:
-      - e9fcc777-c348-47eb-9f7c-d051c39f3e4c
+      - 19c4efd7-9867-4e98-afd3-3aa24338352d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,7 +736,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:09:32.5097692Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:09:32.5097692Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:36.5226838Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:36.5226838Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -781,9 +745,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:42 GMT
+      - Mon, 09 Oct 2023 16:10:38 GMT
       etag:
-      - '"1a0a73a3-0000-0100-0000-64af087e0000"'
+      - '"92017292-0000-0100-0000-652425c20000"'
       expires:
       - '-1'
       pragma:
@@ -813,7 +777,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://534361f4-b3a4-4460-a543-148bc9ed596a.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -827,9 +791,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:44 GMT
+      - Mon, 09 Oct 2023 16:10:39 GMT
       mise-correlation-id:
-      - e9138b34-f080-47ec-9d3c-9a6512f695dd
+      - cf311c5b-0540-4002-8633-abb88c813e63
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_delete.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_delete.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:36.5226838Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:36.5226838Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:01.5901684Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:01.5901684Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:09 GMT
+      - Mon, 09 Oct 2023 19:16:35 GMT
       etag:
-      - '"92017292-0000-0100-0000-652425c20000"'
+      - '"5500e3c5-0000-0100-0000-652451730000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:10:11 GMT
+      - Mon, 09 Oct 2023 19:16:36 GMT
       mise-correlation-id:
-      - 8458aad3-ded9-4f91-ae13-6eb9ae41c7a4
+      - 5df870e2-8ed1-4e57-9214-43a614bd9d92
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"fd7025ef-0ed2-4109-9639-28422e4b510d": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "32117491-ad00-4e6f-bd94-85172f8a8de2":
+      {"passFailMetrics": {"1a7c488e-befd-4f18-b689-5d882b14d409": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "5ae6c7b3-fdf1-47b4-88e4-4772cc963474":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "82549f1a-575e-437e-8b9c-762afa2ccf8b": {"aggregate": "avg", "clientMetric":
+      "50"}, "bb63857d-6f26-403d-b757-5a91257b8dd7": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fd7025ef-0ed2-4109-9639-28422e4b510d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"32117491-ad00-4e6f-bd94-85172f8a8de2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"82549f1a-575e-437e-8b9c-762afa2ccf8b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:10:11.816Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:11.816Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1a7c488e-befd-4f18-b689-5d882b14d409":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"5ae6c7b3-fdf1-47b4-88e4-4772cc963474":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bb63857d-6f26-403d-b757-5a91257b8dd7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:16:37.442Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:37.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:11 GMT
+      - Mon, 09 Oct 2023 19:16:37 GMT
       location:
-      - https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+      - https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 1fdf3c5a-9dd4-41f1-9bde-b741c5748336
+      - 212c6ee0-40f5-45d1-9d72-da69792563b8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
+    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:12 GMT
+      - Mon, 09 Oct 2023 19:16:37 GMT
       mise-correlation-id:
-      - 40661ba5-ac1d-4055-b762-0df27ad2da00
+      - f7f17a86-5bfe-407b-87ac-b146efc59c9b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/94f0c583-b512-44aa-bfdf-3d9865b2d4b5/571f1380-0d0c-474e-ac62-363e35af0079?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A13Z&sr=b&sp=r&sig=tMef%2FnELlE0gGOyvPH0byVrN%2Fvqh%2B1yUutuwozvfDQI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:13.4179191","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fe5d4f80-7095-43ab-8470-bd527a1eb14e/4cb4afcd-79e4-4574-bc68-ef23919cb1b9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A39Z&sr=b&sp=r&sig=3DA8EBd8fqP1I6rsmVvu2IuP8faVEpvaX2xpXuZGrDA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:39.1933065","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:13 GMT
+      - Mon, 09 Oct 2023 19:16:39 GMT
       location:
-      - https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - c0709fa4-c3b0-4a5e-98aa-cbaf1a23c172
+      - 47e91044-c19d-4b81-a81f-c222068b4d95
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,118 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/94f0c583-b512-44aa-bfdf-3d9865b2d4b5/571f1380-0d0c-474e-ac62-363e35af0079?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A13Z&sr=b&sp=r&sig=zvp69kgdRSoUvAvxL4uIBuZGm7rhIsj%2F5WFBLArtdys%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:13.6749509","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:10:13 GMT
-      mise-correlation-id:
-      - cba4c52c-2f53-4368-ae5c-a9271f6db86f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/94f0c583-b512-44aa-bfdf-3d9865b2d4b5/571f1380-0d0c-474e-ac62-363e35af0079?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A18Z&sr=b&sp=r&sig=qEUJCiM5M8aAb9T8IrlWQrD2xDP5puuO6NhO3sfw1IA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:18.9428116","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:10:18 GMT
-      mise-correlation-id:
-      - 4b9e2213-1240-41c2-a87b-c87efcdd86ba
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/94f0c583-b512-44aa-bfdf-3d9865b2d4b5/571f1380-0d0c-474e-ac62-363e35af0079?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A24Z&sr=b&sp=r&sig=Ou3Yc9GaTaajIaVz9K1q6zzLLxuw15qDFgp%2FtVWvogY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:24.2249928","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:10:24 GMT
-      mise-correlation-id:
-      - f8f51dbf-8634-466c-a95e-66885d649cb6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/94f0c583-b512-44aa-bfdf-3d9865b2d4b5/571f1380-0d0c-474e-ac62-363e35af0079?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A29Z&sr=b&sp=r&sig=PGNMHNp%2B47ZrA9q39fY%2FpJx%2FSvB70wIgLqbpCJhaAx0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:29.5599532","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fe5d4f80-7095-43ab-8470-bd527a1eb14e/4cb4afcd-79e4-4574-bc68-ef23919cb1b9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A39Z&sr=b&sp=r&sig=aAby04rcVe9%2FB%2BbFuAqsZVRE3SoNWeVj4UlFWOvqSKw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:39.5376267","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:29 GMT
+      - Mon, 09 Oct 2023 19:16:39 GMT
       mise-correlation-id:
-      - 44cc6902-e5ab-4896-9056-aae31cfb6232
+      - 80729403-6893-45db-81fc-e955261e2aea
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +349,132 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fd7025ef-0ed2-4109-9639-28422e4b510d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"32117491-ad00-4e6f-bd94-85172f8a8de2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"82549f1a-575e-437e-8b9c-762afa2ccf8b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/94f0c583-b512-44aa-bfdf-3d9865b2d4b5/571f1380-0d0c-474e-ac62-363e35af0079?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A10%3A29Z&sr=b&sp=r&sig=ILdG5%2BB%2F8ftt5bBJSoPBEKCRFLdzEAMaQc26JJhUFTc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:10:29.8627112","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:10:11.816Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:27.129Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fe5d4f80-7095-43ab-8470-bd527a1eb14e/4cb4afcd-79e4-4574-bc68-ef23919cb1b9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A44Z&sr=b&sp=r&sig=OsrK83FcchFykgXRBa4EqO7StUUU0aak6YPiFfDcd3s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:44.8489294","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1581'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:29 GMT
+      - Mon, 09 Oct 2023 19:16:44 GMT
       mise-correlation-id:
-      - 7333ed4a-7072-4837-8e66-e5546377901f
+      - dd149580-9961-4487-9d72-eba858f23d6d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fe5d4f80-7095-43ab-8470-bd527a1eb14e/4cb4afcd-79e4-4574-bc68-ef23919cb1b9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A50Z&sr=b&sp=r&sig=neKljQqz1fQL2Yu6ljnawE5ulElZ80YLeHtOc1QsUhM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:50.2243061","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:16:50 GMT
+      mise-correlation-id:
+      - 63282489-2dee-4abf-8b15-327e680e203c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fe5d4f80-7095-43ab-8470-bd527a1eb14e/4cb4afcd-79e4-4574-bc68-ef23919cb1b9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A55Z&sr=b&sp=r&sig=69t%2Bkg4ePLsDGltqE3BsRXdTTI%2BQxU2vClKFDs06Wpk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:55.4863566","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:16:55 GMT
+      mise-correlation-id:
+      - c2e78fa5-da22-46c4-a6b3-2b24d6bbdf10
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1a7c488e-befd-4f18-b689-5d882b14d409":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"5ae6c7b3-fdf1-47b4-88e4-4772cc963474":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bb63857d-6f26-403d-b757-5a91257b8dd7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fe5d4f80-7095-43ab-8470-bd527a1eb14e/4cb4afcd-79e4-4574-bc68-ef23919cb1b9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A16%3A55Z&sr=b&sp=r&sig=X%2FdlSwRSxGVq2Xei5kF9Jm3k5cGY6bxlfMfNNViZyS8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:16:55.8207404","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:16:37.442Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:52.412Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1579'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:16:55 GMT
+      mise-correlation-id:
+      - abdbc2b6-710c-47d6-a61a-80e1ff150fcf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:36.5226838Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:36.5226838Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:01.5901684Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:01.5901684Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:30 GMT
+      - Mon, 09 Oct 2023 19:16:57 GMT
       etag:
-      - '"92017292-0000-0100-0000-652425c20000"'
+      - '"5500e3c5-0000-0100-0000-652451730000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"fd7025ef-0ed2-4109-9639-28422e4b510d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"32117491-ad00-4e6f-bd94-85172f8a8de2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"82549f1a-575e-437e-8b9c-762afa2ccf8b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/94f0c583-b512-44aa-bfdf-3d9865b2d4b5/571f1380-0d0c-474e-ac62-363e35af0079?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A10%3A32Z&sr=b&sp=r&sig=EZ745E4CrL4NVX%2B4F%2Bzbi4RUVVPNJRF1dVf38g8a96g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:10:32.9000286","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:10:11.816Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:27.129Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"1a7c488e-befd-4f18-b689-5d882b14d409":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"5ae6c7b3-fdf1-47b4-88e4-4772cc963474":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bb63857d-6f26-403d-b757-5a91257b8dd7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fe5d4f80-7095-43ab-8470-bd527a1eb14e/4cb4afcd-79e4-4574-bc68-ef23919cb1b9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A16%3A58Z&sr=b&sp=r&sig=OEIw8ozgv12xx2dWGdfjuB4qIFvg6kyeUsSiUWeo9u8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:16:58.3721749","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:16:37.442Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:52.412Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1593'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:32 GMT
+      - Mon, 09 Oct 2023 19:16:58 GMT
       mise-correlation-id:
-      - fd6ebb67-6bee-4861-98aa-d8d081be41a1
+      - 20897d40-1428-485c-891c-83ac7c1cd98f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:36.5226838Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:36.5226838Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:01.5901684Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:01.5901684Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:33 GMT
+      - Mon, 09 Oct 2023 19:16:59 GMT
       etag:
-      - '"92017292-0000-0100-0000-652425c20000"'
+      - '"5500e3c5-0000-0100-0000-652451730000"'
       expires:
       - '-1'
       pragma:
@@ -621,7 +621,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -631,9 +631,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Mon, 09 Oct 2023 16:10:35 GMT
+      - Mon, 09 Oct 2023 19:17:00 GMT
       mise-correlation-id:
-      - 91b3dbb0-cb8b-4b87-b8d0-7beb9b3851e8
+      - d8b225e5-cfe0-4115-a38d-c0dd7542d68a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -656,7 +656,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:36.5226838Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:36.5226838Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:01.5901684Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:01.5901684Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -665,9 +665,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:36 GMT
+      - Mon, 09 Oct 2023 19:17:01 GMT
       etag:
-      - '"92017292-0000-0100-0000-652425c20000"'
+      - '"5500e3c5-0000-0100-0000-652451730000"'
       expires:
       - '-1'
       pragma:
@@ -697,7 +697,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -711,9 +711,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:37 GMT
+      - Mon, 09 Oct 2023 19:17:03 GMT
       mise-correlation-id:
-      - 19c4efd7-9867-4e98-afd3-3aa24338352d
+      - a842d48f-3ae4-403d-b56a-9388985ae928
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,7 +736,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:36.5226838Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:36.5226838Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:01.5901684Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:01.5901684Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -745,9 +745,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:38 GMT
+      - Mon, 09 Oct 2023 19:17:05 GMT
       etag:
-      - '"92017292-0000-0100-0000-652425c20000"'
+      - '"5500e3c5-0000-0100-0000-652451730000"'
       expires:
       - '-1'
       pragma:
@@ -777,7 +777,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d43f630b-2e66-4233-aaba-e8b28aaa710f.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://54f56e0c-d21b-4687-bf46-f5d8806cb2ac.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -791,9 +791,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:39 GMT
+      - Mon, 09 Oct 2023 19:17:06 GMT
       mise-correlation-id:
-      - cf311c5b-0540-4002-8633-abb88c813e63
+      - dbf46154-5122-4106-b61b-9b756ec173bd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_delete.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_delete.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:50.53428Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:50.53428Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:30.0153215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:30.0153215Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '649'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:53 GMT
+      - Mon, 30 Oct 2023 07:19:04 GMT
       etag:
-      - '"3c001924-0000-0100-0000-653eda4b0000"'
+      - '"3f000f67-0000-0100-0000-653f58c70000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:18:54 GMT
+      - Mon, 30 Oct 2023 07:19:05 GMT
       mise-correlation-id:
-      - d5d12df7-4249-467c-a24d-7c8b5057210c
+      - 2cc8e949-6a81-44df-a833-783f7d89a5a4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"0b234a2a-d9a4-40b8-99bc-ff67bfd34e5d": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "295e741b-d23f-4572-948f-acd2ed7ab568":
+      {"passFailMetrics": {"559fa96a-42cd-4a57-9129-4faaca50edb4": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "5c3e40de-2440-4d03-8f3a-948fabfea556":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "aa117dcc-46b9-47e9-8a59-c3cf452a4410": {"aggregate": "avg", "clientMetric":
+      "50"}, "2139fc60-d16c-466f-8036-f04d492a5a2f": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0b234a2a-d9a4-40b8-99bc-ff67bfd34e5d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"295e741b-d23f-4572-948f-acd2ed7ab568":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aa117dcc-46b9-47e9-8a59-c3cf452a4410":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:54.648Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:54.648Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"559fa96a-42cd-4a57-9129-4faaca50edb4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"5c3e40de-2440-4d03-8f3a-948fabfea556":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2139fc60-d16c-466f-8036-f04d492a5a2f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:19:06.189Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:19:06.189Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:54 GMT
+      - Mon, 30 Oct 2023 07:19:06 GMT
       location:
-      - https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+      - https://70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - e334230b-686e-49e2-8fbd-c41b1773ec2f
+      - 1ea54f52-7557-4ad3-8485-a5281c2245ef
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
+    uri: https://70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:54 GMT
+      - Mon, 30 Oct 2023 07:19:06 GMT
       mise-correlation-id:
-      - f816399c-f3c9-407f-8951-be11317303a3
+      - 94680c13-8201-499b-8c36-2b21a1d8ba10
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0884bd41-3fbb-43de-afa4-37fc52ef49f3/eace4165-6d7d-4aad-8889-f21e51d742ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A55Z&sr=b&sp=r&sig=63v8cr7mMKllGzHjK8rP683ChLV%2FYzMLh7RrAXI5x1E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:55.8007539","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7289e52c-47b0-4c98-9a40-b38cb3ffd283/3c24c3d6-b9a1-4126-9664-0643eb927ecb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A29%3A07Z&sr=b&sp=r&sig=%2Bp8KndVgol3PH%2Fvkf%2Fy3s0zK421wPRMTjmkVpj5%2FbUw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:29:07.7802679","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '557'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:55 GMT
+      - Mon, 30 Oct 2023 07:19:07 GMT
       location:
-      - https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 4e5b6f2a-7679-4164-8f65-e5c37b7d1050
+      - 417b293c-0217-4ee5-bf5b-971ab2bc6b57
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0884bd41-3fbb-43de-afa4-37fc52ef49f3/eace4165-6d7d-4aad-8889-f21e51d742ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A56Z&sr=b&sp=r&sig=3BhyGku8A8O9g0m74b2OgaC37wf6lgw2kePGYykTSnU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:56.0443237","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:18:56 GMT
-      mise-correlation-id:
-      - ac6bb70b-ef6f-4d70-9d91-40d59970d3f0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0884bd41-3fbb-43de-afa4-37fc52ef49f3/eace4165-6d7d-4aad-8889-f21e51d742ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A01Z&sr=b&sp=r&sig=Va%2FRDLFLLqq6V6X1pVQ6UvRsE1QzLXPL4WaI7fo0Kco%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:01.284891","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '550'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:19:01 GMT
-      mise-correlation-id:
-      - eb0764f8-1465-49dd-8c86-ed7003bd5f00
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0884bd41-3fbb-43de-afa4-37fc52ef49f3/eace4165-6d7d-4aad-8889-f21e51d742ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A06Z&sr=b&sp=r&sig=pUdXGexv5mpmuwDpKo121qsSm4ZguJIvK%2BTYxqjJPqM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:06.5235796","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7289e52c-47b0-4c98-9a40-b38cb3ffd283/3c24c3d6-b9a1-4126-9664-0643eb927ecb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A29%3A08Z&sr=b&sp=r&sig=lrDjjlMvZaNkY5TYW7YbzX4p0S1l%2BDquHKvKANdEkN8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:29:08.0544191","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:06 GMT
+      - Mon, 30 Oct 2023 07:19:08 GMT
       mise-correlation-id:
-      - 380b85a3-eebb-4cd0-8727-970e81891edf
+      - aed16d99-a604-4d78-84c3-1398c40429eb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0884bd41-3fbb-43de-afa4-37fc52ef49f3/eace4165-6d7d-4aad-8889-f21e51d742ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A11Z&sr=b&sp=r&sig=tFtqYDy3wVaGZN%2Bhgo6M6DjCpUavDINMlQj%2BrYSEODQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:11.8247219","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7289e52c-47b0-4c98-9a40-b38cb3ffd283/3c24c3d6-b9a1-4126-9664-0643eb927ecb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A29%3A13Z&sr=b&sp=r&sig=wsAK8%2FfaVD9UBisIPXC00q2%2BBKhchbslBAUwPJFjxsU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:29:13.4331481","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:11 GMT
+      - Mon, 30 Oct 2023 07:19:13 GMT
       mise-correlation-id:
-      - b552e871-c830-459a-b431-6828db4ff059
+      - 2a0aac9b-99a7-4fee-b7fd-b7e80335b51a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +385,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0b234a2a-d9a4-40b8-99bc-ff67bfd34e5d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"295e741b-d23f-4572-948f-acd2ed7ab568":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aa117dcc-46b9-47e9-8a59-c3cf452a4410":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0884bd41-3fbb-43de-afa4-37fc52ef49f3/eace4165-6d7d-4aad-8889-f21e51d742ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A19%3A12Z&sr=b&sp=r&sig=bkqsS2J9szaxNDvyySh7WgLcSWMknAWbwR5t9PoZff8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:19:12.0560704","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:54.648Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:19:10.436Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7289e52c-47b0-4c98-9a40-b38cb3ffd283/3c24c3d6-b9a1-4126-9664-0643eb927ecb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A29%3A18Z&sr=b&sp=r&sig=DP%2B5Pu90B8iS9XqnbfjBde6fkKCGotq6%2Bt3rWhSKN0w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:29:18.6919735","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1577'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:12 GMT
+      - Mon, 30 Oct 2023 07:19:18 GMT
       mise-correlation-id:
-      - e2f087ff-ca80-40bc-ae26-a6bfb9baf83a
+      - cc9212df-7317-4822-9e62-5db4e28fb043
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7289e52c-47b0-4c98-9a40-b38cb3ffd283/3c24c3d6-b9a1-4126-9664-0643eb927ecb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A29%3A23Z&sr=b&sp=r&sig=%2FtvtFxeXAeGNBJaBWTEM24jqsiCZ0wWgIsKBsoxtWrc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:29:23.984609","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '548'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:19:23 GMT
+      mise-correlation-id:
+      - 7465d34c-1214-4d1d-ba9a-6f323dcd726b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"559fa96a-42cd-4a57-9129-4faaca50edb4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"5c3e40de-2440-4d03-8f3a-948fabfea556":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2139fc60-d16c-466f-8036-f04d492a5a2f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7289e52c-47b0-4c98-9a40-b38cb3ffd283/3c24c3d6-b9a1-4126-9664-0643eb927ecb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A19%3A24Z&sr=b&sp=r&sig=9sCOvzwd7vjoLlJELadVmMAH%2BUzSE9zipWSr3fLsMhE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:19:24.2310691","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:19:06.189Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:19:20.834Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1579'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:19:24 GMT
+      mise-correlation-id:
+      - 5d24c7b1-d489-40d5-906e-8adf82077a0f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:50.53428Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:50.53428Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:30.0153215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:30.0153215Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '649'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:13 GMT
+      - Mon, 30 Oct 2023 07:19:25 GMT
       etag:
-      - '"3c001924-0000-0100-0000-653eda4b0000"'
+      - '"3f000f67-0000-0100-0000-653f58c70000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0b234a2a-d9a4-40b8-99bc-ff67bfd34e5d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"295e741b-d23f-4572-948f-acd2ed7ab568":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aa117dcc-46b9-47e9-8a59-c3cf452a4410":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0884bd41-3fbb-43de-afa4-37fc52ef49f3/eace4165-6d7d-4aad-8889-f21e51d742ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A19%3A14Z&sr=b&sp=r&sig=xheLLgHO7nFvAmL27Wxh%2BqekM01Xcwf1uI39ogl6bmY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:19:14.0694456","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:54.648Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:19:10.436Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"559fa96a-42cd-4a57-9129-4faaca50edb4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"5c3e40de-2440-4d03-8f3a-948fabfea556":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2139fc60-d16c-466f-8036-f04d492a5a2f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7289e52c-47b0-4c98-9a40-b38cb3ffd283/3c24c3d6-b9a1-4126-9664-0643eb927ecb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A19%3A26Z&sr=b&sp=r&sig=BfW6iiacidEwIFJXtevzInO96ctsDfx7V8AvOq5yn9Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:19:26.8894553","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:19:06.189Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:19:20.834Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1591'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:14 GMT
+      - Mon, 30 Oct 2023 07:19:26 GMT
       mise-correlation-id:
-      - efaa104a-896c-4d46-b87f-7e0d6f5bd9e7
+      - 72fdcf26-3dbf-4420-a160-f9c52cd7bce2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:50.53428Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:50.53428Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:30.0153215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:30.0153215Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '649'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:15 GMT
+      - Mon, 30 Oct 2023 07:19:28 GMT
       etag:
-      - '"3c001924-0000-0100-0000-653eda4b0000"'
+      - '"3f000f67-0000-0100-0000-653f58c70000"'
       expires:
       - '-1'
       pragma:
@@ -621,7 +621,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -631,9 +631,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Sun, 29 Oct 2023 22:19:16 GMT
+      - Mon, 30 Oct 2023 07:19:29 GMT
       mise-correlation-id:
-      - 588230ea-63df-4d9f-af80-07e9cca6a264
+      - 84d834a8-bf4e-4e78-813a-8965c7abc250
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -656,18 +656,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:50.53428Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:50.53428Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:30.0153215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:30.0153215Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '649'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:17 GMT
+      - Mon, 30 Oct 2023 07:19:30 GMT
       etag:
-      - '"3c001924-0000-0100-0000-653eda4b0000"'
+      - '"3f000f67-0000-0100-0000-653f58c70000"'
       expires:
       - '-1'
       pragma:
@@ -697,7 +697,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -711,9 +711,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:18 GMT
+      - Mon, 30 Oct 2023 07:19:32 GMT
       mise-correlation-id:
-      - f71d88c4-1160-4c71-b4c1-7ae7fb4068b7
+      - 8101e059-4ab6-4330-aa59-6397d082a3ce
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,18 +736,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:50.53428Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:50.53428Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:30.0153215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:30.0153215Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '649'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:18 GMT
+      - Mon, 30 Oct 2023 07:19:32 GMT
       etag:
-      - '"3c001924-0000-0100-0000-653eda4b0000"'
+      - '"3f000f67-0000-0100-0000-653f58c70000"'
       expires:
       - '-1'
       pragma:
@@ -777,7 +777,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f9f4cd48-9b34-404d-a1e8-2a35b4136922.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://70a34f99-970e-4ca4-a7e9-4af738ff348f.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -791,9 +791,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:19 GMT
+      - Mon, 30 Oct 2023 07:19:34 GMT
       mise-correlation-id:
-      - fc15b9a5-1bd3-4ab8-bfd1-c1b0268dbc95
+      - ccc1f0db-cd0d-40e6-b370-ba5c1c9f8b51
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_download_files.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_download_files.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:53.275839Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:53.275839Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.5753531Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.5753531Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:26 GMT
+      - Fri, 13 Oct 2023 13:48:29 GMT
       etag:
-      - '"550015a4-0000-0100-0000-6524512f0000"'
+      - '"d801d3a4-0000-0100-0000-65294a8c0000"'
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:15:28 GMT
+      - Fri, 13 Oct 2023 13:48:31 GMT
       mise-correlation-id:
-      - 6c21f2bc-b72a-466f-a134-ff8e02085c02
+      - 5961da81-2dce-46b7-b087-af2e345c537b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"7b4772c6-f11b-4402-a866-887422b2dded": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "7ed55eb4-51a7-4f6e-945d-6dce008762b4":
+      {"passFailMetrics": {"417cbac3-6074-4bca-83e1-56875b6388d5": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "53604b47-7bd0-4bdd-bbf0-4da3402ae009":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "c6d8659b-7e78-4c3b-a068-2bfa2ed898bf": {"aggregate": "avg", "clientMetric":
+      "50"}, "93508ac0-3da2-4cc5-b945-4c20b122dd88": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -104,13 +104,13 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7b4772c6-f11b-4402-a866-887422b2dded":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7ed55eb4-51a7-4f6e-945d-6dce008762b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c6d8659b-7e78-4c3b-a068-2bfa2ed898bf":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:28.862Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:28.862Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"417cbac3-6074-4bca-83e1-56875b6388d5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"53604b47-7bd0-4bdd-bbf0-4da3402ae009":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"93508ac0-3da2-4cc5-b945-4c20b122dd88":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:31.728Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:31.728Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:28 GMT
+      - Fri, 13 Oct 2023 13:48:31 GMT
       location:
-      - https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+      - https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 46e01684-3435-492d-89e6-b59bf7f04c28
+      - de7299df-d1c7-4cc9-9e0e-eb36480df6af
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -143,9 +143,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:29 GMT
+      - Fri, 13 Oct 2023 13:48:31 GMT
       mise-correlation-id:
-      - 7a864b10-9cbb-4e44-9b0b-4217c4d1a388
+      - a8819ee4-f77c-4e04-9eb2-7f8c6e919e12
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -273,27 +273,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A31Z&sr=b&sp=r&sig=hrUHi1HQsI9IvYA11FEtcHUZI0PMwouWLAbVtvN5pQs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:31.8821314","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A32Z&sr=b&sp=r&sig=IPCHIhSiyGAKA0TNV0H7VkxPPDzzxIyeMZNW%2BZjf73I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:32.460022","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:31 GMT
+      - Fri, 13 Oct 2023 13:48:32 GMT
       location:
-      - https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - d0e6f90c-e348-4249-bdda-e295acd783a3
+      - 359cb406-f675-4f5a-808b-b15e8e5e9b9d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -311,12 +311,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A32Z&sr=b&sp=r&sig=yXMsbKs%2F1hHTujLfwXIrKCKqjNB7OpRz%2FRGoKXAa4Pg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:32.1380461","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A32Z&sr=b&sp=r&sig=qOjRri9geSYXYp8rICrDlzTsGr%2Bt%2BtOcM0zwn9VgQHs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:32.6884774","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:32 GMT
+      - Fri, 13 Oct 2023 13:48:32 GMT
       mise-correlation-id:
-      - 5b0dadb6-cf80-42b8-a3d4-be0eee694340
+      - 9d32718e-da64-4a26-ac33-e39deb929997
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -347,84 +347,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A37Z&sr=b&sp=r&sig=%2Fdyuscv1lFEUbBUUTU%2FI6ggDHlhxtqWP5jhRUjuvEuw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:37.3933334","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:15:37 GMT
-      mise-correlation-id:
-      - 9cc01ec6-0640-4b53-8187-f89d3ccec21c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A42Z&sr=b&sp=r&sig=Iuw%2BHwKVrE%2B4oxQCDQvTotF75raoObEaW%2FYO5PvNLtM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:42.661489","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '554'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:15:42 GMT
-      mise-correlation-id:
-      - 3e5e9788-4687-4905-8c53-71a80afa88f5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A47Z&sr=b&sp=r&sig=0jT%2BZOBAMxn379RDDqgWKw%2FZxR3KGzLwLuQ9C3yno0A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:47.9183009","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A37Z&sr=b&sp=r&sig=IZW3Cv%2FrSNu78S1miLD1rOvIW68G9h7OA5zF41pFEwk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:37.9515295","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:47 GMT
+      - Fri, 13 Oct 2023 13:48:37 GMT
       mise-correlation-id:
-      - 8f5f4364-5ae4-4840-8755-33e95ad01465
+      - 5a08c29d-3912-4032-8554-e7ac6146fe17
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -455,26 +383,98 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7b4772c6-f11b-4402-a866-887422b2dded":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7ed55eb4-51a7-4f6e-945d-6dce008762b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c6d8659b-7e78-4c3b-a068-2bfa2ed898bf":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A15%3A48Z&sr=b&sp=r&sig=m5NAYClMxgVqKfmizxIiPOFGOlDNENu9u145GU2Ln9A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:15:48.2291333","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:28.862Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:45.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A43Z&sr=b&sp=r&sig=w5fLkKUY%2FbqVNRB%2FnbNO3RNgY81XM7Q350wokpAdL5Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:43.1965056","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1579'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:48 GMT
+      - Fri, 13 Oct 2023 13:48:43 GMT
       mise-correlation-id:
-      - da3e37e0-2846-4966-ad67-d7e6ee2ccb6a
+      - 0436a313-0125-462e-b34f-979ac9572b96
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A48Z&sr=b&sp=r&sig=nbbd7%2Flyf9Eqq4nS79ZSGTfLDBvIxSnPqSBiQd1EUzg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:48.4399195","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:48:48 GMT
+      mise-correlation-id:
+      - 4ae8b10e-aa36-47cd-9423-120fa4d25109
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"417cbac3-6074-4bca-83e1-56875b6388d5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"53604b47-7bd0-4bdd-bbf0-4da3402ae009":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"93508ac0-3da2-4cc5-b945-4c20b122dd88":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A48%3A48Z&sr=b&sp=r&sig=%2FiGiZWkW6hcnEMiE0W%2BeuQDI%2B034RQ9TLvlxB%2B58GK0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:48:48.6797668","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:31.728Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:45.515Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1587'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:48:48 GMT
+      mise-correlation-id:
+      - b12004c9-dd19-49d9-b0fe-a25d3c20374d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:53.275839Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:53.275839Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.5753531Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.5753531Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:48 GMT
+      - Fri, 13 Oct 2023 13:48:50 GMT
       etag:
-      - '"550015a4-0000-0100-0000-6524512f0000"'
+      - '"d801d3a4-0000-0100-0000-65294a8c0000"'
       expires:
       - '-1'
       pragma:
@@ -536,26 +536,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"7b4772c6-f11b-4402-a866-887422b2dded":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7ed55eb4-51a7-4f6e-945d-6dce008762b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c6d8659b-7e78-4c3b-a068-2bfa2ed898bf":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A15%3A50Z&sr=b&sp=r&sig=ZhkIiPpI1qgZ9g65e3Ex8bM%2B6zaC%2BPWhHE0Dh7z3dYQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:15:50.5330851","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:28.862Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:45.901Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"417cbac3-6074-4bca-83e1-56875b6388d5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"53604b47-7bd0-4bdd-bbf0-4da3402ae009":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"93508ac0-3da2-4cc5-b945-4c20b122dd88":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A48%3A51Z&sr=b&sp=r&sig=9TvbuMC58zylgy%2FSC%2BxL4vJmKd5%2BzPGEee8weFLC%2FQ8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:48:51.607108","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:31.728Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:45.515Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1595'
+      - '1598'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:50 GMT
+      - Fri, 13 Oct 2023 13:48:51 GMT
       mise-correlation-id:
-      - 0e450073-5743-4d68-9fb8-dbf2f2bdd742
+      - a4c4a4af-ec0e-4613-b501-10adada9dc52
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:53.275839Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:53.275839Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.5753531Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.5753531Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:52 GMT
+      - Fri, 13 Oct 2023 13:48:52 GMT
       etag:
-      - '"550015a4-0000-0100-0000-6524512f0000"'
+      - '"d801d3a4-0000-0100-0000-65294a8c0000"'
       expires:
       - '-1'
       pragma:
@@ -617,25 +617,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A52Z&sr=b&sp=r&sig=A3mhKXyZwe%2BEjzjr1npTVd%2BR0xQ%2FpzeV90F9ESF9BtQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:52.9834831","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A53Z&sr=b&sp=r&sig=JZDfoqCxT1znyJJwioldWuUmDdz1B0fhgDUMuFXYeTo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:53.4055927","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '565'
+      - '559'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:52 GMT
+      - Fri, 13 Oct 2023 13:48:53 GMT
       mise-correlation-id:
-      - d21644a2-7a81-47f3-984d-8822e24797f5
+      - 9a1e47b1-11c4-4226-8de8-c91f01fe2094
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -653,9 +653,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A52Z&sr=b&sp=r&sig=A3mhKXyZwe%2BEjzjr1npTVd%2BR0xQ%2FpzeV90F9ESF9BtQ%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A53Z&sr=b&sp=r&sig=JZDfoqCxT1znyJJwioldWuUmDdz1B0fhgDUMuFXYeTo%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -728,17 +728,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Mon, 09 Oct 2023 19:15:54 GMT
+      - Fri, 13 Oct 2023 13:48:53 GMT
       etag:
-      - '"0x8DBC8FC1B21FB47"'
+      - '"0x8DBCBF316D2753A"'
       last-modified:
-      - Mon, 09 Oct 2023 19:15:31 GMT
+      - Fri, 13 Oct 2023 13:48:32 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 09 Oct 2023 19:15:31 GMT
+      - Fri, 13 Oct 2023 13:48:32 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -771,18 +771,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:53.275839Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:53.275839Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.5753531Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.5753531Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:54 GMT
+      - Fri, 13 Oct 2023 13:48:55 GMT
       etag:
-      - '"550015a4-0000-0100-0000-6524512f0000"'
+      - '"d801d3a4-0000-0100-0000-65294a8c0000"'
       expires:
       - '-1'
       pragma:
@@ -810,12 +810,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A56Z&sr=b&sp=r&sig=Pc3UFCGwb4po0VxkIsiR6YaWOpM4dQa4QfSBTbHNu04%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:56.5340307","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A56Z&sr=b&sp=r&sig=mh9fmUD8qdet2AuoOmoA0z7flr72JBEw6gUiKGbpNgQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:56.8205489","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -826,9 +826,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:56 GMT
+      - Fri, 13 Oct 2023 13:48:56 GMT
       mise-correlation-id:
-      - 4f93d385-c97e-4132-8064-4993a8cadfa2
+      - be096ee5-c74b-420d-aca1-b04b870a987d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_download_files.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_download_files.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.5753531Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.5753531Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:04.6018485Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:04.6018485Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:29 GMT
+      - Wed, 18 Oct 2023 20:48:38 GMT
       etag:
-      - '"d801d3a4-0000-0100-0000-65294a8c0000"'
+      - '"7500f939-0000-0100-0000-653044860000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:48:31 GMT
+      - Wed, 18 Oct 2023 20:48:40 GMT
       mise-correlation-id:
-      - 5961da81-2dce-46b7-b087-af2e345c537b
+      - 65e48493-07f2-45ad-86be-3aa35d4f39bf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"417cbac3-6074-4bca-83e1-56875b6388d5": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "53604b47-7bd0-4bdd-bbf0-4da3402ae009":
+      {"passFailMetrics": {"ee6e3286-09fc-404b-b551-7c1cdd9bc4ae": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "02cbe82f-2afc-495e-9a8f-c7da8be685a9":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "93508ac0-3da2-4cc5-b945-4c20b122dd88": {"aggregate": "avg", "clientMetric":
+      "50"}, "9b8c1e99-b714-4cc5-a0e8-8188f75cedda": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"417cbac3-6074-4bca-83e1-56875b6388d5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"53604b47-7bd0-4bdd-bbf0-4da3402ae009":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"93508ac0-3da2-4cc5-b945-4c20b122dd88":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:31.728Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:31.728Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ee6e3286-09fc-404b-b551-7c1cdd9bc4ae":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"02cbe82f-2afc-495e-9a8f-c7da8be685a9":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9b8c1e99-b714-4cc5-a0e8-8188f75cedda":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:41.256Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:41.256Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:31 GMT
+      - Wed, 18 Oct 2023 20:48:41 GMT
       location:
-      - https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+      - https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - de7299df-d1c7-4cc9-9e0e-eb36480df6af
+      - 6dcfadfc-e27e-4818-bc5f-faaf104983af
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:31 GMT
+      - Wed, 18 Oct 2023 20:48:41 GMT
       mise-correlation-id:
-      - a8819ee4-f77c-4e04-9eb2-7f8c6e919e12
+      - bd1d61ee-4628-4778-937f-a0434d2eb0f5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A32Z&sr=b&sp=r&sig=IPCHIhSiyGAKA0TNV0H7VkxPPDzzxIyeMZNW%2BZjf73I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:32.460022","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A42Z&sr=b&sp=r&sig=QawUttm%2BRA0e7d0vx2%2B%2FzWny6R7LyhlKt%2FHKJmn94zA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:42.4701849","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '557'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:32 GMT
+      - Wed, 18 Oct 2023 20:48:42 GMT
       location:
-      - https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 359cb406-f675-4f5a-808b-b15e8e5e9b9d
+      - 30f40a1b-9b90-421c-9cd7-c631995256cd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A32Z&sr=b&sp=r&sig=qOjRri9geSYXYp8rICrDlzTsGr%2Bt%2BtOcM0zwn9VgQHs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:32.6884774","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A42Z&sr=b&sp=r&sig=PJpi8akEpEl0%2FSjoM%2FfFT9NO9cPfnM4d%2BIn%2FjXSsm9c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:42.717056","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '556'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:48:42 GMT
+      mise-correlation-id:
+      - 7415ebcc-ba1b-475c-90ef-9460aebcdf59
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A47Z&sr=b&sp=r&sig=8eWA6CUqRd2T%2BZiayQk%2BQpWdxVlHS3Hqf9fEUMnjAfs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:47.9756882","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:32 GMT
+      - Wed, 18 Oct 2023 20:48:47 GMT
       mise-correlation-id:
-      - 9d32718e-da64-4a26-ac33-e39deb929997
+      - 57af050b-6a2f-4b1e-a8cd-cac65b93add7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,82 +385,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A37Z&sr=b&sp=r&sig=IZW3Cv%2FrSNu78S1miLD1rOvIW68G9h7OA5zF41pFEwk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:37.9515295","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:48:37 GMT
-      mise-correlation-id:
-      - 5a08c29d-3912-4032-8554-e7ac6146fe17
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A43Z&sr=b&sp=r&sig=w5fLkKUY%2FbqVNRB%2FnbNO3RNgY81XM7Q350wokpAdL5Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:43.1965056","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:48:43 GMT
-      mise-correlation-id:
-      - 0436a313-0125-462e-b34f-979ac9572b96
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A48Z&sr=b&sp=r&sig=nbbd7%2Flyf9Eqq4nS79ZSGTfLDBvIxSnPqSBiQd1EUzg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:48.4399195","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A53Z&sr=b&sp=r&sig=N7PSzhFpZ5BLzG66lEQmS8mO2lTv0IMTy3kCRx7Wyow%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:53.2552763","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:48 GMT
+      - Wed, 18 Oct 2023 20:48:53 GMT
       mise-correlation-id:
-      - 4ae8b10e-aa36-47cd-9423-120fa4d25109
+      - 459dfc58-c17f-4784-9992-09105a703928
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +421,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"417cbac3-6074-4bca-83e1-56875b6388d5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"53604b47-7bd0-4bdd-bbf0-4da3402ae009":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"93508ac0-3da2-4cc5-b945-4c20b122dd88":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A48%3A48Z&sr=b&sp=r&sig=%2FiGiZWkW6hcnEMiE0W%2BeuQDI%2B034RQ9TLvlxB%2B58GK0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:48:48.6797668","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:31.728Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:45.515Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A58Z&sr=b&sp=r&sig=zxII7J1gDpvzyfEDu%2FA76xVPdsndGmiXDhkY9GVIY34%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:58.551762","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1587'
+      - '548'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:48 GMT
+      - Wed, 18 Oct 2023 20:48:58 GMT
       mise-correlation-id:
-      - b12004c9-dd19-49d9-b0fe-a25d3c20374d
+      - a54d2f73-db34-4378-9f46-db4a7b902f4d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ee6e3286-09fc-404b-b551-7c1cdd9bc4ae":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"02cbe82f-2afc-495e-9a8f-c7da8be685a9":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9b8c1e99-b714-4cc5-a0e8-8188f75cedda":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A48%3A58Z&sr=b&sp=r&sig=d1anpRjtiZBL36mQkaTEIkYF0McWhkPzf9iVMm8pCJw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:48:58.8607626","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:41.256Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:54.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1579'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:48:58 GMT
+      mise-correlation-id:
+      - d176a38a-d9b7-4242-9a98-5a680a6b1b0c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.5753531Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.5753531Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:04.6018485Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:04.6018485Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:50 GMT
+      - Wed, 18 Oct 2023 20:49:00 GMT
       etag:
-      - '"d801d3a4-0000-0100-0000-65294a8c0000"'
+      - '"7500f939-0000-0100-0000-653044860000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"417cbac3-6074-4bca-83e1-56875b6388d5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"53604b47-7bd0-4bdd-bbf0-4da3402ae009":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"93508ac0-3da2-4cc5-b945-4c20b122dd88":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A48%3A51Z&sr=b&sp=r&sig=9TvbuMC58zylgy%2FSC%2BxL4vJmKd5%2BzPGEee8weFLC%2FQ8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:48:51.607108","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:31.728Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:45.515Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ee6e3286-09fc-404b-b551-7c1cdd9bc4ae":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"02cbe82f-2afc-495e-9a8f-c7da8be685a9":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9b8c1e99-b714-4cc5-a0e8-8188f75cedda":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A49%3A01Z&sr=b&sp=r&sig=Gp3xs3xBQwDMZqisIDpWpz5cp%2Ff63d4Bvt6pWRHBaFs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:49:01.0979875","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:41.256Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:54.998Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1598'
+      - '1593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:51 GMT
+      - Wed, 18 Oct 2023 20:49:01 GMT
       mise-correlation-id:
-      - a4c4a4af-ec0e-4613-b501-10adada9dc52
+      - 8a448a1a-eb39-4eb9-8423-94fab39289cc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.5753531Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.5753531Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:04.6018485Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:04.6018485Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:52 GMT
+      - Wed, 18 Oct 2023 20:49:02 GMT
       etag:
-      - '"d801d3a4-0000-0100-0000-65294a8c0000"'
+      - '"7500f939-0000-0100-0000-653044860000"'
       expires:
       - '-1'
       pragma:
@@ -619,23 +619,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A53Z&sr=b&sp=r&sig=JZDfoqCxT1znyJJwioldWuUmDdz1B0fhgDUMuFXYeTo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:53.4055927","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A03Z&sr=b&sp=r&sig=4XQU1dgYfEocIyOrOidwj3W2FL0yn1UcXQ%2Bm6ypUlJo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:03.2917591","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '559'
+      - '561'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:53 GMT
+      - Wed, 18 Oct 2023 20:49:03 GMT
       mise-correlation-id:
-      - 9a1e47b1-11c4-4226-8de8-c91f01fe2094
+      - 169d3cd2-9a95-4bf4-9b06-5c8eeebdf38b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -655,7 +655,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A53Z&sr=b&sp=r&sig=JZDfoqCxT1znyJJwioldWuUmDdz1B0fhgDUMuFXYeTo%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A03Z&sr=b&sp=r&sig=4XQU1dgYfEocIyOrOidwj3W2FL0yn1UcXQ%2Bm6ypUlJo%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -728,17 +728,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 13 Oct 2023 13:48:53 GMT
+      - Wed, 18 Oct 2023 20:49:04 GMT
       etag:
-      - '"0x8DBCBF316D2753A"'
+      - '"0x8DBD01B9D2DB0B8"'
       last-modified:
-      - Fri, 13 Oct 2023 13:48:32 GMT
+      - Wed, 18 Oct 2023 20:48:42 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 13 Oct 2023 13:48:32 GMT
+      - Wed, 18 Oct 2023 20:48:42 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -771,7 +771,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:54.5753531Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:54.5753531Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:04.6018485Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:04.6018485Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -780,9 +780,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:55 GMT
+      - Wed, 18 Oct 2023 20:49:04 GMT
       etag:
-      - '"d801d3a4-0000-0100-0000-65294a8c0000"'
+      - '"7500f939-0000-0100-0000-653044860000"'
       expires:
       - '-1'
       pragma:
@@ -812,23 +812,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0382e63b-3c36-49c4-b78a-1985bb63c3f5.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/379689ca-3c7b-4794-8cd4-b9425a4086ef/d7c20a33-8d0b-48e4-9268-cb250722e645?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A56Z&sr=b&sp=r&sig=mh9fmUD8qdet2AuoOmoA0z7flr72JBEw6gUiKGbpNgQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:56.8205489","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A05Z&sr=b&sp=r&sig=IiTbdQiL24LyIIsxvQZX8SfPiOfc6IpYzW5zU%2BH1nuU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:05.9031791","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '559'
+      - '561'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:56 GMT
+      - Wed, 18 Oct 2023 20:49:05 GMT
       mise-correlation-id:
-      - be096ee5-c74b-420d-aca1-b04b870a987d
+      - 8b70dfc6-577e-4d02-86f2-bf25114bc99e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_download_files.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_download_files.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:40.8931233Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:40.8931233Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:39.8587855Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:39.8587855Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:15 GMT
+      - Sun, 29 Oct 2023 22:18:14 GMT
       etag:
-      - '"d300eb31-0000-0100-0000-6537b78a0000"'
+      - '"3c00f621-0000-0100-0000-653eda060000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:25:16 GMT
+      - Sun, 29 Oct 2023 22:18:16 GMT
       mise-correlation-id:
-      - a16e7df0-eaa7-4575-b519-bbdf0d786f85
+      - 6129a4a0-b173-4ee2-94d2-6429f060e2d8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"b70836db-2f7d-4a11-9034-f48d8d0334fb": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "2f0e2d7e-4a15-420d-8af4-9580f3ef5467":
+      {"passFailMetrics": {"7c26b6fc-4baf-415c-844e-9eda11c808f1": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "84f5cdd0-8ab6-40ac-a43a-48b3c252b345":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "653cdc18-1d81-4e28-b025-2bad816a0495": {"aggregate": "avg", "clientMetric":
+      "50"}, "1cf34253-8265-4493-bfc7-97fe3744e0fa": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b70836db-2f7d-4a11-9034-f48d8d0334fb":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f0e2d7e-4a15-420d-8af4-9580f3ef5467":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"653cdc18-1d81-4e28-b025-2bad816a0495":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:17.391Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:17.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7c26b6fc-4baf-415c-844e-9eda11c808f1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"84f5cdd0-8ab6-40ac-a43a-48b3c252b345":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1cf34253-8265-4493-bfc7-97fe3744e0fa":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.782Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:16.782Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:17 GMT
+      - Sun, 29 Oct 2023 22:18:16 GMT
       location:
-      - https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+      - https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 48d14da5-3628-4d8c-9911-381d379bbce5
+      - e5530809-8408-4c71-bc69-f35a0f68cf38
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:17 GMT
+      - Sun, 29 Oct 2023 22:18:17 GMT
       mise-correlation-id:
-      - ed22da42-2d92-4088-bc53-858c73fcbb6b
+      - aa4b5edf-1589-405a-a34d-84f30d57000e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A18Z&sr=b&sp=r&sig=58SG25yNuXTtXH%2B1xSg%2BSSLba1FncgAXd%2BhbKBPMNkM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:18.2752673","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A17Z&sr=b&sp=r&sig=L7X4pxEUc5PFWWfsx2CC9fpfJvUU7Afw6o8851GFUzg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:17.5832916","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:18 GMT
+      - Sun, 29 Oct 2023 22:18:17 GMT
       location:
-      - https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 58788f95-8c0b-4f4e-be80-d356783f01e0
+      - ce4ab8c6-0f42-400a-be49-0ca1f7187adf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,46 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A18Z&sr=b&sp=r&sig=0b0LUEoh0Jzhb2Jn9bXUC4DiVKCsqLHh9M3XRvKdRt4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:18.5656607","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:25:18 GMT
-      mise-correlation-id:
-      - 57f93472-067d-4db7-ac8a-a2ad2c055ee6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A23Z&sr=b&sp=r&sig=szWq3LcmgLoFL%2BNLaSbJOgXbyZPK9JPiw5pmfo5TPbE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:23.8379018","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A17Z&sr=b&sp=r&sig=HMUSt1WW4PPfO4kMC%2BeHseyqN6eXnP7GX5tV2j2rlvg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:17.8288542","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:23 GMT
+      - Sun, 29 Oct 2023 22:18:17 GMT
       mise-correlation-id:
-      - d807f9cf-6d1f-4557-ac24-e5135d1b1a31
+      - 52d1c881-6850-4350-badf-e36bf1673bc8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A29Z&sr=b&sp=r&sig=9bVxMhLSrgoSafN%2FsQmE59Gq9GE9G2i0bKm6DGaaITo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:29.1125197","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A23Z&sr=b&sp=r&sig=wXPGjseyl4BzrTZsD%2B%2FTSAwof1941miRmboU5Yb%2FCSc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:23.0790508","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:29 GMT
+      - Sun, 29 Oct 2023 22:18:23 GMT
       mise-correlation-id:
-      - ee55c5f1-0358-412c-b680-ae4d2a32e624
+      - 9d82e71f-6e55-466a-b2e9-608fee837c03
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A34Z&sr=b&sp=r&sig=h3i1R02Yijt4x9EGubV0X66OO88W1%2ByNHiDOolqd%2BHI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:34.3780675","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A28Z&sr=b&sp=r&sig=oN%2FQEaaxSHvqgzaomwPainXV%2BJ%2FrrMW3IV49bPogJxU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:28.3355932","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:34 GMT
+      - Sun, 29 Oct 2023 22:18:28 GMT
       mise-correlation-id:
-      - d4269557-a781-4e9e-9e62-016d2f969f52
+      - 7769be2c-f928-4c08-8fc7-308cd9e3b207
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +421,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b70836db-2f7d-4a11-9034-f48d8d0334fb":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f0e2d7e-4a15-420d-8af4-9580f3ef5467":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"653cdc18-1d81-4e28-b025-2bad816a0495":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A25%3A34Z&sr=b&sp=r&sig=HiKo2OQnA79ZxOmjwOwIOq39PJFdW0XkJajy14ZISBk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:25:34.7274447","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:17.391Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:30.791Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A33Z&sr=b&sp=r&sig=uDoNnilZBkmbCG9oGxACDXzkSZpcA2TtYtcWBWVALQg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:33.5847509","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1579'
+      - '547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:34 GMT
+      - Sun, 29 Oct 2023 22:18:33 GMT
       mise-correlation-id:
-      - e8751153-9ca0-4289-a068-19a9bfc00e37
+      - 6137f637-9f6b-4b29-9c30-31ba4e92d3c9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7c26b6fc-4baf-415c-844e-9eda11c808f1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"84f5cdd0-8ab6-40ac-a43a-48b3c252b345":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1cf34253-8265-4493-bfc7-97fe3744e0fa":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A18%3A33Z&sr=b&sp=r&sig=ELY68063ZauZxGOjgi4CcQou%2FoiSMdNiUekF4FVYt8g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:18:33.8273917","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.782Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:29.764Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1581'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:18:33 GMT
+      mise-correlation-id:
+      - 2978327f-9c2c-4066-9eb2-bad9fdec906b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:40.8931233Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:40.8931233Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:39.8587855Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:39.8587855Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:36 GMT
+      - Sun, 29 Oct 2023 22:18:34 GMT
       etag:
-      - '"d300eb31-0000-0100-0000-6537b78a0000"'
+      - '"3c00f621-0000-0100-0000-653eda060000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"b70836db-2f7d-4a11-9034-f48d8d0334fb":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f0e2d7e-4a15-420d-8af4-9580f3ef5467":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"653cdc18-1d81-4e28-b025-2bad816a0495":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A25%3A37Z&sr=b&sp=r&sig=6KQKRn9iIo%2BbwlejiYNgd8O81UuAQZOMDRf6IQcxQzs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:25:37.4299883","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:17.391Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:30.791Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"7c26b6fc-4baf-415c-844e-9eda11c808f1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"84f5cdd0-8ab6-40ac-a43a-48b3c252b345":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1cf34253-8265-4493-bfc7-97fe3744e0fa":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A18%3A36Z&sr=b&sp=r&sig=aJAhvlPBdiku%2BSYK87Yle%2FWNSLRVgI3LFyJGKs7zC50%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:18:36.1578677","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.782Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:29.764Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1593'
+      - '1595'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:37 GMT
+      - Sun, 29 Oct 2023 22:18:36 GMT
       mise-correlation-id:
-      - ae33d648-10bc-4efa-b479-7494440a2fc7
+      - 7cd3c47c-fa5e-4e80-bf68-11022549dac1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:40.8931233Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:40.8931233Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:39.8587855Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:39.8587855Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:38 GMT
+      - Sun, 29 Oct 2023 22:18:37 GMT
       etag:
-      - '"d300eb31-0000-0100-0000-6537b78a0000"'
+      - '"3c00f621-0000-0100-0000-653eda060000"'
       expires:
       - '-1'
       pragma:
@@ -619,23 +619,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A39Z&sr=b&sp=r&sig=sh1WwTS2MvyCqSdm82dVnOzv2id%2BC0w74gyioAmTwys%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:39.183621","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A38Z&sr=b&sp=r&sig=3elWd8jYeLfHQCd6AqKcQVPLU4ux0ANZVJ6TopgLhw4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:38.9516278","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '560'
+      - '559'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:39 GMT
+      - Sun, 29 Oct 2023 22:18:38 GMT
       mise-correlation-id:
-      - 8698b2c8-ed68-4d6e-837b-5234eaa9958e
+      - bbc6ed35-1dc8-476b-87b3-d84d1224dcba
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -655,7 +655,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A39Z&sr=b&sp=r&sig=sh1WwTS2MvyCqSdm82dVnOzv2id%2BC0w74gyioAmTwys%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A38Z&sr=b&sp=r&sig=3elWd8jYeLfHQCd6AqKcQVPLU4ux0ANZVJ6TopgLhw4%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -728,17 +728,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Tue, 24 Oct 2023 12:25:39 GMT
+      - Sun, 29 Oct 2023 22:18:39 GMT
       etag:
-      - '"0x8DBD48C488A2D4C"'
+      - '"0x8DBD8CCF38AB4F6"'
       last-modified:
-      - Tue, 24 Oct 2023 12:25:18 GMT
+      - Sun, 29 Oct 2023 22:18:17 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Tue, 24 Oct 2023 12:25:18 GMT
+      - Sun, 29 Oct 2023 22:18:17 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -771,18 +771,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:40.8931233Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:40.8931233Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:39.8587855Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:39.8587855Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:41 GMT
+      - Sun, 29 Oct 2023 22:18:40 GMT
       etag:
-      - '"d300eb31-0000-0100-0000-6537b78a0000"'
+      - '"3c00f621-0000-0100-0000-653eda060000"'
       expires:
       - '-1'
       pragma:
@@ -812,10 +812,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A42Z&sr=b&sp=r&sig=X8VEtS4NSPVhNkZviyxSOZfw%2BL4kLgMBQd0CY1ZlfjM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:42.2122716","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A41Z&sr=b&sp=r&sig=Ud1eAt40bVI5uJw3m1%2Bb4g6YYkdLOCvuqkZBzQsGzk0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:41.7293352","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -826,9 +826,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:42 GMT
+      - Sun, 29 Oct 2023 22:18:41 GMT
       mise-correlation-id:
-      - 10430d69-4721-4e1c-a01c-ff00c4db1027
+      - 8c7a6483-1529-4c29-8c41-a35f0d3c6680
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_download_files.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_download_files.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:04.6018485Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:04.6018485Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:40.8931233Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:40.8931233Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:38 GMT
+      - Tue, 24 Oct 2023 12:25:15 GMT
       etag:
-      - '"7500f939-0000-0100-0000-653044860000"'
+      - '"d300eb31-0000-0100-0000-6537b78a0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:48:40 GMT
+      - Tue, 24 Oct 2023 12:25:16 GMT
       mise-correlation-id:
-      - 65e48493-07f2-45ad-86be-3aa35d4f39bf
+      - a16e7df0-eaa7-4575-b519-bbdf0d786f85
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"ee6e3286-09fc-404b-b551-7c1cdd9bc4ae": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "02cbe82f-2afc-495e-9a8f-c7da8be685a9":
+      {"passFailMetrics": {"b70836db-2f7d-4a11-9034-f48d8d0334fb": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "2f0e2d7e-4a15-420d-8af4-9580f3ef5467":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "9b8c1e99-b714-4cc5-a0e8-8188f75cedda": {"aggregate": "avg", "clientMetric":
+      "50"}, "653cdc18-1d81-4e28-b025-2bad816a0495": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ee6e3286-09fc-404b-b551-7c1cdd9bc4ae":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"02cbe82f-2afc-495e-9a8f-c7da8be685a9":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9b8c1e99-b714-4cc5-a0e8-8188f75cedda":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:41.256Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:41.256Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b70836db-2f7d-4a11-9034-f48d8d0334fb":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f0e2d7e-4a15-420d-8af4-9580f3ef5467":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"653cdc18-1d81-4e28-b025-2bad816a0495":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:17.391Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:17.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:41 GMT
+      - Tue, 24 Oct 2023 12:25:17 GMT
       location:
-      - https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+      - https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 6dcfadfc-e27e-4818-bc5f-faaf104983af
+      - 48d14da5-3628-4d8c-9911-381d379bbce5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:41 GMT
+      - Tue, 24 Oct 2023 12:25:17 GMT
       mise-correlation-id:
-      - bd1d61ee-4628-4778-937f-a0434d2eb0f5
+      - ed22da42-2d92-4088-bc53-858c73fcbb6b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A42Z&sr=b&sp=r&sig=QawUttm%2BRA0e7d0vx2%2B%2FzWny6R7LyhlKt%2FHKJmn94zA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:42.4701849","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A18Z&sr=b&sp=r&sig=58SG25yNuXTtXH%2B1xSg%2BSSLba1FncgAXd%2BhbKBPMNkM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:18.2752673","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '557'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:42 GMT
+      - Tue, 24 Oct 2023 12:25:18 GMT
       location:
-      - https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 30f40a1b-9b90-421c-9cd7-c631995256cd
+      - 58788f95-8c0b-4f4e-be80-d356783f01e0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A42Z&sr=b&sp=r&sig=PJpi8akEpEl0%2FSjoM%2FfFT9NO9cPfnM4d%2BIn%2FjXSsm9c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:42.717056","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '556'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:48:42 GMT
-      mise-correlation-id:
-      - 7415ebcc-ba1b-475c-90ef-9460aebcdf59
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A47Z&sr=b&sp=r&sig=8eWA6CUqRd2T%2BZiayQk%2BQpWdxVlHS3Hqf9fEUMnjAfs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:47.9756882","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:48:47 GMT
-      mise-correlation-id:
-      - 57af050b-6a2f-4b1e-a8cd-cac65b93add7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A53Z&sr=b&sp=r&sig=N7PSzhFpZ5BLzG66lEQmS8mO2lTv0IMTy3kCRx7Wyow%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:53.2552763","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A18Z&sr=b&sp=r&sig=0b0LUEoh0Jzhb2Jn9bXUC4DiVKCsqLHh9M3XRvKdRt4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:18.5656607","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:53 GMT
+      - Tue, 24 Oct 2023 12:25:18 GMT
       mise-correlation-id:
-      - 459dfc58-c17f-4784-9992-09105a703928
+      - 57f93472-067d-4db7-ac8a-a2ad2c055ee6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A58Z&sr=b&sp=r&sig=zxII7J1gDpvzyfEDu%2FA76xVPdsndGmiXDhkY9GVIY34%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:58.551762","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A23Z&sr=b&sp=r&sig=szWq3LcmgLoFL%2BNLaSbJOgXbyZPK9JPiw5pmfo5TPbE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:23.8379018","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '548'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:58 GMT
+      - Tue, 24 Oct 2023 12:25:23 GMT
       mise-correlation-id:
-      - a54d2f73-db34-4378-9f46-db4a7b902f4d
+      - d807f9cf-6d1f-4557-ac24-e5135d1b1a31
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,11 +385,83 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ee6e3286-09fc-404b-b551-7c1cdd9bc4ae":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"02cbe82f-2afc-495e-9a8f-c7da8be685a9":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9b8c1e99-b714-4cc5-a0e8-8188f75cedda":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A48%3A58Z&sr=b&sp=r&sig=d1anpRjtiZBL36mQkaTEIkYF0McWhkPzf9iVMm8pCJw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:48:58.8607626","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:41.256Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:54.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A29Z&sr=b&sp=r&sig=9bVxMhLSrgoSafN%2FsQmE59Gq9GE9G2i0bKm6DGaaITo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:29.1125197","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:25:29 GMT
+      mise-correlation-id:
+      - ee55c5f1-0358-412c-b680-ae4d2a32e624
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A34Z&sr=b&sp=r&sig=h3i1R02Yijt4x9EGubV0X66OO88W1%2ByNHiDOolqd%2BHI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:34.3780675","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:25:34 GMT
+      mise-correlation-id:
+      - d4269557-a781-4e9e-9e62-016d2f969f52
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b70836db-2f7d-4a11-9034-f48d8d0334fb":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f0e2d7e-4a15-420d-8af4-9580f3ef5467":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"653cdc18-1d81-4e28-b025-2bad816a0495":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A25%3A34Z&sr=b&sp=r&sig=HiKo2OQnA79ZxOmjwOwIOq39PJFdW0XkJajy14ZISBk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:25:34.7274447","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:17.391Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:30.791Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,9 +472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:58 GMT
+      - Tue, 24 Oct 2023 12:25:34 GMT
       mise-correlation-id:
-      - d176a38a-d9b7-4242-9a98-5a680a6b1b0c
+      - e8751153-9ca0-4289-a068-19a9bfc00e37
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:04.6018485Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:04.6018485Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:40.8931233Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:40.8931233Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:00 GMT
+      - Tue, 24 Oct 2023 12:25:36 GMT
       etag:
-      - '"7500f939-0000-0100-0000-653044860000"'
+      - '"d300eb31-0000-0100-0000-6537b78a0000"'
       expires:
       - '-1'
       pragma:
@@ -538,11 +538,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ee6e3286-09fc-404b-b551-7c1cdd9bc4ae":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"02cbe82f-2afc-495e-9a8f-c7da8be685a9":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9b8c1e99-b714-4cc5-a0e8-8188f75cedda":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A49%3A01Z&sr=b&sp=r&sig=Gp3xs3xBQwDMZqisIDpWpz5cp%2Ff63d4Bvt6pWRHBaFs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:49:01.0979875","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:41.256Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:54.998Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"b70836db-2f7d-4a11-9034-f48d8d0334fb":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f0e2d7e-4a15-420d-8af4-9580f3ef5467":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"653cdc18-1d81-4e28-b025-2bad816a0495":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A25%3A37Z&sr=b&sp=r&sig=6KQKRn9iIo%2BbwlejiYNgd8O81UuAQZOMDRf6IQcxQzs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:25:37.4299883","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:17.391Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:30.791Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:01 GMT
+      - Tue, 24 Oct 2023 12:25:37 GMT
       mise-correlation-id:
-      - 8a448a1a-eb39-4eb9-8423-94fab39289cc
+      - ae33d648-10bc-4efa-b479-7494440a2fc7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:04.6018485Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:04.6018485Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:40.8931233Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:40.8931233Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:02 GMT
+      - Tue, 24 Oct 2023 12:25:38 GMT
       etag:
-      - '"7500f939-0000-0100-0000-653044860000"'
+      - '"d300eb31-0000-0100-0000-6537b78a0000"'
       expires:
       - '-1'
       pragma:
@@ -619,23 +619,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A03Z&sr=b&sp=r&sig=4XQU1dgYfEocIyOrOidwj3W2FL0yn1UcXQ%2Bm6ypUlJo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:03.2917591","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A39Z&sr=b&sp=r&sig=sh1WwTS2MvyCqSdm82dVnOzv2id%2BC0w74gyioAmTwys%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:39.183621","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '561'
+      - '560'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:03 GMT
+      - Tue, 24 Oct 2023 12:25:39 GMT
       mise-correlation-id:
-      - 169d3cd2-9a95-4bf4-9b06-5c8eeebdf38b
+      - 8698b2c8-ed68-4d6e-837b-5234eaa9958e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -655,7 +655,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A03Z&sr=b&sp=r&sig=4XQU1dgYfEocIyOrOidwj3W2FL0yn1UcXQ%2Bm6ypUlJo%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A39Z&sr=b&sp=r&sig=sh1WwTS2MvyCqSdm82dVnOzv2id%2BC0w74gyioAmTwys%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -728,17 +728,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 18 Oct 2023 20:49:04 GMT
+      - Tue, 24 Oct 2023 12:25:39 GMT
       etag:
-      - '"0x8DBD01B9D2DB0B8"'
+      - '"0x8DBD48C488A2D4C"'
       last-modified:
-      - Wed, 18 Oct 2023 20:48:42 GMT
+      - Tue, 24 Oct 2023 12:25:18 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 18 Oct 2023 20:48:42 GMT
+      - Tue, 24 Oct 2023 12:25:18 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -771,7 +771,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:04.6018485Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:04.6018485Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:40.8931233Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:40.8931233Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -780,9 +780,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:04 GMT
+      - Tue, 24 Oct 2023 12:25:41 GMT
       etag:
-      - '"7500f939-0000-0100-0000-653044860000"'
+      - '"d300eb31-0000-0100-0000-6537b78a0000"'
       expires:
       - '-1'
       pragma:
@@ -812,10 +812,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b152af73-9ef8-4d84-acd9-c467123e4dbb.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://a5894a9e-71be-4584-96be-146253ffd44e.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0b999ae7-f313-4adb-9af5-6df795826fe5/00a5fd07-c0b5-45d1-a764-e02bda9bd69a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A59%3A05Z&sr=b&sp=r&sig=IiTbdQiL24LyIIsxvQZX8SfPiOfc6IpYzW5zU%2BH1nuU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:59:05.9031791","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2ec3efd6-5e5e-4b23-b929-edbbd6390986/4cb28623-3f28-4b65-af8b-97354e79f888?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A42Z&sr=b&sp=r&sig=X8VEtS4NSPVhNkZviyxSOZfw%2BL4kLgMBQd0CY1ZlfjM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:42.2122716","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -826,9 +826,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:05 GMT
+      - Tue, 24 Oct 2023 12:25:42 GMT
       mise-correlation-id:
-      - 8b70dfc6-577e-4d02-86f2-bf25114bc99e
+      - 10430d69-4721-4e1c-a01c-ff00c4db1027
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_download_files.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_download_files.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:39.8587855Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:39.8587855Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:17:21.0307622Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:17:21.0307622Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"010d8913-81b6-40b4-8bfa-e8b46502d5e4.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:14 GMT
+      - Mon, 30 Oct 2023 07:17:56 GMT
       etag:
-      - '"3c00f621-0000-0100-0000-653eda060000"'
+      - '"3f00b665-0000-0100-0000-653f58830000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://010d8913-81b6-40b4-8bfa-e8b46502d5e4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:18:16 GMT
+      - Mon, 30 Oct 2023 07:17:58 GMT
       mise-correlation-id:
-      - 6129a4a0-b173-4ee2-94d2-6429f060e2d8
+      - b6d9dc9c-5ec0-4752-8d56-1440adda1455
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"7c26b6fc-4baf-415c-844e-9eda11c808f1": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "84f5cdd0-8ab6-40ac-a43a-48b3c252b345":
+      {"passFailMetrics": {"e8feaa4d-6bf1-42a8-9dec-54012ebc9a82": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "00539954-9ccd-4ba3-9765-23cf1497544a":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "1cf34253-8265-4493-bfc7-97fe3744e0fa": {"aggregate": "avg", "clientMetric":
+      "50"}, "85903b17-71bf-4f51-8b68-0807682b50eb": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://010d8913-81b6-40b4-8bfa-e8b46502d5e4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7c26b6fc-4baf-415c-844e-9eda11c808f1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"84f5cdd0-8ab6-40ac-a43a-48b3c252b345":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1cf34253-8265-4493-bfc7-97fe3744e0fa":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.782Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:16.782Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"e8feaa4d-6bf1-42a8-9dec-54012ebc9a82":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"00539954-9ccd-4ba3-9765-23cf1497544a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"85903b17-71bf-4f51-8b68-0807682b50eb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:17:59.548Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:17:59.548Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:16 GMT
+      - Mon, 30 Oct 2023 07:17:59 GMT
       location:
-      - https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+      - https://010d8913-81b6-40b4-8bfa-e8b46502d5e4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - e5530809-8408-4c71-bc69-f35a0f68cf38
+      - b4d4ff30-459e-49f5-b419-eb0d9337d455
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://010d8913-81b6-40b4-8bfa-e8b46502d5e4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:17 GMT
+      - Mon, 30 Oct 2023 07:17:59 GMT
       mise-correlation-id:
-      - aa4b5edf-1589-405a-a34d-84f30d57000e
+      - fd9e165a-3211-496c-9047-38be99c473fa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://010d8913-81b6-40b4-8bfa-e8b46502d5e4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A17Z&sr=b&sp=r&sig=L7X4pxEUc5PFWWfsx2CC9fpfJvUU7Afw6o8851GFUzg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:17.5832916","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/218eb53f-2449-4dc9-b94a-767c1f284057/fee58eaf-36e8-46f3-b82d-4bcec2ea2a50?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A00Z&sr=b&sp=r&sig=m0k5aKoknak1wGRUu%2BQOvDgdDUXXZwrH1TK7urBgh2g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:00.7067977","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:17 GMT
+      - Mon, 30 Oct 2023 07:18:00 GMT
       location:
-      - https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://010d8913-81b6-40b4-8bfa-e8b46502d5e4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - ce4ab8c6-0f42-400a-be49-0ca1f7187adf
+      - 0405a2c8-b4ca-496a-82c1-a461e4fa6a36
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://010d8913-81b6-40b4-8bfa-e8b46502d5e4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A17Z&sr=b&sp=r&sig=HMUSt1WW4PPfO4kMC%2BeHseyqN6eXnP7GX5tV2j2rlvg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:17.8288542","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/218eb53f-2449-4dc9-b94a-767c1f284057/fee58eaf-36e8-46f3-b82d-4bcec2ea2a50?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A00Z&sr=b&sp=r&sig=eBbhEpuROpvSf9VnboIGRG0%2FLS4OY8UEOEniacseQdg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:00.9535324","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:17 GMT
+      - Mon, 30 Oct 2023 07:18:00 GMT
       mise-correlation-id:
-      - 52d1c881-6850-4350-badf-e36bf1673bc8
+      - 202220fb-0094-4582-b22a-3db2cce06433
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://010d8913-81b6-40b4-8bfa-e8b46502d5e4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A23Z&sr=b&sp=r&sig=wXPGjseyl4BzrTZsD%2B%2FTSAwof1941miRmboU5Yb%2FCSc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:23.0790508","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/218eb53f-2449-4dc9-b94a-767c1f284057/fee58eaf-36e8-46f3-b82d-4bcec2ea2a50?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A06Z&sr=b&sp=r&sig=fPVR%2FUQ5wpqkyuJAG37HNsoZYNYlCiHOr7cwUQrfc1o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:06.201596","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:23 GMT
+      - Mon, 30 Oct 2023 07:18:06 GMT
       mise-correlation-id:
-      - 9d82e71f-6e55-466a-b2e9-608fee837c03
+      - 98435279-e749-441b-bb92-23fb6d8b48d5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://010d8913-81b6-40b4-8bfa-e8b46502d5e4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A28Z&sr=b&sp=r&sig=oN%2FQEaaxSHvqgzaomwPainXV%2BJ%2FrrMW3IV49bPogJxU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:28.3355932","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/218eb53f-2449-4dc9-b94a-767c1f284057/fee58eaf-36e8-46f3-b82d-4bcec2ea2a50?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A11Z&sr=b&sp=r&sig=46KGDGKw%2FHCeI1tMWOxzU1W0IkmWzzdwGl7TdTVA95o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:11.4483584","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:28 GMT
+      - Mon, 30 Oct 2023 07:18:11 GMT
       mise-correlation-id:
-      - 7769be2c-f928-4c08-8fc7-308cd9e3b207
+      - 5ef7bc37-458d-4673-be0d-34ef8eb3932c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://010d8913-81b6-40b4-8bfa-e8b46502d5e4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A33Z&sr=b&sp=r&sig=uDoNnilZBkmbCG9oGxACDXzkSZpcA2TtYtcWBWVALQg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:33.5847509","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/218eb53f-2449-4dc9-b94a-767c1f284057/fee58eaf-36e8-46f3-b82d-4bcec2ea2a50?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A16Z&sr=b&sp=r&sig=Vj%2FGWmTVL0ckTpDgWehQ89WbawN%2FYCTrEfxcnhcR9cY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:16.7014206","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:33 GMT
+      - Mon, 30 Oct 2023 07:18:16 GMT
       mise-correlation-id:
-      - 6137f637-9f6b-4b29-9c30-31ba4e92d3c9
+      - 51911c2b-07f5-4632-a299-832dc96ccac8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://010d8913-81b6-40b4-8bfa-e8b46502d5e4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7c26b6fc-4baf-415c-844e-9eda11c808f1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"84f5cdd0-8ab6-40ac-a43a-48b3c252b345":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1cf34253-8265-4493-bfc7-97fe3744e0fa":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A18%3A33Z&sr=b&sp=r&sig=ELY68063ZauZxGOjgi4CcQou%2FoiSMdNiUekF4FVYt8g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:18:33.8273917","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.782Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:29.764Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"e8feaa4d-6bf1-42a8-9dec-54012ebc9a82":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"00539954-9ccd-4ba3-9765-23cf1497544a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"85903b17-71bf-4f51-8b68-0807682b50eb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/218eb53f-2449-4dc9-b94a-767c1f284057/fee58eaf-36e8-46f3-b82d-4bcec2ea2a50?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A18%3A16Z&sr=b&sp=r&sig=osmuXNhTFkSzL1cQcoBKEGIZhWDfsAWMB90k7Ym3arU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:18:16.948021","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:17:59.548Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:18:14.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1581'
+      - '1578'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:33 GMT
+      - Mon, 30 Oct 2023 07:18:17 GMT
       mise-correlation-id:
-      - 2978327f-9c2c-4066-9eb2-bad9fdec906b
+      - 55191813-c7cf-44a4-b5e1-98ca42d1d9c6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:39.8587855Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:39.8587855Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:17:21.0307622Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:17:21.0307622Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"010d8913-81b6-40b4-8bfa-e8b46502d5e4.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:34 GMT
+      - Mon, 30 Oct 2023 07:18:18 GMT
       etag:
-      - '"3c00f621-0000-0100-0000-653eda060000"'
+      - '"3f00b665-0000-0100-0000-653f58830000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://010d8913-81b6-40b4-8bfa-e8b46502d5e4.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"7c26b6fc-4baf-415c-844e-9eda11c808f1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"84f5cdd0-8ab6-40ac-a43a-48b3c252b345":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1cf34253-8265-4493-bfc7-97fe3744e0fa":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A18%3A36Z&sr=b&sp=r&sig=aJAhvlPBdiku%2BSYK87Yle%2FWNSLRVgI3LFyJGKs7zC50%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:18:36.1578677","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.782Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:29.764Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"e8feaa4d-6bf1-42a8-9dec-54012ebc9a82":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"00539954-9ccd-4ba3-9765-23cf1497544a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"85903b17-71bf-4f51-8b68-0807682b50eb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/218eb53f-2449-4dc9-b94a-767c1f284057/fee58eaf-36e8-46f3-b82d-4bcec2ea2a50?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A18%3A19Z&sr=b&sp=r&sig=HowF%2BKe7IainGZR4HDwaJESjkIrmOZtcPzz9klou6aY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:18:19.4549402","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:17:59.548Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:18:14.176Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1595'
+      - '1593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:36 GMT
+      - Mon, 30 Oct 2023 07:18:19 GMT
       mise-correlation-id:
-      - 7cd3c47c-fa5e-4e80-bf68-11022549dac1
+      - 0856d8aa-925f-48c6-b9f8-490f94dfbb57
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:39.8587855Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:39.8587855Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:17:21.0307622Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:17:21.0307622Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"010d8913-81b6-40b4-8bfa-e8b46502d5e4.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:37 GMT
+      - Mon, 30 Oct 2023 07:18:21 GMT
       etag:
-      - '"3c00f621-0000-0100-0000-653eda060000"'
+      - '"3f00b665-0000-0100-0000-653f58830000"'
       expires:
       - '-1'
       pragma:
@@ -619,23 +619,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://010d8913-81b6-40b4-8bfa-e8b46502d5e4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A38Z&sr=b&sp=r&sig=3elWd8jYeLfHQCd6AqKcQVPLU4ux0ANZVJ6TopgLhw4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:38.9516278","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/218eb53f-2449-4dc9-b94a-767c1f284057/fee58eaf-36e8-46f3-b82d-4bcec2ea2a50?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A21Z&sr=b&sp=r&sig=ithHsJY3IGlEmgezoKbSiYjSv%2FsfGmOFhJl0%2FgPgIPk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:21.871142","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '559'
+      - '562'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:38 GMT
+      - Mon, 30 Oct 2023 07:18:21 GMT
       mise-correlation-id:
-      - bbc6ed35-1dc8-476b-87b3-d84d1224dcba
+      - 8c238941-9329-49a6-a5b8-c6aab24c0ccf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -655,7 +655,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A38Z&sr=b&sp=r&sig=3elWd8jYeLfHQCd6AqKcQVPLU4ux0ANZVJ6TopgLhw4%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/218eb53f-2449-4dc9-b94a-767c1f284057/fee58eaf-36e8-46f3-b82d-4bcec2ea2a50?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A21Z&sr=b&sp=r&sig=ithHsJY3IGlEmgezoKbSiYjSv%2FsfGmOFhJl0%2FgPgIPk%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -728,17 +728,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Sun, 29 Oct 2023 22:18:39 GMT
+      - Mon, 30 Oct 2023 07:18:22 GMT
       etag:
-      - '"0x8DBD8CCF38AB4F6"'
+      - '"0x8DBD9185968C24B"'
       last-modified:
-      - Sun, 29 Oct 2023 22:18:17 GMT
+      - Mon, 30 Oct 2023 07:18:00 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Sun, 29 Oct 2023 22:18:17 GMT
+      - Mon, 30 Oct 2023 07:18:00 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -771,7 +771,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:39.8587855Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:39.8587855Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:17:21.0307622Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:17:21.0307622Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"010d8913-81b6-40b4-8bfa-e8b46502d5e4.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -780,9 +780,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:40 GMT
+      - Mon, 30 Oct 2023 07:18:24 GMT
       etag:
-      - '"3c00f621-0000-0100-0000-653eda060000"'
+      - '"3f00b665-0000-0100-0000-653f58830000"'
       expires:
       - '-1'
       pragma:
@@ -812,10 +812,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5249f6c-68a3-41ef-a882-32f571d1f3ce.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://010d8913-81b6-40b4-8bfa-e8b46502d5e4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c66d49bd-70c4-489a-bc72-5c2087024dd2/ddec3a17-6a1e-4cbd-9805-3c9b8ee691bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A41Z&sr=b&sp=r&sig=Ud1eAt40bVI5uJw3m1%2Bb4g6YYkdLOCvuqkZBzQsGzk0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:41.7293352","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/218eb53f-2449-4dc9-b94a-767c1f284057/fee58eaf-36e8-46f3-b82d-4bcec2ea2a50?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A25Z&sr=b&sp=r&sig=n1mWrDV0Dj6fKzjmvK7MW53KlhIBAtCe5d3rQ%2Bp5Qj8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:25.6538601","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -826,9 +826,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:41 GMT
+      - Mon, 30 Oct 2023 07:18:25 GMT
       mise-correlation-id:
-      - 8c7a6483-1529-4c29-8c41-a35f0d3c6680
+      - 289b1712-9b9b-472b-815d-9d533ec7105a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_download_files.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_download_files.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:08:18.8481821Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:08:18.8481821Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e242f6a9-fe99-4f9e-b0d5-67c4ecb42936.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5109652Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5109652Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:08:53 GMT
+      - Mon, 09 Oct 2023 16:09:07 GMT
       etag:
-      - '"1a0aac97-0000-0100-0000-64af08350000"'
+      - '"92014d89-0000-0100-0000-652425830000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e242f6a9-fe99-4f9e-b0d5-67c4ecb42936.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:08:54 GMT
+      - Mon, 09 Oct 2023 16:09:08 GMT
       mise-correlation-id:
-      - 6ee1864f-8a38-4358-9f4d-8633c89b6d6a
+      - 89ddf57c-be54-4427-99f3-bdc6d1fd4984
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -85,12 +85,12 @@ interactions:
 - request:
     body: '{"displayName": "CLI-Test", "description": "Test created from az load test
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
-      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "loadTestConfiguration":
+      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"a7d12acd-8d46-46cd-ad9b-b1ce80286f62": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "121493fc-52bc-44eb-af5b-cd474dda8da5":
+      {"passFailMetrics": {"9b5e46e4-24f6-4585-9169-947f4fe5c111": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "a746bd92-bb50-4d23-a854-5759986dd7bf":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "099eed5c-bef7-40d0-89e6-9c3946de8e54": {"aggregate": "avg", "clientMetric":
+      "50"}, "a9449f9d-edda-43ef-940a-d20e2395a1ff": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -100,32 +100,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '768'
+      - '789'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://e242f6a9-fe99-4f9e-b0d5-67c4ecb42936.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"a7d12acd-8d46-46cd-ad9b-b1ce80286f62":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"121493fc-52bc-44eb-af5b-cd474dda8da5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"099eed5c-bef7-40d0-89e6-9c3946de8e54":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:08:54.935Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:08:54.935Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9b5e46e4-24f6-4585-9169-947f4fe5c111":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a746bd92-bb50-4d23-a854-5759986dd7bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"a9449f9d-edda-43ef-940a-d20e2395a1ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:09.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:09.208Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1064'
+      - '1010'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:08:54 GMT
+      - Mon, 09 Oct 2023 16:09:09 GMT
       location:
-      - https://e242f6a9-fe99-4f9e-b0d5-67c4ecb42936.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+      - https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - eac2a29a-1f24-4f4d-9d71-867db52f339c
+      - ea700970-5971-4720-8a9b-a3247f79a743
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e242f6a9-fe99-4f9e-b0d5-67c4ecb42936.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:08:55 GMT
+      - Mon, 09 Oct 2023 16:09:09 GMT
       mise-correlation-id:
-      - f26d945f-cf58-4f86-892f-669c38b76440
+      - d10b0bd0-9be9-4c28-9230-3ff88c9b630c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://e242f6a9-fe99-4f9e-b0d5-67c4ecb42936.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a828e1c9-8566-42e4-81e5-c43d3e48b371/60910128-b7c4-4cce-b937-48e6333c08c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A18%3A55Z&sr=b&sp=r&sig=3beqSkvVj0S3NyBCmB85dZbGwVlBVeYnqeh9rIF4bkI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:18:55.7477662","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A10Z&sr=b&sp=r&sig=RJntwhdlNd2W8Jpag470xLZEd5NZ%2F995Lm4d08Nyze4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:10.0542915","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:08:55 GMT
+      - Mon, 09 Oct 2023 16:09:10 GMT
       location:
-      - https://e242f6a9-fe99-4f9e-b0d5-67c4ecb42936.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - c7859596-abbc-4aef-942e-9306d1303f2a
+      - 7b20afe8-7b79-4f7c-892c-98e8a32f4d6f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e242f6a9-fe99-4f9e-b0d5-67c4ecb42936.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a828e1c9-8566-42e4-81e5-c43d3e48b371/60910128-b7c4-4cce-b937-48e6333c08c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A18%3A56Z&sr=b&sp=r&sig=OoiHziB%2BtsMs8wALs61WH8j5X%2F0QqaTPX9JvJPj%2BFpQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:18:56.0555164","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A10Z&sr=b&sp=r&sig=xsHOG6BgtwauVIXsS5Wr%2BeCNARn2n%2FsTzMBndQlhRMA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:10.3891653","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:08:56 GMT
+      - Mon, 09 Oct 2023 16:09:10 GMT
       mise-correlation-id:
-      - e48f3fe9-a5e6-4fa0-81fc-22f5406297be
+      - e9e60c22-2e11-413c-aba3-48c1ea11f008
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,10 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e242f6a9-fe99-4f9e-b0d5-67c4ecb42936.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a828e1c9-8566-42e4-81e5-c43d3e48b371/60910128-b7c4-4cce-b937-48e6333c08c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A19%3A01Z&sr=b&sp=r&sig=mweMoX4UAVN44lC7blqTwQGj%2Bq5rB7l1sCGSIQKw3qY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:19:01.3274074","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A15Z&sr=b&sp=r&sig=GyhEekBLXS7uyuzP%2Bdz1mQ3OP8TbOG1sfdJh4qBtOh0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:15.7144511","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:01 GMT
+      - Mon, 09 Oct 2023 16:09:15 GMT
       mise-correlation-id:
-      - 9ba46749-bf0b-4433-a9b6-ff1035c96b13
+      - 91d077c3-7cea-46ec-9ca2-4258ee195a6b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e242f6a9-fe99-4f9e-b0d5-67c4ecb42936.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a828e1c9-8566-42e4-81e5-c43d3e48b371/60910128-b7c4-4cce-b937-48e6333c08c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A19%3A06Z&sr=b&sp=r&sig=2Dhdi00Z4ezDy1FBxTNkgWvwGe5hpNTihzQarAeqHEE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:19:06.6106203","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A20Z&sr=b&sp=r&sig=yQOzjUwKgxgI7Rdy5x%2BMltW6FmfMQy7Rqf7fTdhDBjQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:20.9837472","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:06 GMT
+      - Mon, 09 Oct 2023 16:09:20 GMT
       mise-correlation-id:
-      - 8ef21bd8-cc41-481b-9179-0a0be88dc7a4
+      - 63ddc570-30e0-4034-8a1c-e5368fd79895
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,10 +421,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e242f6a9-fe99-4f9e-b0d5-67c4ecb42936.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a828e1c9-8566-42e4-81e5-c43d3e48b371/60910128-b7c4-4cce-b937-48e6333c08c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A19%3A11Z&sr=b&sp=r&sig=rQf9hcOxQajP0vV1O9K1jer90AhL8M7Np9R%2Bh1Lj1As%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:19:11.88507","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A26Z&sr=b&sp=r&sig=3390APcQOI7yYDf6ixD2Uvhpzze7JC2GjjJJow5YYBc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:26.2550156","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:11 GMT
+      - Mon, 09 Oct 2023 16:09:26 GMT
       mise-correlation-id:
-      - bc391851-f9c9-4d5a-84f8-6f4f54d9eea9
+      - 4c086236-3d7c-4dd4-b706-044d4ba609ee
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e242f6a9-fe99-4f9e-b0d5-67c4ecb42936.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"a7d12acd-8d46-46cd-ad9b-b1ce80286f62":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"121493fc-52bc-44eb-af5b-cd474dda8da5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"099eed5c-bef7-40d0-89e6-9c3946de8e54":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a828e1c9-8566-42e4-81e5-c43d3e48b371/60910128-b7c4-4cce-b937-48e6333c08c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A09%3A12Z&sr=b&sp=r&sig=cjv2x97YA1u0e%2FloBzSPUVZByP6keei2a%2F%2BMp2DpMa0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:09:12.1622472","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:08:54.935Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:09:09.312Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9b5e46e4-24f6-4585-9169-947f4fe5c111":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a746bd92-bb50-4d23-a854-5759986dd7bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"a9449f9d-edda-43ef-940a-d20e2395a1ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A09%3A26Z&sr=b&sp=r&sig=BLYMK1A%2FwRvSe9ZnhQOqvXEQz3saYjXixWGiD8OT%2B6I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:09:26.5256914","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:09.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:23.229Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1639'
+      - '1583'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:12 GMT
+      - Mon, 09 Oct 2023 16:09:26 GMT
       mise-correlation-id:
-      - f5d35846-fab3-40d4-85a5-2771c0f8bd97
+      - 6ae79b1d-196f-44af-a871-0af6b2d79392
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:08:18.8481821Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:08:18.8481821Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e242f6a9-fe99-4f9e-b0d5-67c4ecb42936.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5109652Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5109652Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:13 GMT
+      - Mon, 09 Oct 2023 16:09:27 GMT
       etag:
-      - '"1a0aac97-0000-0100-0000-64af08350000"'
+      - '"92014d89-0000-0100-0000-652425830000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e242f6a9-fe99-4f9e-b0d5-67c4ecb42936.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"a7d12acd-8d46-46cd-ad9b-b1ce80286f62":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"121493fc-52bc-44eb-af5b-cd474dda8da5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"099eed5c-bef7-40d0-89e6-9c3946de8e54":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a828e1c9-8566-42e4-81e5-c43d3e48b371/60910128-b7c4-4cce-b937-48e6333c08c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A09%3A14Z&sr=b&sp=r&sig=EXDVNV%2F3CE2EhO7l7lOQvBGMv6q5HVynAoVFo56%2FStQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:09:14.4801333","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:08:54.935Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:09:09.312Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"9b5e46e4-24f6-4585-9169-947f4fe5c111":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a746bd92-bb50-4d23-a854-5759986dd7bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"a9449f9d-edda-43ef-940a-d20e2395a1ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A09%3A28Z&sr=b&sp=r&sig=TIapSigvgzPaCEug4Xw3lAxPzu%2FT4dHQF3ZOmtWEJQ8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:09:28.7797415","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:09.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:23.229Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1649'
+      - '1593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:14 GMT
+      - Mon, 09 Oct 2023 16:09:28 GMT
       mise-correlation-id:
-      - ee856731-512a-4490-97f5-6b0c3612707f
+      - d49c86d7-7c94-4d09-abad-6d2748b81716
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:08:18.8481821Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:08:18.8481821Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e242f6a9-fe99-4f9e-b0d5-67c4ecb42936.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5109652Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5109652Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:15 GMT
+      - Mon, 09 Oct 2023 16:09:29 GMT
       etag:
-      - '"1a0aac97-0000-0100-0000-64af08350000"'
+      - '"92014d89-0000-0100-0000-652425830000"'
       expires:
       - '-1'
       pragma:
@@ -619,23 +619,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e242f6a9-fe99-4f9e-b0d5-67c4ecb42936.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a828e1c9-8566-42e4-81e5-c43d3e48b371/60910128-b7c4-4cce-b937-48e6333c08c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A19%3A16Z&sr=b&sp=r&sig=7efBlAQmJdA8gbhRa5qZxkG0QdD%2FOZ8pLR%2FeN%2BpMiFo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:19:16.8460607","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A31Z&sr=b&sp=r&sig=I3fwZ%2BTWcxcINFgSTp8fjj%2FSAtIphaYwQ6vlm7DqGpw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:31.1840862","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '565'
+      - '563'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:16 GMT
+      - Mon, 09 Oct 2023 16:09:31 GMT
       mise-correlation-id:
-      - 409fa049-b1fb-4b8b-af70-7b3cc86a1a0d
+      - 2efa91a0-2709-4d8f-8e48-5c9ffd22ba18
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -655,75 +655,69 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/a828e1c9-8566-42e4-81e5-c43d3e48b371/60910128-b7c4-4cce-b937-48e6333c08c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A19%3A16Z&sr=b&sp=r&sig=7efBlAQmJdA8gbhRa5qZxkG0QdD%2FOZ8pLR%2FeN%2BpMiFo%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A31Z&sr=b&sp=r&sig=I3fwZ%2BTWcxcINFgSTp8fjj%2FSAtIphaYwQ6vlm7DqGpw%3D
   response:
     body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"\
-        1.2\" properties=\"5.0\" jmeter=\"5.5\">\r\n  <hashTree>\r\n    <TestPlan\
-        \ guiclass=\"TestPlanGui\" testclass=\"TestPlan\" testname=\"Azure Load Testing\"\
-        \ enabled=\"true\">\r\n      <stringProp name=\"TestPlan.comments\"></stringProp>\r\
-        \n      <boolProp name=\"TestPlan.functional_mode\">false</boolProp>\r\n \
-        \     <boolProp name=\"TestPlan.tearDown_on_shutdown\">true</boolProp>\r\n\
-        \      <boolProp name=\"TestPlan.serialize_threadgroups\">false</boolProp>\r\
-        \n      <elementProp name=\"TestPlan.user_defined_variables\" elementType=\"\
-        Arguments\" guiclass=\"ArgumentsPanel\" testclass=\"Arguments\" testname=\"\
-        User Defined Variables\" enabled=\"true\">\r\n        <collectionProp name=\"\
-        Arguments.arguments\"/>\r\n      </elementProp>\r\n      <stringProp name=\"\
-        TestPlan.user_define_classpath\"></stringProp>\r\n    </TestPlan>\r\n    <hashTree>\r\
-        \n      <Arguments guiclass=\"ArgumentsPanel\" testclass=\"Arguments\" testname=\"\
-        User Defined Variables\" enabled=\"true\">\r\n        <collectionProp name=\"\
-        Arguments.arguments\">\r\n          <elementProp name=\"duration_in_sec\"\
-        \ elementType=\"Argument\">\r\n            <stringProp name=\"Argument.name\"\
-        >duration_in_sec</stringProp>\r\n            <stringProp name=\"Argument.value\"\
-        >${__groovy( System.getenv(&quot;duration_in_sec&quot;) ?: &quot;10&quot;\
-        \ )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\
-        \n          </elementProp>\r\n          <elementProp name=\"rps\" elementType=\"\
-        Argument\">\r\n            <stringProp name=\"Argument.name\">rps</stringProp>\r\
-        \n            <stringProp name=\"Argument.value\">${__groovy( System.getenv(&quot;rps&quot;)\
-        \ ?: &quot;1&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\"\
-        >=</stringProp>\r\n          </elementProp>\r\n          <elementProp name=\"\
-        domain\" elementType=\"Argument\">\r\n            <stringProp name=\"Argument.name\"\
-        >domain</stringProp>\r\n            <stringProp name=\"Argument.value\">${__groovy(\
-        \ System.getenv(&quot;domain&quot;) ?: &quot;example.com&quot; )}</stringProp>\r\
-        \n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n  \
-        \        </elementProp>\r\n          <elementProp name=\"protocol\" elementType=\"\
-        Argument\">\r\n            <stringProp name=\"Argument.name\">protocol</stringProp>\r\
-        \n            <stringProp name=\"Argument.value\">${__groovy( System.getenv(&quot;protocol&quot;)\
-        \ ?: &quot;https&quot; )}</stringProp>\r\n            <stringProp name=\"\
-        Argument.metadata\">=</stringProp>\r\n          </elementProp>\r\n       \
-        \   <elementProp name=\"url_path\" elementType=\"Argument\">\r\n         \
-        \   <stringProp name=\"Argument.name\">url_path</stringProp>\r\n         \
-        \   <stringProp name=\"Argument.value\">${__groovy( System.getenv(&quot;url_path&quot;)\
-        \ ?: &quot;/&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\"\
-        >=</stringProp>\r\n          </elementProp>\r\n        </collectionProp>\r\
-        \n      </Arguments>\r\n      <hashTree/>\r\n      <OpenModelThreadGroup guiclass=\"\
-        OpenModelThreadGroupGui\" testclass=\"OpenModelThreadGroup\" testname=\"Open\
-        \ Model Thread Group\" enabled=\"true\">\r\n        <elementProp name=\"ThreadGroup.main_controller\"\
-        \ elementType=\"OpenModelThreadGroupController\"/>\r\n        <stringProp\
-        \ name=\"ThreadGroup.on_sample_error\">continue</stringProp>\r\n        <stringProp\
-        \ name=\"OpenModelThreadGroup.schedule\">rate(${rps}/sec) random_arrivals(${duration_in_sec}\
-        \ sec)</stringProp>\r\n        <stringProp name=\"OpenModelThreadGroup.random_seed\"\
-        ></stringProp>\r\n      </OpenModelThreadGroup>\r\n      <hashTree>\r\n  \
-        \      <HTTPSamplerProxy guiclass=\"HttpTestSampleGui\" testclass=\"HTTPSamplerProxy\"\
-        \ testname=\"HTTP Request\" enabled=\"true\">\r\n          <elementProp name=\"\
-        HTTPsampler.Arguments\" elementType=\"Arguments\" guiclass=\"HTTPArgumentsPanel\"\
-        \ testclass=\"Arguments\" testname=\"User Defined Variables\" enabled=\"true\"\
-        >\r\n            <collectionProp name=\"Arguments.arguments\"/>\r\n      \
-        \    </elementProp>\r\n          <stringProp name=\"HTTPSampler.domain\">${domain}</stringProp>\r\
-        \n          <stringProp name=\"HTTPSampler.port\"></stringProp>\r\n      \
-        \    <stringProp name=\"HTTPSampler.protocol\">${protocol}</stringProp>\r\n\
-        \          <stringProp name=\"HTTPSampler.contentEncoding\"></stringProp>\r\
-        \n          <stringProp name=\"HTTPSampler.path\">${url_path}</stringProp>\r\
-        \n          <stringProp name=\"HTTPSampler.method\">GET</stringProp>\r\n \
-        \         <boolProp name=\"HTTPSampler.follow_redirects\">true</boolProp>\r\
-        \n          <boolProp name=\"HTTPSampler.auto_redirects\">false</boolProp>\r\
-        \n          <boolProp name=\"HTTPSampler.use_keepalive\">true</boolProp>\r\
-        \n          <boolProp name=\"HTTPSampler.DO_MULTIPART_POST\">false</boolProp>\r\
-        \n          <stringProp name=\"HTTPSampler.embedded_url_re\"></stringProp>\r\
-        \n          <stringProp name=\"HTTPSampler.connect_timeout\"></stringProp>\r\
-        \n          <stringProp name=\"HTTPSampler.response_timeout\"></stringProp>\r\
-        \n        </HTTPSamplerProxy>\r\n        <hashTree/>\r\n      </hashTree>\r\
-        \n    </hashTree>\r\n  </hashTree>\r\n</jmeterTestPlan>\r\n"
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
+        properties=\"5.0\" jmeter=\"5.5\">\r\n  <hashTree>\r\n    <TestPlan guiclass=\"TestPlanGui\"
+        testclass=\"TestPlan\" testname=\"Azure Load Testing\" enabled=\"true\">\r\n
+        \     <stringProp name=\"TestPlan.comments\"></stringProp>\r\n      <boolProp
+        name=\"TestPlan.functional_mode\">false</boolProp>\r\n      <boolProp name=\"TestPlan.tearDown_on_shutdown\">true</boolProp>\r\n
+        \     <boolProp name=\"TestPlan.serialize_threadgroups\">false</boolProp>\r\n
+        \     <elementProp name=\"TestPlan.user_defined_variables\" elementType=\"Arguments\"
+        guiclass=\"ArgumentsPanel\" testclass=\"Arguments\" testname=\"User Defined
+        Variables\" enabled=\"true\">\r\n        <collectionProp name=\"Arguments.arguments\"/>\r\n
+        \     </elementProp>\r\n      <stringProp name=\"TestPlan.user_define_classpath\"></stringProp>\r\n
+        \   </TestPlan>\r\n    <hashTree>\r\n      <Arguments guiclass=\"ArgumentsPanel\"
+        testclass=\"Arguments\" testname=\"User Defined Variables\" enabled=\"true\">\r\n
+        \       <collectionProp name=\"Arguments.arguments\">\r\n          <elementProp
+        name=\"duration_in_sec\" elementType=\"Argument\">\r\n            <stringProp
+        name=\"Argument.name\">duration_in_sec</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;duration_in_sec&quot;)
+        ?: &quot;10&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n          <elementProp name=\"rps\" elementType=\"Argument\">\r\n
+        \           <stringProp name=\"Argument.name\">rps</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;rps&quot;) ?: &quot;1&quot;
+        )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n          <elementProp name=\"domain\" elementType=\"Argument\">\r\n
+        \           <stringProp name=\"Argument.name\">domain</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;domain&quot;) ?: &quot;example.com&quot;
+        )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n          <elementProp name=\"protocol\" elementType=\"Argument\">\r\n
+        \           <stringProp name=\"Argument.name\">protocol</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;protocol&quot;) ?:
+        &quot;https&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n          <elementProp name=\"url_path\" elementType=\"Argument\">\r\n
+        \           <stringProp name=\"Argument.name\">url_path</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;url_path&quot;) ?:
+        &quot;/&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n        </collectionProp>\r\n      </Arguments>\r\n
+        \     <hashTree/>\r\n      <OpenModelThreadGroup guiclass=\"OpenModelThreadGroupGui\"
+        testclass=\"OpenModelThreadGroup\" testname=\"Open Model Thread Group\" enabled=\"true\">\r\n
+        \       <elementProp name=\"ThreadGroup.main_controller\" elementType=\"OpenModelThreadGroupController\"/>\r\n
+        \       <stringProp name=\"ThreadGroup.on_sample_error\">continue</stringProp>\r\n
+        \       <stringProp name=\"OpenModelThreadGroup.schedule\">rate(${rps}/sec)
+        random_arrivals(${duration_in_sec} sec)</stringProp>\r\n        <stringProp
+        name=\"OpenModelThreadGroup.random_seed\"></stringProp>\r\n      </OpenModelThreadGroup>\r\n
+        \     <hashTree>\r\n        <HTTPSamplerProxy guiclass=\"HttpTestSampleGui\"
+        testclass=\"HTTPSamplerProxy\" testname=\"HTTP Request\" enabled=\"true\">\r\n
+        \         <elementProp name=\"HTTPsampler.Arguments\" elementType=\"Arguments\"
+        guiclass=\"HTTPArgumentsPanel\" testclass=\"Arguments\" testname=\"User Defined
+        Variables\" enabled=\"true\">\r\n            <collectionProp name=\"Arguments.arguments\"/>\r\n
+        \         </elementProp>\r\n          <stringProp name=\"HTTPSampler.domain\">${domain}</stringProp>\r\n
+        \         <stringProp name=\"HTTPSampler.port\"></stringProp>\r\n          <stringProp
+        name=\"HTTPSampler.protocol\">${protocol}</stringProp>\r\n          <stringProp
+        name=\"HTTPSampler.contentEncoding\"></stringProp>\r\n          <stringProp
+        name=\"HTTPSampler.path\">${url_path}</stringProp>\r\n          <stringProp
+        name=\"HTTPSampler.method\">GET</stringProp>\r\n          <boolProp name=\"HTTPSampler.follow_redirects\">true</boolProp>\r\n
+        \         <boolProp name=\"HTTPSampler.auto_redirects\">false</boolProp>\r\n
+        \         <boolProp name=\"HTTPSampler.use_keepalive\">true</boolProp>\r\n
+        \         <boolProp name=\"HTTPSampler.DO_MULTIPART_POST\">false</boolProp>\r\n
+        \         <stringProp name=\"HTTPSampler.embedded_url_re\"></stringProp>\r\n
+        \         <stringProp name=\"HTTPSampler.connect_timeout\"></stringProp>\r\n
+        \         <stringProp name=\"HTTPSampler.response_timeout\"></stringProp>\r\n
+        \       </HTTPSamplerProxy>\r\n        <hashTree/>\r\n      </hashTree>\r\n
+        \   </hashTree>\r\n  </hashTree>\r\n</jmeterTestPlan>\r\n"
     headers:
       accept-ranges:
       - bytes
@@ -734,23 +728,25 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 12 Jul 2023 20:09:17 GMT
+      - Mon, 09 Oct 2023 16:09:32 GMT
       etag:
-      - '"0x8DB8313D221EF65"'
+      - '"0x8DBC8E212570477"'
       last-modified:
-      - Wed, 12 Jul 2023 20:08:55 GMT
+      - Mon, 09 Oct 2023 16:09:09 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 12 Jul 2023 20:08:55 GMT
+      - Mon, 09 Oct 2023 16:09:09 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-meta-filename:
       - c2FtcGxlLUpNWC1maWxlLmpteA==
+      x-ms-meta-filetype:
+      - JMX_FILE
       x-ms-meta-isencoded:
       - 'true'
       x-ms-server-encrypted:
@@ -775,7 +771,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:08:18.8481821Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:08:18.8481821Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e242f6a9-fe99-4f9e-b0d5-67c4ecb42936.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5109652Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5109652Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -784,9 +780,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:19 GMT
+      - Mon, 09 Oct 2023 16:09:37 GMT
       etag:
-      - '"1a0aac97-0000-0100-0000-64af08350000"'
+      - '"92014d89-0000-0100-0000-652425830000"'
       expires:
       - '-1'
       pragma:
@@ -816,10 +812,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e242f6a9-fe99-4f9e-b0d5-67c4ecb42936.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a828e1c9-8566-42e4-81e5-c43d3e48b371/60910128-b7c4-4cce-b937-48e6333c08c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A19%3A20Z&sr=b&sp=r&sig=dEjaqyHlcmMBE2pLgOm0Zkxyx1PMv%2F1Rq38GS%2FkAnUA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:19:20.6872601","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A38Z&sr=b&sp=r&sig=E8VEJD%2BTheeS7HsOc16VbS%2B3pmL4UncQH7PIeZ7VNzg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:38.9433312","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -830,9 +826,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:20 GMT
+      - Mon, 09 Oct 2023 16:09:38 GMT
       mise-correlation-id:
-      - 59da7566-63c7-429e-bc4e-81025eba5706
+      - 59fcb961-e43e-42d2-a500-6b1b7f4e7818
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_download_files.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_download_files.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5109652Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5109652Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:53.275839Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:53.275839Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:07 GMT
+      - Mon, 09 Oct 2023 19:15:26 GMT
       etag:
-      - '"92014d89-0000-0100-0000-652425830000"'
+      - '"550015a4-0000-0100-0000-6524512f0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:09:08 GMT
+      - Mon, 09 Oct 2023 19:15:28 GMT
       mise-correlation-id:
-      - 89ddf57c-be54-4427-99f3-bdc6d1fd4984
+      - 6c21f2bc-b72a-466f-a134-ff8e02085c02
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"9b5e46e4-24f6-4585-9169-947f4fe5c111": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "a746bd92-bb50-4d23-a854-5759986dd7bf":
+      {"passFailMetrics": {"7b4772c6-f11b-4402-a866-887422b2dded": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "7ed55eb4-51a7-4f6e-945d-6dce008762b4":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "a9449f9d-edda-43ef-940a-d20e2395a1ff": {"aggregate": "avg", "clientMetric":
+      "50"}, "c6d8659b-7e78-4c3b-a068-2bfa2ed898bf": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9b5e46e4-24f6-4585-9169-947f4fe5c111":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a746bd92-bb50-4d23-a854-5759986dd7bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"a9449f9d-edda-43ef-940a-d20e2395a1ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:09.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:09.208Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7b4772c6-f11b-4402-a866-887422b2dded":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7ed55eb4-51a7-4f6e-945d-6dce008762b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c6d8659b-7e78-4c3b-a068-2bfa2ed898bf":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:28.862Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:28.862Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:09 GMT
+      - Mon, 09 Oct 2023 19:15:28 GMT
       location:
-      - https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+      - https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - ea700970-5971-4720-8a9b-a3247f79a743
+      - 46e01684-3435-492d-89e6-b59bf7f04c28
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:09 GMT
+      - Mon, 09 Oct 2023 19:15:29 GMT
       mise-correlation-id:
-      - d10b0bd0-9be9-4c28-9230-3ff88c9b630c
+      - 7a864b10-9cbb-4e44-9b0b-4217c4d1a388
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A10Z&sr=b&sp=r&sig=RJntwhdlNd2W8Jpag470xLZEd5NZ%2F995Lm4d08Nyze4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:10.0542915","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A31Z&sr=b&sp=r&sig=hrUHi1HQsI9IvYA11FEtcHUZI0PMwouWLAbVtvN5pQs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:31.8821314","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:10 GMT
+      - Mon, 09 Oct 2023 19:15:31 GMT
       location:
-      - https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 7b20afe8-7b79-4f7c-892c-98e8a32f4d6f
+      - d0e6f90c-e348-4249-bdda-e295acd783a3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A10Z&sr=b&sp=r&sig=xsHOG6BgtwauVIXsS5Wr%2BeCNARn2n%2FsTzMBndQlhRMA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:10.3891653","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A32Z&sr=b&sp=r&sig=yXMsbKs%2F1hHTujLfwXIrKCKqjNB7OpRz%2FRGoKXAa4Pg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:32.1380461","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:10 GMT
+      - Mon, 09 Oct 2023 19:15:32 GMT
       mise-correlation-id:
-      - e9e60c22-2e11-413c-aba3-48c1ea11f008
+      - 5b0dadb6-cf80-42b8-a3d4-be0eee694340
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,10 +349,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A15Z&sr=b&sp=r&sig=GyhEekBLXS7uyuzP%2Bdz1mQ3OP8TbOG1sfdJh4qBtOh0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:15.7144511","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A37Z&sr=b&sp=r&sig=%2Fdyuscv1lFEUbBUUTU%2FI6ggDHlhxtqWP5jhRUjuvEuw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:37.3933334","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:15:37 GMT
+      mise-correlation-id:
+      - 9cc01ec6-0640-4b53-8187-f89d3ccec21c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A42Z&sr=b&sp=r&sig=Iuw%2BHwKVrE%2B4oxQCDQvTotF75raoObEaW%2FYO5PvNLtM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:42.661489","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '554'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:15:42 GMT
+      mise-correlation-id:
+      - 3e5e9788-4687-4905-8c53-71a80afa88f5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A47Z&sr=b&sp=r&sig=0jT%2BZOBAMxn379RDDqgWKw%2FZxR3KGzLwLuQ9C3yno0A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:47.9183009","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:15 GMT
+      - Mon, 09 Oct 2023 19:15:47 GMT
       mise-correlation-id:
-      - 91d077c3-7cea-46ec-9ca2-4258ee195a6b
+      - 8f5f4364-5ae4-4840-8755-33e95ad01465
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,96 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A20Z&sr=b&sp=r&sig=yQOzjUwKgxgI7Rdy5x%2BMltW6FmfMQy7Rqf7fTdhDBjQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:20.9837472","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7b4772c6-f11b-4402-a866-887422b2dded":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7ed55eb4-51a7-4f6e-945d-6dce008762b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c6d8659b-7e78-4c3b-a068-2bfa2ed898bf":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A15%3A48Z&sr=b&sp=r&sig=m5NAYClMxgVqKfmizxIiPOFGOlDNENu9u145GU2Ln9A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:15:48.2291333","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:28.862Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:45.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '1579'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:20 GMT
+      - Mon, 09 Oct 2023 19:15:48 GMT
       mise-correlation-id:
-      - 63ddc570-30e0-4034-8a1c-e5368fd79895
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A26Z&sr=b&sp=r&sig=3390APcQOI7yYDf6ixD2Uvhpzze7JC2GjjJJow5YYBc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:26.2550156","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '547'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:09:26 GMT
-      mise-correlation-id:
-      - 4c086236-3d7c-4dd4-b706-044d4ba609ee
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9b5e46e4-24f6-4585-9169-947f4fe5c111":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a746bd92-bb50-4d23-a854-5759986dd7bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"a9449f9d-edda-43ef-940a-d20e2395a1ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A09%3A26Z&sr=b&sp=r&sig=BLYMK1A%2FwRvSe9ZnhQOqvXEQz3saYjXixWGiD8OT%2B6I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:09:26.5256914","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:09.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:23.229Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1583'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:09:26 GMT
-      mise-correlation-id:
-      - 6ae79b1d-196f-44af-a871-0af6b2d79392
+      - da3e37e0-2846-4966-ad67-d7e6ee2ccb6a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5109652Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5109652Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:53.275839Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:53.275839Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:27 GMT
+      - Mon, 09 Oct 2023 19:15:48 GMT
       etag:
-      - '"92014d89-0000-0100-0000-652425830000"'
+      - '"550015a4-0000-0100-0000-6524512f0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"9b5e46e4-24f6-4585-9169-947f4fe5c111":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a746bd92-bb50-4d23-a854-5759986dd7bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"a9449f9d-edda-43ef-940a-d20e2395a1ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A09%3A28Z&sr=b&sp=r&sig=TIapSigvgzPaCEug4Xw3lAxPzu%2FT4dHQF3ZOmtWEJQ8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:09:28.7797415","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:09.208Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:23.229Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"7b4772c6-f11b-4402-a866-887422b2dded":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7ed55eb4-51a7-4f6e-945d-6dce008762b4":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c6d8659b-7e78-4c3b-a068-2bfa2ed898bf":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A15%3A50Z&sr=b&sp=r&sig=ZhkIiPpI1qgZ9g65e3Ex8bM%2B6zaC%2BPWhHE0Dh7z3dYQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:15:50.5330851","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:28.862Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:45.901Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1593'
+      - '1595'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:28 GMT
+      - Mon, 09 Oct 2023 19:15:50 GMT
       mise-correlation-id:
-      - d49c86d7-7c94-4d09-abad-6d2748b81716
+      - 0e450073-5743-4d68-9fb8-dbf2f2bdd742
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5109652Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5109652Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:53.275839Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:53.275839Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:29 GMT
+      - Mon, 09 Oct 2023 19:15:52 GMT
       etag:
-      - '"92014d89-0000-0100-0000-652425830000"'
+      - '"550015a4-0000-0100-0000-6524512f0000"'
       expires:
       - '-1'
       pragma:
@@ -619,23 +619,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A31Z&sr=b&sp=r&sig=I3fwZ%2BTWcxcINFgSTp8fjj%2FSAtIphaYwQ6vlm7DqGpw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:31.1840862","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A52Z&sr=b&sp=r&sig=A3mhKXyZwe%2BEjzjr1npTVd%2BR0xQ%2FpzeV90F9ESF9BtQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:52.9834831","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '563'
+      - '565'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:31 GMT
+      - Mon, 09 Oct 2023 19:15:52 GMT
       mise-correlation-id:
-      - 2efa91a0-2709-4d8f-8e48-5c9ffd22ba18
+      - d21644a2-7a81-47f3-984d-8822e24797f5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -655,7 +655,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A31Z&sr=b&sp=r&sig=I3fwZ%2BTWcxcINFgSTp8fjj%2FSAtIphaYwQ6vlm7DqGpw%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A52Z&sr=b&sp=r&sig=A3mhKXyZwe%2BEjzjr1npTVd%2BR0xQ%2FpzeV90F9ESF9BtQ%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -728,17 +728,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Mon, 09 Oct 2023 16:09:32 GMT
+      - Mon, 09 Oct 2023 19:15:54 GMT
       etag:
-      - '"0x8DBC8E212570477"'
+      - '"0x8DBC8FC1B21FB47"'
       last-modified:
-      - Mon, 09 Oct 2023 16:09:09 GMT
+      - Mon, 09 Oct 2023 19:15:31 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 09 Oct 2023 16:09:09 GMT
+      - Mon, 09 Oct 2023 19:15:31 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -771,18 +771,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.5109652Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.5109652Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:53.275839Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:53.275839Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:37 GMT
+      - Mon, 09 Oct 2023 19:15:54 GMT
       etag:
-      - '"92014d89-0000-0100-0000-652425830000"'
+      - '"550015a4-0000-0100-0000-6524512f0000"'
       expires:
       - '-1'
       pragma:
@@ -812,23 +812,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e2d6d304-8c6a-4ec8-b818-c81196addc96.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://bb88e211-f20f-4796-a748-cb0eb5453783.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1f8e7261-363e-4603-b29c-5595ab7d0ab2/eaa74066-67b9-4770-ba50-500f0a6434ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A38Z&sr=b&sp=r&sig=E8VEJD%2BTheeS7HsOc16VbS%2B3pmL4UncQH7PIeZ7VNzg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:38.9433312","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9e6daaf1-32da-40fc-b229-dc595049785d/cc083f66-ac00-4191-b967-9762b2b7da4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A56Z&sr=b&sp=r&sig=Pc3UFCGwb4po0VxkIsiR6YaWOpM4dQa4QfSBTbHNu04%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:56.5340307","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '563'
+      - '559'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:38 GMT
+      - Mon, 09 Oct 2023 19:15:56 GMT
       mise-correlation-id:
-      - 59fcb961-e43e-42d2-a500-6b1b7f4e7818
+      - 4f93d385-c97e-4132-8064-4993a8cadfa2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_file.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_file.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:58.5677517Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:58.5677517Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:19.2451554Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:19.2451554Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:32 GMT
+      - Mon, 09 Oct 2023 19:16:53 GMT
       etag:
-      - '"9201ee96-0000-0100-0000-652425d90000"'
+      - '"5500bfce-0000-0100-0000-652451850000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:10:33 GMT
+      - Mon, 09 Oct 2023 19:16:54 GMT
       mise-correlation-id:
-      - 473d04da-49d9-48a2-8249-017ec12b2099
+      - 31ea0608-d94c-4ed2-ae7f-64aab79702d8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"f1031edb-1077-4996-9aba-e9f2a5ae6f66": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "1f15e734-c205-472d-8db8-670165b574ba":
+      {"passFailMetrics": {"48e206be-1222-44b8-8439-14af28125cb0": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "5d4e551a-445e-4ffe-aa33-723cd1ab9622":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "d7cdca7d-179b-4d71-8d89-db24c73787bf": {"aggregate": "avg", "clientMetric":
+      "50"}, "603c001b-bbfb-4cc8-8543-67eab0d7eeef": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f1031edb-1077-4996-9aba-e9f2a5ae6f66":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1f15e734-c205-472d-8db8-670165b574ba":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d7cdca7d-179b-4d71-8d89-db24c73787bf":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:10:34.569Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:34.569Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"48e206be-1222-44b8-8439-14af28125cb0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"5d4e551a-445e-4ffe-aa33-723cd1ab9622":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"603c001b-bbfb-4cc8-8543-67eab0d7eeef":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:16:54.917Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:54.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:34 GMT
+      - Mon, 09 Oct 2023 19:16:54 GMT
       location:
-      - https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+      - https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 68202cd5-4ff3-48fb-aef5-8e2940bf555e
+      - 703ca6af-fd98-4f88-99b2-9c5ee1bb2a6c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:34 GMT
+      - Mon, 09 Oct 2023 19:16:55 GMT
       mise-correlation-id:
-      - f903845c-d793-4322-913c-9ebfd3322392
+      - e470c37b-d492-436d-aae0-dd45cff7a22e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/56e6a696-040b-487d-a86a-1331e0c82bd5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A35Z&sr=b&sp=r&sig=l2bT6T7XHYlbdkPrf6Dn5MsXHFA%2BOq7ErzOCMsbfljQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:35.390411","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/d7e0de5e-b711-45e6-a7b3-c22574cb1bab?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A55Z&sr=b&sp=r&sig=i9XGr%2Fc6mLDaYhXknG2hf5zu31ZHc5s4SaIfjt1%2BQlQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:55.7366423","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:35 GMT
+      - Mon, 09 Oct 2023 19:16:55 GMT
       location:
-      - https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - e2c70368-ca3f-4e1a-987f-647a24e1dd7e
+      - b64c2f90-676d-4abe-8125-d6729f5fccc1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/56e6a696-040b-487d-a86a-1331e0c82bd5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A35Z&sr=b&sp=r&sig=cke9Y3fFoB%2FoSVavEvoTDPjMbDiBUEq2z%2B3%2F3bmJ910%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:35.9194169","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:10:35 GMT
-      mise-correlation-id:
-      - 2ea74362-796e-432b-9088-594d6eaebf2a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/56e6a696-040b-487d-a86a-1331e0c82bd5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A41Z&sr=b&sp=r&sig=qB2c9ymlLGWeHBHwJpPO39UZmJchFvjH1OUaTcCDp7g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:41.2280139","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:10:41 GMT
-      mise-correlation-id:
-      - ae40716c-7de9-4dea-b4c2-3481792a6cc3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/56e6a696-040b-487d-a86a-1331e0c82bd5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A46Z&sr=b&sp=r&sig=Yws2SsdT7My5%2BBvaO6UQ60rHlP1nhrf05vaiIWOhw7o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:46.5376017","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/d7e0de5e-b711-45e6-a7b3-c22574cb1bab?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A56Z&sr=b&sp=r&sig=G7RJReftsojZieW27n7pOSPkMa9HL9VUWAP%2BQ31GoAI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:56.0244172","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:46 GMT
+      - Mon, 09 Oct 2023 19:16:56 GMT
       mise-correlation-id:
-      - cb831a47-bfe5-4229-9116-1cc6c8f1c0c0
+      - 8c0e6fbf-2f22-4a7a-bcd2-6857b00592bc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/56e6a696-040b-487d-a86a-1331e0c82bd5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A51Z&sr=b&sp=r&sig=GnK3BjVu15Q1vRNjw%2BpoahazcVoGS%2FFldG2%2B%2FvqHjtA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:51.8648996","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/d7e0de5e-b711-45e6-a7b3-c22574cb1bab?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A01Z&sr=b&sp=r&sig=tSIOhPr569cNvEqt%2BvaTuucJKzVB8F0xnJidt57oCwk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:01.3539687","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:51 GMT
+      - Mon, 09 Oct 2023 19:17:01 GMT
       mise-correlation-id:
-      - 7b02a0d4-3086-4d9b-bf26-3bc16cba3f9e
+      - 3b445ade-d018-4d2b-932b-a48cb733eec0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +385,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f1031edb-1077-4996-9aba-e9f2a5ae6f66":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1f15e734-c205-472d-8db8-670165b574ba":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d7cdca7d-179b-4d71-8d89-db24c73787bf":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/56e6a696-040b-487d-a86a-1331e0c82bd5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A10%3A52Z&sr=b&sp=r&sig=aLhWzsRCRczJXSLzVuC4XgGk7XKzz8sVTv3sypREfw0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:10:52.124739","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:10:34.569Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:47.982Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/d7e0de5e-b711-45e6-a7b3-c22574cb1bab?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A06Z&sr=b&sp=r&sig=eJfRYmO%2FWa3zr%2BvEsowwPi0xWrotAxHFZrUSy3BkEtw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:06.6313026","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1574'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:52 GMT
+      - Mon, 09 Oct 2023 19:17:06 GMT
       mise-correlation-id:
-      - 4dc219b2-bbdf-4d6e-a75f-5ac4dd059239
+      - bee52083-f9a6-40c2-b5d0-53de73570fce
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/d7e0de5e-b711-45e6-a7b3-c22574cb1bab?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A11Z&sr=b&sp=r&sig=8U0WdKZvko8n9DVuXKqj7sfWRV3dsaIJ4326iB31ZQw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:11.8950886","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '547'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:17:11 GMT
+      mise-correlation-id:
+      - c5eb8e02-4a37-465f-b3f8-85905a33bb14
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"48e206be-1222-44b8-8439-14af28125cb0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"5d4e551a-445e-4ffe-aa33-723cd1ab9622":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"603c001b-bbfb-4cc8-8543-67eab0d7eeef":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/d7e0de5e-b711-45e6-a7b3-c22574cb1bab?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A17%3A12Z&sr=b&sp=r&sig=gC9SPkZsmO7k6AL%2F%2FEafNr3zVcpRW0EhgYokGdeTISk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:17:12.1998235","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:16:54.917Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:08.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1579'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:17:12 GMT
+      mise-correlation-id:
+      - ddcc5c7a-2f0a-4b96-8e0f-fa9bebf34cd8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:58.5677517Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:58.5677517Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:19.2451554Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:19.2451554Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:52 GMT
+      - Mon, 09 Oct 2023 19:17:13 GMT
       etag:
-      - '"9201ee96-0000-0100-0000-652425d90000"'
+      - '"5500bfce-0000-0100-0000-652451850000"'
       expires:
       - '-1'
       pragma:
@@ -538,11 +538,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f1031edb-1077-4996-9aba-e9f2a5ae6f66":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1f15e734-c205-472d-8db8-670165b574ba":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d7cdca7d-179b-4d71-8d89-db24c73787bf":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/56e6a696-040b-487d-a86a-1331e0c82bd5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A10%3A53Z&sr=b&sp=r&sig=YbGDVhQ47BkwrFVtzqGwOn%2BDnAZPD%2FajzcckHjJeBK8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:10:53.8063922","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:10:34.569Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:47.982Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"48e206be-1222-44b8-8439-14af28125cb0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"5d4e551a-445e-4ffe-aa33-723cd1ab9622":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"603c001b-bbfb-4cc8-8543-67eab0d7eeef":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/d7e0de5e-b711-45e6-a7b3-c22574cb1bab?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A17%3A14Z&sr=b&sp=r&sig=WnN0wH4sPDEFtbmZgIF%2FSRcEq4NpQV%2FFWPdd08XcxfY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:17:14.5532005","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:16:54.917Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:08.536Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:53 GMT
+      - Mon, 09 Oct 2023 19:17:14 GMT
       mise-correlation-id:
-      - afcc6e98-f009-4b24-b099-5cab4d1df2d2
+      - 05b0f7d8-d45e-449d-9bf1-3655e9ce4606
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:58.5677517Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:58.5677517Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:19.2451554Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:19.2451554Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:54 GMT
+      - Mon, 09 Oct 2023 19:17:15 GMT
       etag:
-      - '"9201ee96-0000-0100-0000-652425d90000"'
+      - '"5500bfce-0000-0100-0000-652451850000"'
       expires:
       - '-1'
       pragma:
@@ -621,7 +621,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -631,9 +631,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Mon, 09 Oct 2023 16:10:56 GMT
+      - Mon, 09 Oct 2023 19:17:17 GMT
       mise-correlation-id:
-      - 59949f69-984b-448d-9572-09c95a003c4b
+      - c9c77027-5e57-45aa-88ce-93b813ed73e8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -656,7 +656,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:58.5677517Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:58.5677517Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:19.2451554Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:19.2451554Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -665,9 +665,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:57 GMT
+      - Mon, 09 Oct 2023 19:17:18 GMT
       etag:
-      - '"9201ee96-0000-0100-0000-652425d90000"'
+      - '"5500bfce-0000-0100-0000-652451850000"'
       expires:
       - '-1'
       pragma:
@@ -697,7 +697,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -711,9 +711,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:58 GMT
+      - Mon, 09 Oct 2023 19:17:19 GMT
       mise-correlation-id:
-      - ff210269-447e-4789-b04a-2cde322e0b97
+      - 77084ffe-d65d-4ce6-9ef6-f5cfae57dbd2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,7 +736,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:58.5677517Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:58.5677517Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:19.2451554Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:19.2451554Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -745,9 +745,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:00 GMT
+      - Mon, 09 Oct 2023 19:17:20 GMT
       etag:
-      - '"9201ee96-0000-0100-0000-652425d90000"'
+      - '"5500bfce-0000-0100-0000-652451850000"'
       expires:
       - '-1'
       pragma:
@@ -871,25 +871,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/65e56535-8aef-4dfd-a459-9703f191df7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A02Z&sr=b&sp=r&sig=MtvbPC2ZL%2Fe%2BEtrcDpVf3yLH2KVXTZT6i2l3F2VuqgY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:02.9718868","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/dd1611fa-4d16-4250-b77a-fb50700dd8c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A23Z&sr=b&sp=r&sig=JvyPF7Ia3%2Bms0ac2pU92tdz7f5pNa6UvvrF8FoTJCoY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:23.3348482","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:02 GMT
+      - Mon, 09 Oct 2023 19:17:23 GMT
       location:
-      - https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 2449f433-a1e0-47db-bb59-8623877b39cb
+      - ed48b854-ebf9-4a4a-8205-e320a7b0d9aa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -909,10 +909,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/65e56535-8aef-4dfd-a459-9703f191df7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A03Z&sr=b&sp=r&sig=m1MaEcG5r%2BbY4VHPHfUXFcUBHJCnf2NINrl3GTryC3A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:03.3490215","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/dd1611fa-4d16-4250-b77a-fb50700dd8c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A23Z&sr=b&sp=r&sig=uO7NF%2FyhHMoqmq9F3lRSS1ahXgYF1CiG45Ge6Ym5nAE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:23.6022916","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -923,9 +923,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:03 GMT
+      - Mon, 09 Oct 2023 19:17:23 GMT
       mise-correlation-id:
-      - d163d35c-071d-4d9c-bb69-60f0eff872c7
+      - b23a5653-f94e-4157-a983-6a0f5493392f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -945,23 +945,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/65e56535-8aef-4dfd-a459-9703f191df7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A08Z&sr=b&sp=r&sig=YH%2FaTJQ9%2BchRn3WHV2veRj424hRxn59G4VP37nuI4YY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:08.669138","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/dd1611fa-4d16-4250-b77a-fb50700dd8c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A28Z&sr=b&sp=r&sig=n7pCazxBsP%2BjkwRUmxABZZQB4h4irNE0he5GLNTweqw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:28.8869512","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '552'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:08 GMT
+      - Mon, 09 Oct 2023 19:17:28 GMT
       mise-correlation-id:
-      - 2584420e-7dd8-4293-9268-a8eef56cf201
+      - e5db74f8-a9ac-4f99-a5fc-60fc018fc426
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -981,23 +981,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/65e56535-8aef-4dfd-a459-9703f191df7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A13Z&sr=b&sp=r&sig=qwQDa8r%2FJ%2FhazsYX4ZinD10OGvRmyIM9I14V3GtImQo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:13.9958529","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/dd1611fa-4d16-4250-b77a-fb50700dd8c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A34Z&sr=b&sp=r&sig=T6gSXGmR6rLA7n8Ve8YxzahS0Sa8eb9zsexcTuglOpg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:34.2083431","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:13 GMT
+      - Mon, 09 Oct 2023 19:17:34 GMT
       mise-correlation-id:
-      - c962f202-bb3e-4821-aca2-528d7466a8aa
+      - a2908fd3-48a5-42e9-9344-8ec2c4288e1a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1020,7 +1020,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:58.5677517Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:58.5677517Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:19.2451554Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:19.2451554Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1029,9 +1029,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:14 GMT
+      - Mon, 09 Oct 2023 19:17:34 GMT
       etag:
-      - '"9201ee96-0000-0100-0000-652425d90000"'
+      - '"5500bfce-0000-0100-0000-652451850000"'
       expires:
       - '-1'
       pragma:
@@ -1061,10 +1061,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/65e56535-8aef-4dfd-a459-9703f191df7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A15Z&sr=b&sp=r&sig=eBkPBRUAxpxlZdQn0sTAOlOVw8XX1gddFHJqOvo5%2Bp0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:15.7412449","validationStatus":"VALIDATION_INITIATED"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/dd1611fa-4d16-4250-b77a-fb50700dd8c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A35Z&sr=b&sp=r&sig=DQf7vGznQV5XsjXBUxpgYOxi1AggDPIPHJQbrZ1j%2Fhk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:35.7784432","validationStatus":"VALIDATION_INITIATED"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1075,9 +1075,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:15 GMT
+      - Mon, 09 Oct 2023 19:17:35 GMT
       mise-correlation-id:
-      - bc68cc02-30c1-48e7-948f-e676789c4d70
+      - 6b9cee54-5c4a-402e-913a-39c14ebdd30f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1100,7 +1100,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:58.5677517Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:58.5677517Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:19.2451554Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:19.2451554Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1109,9 +1109,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:16 GMT
+      - Mon, 09 Oct 2023 19:17:36 GMT
       etag:
-      - '"9201ee96-0000-0100-0000-652425d90000"'
+      - '"5500bfce-0000-0100-0000-652451850000"'
       expires:
       - '-1'
       pragma:
@@ -1141,23 +1141,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/65e56535-8aef-4dfd-a459-9703f191df7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A17Z&sr=b&sp=r&sig=mOe9JbCGp4YYMduRRdYH0kGNtfuZHOyPulS90X%2Fd%2Fps%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:17.9891097","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/dd1611fa-4d16-4250-b77a-fb50700dd8c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A37Z&sr=b&sp=r&sig=5ed5qyHC5p%2BHZKLBXBXwqAx%2FZ76BsZWdRQW540OWUg8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:37.6001873","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:17 GMT
+      - Mon, 09 Oct 2023 19:17:37 GMT
       mise-correlation-id:
-      - 06bf1be2-7e1a-4f96-ad9b-5d68be2e6bf9
+      - b3c35e30-0de5-408f-abc5-db1083da6b6c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1177,7 +1177,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/65e56535-8aef-4dfd-a459-9703f191df7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A17Z&sr=b&sp=r&sig=mOe9JbCGp4YYMduRRdYH0kGNtfuZHOyPulS90X%2Fd%2Fps%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/dd1611fa-4d16-4250-b77a-fb50700dd8c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A37Z&sr=b&sp=r&sig=5ed5qyHC5p%2BHZKLBXBXwqAx%2FZ76BsZWdRQW540OWUg8%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -1250,17 +1250,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Mon, 09 Oct 2023 16:11:18 GMT
+      - Mon, 09 Oct 2023 19:17:38 GMT
       etag:
-      - '"0x8DBC8E255A8B8EF"'
+      - '"0x8DBC8FC5DAFB5CA"'
       last-modified:
-      - Mon, 09 Oct 2023 16:11:02 GMT
+      - Mon, 09 Oct 2023 19:17:23 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 09 Oct 2023 16:11:02 GMT
+      - Mon, 09 Oct 2023 19:17:23 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_file.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_file.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:19.2451554Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:19.2451554Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:21.2618497Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:21.2618497Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:53 GMT
+      - Fri, 13 Oct 2023 13:49:54 GMT
       etag:
-      - '"5500bfce-0000-0100-0000-652451850000"'
+      - '"d801e8bd-0000-0100-0000-65294ae30000"'
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:16:54 GMT
+      - Fri, 13 Oct 2023 13:49:55 GMT
       mise-correlation-id:
-      - 31ea0608-d94c-4ed2-ae7f-64aab79702d8
+      - 6e85db7a-459b-47ad-834b-9906195fb384
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"48e206be-1222-44b8-8439-14af28125cb0": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "5d4e551a-445e-4ffe-aa33-723cd1ab9622":
+      {"passFailMetrics": {"3221d294-ef57-4fad-8227-d94d392126a5": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "6c27a8b9-fd49-4014-bae0-1f19a760c59e":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "603c001b-bbfb-4cc8-8543-67eab0d7eeef": {"aggregate": "avg", "clientMetric":
+      "50"}, "5c12a097-0719-41ca-8270-5a22b36707ce": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -104,13 +104,13 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"48e206be-1222-44b8-8439-14af28125cb0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"5d4e551a-445e-4ffe-aa33-723cd1ab9622":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"603c001b-bbfb-4cc8-8543-67eab0d7eeef":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:16:54.917Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:16:54.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3221d294-ef57-4fad-8227-d94d392126a5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6c27a8b9-fd49-4014-bae0-1f19a760c59e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"5c12a097-0719-41ca-8270-5a22b36707ce":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:49:55.962Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:55.962Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:54 GMT
+      - Fri, 13 Oct 2023 13:49:55 GMT
       location:
-      - https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+      - https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 703ca6af-fd98-4f88-99b2-9c5ee1bb2a6c
+      - a238d023-b589-4948-bfa2-0d58c1966593
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -143,9 +143,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:55 GMT
+      - Fri, 13 Oct 2023 13:49:56 GMT
       mise-correlation-id:
-      - e470c37b-d492-436d-aae0-dd45cff7a22e
+      - 138d267a-32d8-4c42-a0e1-0a0e9f6028d4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -273,27 +273,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/d7e0de5e-b711-45e6-a7b3-c22574cb1bab?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A55Z&sr=b&sp=r&sig=i9XGr%2Fc6mLDaYhXknG2hf5zu31ZHc5s4SaIfjt1%2BQlQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:55.7366423","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/53ecb826-02ab-4d5e-972b-0219627bd283?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A56Z&sr=b&sp=r&sig=J2RhZZgySrf1ubRJWJQDr0noSC2cu1keeSSkliFMzfc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:56.8503222","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:55 GMT
+      - Fri, 13 Oct 2023 13:49:56 GMT
       location:
-      - https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - b64c2f90-676d-4abe-8125-d6729f5fccc1
+      - 02b6f8c5-c87e-484c-9e1f-c5545409b2f8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -311,12 +311,48 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/d7e0de5e-b711-45e6-a7b3-c22574cb1bab?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A26%3A56Z&sr=b&sp=r&sig=G7RJReftsojZieW27n7pOSPkMa9HL9VUWAP%2BQ31GoAI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:26:56.0244172","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/53ecb826-02ab-4d5e-972b-0219627bd283?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A57Z&sr=b&sp=r&sig=7NkNwLo7gnUfoxHrhQmbOHTiDn6OcY2zS3KtMsDKTKU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:57.2093083","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:49:57 GMT
+      mise-correlation-id:
+      - d7b8be67-890c-4a3f-8fd4-5959fa99484d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/53ecb826-02ab-4d5e-972b-0219627bd283?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A02Z&sr=b&sp=r&sig=6PxyCO3cUvJzyb4UsubNA2oTtCn9krBofF%2Fkqg3VPYg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:02.4580509","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:16:56 GMT
+      - Fri, 13 Oct 2023 13:50:02 GMT
       mise-correlation-id:
-      - 8c0e6fbf-2f22-4a7a-bcd2-6857b00592bc
+      - 6e61a18e-d5a4-4621-b71c-66fd13945b65
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -347,12 +383,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/d7e0de5e-b711-45e6-a7b3-c22574cb1bab?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A01Z&sr=b&sp=r&sig=tSIOhPr569cNvEqt%2BvaTuucJKzVB8F0xnJidt57oCwk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:01.3539687","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/53ecb826-02ab-4d5e-972b-0219627bd283?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A07Z&sr=b&sp=r&sig=Xmt3fJO9z3gXWWVRITZE5q%2BYqJ5GOGfWrPqMNi3CkDM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:07.7448852","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:01 GMT
+      - Fri, 13 Oct 2023 13:50:07 GMT
       mise-correlation-id:
-      - 3b445ade-d018-4d2b-932b-a48cb733eec0
+      - 14390ede-9c3c-4faf-a837-48a50c042df1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -383,25 +419,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/d7e0de5e-b711-45e6-a7b3-c22574cb1bab?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A06Z&sr=b&sp=r&sig=eJfRYmO%2FWa3zr%2BvEsowwPi0xWrotAxHFZrUSy3BkEtw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:06.6313026","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/53ecb826-02ab-4d5e-972b-0219627bd283?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A12Z&sr=b&sp=r&sig=Xr4%2FUaNB2IMvGjCy9EhRUlBqzcJV%2B%2F7nYqqIU5VjXrI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:12.9932951","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:06 GMT
+      - Fri, 13 Oct 2023 13:50:12 GMT
       mise-correlation-id:
-      - bee52083-f9a6-40c2-b5d0-53de73570fce
+      - 5ae0e56c-c9ef-4bac-bbf6-ee8e8fa64f4b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -419,25 +455,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/d7e0de5e-b711-45e6-a7b3-c22574cb1bab?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A11Z&sr=b&sp=r&sig=8U0WdKZvko8n9DVuXKqj7sfWRV3dsaIJ4326iB31ZQw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:11.8950886","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/53ecb826-02ab-4d5e-972b-0219627bd283?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A18Z&sr=b&sp=r&sig=dcQWsByUSw%2FwPIrXF5yUQqzrFliCdaDfOJPG9Y0rgEQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:18.2560711","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:11 GMT
+      - Fri, 13 Oct 2023 13:50:18 GMT
       mise-correlation-id:
-      - c5eb8e02-4a37-465f-b3f8-85905a33bb14
+      - 730b379a-0259-4f9d-a423-bf7b603794c8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -455,26 +491,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"48e206be-1222-44b8-8439-14af28125cb0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"5d4e551a-445e-4ffe-aa33-723cd1ab9622":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"603c001b-bbfb-4cc8-8543-67eab0d7eeef":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/d7e0de5e-b711-45e6-a7b3-c22574cb1bab?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A17%3A12Z&sr=b&sp=r&sig=gC9SPkZsmO7k6AL%2F%2FEafNr3zVcpRW0EhgYokGdeTISk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:17:12.1998235","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:16:54.917Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:08.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3221d294-ef57-4fad-8227-d94d392126a5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6c27a8b9-fd49-4014-bae0-1f19a760c59e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"5c12a097-0719-41ca-8270-5a22b36707ce":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/53ecb826-02ab-4d5e-972b-0219627bd283?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A50%3A18Z&sr=b&sp=r&sig=QzCEv1KaD1ehTf%2BxjziaxLFyPa%2FWj1LoWIfJDBRkT3c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:50:18.497886","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:49:55.962Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:15.197Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1579'
+      - '1578'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:12 GMT
+      - Fri, 13 Oct 2023 13:50:18 GMT
       mise-correlation-id:
-      - ddcc5c7a-2f0a-4b96-8e0f-fa9bebf34cd8
+      - bf489f80-80c1-4ece-99ce-3260a132c5f5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +533,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:19.2451554Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:19.2451554Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:21.2618497Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:21.2618497Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +542,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:13 GMT
+      - Fri, 13 Oct 2023 13:50:19 GMT
       etag:
-      - '"5500bfce-0000-0100-0000-652451850000"'
+      - '"d801e8bd-0000-0100-0000-65294ae30000"'
       expires:
       - '-1'
       pragma:
@@ -536,26 +572,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"48e206be-1222-44b8-8439-14af28125cb0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"5d4e551a-445e-4ffe-aa33-723cd1ab9622":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"603c001b-bbfb-4cc8-8543-67eab0d7eeef":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/d7e0de5e-b711-45e6-a7b3-c22574cb1bab?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A17%3A14Z&sr=b&sp=r&sig=WnN0wH4sPDEFtbmZgIF%2FSRcEq4NpQV%2FFWPdd08XcxfY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:17:14.5532005","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:16:54.917Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:08.536Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"3221d294-ef57-4fad-8227-d94d392126a5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6c27a8b9-fd49-4014-bae0-1f19a760c59e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"5c12a097-0719-41ca-8270-5a22b36707ce":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/53ecb826-02ab-4d5e-972b-0219627bd283?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A50%3A21Z&sr=b&sp=r&sig=aQuhSeU4XKwa7aMhj0FvJzGo8ZSilwJ3Gwz6Or%2BCsjQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:50:21.0267736","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:49:55.962Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:15.197Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1591'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:14 GMT
+      - Fri, 13 Oct 2023 13:50:21 GMT
       mise-correlation-id:
-      - 05b0f7d8-d45e-449d-9bf1-3655e9ce4606
+      - 2ca9880a-0194-4ed2-b3ea-c15f7984bf12
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +614,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:19.2451554Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:19.2451554Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:21.2618497Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:21.2618497Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +623,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:15 GMT
+      - Fri, 13 Oct 2023 13:50:22 GMT
       etag:
-      - '"5500bfce-0000-0100-0000-652451850000"'
+      - '"d801e8bd-0000-0100-0000-65294ae30000"'
       expires:
       - '-1'
       pragma:
@@ -619,9 +655,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -631,9 +667,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Mon, 09 Oct 2023 19:17:17 GMT
+      - Fri, 13 Oct 2023 13:50:23 GMT
       mise-correlation-id:
-      - c9c77027-5e57-45aa-88ce-93b813ed73e8
+      - f3414bc8-2341-4403-8fd8-261307fdb4c0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -656,7 +692,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:19.2451554Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:19.2451554Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:21.2618497Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:21.2618497Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -665,9 +701,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:18 GMT
+      - Fri, 13 Oct 2023 13:50:25 GMT
       etag:
-      - '"5500bfce-0000-0100-0000-652451850000"'
+      - '"d801e8bd-0000-0100-0000-65294ae30000"'
       expires:
       - '-1'
       pragma:
@@ -695,9 +731,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -711,9 +747,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:19 GMT
+      - Fri, 13 Oct 2023 13:50:26 GMT
       mise-correlation-id:
-      - 77084ffe-d65d-4ce6-9ef6-f5cfae57dbd2
+      - e66720c2-ba0d-472d-9b48-2f8c22d62702
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,7 +772,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:19.2451554Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:19.2451554Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:21.2618497Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:21.2618497Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -745,9 +781,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:20 GMT
+      - Fri, 13 Oct 2023 13:50:26 GMT
       etag:
-      - '"5500bfce-0000-0100-0000-652451850000"'
+      - '"d801e8bd-0000-0100-0000-65294ae30000"'
       expires:
       - '-1'
       pragma:
@@ -869,12 +905,12 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/dd1611fa-4d16-4250-b77a-fb50700dd8c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A23Z&sr=b&sp=r&sig=JvyPF7Ia3%2Bms0ac2pU92tdz7f5pNa6UvvrF8FoTJCoY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:23.3348482","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/5a4b226e-9362-4209-958e-24e32f84342c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A28Z&sr=b&sp=r&sig=QcApTnG%2BRVMoKPQCOB6fe1fWrV9r4rjFJJZwCkVARDQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:28.5758915","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -885,11 +921,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:23 GMT
+      - Fri, 13 Oct 2023 13:50:28 GMT
       location:
-      - https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - ed48b854-ebf9-4a4a-8205-e320a7b0d9aa
+      - 0decf73a-08a0-4aed-92ff-e17a307c471d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -907,244 +943,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/dd1611fa-4d16-4250-b77a-fb50700dd8c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A23Z&sr=b&sp=r&sig=uO7NF%2FyhHMoqmq9F3lRSS1ahXgYF1CiG45Ge6Ym5nAE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:23.6022916","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:17:23 GMT
-      mise-correlation-id:
-      - b23a5653-f94e-4157-a983-6a0f5493392f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/dd1611fa-4d16-4250-b77a-fb50700dd8c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A28Z&sr=b&sp=r&sig=n7pCazxBsP%2BjkwRUmxABZZQB4h4irNE0he5GLNTweqw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:28.8869512","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:17:28 GMT
-      mise-correlation-id:
-      - e5db74f8-a9ac-4f99-a5fc-60fc018fc426
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/dd1611fa-4d16-4250-b77a-fb50700dd8c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A34Z&sr=b&sp=r&sig=T6gSXGmR6rLA7n8Ve8YxzahS0Sa8eb9zsexcTuglOpg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:34.2083431","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:17:34 GMT
-      mise-correlation-id:
-      - a2908fd3-48a5-42e9-9344-8ec2c4288e1a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:19.2451554Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:19.2451554Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:17:34 GMT
-      etag:
-      - '"5500bfce-0000-0100-0000-652451850000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
-  response:
-    body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/dd1611fa-4d16-4250-b77a-fb50700dd8c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A35Z&sr=b&sp=r&sig=DQf7vGznQV5XsjXBUxpgYOxi1AggDPIPHJQbrZ1j%2Fhk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:35.7784432","validationStatus":"VALIDATION_INITIATED"}]}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '563'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:17:35 GMT
-      mise-correlation-id:
-      - 6b9cee54-5c4a-402e-913a-39c14ebdd30f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:19.2451554Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:19.2451554Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:17:36 GMT
-      etag:
-      - '"5500bfce-0000-0100-0000-652451850000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://84d75078-f00c-4f60-860c-6176ccb311b5.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/dd1611fa-4d16-4250-b77a-fb50700dd8c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A37Z&sr=b&sp=r&sig=5ed5qyHC5p%2BHZKLBXBXwqAx%2FZ76BsZWdRQW540OWUg8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:37.6001873","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/5a4b226e-9362-4209-958e-24e32f84342c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A28Z&sr=b&sp=r&sig=cvGUOo%2BgyjvlQO1D4rKxZihDahS%2BOxkKKhcSZzfs18c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:28.8230417","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1155,9 +959,241 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:37 GMT
+      - Fri, 13 Oct 2023 13:50:28 GMT
       mise-correlation-id:
-      - b3c35e30-0de5-408f-abc5-db1083da6b6c
+      - 2b9bf66b-c67e-4c2b-896f-67aed9e765cb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/5a4b226e-9362-4209-958e-24e32f84342c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A34Z&sr=b&sp=r&sig=SHvOcURDzC8gn3Ixu2jS9WmriyrLnG5PjPoIBHJIgtI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:34.0858579","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:50:34 GMT
+      mise-correlation-id:
+      - 7bdfb4dd-9504-46ed-8e35-0a5d7a20d153
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/5a4b226e-9362-4209-958e-24e32f84342c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A39Z&sr=b&sp=r&sig=R5dUZna0OEb0uQL7bpal9uUYPc61fpd9LoJ1z7ooXgM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:39.3297745","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:50:39 GMT
+      mise-correlation-id:
+      - b1a2ab3e-e0ed-49fe-bd10-9eb13d304043
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:21.2618497Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:21.2618497Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:50:40 GMT
+      etag:
+      - '"d801e8bd-0000-0100-0000-65294ae30000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+  response:
+    body:
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/5a4b226e-9362-4209-958e-24e32f84342c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A41Z&sr=b&sp=r&sig=BazdNw%2BqC7a9zs%2Fl6dmB6LL%2FH%2BKNZJUi%2F0npQbLmYzQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:41.0829429","validationStatus":"VALIDATION_INITIATED"}]}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '571'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:50:41 GMT
+      mise-correlation-id:
+      - f3e37cbd-0aac-47a4-8e38-16065e75d38f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:21.2618497Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:21.2618497Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:50:42 GMT
+      etag:
+      - '"d801e8bd-0000-0100-0000-65294ae30000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/5a4b226e-9362-4209-958e-24e32f84342c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A42Z&sr=b&sp=r&sig=fDq6%2FJXlx4zJQZU5PJhG%2FBbGWfHCrsBp2gqHDUSgPyc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:42.974957","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '550'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:50:42 GMT
+      mise-correlation-id:
+      - dece5d08-9ed9-403f-8876-b72858a3fbe1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1175,9 +1211,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/4352d9a9-8c73-4bed-b93f-8f798b868e04/dd1611fa-4d16-4250-b77a-fb50700dd8c9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A37Z&sr=b&sp=r&sig=5ed5qyHC5p%2BHZKLBXBXwqAx%2FZ76BsZWdRQW540OWUg8%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/5a4b226e-9362-4209-958e-24e32f84342c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A42Z&sr=b&sp=r&sig=fDq6%2FJXlx4zJQZU5PJhG%2FBbGWfHCrsBp2gqHDUSgPyc%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -1250,17 +1286,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Mon, 09 Oct 2023 19:17:38 GMT
+      - Fri, 13 Oct 2023 13:50:43 GMT
       etag:
-      - '"0x8DBC8FC5DAFB5CA"'
+      - '"0x8DBCBF35C0AA66A"'
       last-modified:
-      - Mon, 09 Oct 2023 19:17:23 GMT
+      - Fri, 13 Oct 2023 13:50:28 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 09 Oct 2023 19:17:23 GMT
+      - Fri, 13 Oct 2023 13:50:28 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_file.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_file.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:29.0635736Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:29.0635736Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:04.0427928Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:04.0427928Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:05 GMT
+      - Tue, 24 Oct 2023 12:26:38 GMT
       etag:
-      - '"7500d641-0000-0100-0000-653044dd0000"'
+      - '"d3001435-0000-0100-0000-6537b7dd0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:50:06 GMT
+      - Tue, 24 Oct 2023 12:26:39 GMT
       mise-correlation-id:
-      - 3ce42bae-680e-4981-ad22-8ad57a5dbf9f
+      - 13113ee4-8028-417b-ba2e-0e28cadb9f2e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"7bcae25d-9120-4903-be43-21b65ef8d78a": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "bb850de9-58aa-4c59-926a-2e4362a70460":
+      {"passFailMetrics": {"9cd04cd5-84bf-461c-a09e-558d888ded37": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "4c5cce21-7b81-4b91-8ca2-58e9c4b24bbd":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "ef9c5e25-9ef1-4d17-9f7d-645b96466567": {"aggregate": "avg", "clientMetric":
+      "50"}, "9c7de111-e11b-4faf-9470-e83b529c820a": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,26 +106,26 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7bcae25d-9120-4903-be43-21b65ef8d78a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bb850de9-58aa-4c59-926a-2e4362a70460":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ef9c5e25-9ef1-4d17-9f7d-645b96466567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:50:07.082Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:07.082Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9cd04cd5-84bf-461c-a09e-558d888ded37":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4c5cce21-7b81-4b91-8ca2-58e9c4b24bbd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9c7de111-e11b-4faf-9470-e83b529c820a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:26:39.56Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:39.56Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1006'
+      - '1004'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:07 GMT
+      - Tue, 24 Oct 2023 12:26:39 GMT
       location:
-      - https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+      - https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 5222ea78-1965-4e8a-a2df-78db6a9c4b17
+      - b74d0496-316a-40d3-a813-8612d3e17301
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:07 GMT
+      - Tue, 24 Oct 2023 12:26:39 GMT
       mise-correlation-id:
-      - 1808500b-2d98-4fd4-a714-fbafecabb04b
+      - 1805130d-0d7c-4407-9bb0-8fdf33fcbf2d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/862a0120-b1c4-4c0b-b7e8-df22c61c5efc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A09Z&sr=b&sp=r&sig=%2B847HR5vNwlLwliULDAJKfJ0FQACdwrH2VQuz9t9sRo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:09.664338","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/eba052e2-6682-4672-9348-7701b267adf7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A41Z&sr=b&sp=r&sig=i9vFiz%2FzuhGuee7aGLFLavXqreE6TD7qtcIOcca1YKE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:41.0048241","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:09 GMT
+      - Tue, 24 Oct 2023 12:26:41 GMT
       location:
-      - https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - cc0e53e6-681d-4c1a-bfed-acef0f4b6f25
+      - ebbcdcd0-37bb-4ef6-b7df-54c4bd52f7ba
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/862a0120-b1c4-4c0b-b7e8-df22c61c5efc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A09Z&sr=b&sp=r&sig=Qgao6FzaKiugg9VtGPToZnppR8BLa4GiBtn3IwzFkFE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:09.9153065","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/eba052e2-6682-4672-9348-7701b267adf7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A41Z&sr=b&sp=r&sig=8iH2QtimKT12GrmElDnA3q3fvAWwKr3SCDaXft4YUSY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:41.3099373","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:09 GMT
+      - Tue, 24 Oct 2023 12:26:41 GMT
       mise-correlation-id:
-      - 84022b2d-06a7-4d43-b3c4-92f830a446c7
+      - edbec9f9-098d-44f2-8818-f305100c7b97
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/862a0120-b1c4-4c0b-b7e8-df22c61c5efc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A15Z&sr=b&sp=r&sig=9C%2FPhGZeHIicrE%2B%2FEhkshAbsqOO0noDwiQKjYYQN%2BKI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:15.1748936","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/eba052e2-6682-4672-9348-7701b267adf7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A46Z&sr=b&sp=r&sig=mO6DAVlJyQIXdLd4YxYOYnaVwysE%2BiVEzJVR7wqrs8Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:46.5729371","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '557'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:15 GMT
+      - Tue, 24 Oct 2023 12:26:46 GMT
       mise-correlation-id:
-      - 4c8730fc-e2f2-4500-ab3b-ac2fce8f57c3
+      - 5879e6f4-c0d4-4c79-a6ed-44c1d2226953
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,46 +385,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/862a0120-b1c4-4c0b-b7e8-df22c61c5efc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A20Z&sr=b&sp=r&sig=2%2F9ZhHlzikMoy00Xxh7OT%2Bk%2FoqHRvxlXnd%2BcO8Uraf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:20.4343125","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '557'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:50:20 GMT
-      mise-correlation-id:
-      - 3e4d0715-cd80-4050-b6a2-9e13a15451e6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/862a0120-b1c4-4c0b-b7e8-df22c61c5efc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A25Z&sr=b&sp=r&sig=ZxeINZbBxvCMVQvF2p6q1T6xItihnGl4%2FEf6JsBctAA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:25.6959582","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/eba052e2-6682-4672-9348-7701b267adf7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A51Z&sr=b&sp=r&sig=jsBvts03EgbVzZ2LUvJYyyzdLOaxkmuq4nL0R2ALupQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:51.8341416","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:25 GMT
+      - Tue, 24 Oct 2023 12:26:51 GMT
       mise-correlation-id:
-      - a709f96a-51bd-45b4-9693-ff4cfc3a5f0b
+      - a5a15825-c732-4715-a47d-3c1b056bb3ab
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +421,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7bcae25d-9120-4903-be43-21b65ef8d78a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bb850de9-58aa-4c59-926a-2e4362a70460":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ef9c5e25-9ef1-4d17-9f7d-645b96466567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/862a0120-b1c4-4c0b-b7e8-df22c61c5efc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A50%3A25Z&sr=b&sp=r&sig=TnzbyrlvTAQOIMrCvVswfWVDJPDkPKxq3KkH2%2BcV02Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:50:25.942842","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:50:07.082Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:22.447Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/eba052e2-6682-4672-9348-7701b267adf7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A57Z&sr=b&sp=r&sig=gb0uACjfEjlIk0J6uHL%2BNwvgnSTZarrsvy6lThg487o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:57.0792343","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1576'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:25 GMT
+      - Tue, 24 Oct 2023 12:26:57 GMT
       mise-correlation-id:
-      - 1e4a17a8-bae3-41cb-8208-ec63033fb6b0
+      - 03d1ba83-2516-42e8-bb44-f747677a24f3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9cd04cd5-84bf-461c-a09e-558d888ded37":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4c5cce21-7b81-4b91-8ca2-58e9c4b24bbd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9c7de111-e11b-4faf-9470-e83b529c820a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/eba052e2-6682-4672-9348-7701b267adf7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A26%3A57Z&sr=b&sp=r&sig=23X5SsmBy3NoshMc4rdfjmuIRd2TIhI2Zv2XPJ9mITs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:26:57.3767979","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:26:39.56Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:54.354Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1574'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:26:57 GMT
+      mise-correlation-id:
+      - bdebc2b3-37f0-484a-8257-ff187e1931ce
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:29.0635736Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:29.0635736Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:04.0427928Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:04.0427928Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:26 GMT
+      - Tue, 24 Oct 2023 12:26:57 GMT
       etag:
-      - '"7500d641-0000-0100-0000-653044dd0000"'
+      - '"d3001435-0000-0100-0000-6537b7dd0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"7bcae25d-9120-4903-be43-21b65ef8d78a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bb850de9-58aa-4c59-926a-2e4362a70460":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ef9c5e25-9ef1-4d17-9f7d-645b96466567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/862a0120-b1c4-4c0b-b7e8-df22c61c5efc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A50%3A28Z&sr=b&sp=r&sig=nIHLigL1N%2BK%2BnqDZMf2S9f7T40KstlQETuZGBLSzWaA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:50:28.2370149","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:50:07.082Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:22.447Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"9cd04cd5-84bf-461c-a09e-558d888ded37":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4c5cce21-7b81-4b91-8ca2-58e9c4b24bbd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9c7de111-e11b-4faf-9470-e83b529c820a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/eba052e2-6682-4672-9348-7701b267adf7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A26%3A58Z&sr=b&sp=r&sig=nmGBeWLjEqdHCI%2FQbDyLBw1iXawWa%2F2lkPxJcJAahVU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:26:58.9173976","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:26:39.56Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:54.354Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1591'
+      - '1590'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:28 GMT
+      - Tue, 24 Oct 2023 12:26:58 GMT
       mise-correlation-id:
-      - df60a23d-131c-4691-8072-b2224c695132
+      - d061a66f-f25e-4b31-a33e-04237a97e23a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:29.0635736Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:29.0635736Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:04.0427928Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:04.0427928Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:29 GMT
+      - Tue, 24 Oct 2023 12:27:00 GMT
       etag:
-      - '"7500d641-0000-0100-0000-653044dd0000"'
+      - '"d3001435-0000-0100-0000-6537b7dd0000"'
       expires:
       - '-1'
       pragma:
@@ -621,7 +621,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -631,9 +631,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Wed, 18 Oct 2023 20:50:29 GMT
+      - Tue, 24 Oct 2023 12:27:01 GMT
       mise-correlation-id:
-      - 761c6c5f-0ece-460d-a5d8-338432179c28
+      - b8dd50f1-ec5c-475c-a83d-dc0848da6ff6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -656,7 +656,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:29.0635736Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:29.0635736Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:04.0427928Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:04.0427928Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -665,9 +665,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:30 GMT
+      - Tue, 24 Oct 2023 12:27:02 GMT
       etag:
-      - '"7500d641-0000-0100-0000-653044dd0000"'
+      - '"d3001435-0000-0100-0000-6537b7dd0000"'
       expires:
       - '-1'
       pragma:
@@ -697,7 +697,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -711,9 +711,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:32 GMT
+      - Tue, 24 Oct 2023 12:27:03 GMT
       mise-correlation-id:
-      - 2f5587fc-beb4-46fd-a9da-79c253bddfaa
+      - 8175850d-b057-48d7-be19-8ab59f6c73bb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,7 +736,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:29.0635736Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:29.0635736Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:04.0427928Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:04.0427928Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -745,9 +745,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:33 GMT
+      - Tue, 24 Oct 2023 12:27:03 GMT
       etag:
-      - '"7500d641-0000-0100-0000-653044dd0000"'
+      - '"d3001435-0000-0100-0000-6537b7dd0000"'
       expires:
       - '-1'
       pragma:
@@ -871,25 +871,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/892c89ff-e921-413c-b1da-a27d0aca22c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A34Z&sr=b&sp=r&sig=%2FpdlJYab%2BufQAIOAlO%2BQEUP1igfKbgy%2B1lR%2BQZ3Qlqk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:34.4885706","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/487c53ce-38ec-41e3-b3e1-f975cbb5a01c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A05Z&sr=b&sp=r&sig=NI297wk2xVMhBdYH4HOQU8OO1wSYTQPxvxidbAPrnRY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:05.5945529","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '559'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:34 GMT
+      - Tue, 24 Oct 2023 12:27:05 GMT
       location:
-      - https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 7d5f2acc-3487-467c-9869-1aec7a068709
+      - effe02f9-29f5-4f17-a39f-b86e0b7372ba
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -909,46 +909,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/892c89ff-e921-413c-b1da-a27d0aca22c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A34Z&sr=b&sp=r&sig=e6j7FgSiSJWHDEYOEnzm4iVFZlxrLAp%2B1SaQQo4O6%2Fs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:34.7984656","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:50:34 GMT
-      mise-correlation-id:
-      - c90a17e0-80b7-4f58-b50f-60839979b060
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/892c89ff-e921-413c-b1da-a27d0aca22c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A40Z&sr=b&sp=r&sig=kjg%2FdGWrQbDk1AZ7VEt8HwZ6ckGob0j9YBnswO513wE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:40.0597906","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/487c53ce-38ec-41e3-b3e1-f975cbb5a01c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A05Z&sr=b&sp=r&sig=eq8ibeuXfen4qCq%2BdDyHsyPrixmPEDFBfC7AC7M9zk4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:05.8777506","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -959,9 +923,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:40 GMT
+      - Tue, 24 Oct 2023 12:27:05 GMT
       mise-correlation-id:
-      - f5056f5a-4d27-480a-9263-0f6cc78e787a
+      - 424d4587-1a0a-444e-9f67-33f468921b5f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -981,170 +945,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/892c89ff-e921-413c-b1da-a27d0aca22c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A45Z&sr=b&sp=r&sig=0kFA5n3aiBd2nPX5A7cAQChRhIDf8l4vIXi%2Fb662RKw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:45.3370723","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:50:45 GMT
-      mise-correlation-id:
-      - f7f7712d-f5d9-413a-9085-05eb9fa42762
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:29.0635736Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:29.0635736Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:50:45 GMT
-      etag:
-      - '"7500d641-0000-0100-0000-653044dd0000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
-  response:
-    body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/892c89ff-e921-413c-b1da-a27d0aca22c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A46Z&sr=b&sp=r&sig=x41XycV6y9%2BZj4ZzLfs9l1yh35H2OT%2F5XrV%2Blaq6860%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:46.8753352","validationStatus":"VALIDATION_INITIATED"}]}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '567'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:50:46 GMT
-      mise-correlation-id:
-      - ecf74fd5-f464-4f2f-a813-5f8d9cd7f2de
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:29.0635736Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:29.0635736Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:50:46 GMT
-      etag:
-      - '"7500d641-0000-0100-0000-653044dd0000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/892c89ff-e921-413c-b1da-a27d0aca22c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A48Z&sr=b&sp=r&sig=AOITDFS8MebwAsZR1OCDXl2cMc%2BezYRZxnHuzANN4XQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:48.4189289","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/487c53ce-38ec-41e3-b3e1-f975cbb5a01c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A11Z&sr=b&sp=r&sig=lEE9fedIlG7Wpr1WG8EOISpq5MzGQXhTVrIFOMhYt98%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:11.1584313","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1155,9 +959,205 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:48 GMT
+      - Tue, 24 Oct 2023 12:27:11 GMT
       mise-correlation-id:
-      - 4e60856c-3f46-459a-a1ae-678596593955
+      - f2ef640d-efa9-4d18-b48a-b13f3122500b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/487c53ce-38ec-41e3-b3e1-f975cbb5a01c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A16Z&sr=b&sp=r&sig=NLQ5zGIQLf5eEvs8i7NxMjJIFgIyAxBQ0AM4xyOLebE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:16.4682621","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:27:16 GMT
+      mise-correlation-id:
+      - c0ef28db-4f41-488c-b94a-cc8ebbc31c16
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:04.0427928Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:04.0427928Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:27:17 GMT
+      etag:
+      - '"d3001435-0000-0100-0000-6537b7dd0000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+  response:
+    body:
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/487c53ce-38ec-41e3-b3e1-f975cbb5a01c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A17Z&sr=b&sp=r&sig=ZMiJIz4ienFX4TaTOlBKsErkQ4DHI%2FzMhggqoqiqw1c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:17.8789877","validationStatus":"VALIDATION_INITIATED"}]}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '563'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:27:17 GMT
+      mise-correlation-id:
+      - 725c8405-c37b-49dc-bb0e-90b7f885aba6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:04.0427928Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:04.0427928Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:27:18 GMT
+      etag:
+      - '"d3001435-0000-0100-0000-6537b7dd0000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/487c53ce-38ec-41e3-b3e1-f975cbb5a01c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A20Z&sr=b&sp=r&sig=ikqcLsQKobuS5upktFxyXGkmioZk9GFgqHGRYV2ZPlk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:20.0351292","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '547'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:27:20 GMT
+      mise-correlation-id:
+      - 7cd71a8d-424d-45ad-9c9c-49f603acfde4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1177,7 +1177,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/892c89ff-e921-413c-b1da-a27d0aca22c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A48Z&sr=b&sp=r&sig=AOITDFS8MebwAsZR1OCDXl2cMc%2BezYRZxnHuzANN4XQ%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/487c53ce-38ec-41e3-b3e1-f975cbb5a01c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A20Z&sr=b&sp=r&sig=ikqcLsQKobuS5upktFxyXGkmioZk9GFgqHGRYV2ZPlk%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -1250,17 +1250,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 18 Oct 2023 20:50:49 GMT
+      - Tue, 24 Oct 2023 12:27:20 GMT
       etag:
-      - '"0x8DBD01BDFF5B49D"'
+      - '"0x8DBD48C887A57CE"'
       last-modified:
-      - Wed, 18 Oct 2023 20:50:34 GMT
+      - Tue, 24 Oct 2023 12:27:05 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 18 Oct 2023 20:50:34 GMT
+      - Tue, 24 Oct 2023 12:27:05 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_file.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_file.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:04.0427928Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:04.0427928Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:04.3966435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:04.3966435Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:38 GMT
+      - Sun, 29 Oct 2023 22:19:39 GMT
       etag:
-      - '"d3001435-0000-0100-0000-6537b7dd0000"'
+      - '"3c008224-0000-0100-0000-653eda5a0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:26:39 GMT
+      - Sun, 29 Oct 2023 22:19:40 GMT
       mise-correlation-id:
-      - 13113ee4-8028-417b-ba2e-0e28cadb9f2e
+      - ca63c27f-5a79-4824-a71f-8d09b21c60b9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"9cd04cd5-84bf-461c-a09e-558d888ded37": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "4c5cce21-7b81-4b91-8ca2-58e9c4b24bbd":
+      {"passFailMetrics": {"fc5d4438-7ff3-4a46-858c-231697e4a3f1": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "63c22fc5-1b0b-4d42-81e2-cbbb674ff2e7":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "9c7de111-e11b-4faf-9470-e83b529c820a": {"aggregate": "avg", "clientMetric":
+      "50"}, "fd8d5f11-df51-4d67-90d3-a7faeb04fd0a": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,26 +106,26 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9cd04cd5-84bf-461c-a09e-558d888ded37":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4c5cce21-7b81-4b91-8ca2-58e9c4b24bbd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9c7de111-e11b-4faf-9470-e83b529c820a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:26:39.56Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:39.56Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"fc5d4438-7ff3-4a46-858c-231697e4a3f1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"63c22fc5-1b0b-4d42-81e2-cbbb674ff2e7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fd8d5f11-df51-4d67-90d3-a7faeb04fd0a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:19:40.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:19:40.672Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1004'
+      - '1006'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:39 GMT
+      - Sun, 29 Oct 2023 22:19:40 GMT
       location:
-      - https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+      - https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - b74d0496-316a-40d3-a813-8612d3e17301
+      - 8db0d35a-3d01-4b31-b643-a770cc5e722f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:39 GMT
+      - Sun, 29 Oct 2023 22:19:40 GMT
       mise-correlation-id:
-      - 1805130d-0d7c-4407-9bb0-8fdf33fcbf2d
+      - c4e9944c-0890-4e83-a84c-ac8765184e52
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,10 +275,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/eba052e2-6682-4672-9348-7701b267adf7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A41Z&sr=b&sp=r&sig=i9vFiz%2FzuhGuee7aGLFLavXqreE6TD7qtcIOcca1YKE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:41.0048241","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/650349d7-5fc5-494a-834d-620f732e51d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A41Z&sr=b&sp=r&sig=6PAAOziA4LcdvllcBzCOSC7e%2Bn05956GIgQlg3pHVfw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:41.5100949","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -289,11 +289,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:41 GMT
+      - Sun, 29 Oct 2023 22:19:41 GMT
       location:
-      - https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - ebbcdcd0-37bb-4ef6-b7df-54c4bd52f7ba
+      - fca74cc0-b1b2-4688-a01d-f989e9378e03
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,46 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/eba052e2-6682-4672-9348-7701b267adf7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A41Z&sr=b&sp=r&sig=8iH2QtimKT12GrmElDnA3q3fvAWwKr3SCDaXft4YUSY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:41.3099373","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:26:41 GMT
-      mise-correlation-id:
-      - edbec9f9-098d-44f2-8818-f305100c7b97
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/eba052e2-6682-4672-9348-7701b267adf7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A46Z&sr=b&sp=r&sig=mO6DAVlJyQIXdLd4YxYOYnaVwysE%2BiVEzJVR7wqrs8Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:46.5729371","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/650349d7-5fc5-494a-834d-620f732e51d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A41Z&sr=b&sp=r&sig=151R8ZOq66cVyQ22KNiTLJbXC7%2FX0LKP3UXzMqVyUc0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:41.8084074","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:46 GMT
+      - Sun, 29 Oct 2023 22:19:41 GMT
       mise-correlation-id:
-      - 5879e6f4-c0d4-4c79-a6ed-44c1d2226953
+      - fe7da398-8e70-4629-bf54-ef446630159f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,10 +349,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/eba052e2-6682-4672-9348-7701b267adf7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A51Z&sr=b&sp=r&sig=jsBvts03EgbVzZ2LUvJYyyzdLOaxkmuq4nL0R2ALupQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:51.8341416","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/650349d7-5fc5-494a-834d-620f732e51d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A47Z&sr=b&sp=r&sig=%2F5ZxtY17aWtDlPHsE8nEGypARxd%2BzKwBU7YOJkLC274%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:47.2249729","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:19:47 GMT
+      mise-correlation-id:
+      - ffb3e091-7434-4d04-bdd8-94f5b34ee117
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/650349d7-5fc5-494a-834d-620f732e51d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A52Z&sr=b&sp=r&sig=PgDFKEBYOCtRsl8qsymo1Og74eSdfzIBv0LHJ%2BT9bJk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:52.5275588","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:19:52 GMT
+      mise-correlation-id:
+      - 516ef4e9-ff11-4342-8547-6f00485aac10
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/650349d7-5fc5-494a-834d-620f732e51d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A57Z&sr=b&sp=r&sig=iBqt6WOFeW8y5oHaiR%2BIZUgfG4Y33zQMaLbfJd8oCqg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:57.8149311","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:51 GMT
+      - Sun, 29 Oct 2023 22:19:57 GMT
       mise-correlation-id:
-      - a5a15825-c732-4715-a47d-3c1b056bb3ab
+      - 6cc83935-c802-474e-9fd4-b91456b23884
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,60 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/eba052e2-6682-4672-9348-7701b267adf7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A57Z&sr=b&sp=r&sig=gb0uACjfEjlIk0J6uHL%2BNwvgnSTZarrsvy6lThg487o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:57.0792343","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"fc5d4438-7ff3-4a46-858c-231697e4a3f1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"63c22fc5-1b0b-4d42-81e2-cbbb674ff2e7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fd8d5f11-df51-4d67-90d3-a7faeb04fd0a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/650349d7-5fc5-494a-834d-620f732e51d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A19%3A58Z&sr=b&sp=r&sig=f%2FmdtdNLy8VwD%2FbN1dDb89INuV9UVuZn%2ByHlLwxETg0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:19:58.3797282","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:19:40.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:19:53.713Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '1581'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:57 GMT
+      - Sun, 29 Oct 2023 22:19:58 GMT
       mise-correlation-id:
-      - 03d1ba83-2516-42e8-bb44-f747677a24f3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9cd04cd5-84bf-461c-a09e-558d888ded37":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4c5cce21-7b81-4b91-8ca2-58e9c4b24bbd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9c7de111-e11b-4faf-9470-e83b529c820a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/eba052e2-6682-4672-9348-7701b267adf7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A26%3A57Z&sr=b&sp=r&sig=23X5SsmBy3NoshMc4rdfjmuIRd2TIhI2Zv2XPJ9mITs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:26:57.3767979","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:26:39.56Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:54.354Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1574'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:26:57 GMT
-      mise-correlation-id:
-      - bdebc2b3-37f0-484a-8257-ff187e1931ce
+      - 280836fc-cfcf-4325-bbeb-e5c70eb8f6bf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:04.0427928Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:04.0427928Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:04.3966435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:04.3966435Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:57 GMT
+      - Sun, 29 Oct 2023 22:19:59 GMT
       etag:
-      - '"d3001435-0000-0100-0000-6537b7dd0000"'
+      - '"3c008224-0000-0100-0000-653eda5a0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"9cd04cd5-84bf-461c-a09e-558d888ded37":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4c5cce21-7b81-4b91-8ca2-58e9c4b24bbd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9c7de111-e11b-4faf-9470-e83b529c820a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/eba052e2-6682-4672-9348-7701b267adf7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A26%3A58Z&sr=b&sp=r&sig=nmGBeWLjEqdHCI%2FQbDyLBw1iXawWa%2F2lkPxJcJAahVU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:26:58.9173976","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:26:39.56Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:54.354Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"fc5d4438-7ff3-4a46-858c-231697e4a3f1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"63c22fc5-1b0b-4d42-81e2-cbbb674ff2e7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fd8d5f11-df51-4d67-90d3-a7faeb04fd0a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/650349d7-5fc5-494a-834d-620f732e51d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A20%3A00Z&sr=b&sp=r&sig=szh2wh2VZ6gHUdmz3AL4uZ9FUOPIsR4B3OHA0p8AmUE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:20:00.7501866","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:19:40.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:19:53.713Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1590'
+      - '1587'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:58 GMT
+      - Sun, 29 Oct 2023 22:20:00 GMT
       mise-correlation-id:
-      - d061a66f-f25e-4b31-a33e-04237a97e23a
+      - 2f7e45d3-1061-45a3-b35b-dfe879131502
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:04.0427928Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:04.0427928Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:04.3966435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:04.3966435Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:00 GMT
+      - Sun, 29 Oct 2023 22:20:02 GMT
       etag:
-      - '"d3001435-0000-0100-0000-6537b7dd0000"'
+      - '"3c008224-0000-0100-0000-653eda5a0000"'
       expires:
       - '-1'
       pragma:
@@ -621,7 +621,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -631,9 +631,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Tue, 24 Oct 2023 12:27:01 GMT
+      - Sun, 29 Oct 2023 22:20:03 GMT
       mise-correlation-id:
-      - b8dd50f1-ec5c-475c-a83d-dc0848da6ff6
+      - 4074fd8a-fd1f-4e15-9442-b341473f46dc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -656,18 +656,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:04.0427928Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:04.0427928Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:04.3966435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:04.3966435Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:02 GMT
+      - Sun, 29 Oct 2023 22:20:03 GMT
       etag:
-      - '"d3001435-0000-0100-0000-6537b7dd0000"'
+      - '"3c008224-0000-0100-0000-653eda5a0000"'
       expires:
       - '-1'
       pragma:
@@ -697,7 +697,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -711,9 +711,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:03 GMT
+      - Sun, 29 Oct 2023 22:20:04 GMT
       mise-correlation-id:
-      - 8175850d-b057-48d7-be19-8ab59f6c73bb
+      - a557b464-9a25-4399-8619-aa1f1eeb7518
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,18 +736,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:04.0427928Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:04.0427928Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:04.3966435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:04.3966435Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:03 GMT
+      - Sun, 29 Oct 2023 22:20:06 GMT
       etag:
-      - '"d3001435-0000-0100-0000-6537b7dd0000"'
+      - '"3c008224-0000-0100-0000-653eda5a0000"'
       expires:
       - '-1'
       pragma:
@@ -871,10 +871,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/487c53ce-38ec-41e3-b3e1-f975cbb5a01c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A05Z&sr=b&sp=r&sig=NI297wk2xVMhBdYH4HOQU8OO1wSYTQPxvxidbAPrnRY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:05.5945529","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/39acc83b-5d18-4770-92ca-50f4297190a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A07Z&sr=b&sp=r&sig=vuoVIbsPabQsYePu8EPzk4EEm5rkJ4Y0i2oeO4kSPaY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:07.3649537","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -885,11 +885,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:05 GMT
+      - Sun, 29 Oct 2023 22:20:07 GMT
       location:
-      - https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - effe02f9-29f5-4f17-a39f-b86e0b7372ba
+      - 217552c0-0dc3-422c-9c8c-3dc0b21c2333
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -909,10 +909,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/487c53ce-38ec-41e3-b3e1-f975cbb5a01c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A05Z&sr=b&sp=r&sig=eq8ibeuXfen4qCq%2BdDyHsyPrixmPEDFBfC7AC7M9zk4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:05.8777506","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/39acc83b-5d18-4770-92ca-50f4297190a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A07Z&sr=b&sp=r&sig=Ys6Lw9cx9CPiHX4OiUD14Y3fv3oMW6KL%2BnH2%2B4FwX1E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:07.6096462","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:20:07 GMT
+      mise-correlation-id:
+      - c5024617-13d2-4911-9e6c-ca5fa2256013
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/39acc83b-5d18-4770-92ca-50f4297190a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A12Z&sr=b&sp=r&sig=6piSJ5uA74FJVey8Y9M7%2FFtpNo2T5Zfp7Fukv1W0fGE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:12.8634445","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -923,9 +959,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:05 GMT
+      - Sun, 29 Oct 2023 22:20:12 GMT
       mise-correlation-id:
-      - 424d4587-1a0a-444e-9f67-33f468921b5f
+      - 86e7c879-73de-4579-a163-ac1809087ce4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -945,59 +981,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/487c53ce-38ec-41e3-b3e1-f975cbb5a01c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A11Z&sr=b&sp=r&sig=lEE9fedIlG7Wpr1WG8EOISpq5MzGQXhTVrIFOMhYt98%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:11.1584313","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/39acc83b-5d18-4770-92ca-50f4297190a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A18Z&sr=b&sp=r&sig=CXBmvvID2ndhuQzAhT00qCvncYYS0qgP3RdAlM%2FwJY8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:18.181816","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:11 GMT
+      - Sun, 29 Oct 2023 22:20:18 GMT
       mise-correlation-id:
-      - f2ef640d-efa9-4d18-b48a-b13f3122500b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/487c53ce-38ec-41e3-b3e1-f975cbb5a01c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A16Z&sr=b&sp=r&sig=NLQ5zGIQLf5eEvs8i7NxMjJIFgIyAxBQ0AM4xyOLebE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:16.4682621","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:27:16 GMT
-      mise-correlation-id:
-      - c0ef28db-4f41-488c-b94a-cc8ebbc31c16
+      - 2ba0beff-e298-458b-834e-773803dc9740
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1020,18 +1020,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:04.0427928Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:04.0427928Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:04.3966435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:04.3966435Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:17 GMT
+      - Sun, 29 Oct 2023 22:20:18 GMT
       etag:
-      - '"d3001435-0000-0100-0000-6537b7dd0000"'
+      - '"3c008224-0000-0100-0000-653eda5a0000"'
       expires:
       - '-1'
       pragma:
@@ -1061,10 +1061,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/487c53ce-38ec-41e3-b3e1-f975cbb5a01c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A17Z&sr=b&sp=r&sig=ZMiJIz4ienFX4TaTOlBKsErkQ4DHI%2FzMhggqoqiqw1c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:17.8789877","validationStatus":"VALIDATION_INITIATED"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/39acc83b-5d18-4770-92ca-50f4297190a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A19Z&sr=b&sp=r&sig=tuZZatkNheqcUG58KRtYRc0lsPbb5hfP%2FDHRtXvIJ3Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:19.8012877","validationStatus":"VALIDATION_INITIATED"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1075,9 +1075,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:17 GMT
+      - Sun, 29 Oct 2023 22:20:19 GMT
       mise-correlation-id:
-      - 725c8405-c37b-49dc-bb0e-90b7f885aba6
+      - 5d68b6e1-6c6d-439c-8d18-037de4594453
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1100,18 +1100,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:26:04.0427928Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:26:04.0427928Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:04.3966435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:04.3966435Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:18 GMT
+      - Sun, 29 Oct 2023 22:20:21 GMT
       etag:
-      - '"d3001435-0000-0100-0000-6537b7dd0000"'
+      - '"3c008224-0000-0100-0000-653eda5a0000"'
       expires:
       - '-1'
       pragma:
@@ -1141,23 +1141,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1b291248-57f0-47f0-a04a-46a199664865.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/487c53ce-38ec-41e3-b3e1-f975cbb5a01c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A20Z&sr=b&sp=r&sig=ikqcLsQKobuS5upktFxyXGkmioZk9GFgqHGRYV2ZPlk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:20.0351292","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/39acc83b-5d18-4770-92ca-50f4297190a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A22Z&sr=b&sp=r&sig=f8y6oyi1spGY%2FWL13Aq8%2B1bqjg%2FIsMQ3aJh0rnDXqVI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:22.3305554","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:20 GMT
+      - Sun, 29 Oct 2023 22:20:22 GMT
       mise-correlation-id:
-      - 7cd71a8d-424d-45ad-9c9c-49f603acfde4
+      - 4c467e3d-1b99-41a7-a49e-e0229d6c3fbe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1177,7 +1177,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/d05e7624-7e2a-41aa-840f-782394599af5/487c53ce-38ec-41e3-b3e1-f975cbb5a01c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A20Z&sr=b&sp=r&sig=ikqcLsQKobuS5upktFxyXGkmioZk9GFgqHGRYV2ZPlk%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/39acc83b-5d18-4770-92ca-50f4297190a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A22Z&sr=b&sp=r&sig=f8y6oyi1spGY%2FWL13Aq8%2B1bqjg%2FIsMQ3aJh0rnDXqVI%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -1250,17 +1250,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Tue, 24 Oct 2023 12:27:20 GMT
+      - Sun, 29 Oct 2023 22:20:22 GMT
       etag:
-      - '"0x8DBD48C887A57CE"'
+      - '"0x8DBD8CD34FDAD5E"'
       last-modified:
-      - Tue, 24 Oct 2023 12:27:05 GMT
+      - Sun, 29 Oct 2023 22:20:07 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Tue, 24 Oct 2023 12:27:05 GMT
+      - Sun, 29 Oct 2023 22:20:07 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_file.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_file.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:21.2618497Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:21.2618497Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:29.0635736Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:29.0635736Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:54 GMT
+      - Wed, 18 Oct 2023 20:50:05 GMT
       etag:
-      - '"d801e8bd-0000-0100-0000-65294ae30000"'
+      - '"7500d641-0000-0100-0000-653044dd0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:49:55 GMT
+      - Wed, 18 Oct 2023 20:50:06 GMT
       mise-correlation-id:
-      - 6e85db7a-459b-47ad-834b-9906195fb384
+      - 3ce42bae-680e-4981-ad22-8ad57a5dbf9f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"3221d294-ef57-4fad-8227-d94d392126a5": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "6c27a8b9-fd49-4014-bae0-1f19a760c59e":
+      {"passFailMetrics": {"7bcae25d-9120-4903-be43-21b65ef8d78a": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "bb850de9-58aa-4c59-926a-2e4362a70460":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "5c12a097-0719-41ca-8270-5a22b36707ce": {"aggregate": "avg", "clientMetric":
+      "50"}, "ef9c5e25-9ef1-4d17-9f7d-645b96466567": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3221d294-ef57-4fad-8227-d94d392126a5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6c27a8b9-fd49-4014-bae0-1f19a760c59e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"5c12a097-0719-41ca-8270-5a22b36707ce":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:49:55.962Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:49:55.962Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7bcae25d-9120-4903-be43-21b65ef8d78a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bb850de9-58aa-4c59-926a-2e4362a70460":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ef9c5e25-9ef1-4d17-9f7d-645b96466567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:50:07.082Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:07.082Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:55 GMT
+      - Wed, 18 Oct 2023 20:50:07 GMT
       location:
-      - https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+      - https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - a238d023-b589-4948-bfa2-0d58c1966593
+      - 5222ea78-1965-4e8a-a2df-78db6a9c4b17
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:56 GMT
+      - Wed, 18 Oct 2023 20:50:07 GMT
       mise-correlation-id:
-      - 138d267a-32d8-4c42-a0e1-0a0e9f6028d4
+      - 1808500b-2d98-4fd4-a714-fbafecabb04b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/53ecb826-02ab-4d5e-972b-0219627bd283?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A56Z&sr=b&sp=r&sig=J2RhZZgySrf1ubRJWJQDr0noSC2cu1keeSSkliFMzfc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:56.8503222","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/862a0120-b1c4-4c0b-b7e8-df22c61c5efc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A09Z&sr=b&sp=r&sig=%2B847HR5vNwlLwliULDAJKfJ0FQACdwrH2VQuz9t9sRo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:09.664338","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:56 GMT
+      - Wed, 18 Oct 2023 20:50:09 GMT
       location:
-      - https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 02b6f8c5-c87e-484c-9e1f-c5545409b2f8
+      - cc0e53e6-681d-4c1a-bfed-acef0f4b6f25
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/53ecb826-02ab-4d5e-972b-0219627bd283?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A59%3A57Z&sr=b&sp=r&sig=7NkNwLo7gnUfoxHrhQmbOHTiDn6OcY2zS3KtMsDKTKU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:59:57.2093083","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/862a0120-b1c4-4c0b-b7e8-df22c61c5efc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A09Z&sr=b&sp=r&sig=Qgao6FzaKiugg9VtGPToZnppR8BLa4GiBtn3IwzFkFE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:09.9153065","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:49:57 GMT
+      - Wed, 18 Oct 2023 20:50:09 GMT
       mise-correlation-id:
-      - d7b8be67-890c-4a3f-8fd4-5959fa99484d
+      - 84022b2d-06a7-4d43-b3c4-92f830a446c7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/53ecb826-02ab-4d5e-972b-0219627bd283?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A02Z&sr=b&sp=r&sig=6PxyCO3cUvJzyb4UsubNA2oTtCn9krBofF%2Fkqg3VPYg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:02.4580509","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/862a0120-b1c4-4c0b-b7e8-df22c61c5efc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A15Z&sr=b&sp=r&sig=9C%2FPhGZeHIicrE%2B%2FEhkshAbsqOO0noDwiQKjYYQN%2BKI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:15.1748936","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '557'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:02 GMT
+      - Wed, 18 Oct 2023 20:50:15 GMT
       mise-correlation-id:
-      - 6e61a18e-d5a4-4621-b71c-66fd13945b65
+      - 4c8730fc-e2f2-4500-ab3b-ac2fce8f57c3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/53ecb826-02ab-4d5e-972b-0219627bd283?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A07Z&sr=b&sp=r&sig=Xmt3fJO9z3gXWWVRITZE5q%2BYqJ5GOGfWrPqMNi3CkDM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:07.7448852","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/862a0120-b1c4-4c0b-b7e8-df22c61c5efc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A20Z&sr=b&sp=r&sig=2%2F9ZhHlzikMoy00Xxh7OT%2Bk%2FoqHRvxlXnd%2BcO8Uraf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:20.4343125","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '557'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:07 GMT
+      - Wed, 18 Oct 2023 20:50:20 GMT
       mise-correlation-id:
-      - 14390ede-9c3c-4faf-a837-48a50c042df1
+      - 3e4d0715-cd80-4050-b6a2-9e13a15451e6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,46 +421,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/53ecb826-02ab-4d5e-972b-0219627bd283?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A12Z&sr=b&sp=r&sig=Xr4%2FUaNB2IMvGjCy9EhRUlBqzcJV%2B%2F7nYqqIU5VjXrI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:12.9932951","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:50:12 GMT
-      mise-correlation-id:
-      - 5ae0e56c-c9ef-4bac-bbf6-ee8e8fa64f4b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/53ecb826-02ab-4d5e-972b-0219627bd283?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A18Z&sr=b&sp=r&sig=dcQWsByUSw%2FwPIrXF5yUQqzrFliCdaDfOJPG9Y0rgEQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:18.2560711","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/862a0120-b1c4-4c0b-b7e8-df22c61c5efc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A25Z&sr=b&sp=r&sig=ZxeINZbBxvCMVQvF2p6q1T6xItihnGl4%2FEf6JsBctAA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:25.6959582","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -471,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:18 GMT
+      - Wed, 18 Oct 2023 20:50:25 GMT
       mise-correlation-id:
-      - 730b379a-0259-4f9d-a423-bf7b603794c8
+      - a709f96a-51bd-45b4-9693-ff4cfc3a5f0b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -493,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3221d294-ef57-4fad-8227-d94d392126a5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6c27a8b9-fd49-4014-bae0-1f19a760c59e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"5c12a097-0719-41ca-8270-5a22b36707ce":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/53ecb826-02ab-4d5e-972b-0219627bd283?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A50%3A18Z&sr=b&sp=r&sig=QzCEv1KaD1ehTf%2BxjziaxLFyPa%2FWj1LoWIfJDBRkT3c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:50:18.497886","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:49:55.962Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:15.197Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7bcae25d-9120-4903-be43-21b65ef8d78a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bb850de9-58aa-4c59-926a-2e4362a70460":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ef9c5e25-9ef1-4d17-9f7d-645b96466567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/862a0120-b1c4-4c0b-b7e8-df22c61c5efc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A50%3A25Z&sr=b&sp=r&sig=TnzbyrlvTAQOIMrCvVswfWVDJPDkPKxq3KkH2%2BcV02Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:50:25.942842","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:50:07.082Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:22.447Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1578'
+      - '1576'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:18 GMT
+      - Wed, 18 Oct 2023 20:50:25 GMT
       mise-correlation-id:
-      - bf489f80-80c1-4ece-99ce-3260a132c5f5
+      - 1e4a17a8-bae3-41cb-8208-ec63033fb6b0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -533,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:21.2618497Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:21.2618497Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:29.0635736Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:29.0635736Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -542,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:19 GMT
+      - Wed, 18 Oct 2023 20:50:26 GMT
       etag:
-      - '"d801e8bd-0000-0100-0000-65294ae30000"'
+      - '"7500d641-0000-0100-0000-653044dd0000"'
       expires:
       - '-1'
       pragma:
@@ -574,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"3221d294-ef57-4fad-8227-d94d392126a5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6c27a8b9-fd49-4014-bae0-1f19a760c59e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"5c12a097-0719-41ca-8270-5a22b36707ce":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/53ecb826-02ab-4d5e-972b-0219627bd283?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A50%3A21Z&sr=b&sp=r&sig=aQuhSeU4XKwa7aMhj0FvJzGo8ZSilwJ3Gwz6Or%2BCsjQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:50:21.0267736","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:49:55.962Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:15.197Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"7bcae25d-9120-4903-be43-21b65ef8d78a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bb850de9-58aa-4c59-926a-2e4362a70460":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ef9c5e25-9ef1-4d17-9f7d-645b96466567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/862a0120-b1c4-4c0b-b7e8-df22c61c5efc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A50%3A28Z&sr=b&sp=r&sig=nIHLigL1N%2BK%2BnqDZMf2S9f7T40KstlQETuZGBLSzWaA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:50:28.2370149","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:50:07.082Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:22.447Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1589'
+      - '1591'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:21 GMT
+      - Wed, 18 Oct 2023 20:50:28 GMT
       mise-correlation-id:
-      - 2ca9880a-0194-4ed2-b3ea-c15f7984bf12
+      - df60a23d-131c-4691-8072-b2224c695132
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -614,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:21.2618497Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:21.2618497Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:29.0635736Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:29.0635736Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -623,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:22 GMT
+      - Wed, 18 Oct 2023 20:50:29 GMT
       etag:
-      - '"d801e8bd-0000-0100-0000-65294ae30000"'
+      - '"7500d641-0000-0100-0000-653044dd0000"'
       expires:
       - '-1'
       pragma:
@@ -657,7 +621,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -667,9 +631,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Fri, 13 Oct 2023 13:50:23 GMT
+      - Wed, 18 Oct 2023 20:50:29 GMT
       mise-correlation-id:
-      - f3414bc8-2341-4403-8fd8-261307fdb4c0
+      - 761c6c5f-0ece-460d-a5d8-338432179c28
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -692,7 +656,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:21.2618497Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:21.2618497Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:29.0635736Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:29.0635736Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -701,9 +665,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:25 GMT
+      - Wed, 18 Oct 2023 20:50:30 GMT
       etag:
-      - '"d801e8bd-0000-0100-0000-65294ae30000"'
+      - '"7500d641-0000-0100-0000-653044dd0000"'
       expires:
       - '-1'
       pragma:
@@ -733,7 +697,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -747,9 +711,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:26 GMT
+      - Wed, 18 Oct 2023 20:50:32 GMT
       mise-correlation-id:
-      - e66720c2-ba0d-472d-9b48-2f8c22d62702
+      - 2f5587fc-beb4-46fd-a9da-79c253bddfaa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,7 +736,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:21.2618497Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:21.2618497Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:29.0635736Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:29.0635736Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -781,9 +745,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:26 GMT
+      - Wed, 18 Oct 2023 20:50:33 GMT
       etag:
-      - '"d801e8bd-0000-0100-0000-65294ae30000"'
+      - '"7500d641-0000-0100-0000-653044dd0000"'
       expires:
       - '-1'
       pragma:
@@ -907,25 +871,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/5a4b226e-9362-4209-958e-24e32f84342c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A28Z&sr=b&sp=r&sig=QcApTnG%2BRVMoKPQCOB6fe1fWrV9r4rjFJJZwCkVARDQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:28.5758915","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/892c89ff-e921-413c-b1da-a27d0aca22c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A34Z&sr=b&sp=r&sig=%2FpdlJYab%2BufQAIOAlO%2BQEUP1igfKbgy%2B1lR%2BQZ3Qlqk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:34.4885706","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '559'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:28 GMT
+      - Wed, 18 Oct 2023 20:50:34 GMT
       location:
-      - https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 0decf73a-08a0-4aed-92ff-e17a307c471d
+      - 7d5f2acc-3487-467c-9869-1aec7a068709
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -945,10 +909,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/5a4b226e-9362-4209-958e-24e32f84342c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A28Z&sr=b&sp=r&sig=cvGUOo%2BgyjvlQO1D4rKxZihDahS%2BOxkKKhcSZzfs18c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:28.8230417","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/892c89ff-e921-413c-b1da-a27d0aca22c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A34Z&sr=b&sp=r&sig=e6j7FgSiSJWHDEYOEnzm4iVFZlxrLAp%2B1SaQQo4O6%2Fs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:34.7984656","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -959,9 +923,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:28 GMT
+      - Wed, 18 Oct 2023 20:50:34 GMT
       mise-correlation-id:
-      - 2b9bf66b-c67e-4c2b-896f-67aed9e765cb
+      - c90a17e0-80b7-4f58-b50f-60839979b060
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -981,23 +945,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/5a4b226e-9362-4209-958e-24e32f84342c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A34Z&sr=b&sp=r&sig=SHvOcURDzC8gn3Ixu2jS9WmriyrLnG5PjPoIBHJIgtI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:34.0858579","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/892c89ff-e921-413c-b1da-a27d0aca22c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A40Z&sr=b&sp=r&sig=kjg%2FdGWrQbDk1AZ7VEt8HwZ6ckGob0j9YBnswO513wE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:40.0597906","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:34 GMT
+      - Wed, 18 Oct 2023 20:50:40 GMT
       mise-correlation-id:
-      - 7bdfb4dd-9504-46ed-8e35-0a5d7a20d153
+      - f5056f5a-4d27-480a-9263-0f6cc78e787a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1017,23 +981,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/5a4b226e-9362-4209-958e-24e32f84342c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A39Z&sr=b&sp=r&sig=R5dUZna0OEb0uQL7bpal9uUYPc61fpd9LoJ1z7ooXgM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:39.3297745","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/892c89ff-e921-413c-b1da-a27d0aca22c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A45Z&sr=b&sp=r&sig=0kFA5n3aiBd2nPX5A7cAQChRhIDf8l4vIXi%2Fb662RKw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:45.3370723","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:39 GMT
+      - Wed, 18 Oct 2023 20:50:45 GMT
       mise-correlation-id:
-      - b1a2ab3e-e0ed-49fe-bd10-9eb13d304043
+      - f7f7712d-f5d9-413a-9085-05eb9fa42762
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1056,7 +1020,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:21.2618497Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:21.2618497Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:29.0635736Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:29.0635736Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1065,9 +1029,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:40 GMT
+      - Wed, 18 Oct 2023 20:50:45 GMT
       etag:
-      - '"d801e8bd-0000-0100-0000-65294ae30000"'
+      - '"7500d641-0000-0100-0000-653044dd0000"'
       expires:
       - '-1'
       pragma:
@@ -1097,23 +1061,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/5a4b226e-9362-4209-958e-24e32f84342c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A41Z&sr=b&sp=r&sig=BazdNw%2BqC7a9zs%2Fl6dmB6LL%2FH%2BKNZJUi%2F0npQbLmYzQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:41.0829429","validationStatus":"VALIDATION_INITIATED"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/892c89ff-e921-413c-b1da-a27d0aca22c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A46Z&sr=b&sp=r&sig=x41XycV6y9%2BZj4ZzLfs9l1yh35H2OT%2F5XrV%2Blaq6860%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:46.8753352","validationStatus":"VALIDATION_INITIATED"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '571'
+      - '567'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:41 GMT
+      - Wed, 18 Oct 2023 20:50:46 GMT
       mise-correlation-id:
-      - f3e37cbd-0aac-47a4-8e38-16065e75d38f
+      - ecf74fd5-f464-4f2f-a813-5f8d9cd7f2de
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1136,7 +1100,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:21.2618497Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:21.2618497Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:29.0635736Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:29.0635736Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1145,9 +1109,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:42 GMT
+      - Wed, 18 Oct 2023 20:50:46 GMT
       etag:
-      - '"d801e8bd-0000-0100-0000-65294ae30000"'
+      - '"7500d641-0000-0100-0000-653044dd0000"'
       expires:
       - '-1'
       pragma:
@@ -1177,23 +1141,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://93271b75-1f29-4dcd-87b1-03ec317bda1d.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://820a5078-b210-40d5-b1c7-50a5ae68761a.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/5a4b226e-9362-4209-958e-24e32f84342c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A42Z&sr=b&sp=r&sig=fDq6%2FJXlx4zJQZU5PJhG%2FBbGWfHCrsBp2gqHDUSgPyc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:42.974957","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/892c89ff-e921-413c-b1da-a27d0aca22c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A48Z&sr=b&sp=r&sig=AOITDFS8MebwAsZR1OCDXl2cMc%2BezYRZxnHuzANN4XQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:48.4189289","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:42 GMT
+      - Wed, 18 Oct 2023 20:50:48 GMT
       mise-correlation-id:
-      - dece5d08-9ed9-403f-8876-b72858a3fbe1
+      - 4e60856c-3f46-459a-a1ae-678596593955
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1213,7 +1177,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/aa0fedc9-e151-4ec4-86cb-58ed543decb1/5a4b226e-9362-4209-958e-24e32f84342c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A42Z&sr=b&sp=r&sig=fDq6%2FJXlx4zJQZU5PJhG%2FBbGWfHCrsBp2gqHDUSgPyc%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/ee76f0ff-7a01-430b-85e3-f5f4649b9638/892c89ff-e921-413c-b1da-a27d0aca22c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A48Z&sr=b&sp=r&sig=AOITDFS8MebwAsZR1OCDXl2cMc%2BezYRZxnHuzANN4XQ%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -1286,17 +1250,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 13 Oct 2023 13:50:43 GMT
+      - Wed, 18 Oct 2023 20:50:49 GMT
       etag:
-      - '"0x8DBCBF35C0AA66A"'
+      - '"0x8DBD01BDFF5B49D"'
       last-modified:
-      - Fri, 13 Oct 2023 13:50:28 GMT
+      - Wed, 18 Oct 2023 20:50:34 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 13 Oct 2023 13:50:28 GMT
+      - Wed, 18 Oct 2023 20:50:34 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_file.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_file.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:04.3966435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:04.3966435Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:46.7865681Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:46.7865681Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:39 GMT
+      - Mon, 30 Oct 2023 07:19:22 GMT
       etag:
-      - '"3c008224-0000-0100-0000-653eda5a0000"'
+      - '"3f006867-0000-0100-0000-653f58d90000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:19:40 GMT
+      - Mon, 30 Oct 2023 07:19:23 GMT
       mise-correlation-id:
-      - ca63c27f-5a79-4824-a71f-8d09b21c60b9
+      - 7f090697-83ec-4c43-b8dd-e17eb0c75bc6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"fc5d4438-7ff3-4a46-858c-231697e4a3f1": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "63c22fc5-1b0b-4d42-81e2-cbbb674ff2e7":
+      {"passFailMetrics": {"fcebe16b-3007-4197-b8e3-0b7d12880433": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "502f7eae-ee9c-412b-9d59-2ba3938c9986":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "fd8d5f11-df51-4d67-90d3-a7faeb04fd0a": {"aggregate": "avg", "clientMetric":
+      "50"}, "308ba7a0-77fa-4fe0-9ccb-ae8b554cf65a": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fc5d4438-7ff3-4a46-858c-231697e4a3f1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"63c22fc5-1b0b-4d42-81e2-cbbb674ff2e7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fd8d5f11-df51-4d67-90d3-a7faeb04fd0a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:19:40.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:19:40.672Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"fcebe16b-3007-4197-b8e3-0b7d12880433":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"502f7eae-ee9c-412b-9d59-2ba3938c9986":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"308ba7a0-77fa-4fe0-9ccb-ae8b554cf65a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:19:23.925Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:19:23.925Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:40 GMT
+      - Mon, 30 Oct 2023 07:19:23 GMT
       location:
-      - https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+      - https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 8db0d35a-3d01-4b31-b643-a770cc5e722f
+      - 9b78165f-e73f-4baa-a307-cf862dda57ce
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+    uri: https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:40 GMT
+      - Mon, 30 Oct 2023 07:19:24 GMT
       mise-correlation-id:
-      - c4e9944c-0890-4e83-a84c-ac8765184e52
+      - 7020f854-bdea-48fe-87ec-9f5846c7147a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,10 +275,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/650349d7-5fc5-494a-834d-620f732e51d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A41Z&sr=b&sp=r&sig=6PAAOziA4LcdvllcBzCOSC7e%2Bn05956GIgQlg3pHVfw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:41.5100949","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/468af3fa-7394-4093-b91b-9d5d952170e5/db5bd6e8-78b1-4a6e-8b4d-353519cb0781?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A29%3A25Z&sr=b&sp=r&sig=yYRNEqW3v0BB%2B2zpGVUHZWGgKhlzmD2z5HUe0o75u0c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:29:25.4979484","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -289,11 +289,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:41 GMT
+      - Mon, 30 Oct 2023 07:19:25 GMT
       location:
-      - https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - fca74cc0-b1b2-4688-a01d-f989e9378e03
+      - cbe3186f-8c2e-43e3-8e16-90dd3a4f7f91
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,118 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/650349d7-5fc5-494a-834d-620f732e51d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A41Z&sr=b&sp=r&sig=151R8ZOq66cVyQ22KNiTLJbXC7%2FX0LKP3UXzMqVyUc0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:41.8084074","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:19:41 GMT
-      mise-correlation-id:
-      - fe7da398-8e70-4629-bf54-ef446630159f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/650349d7-5fc5-494a-834d-620f732e51d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A47Z&sr=b&sp=r&sig=%2F5ZxtY17aWtDlPHsE8nEGypARxd%2BzKwBU7YOJkLC274%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:47.2249729","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:19:47 GMT
-      mise-correlation-id:
-      - ffb3e091-7434-4d04-bdd8-94f5b34ee117
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/650349d7-5fc5-494a-834d-620f732e51d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A52Z&sr=b&sp=r&sig=PgDFKEBYOCtRsl8qsymo1Og74eSdfzIBv0LHJ%2BT9bJk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:52.5275588","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:19:52 GMT
-      mise-correlation-id:
-      - 516ef4e9-ff11-4342-8547-6f00485aac10
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/650349d7-5fc5-494a-834d-620f732e51d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A57Z&sr=b&sp=r&sig=iBqt6WOFeW8y5oHaiR%2BIZUgfG4Y33zQMaLbfJd8oCqg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:57.8149311","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/468af3fa-7394-4093-b91b-9d5d952170e5/db5bd6e8-78b1-4a6e-8b4d-353519cb0781?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A29%3A25Z&sr=b&sp=r&sig=oLJ4Wn3u3NvSdTs2ByK2Cr2x1AzU5SECCaxMrXGPVyI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:29:25.7775942","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:57 GMT
+      - Mon, 30 Oct 2023 07:19:25 GMT
       mise-correlation-id:
-      - 6cc83935-c802-474e-9fd4-b91456b23884
+      - 25b44698-f794-462e-aac9-887b98cb8794
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +349,132 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fc5d4438-7ff3-4a46-858c-231697e4a3f1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"63c22fc5-1b0b-4d42-81e2-cbbb674ff2e7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fd8d5f11-df51-4d67-90d3-a7faeb04fd0a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/650349d7-5fc5-494a-834d-620f732e51d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A19%3A58Z&sr=b&sp=r&sig=f%2FmdtdNLy8VwD%2FbN1dDb89INuV9UVuZn%2ByHlLwxETg0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:19:58.3797282","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:19:40.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:19:53.713Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/468af3fa-7394-4093-b91b-9d5d952170e5/db5bd6e8-78b1-4a6e-8b4d-353519cb0781?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A29%3A31Z&sr=b&sp=r&sig=w6%2FWr2sowu9q8V2jcPepTZXrsBVO2xG4wD06AfS0%2BBQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:29:31.0826288","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1581'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:58 GMT
+      - Mon, 30 Oct 2023 07:19:31 GMT
       mise-correlation-id:
-      - 280836fc-cfcf-4325-bbeb-e5c70eb8f6bf
+      - 4ad9b2eb-bbd9-4a72-9e69-ed217ef4855d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/468af3fa-7394-4093-b91b-9d5d952170e5/db5bd6e8-78b1-4a6e-8b4d-353519cb0781?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A29%3A36Z&sr=b&sp=r&sig=4CaLhzdKhyXSZginsDnNNUys8zSK1BzRC%2BbHanDjem8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:29:36.3414387","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:19:36 GMT
+      mise-correlation-id:
+      - 7be78b1a-9be3-4ba7-a31b-e48694e008b7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/468af3fa-7394-4093-b91b-9d5d952170e5/db5bd6e8-78b1-4a6e-8b4d-353519cb0781?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A29%3A41Z&sr=b&sp=r&sig=%2F7ISb8t9LRi8KtFl7iMA5es0aKRTONV3Q2sJGRPW8LQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:29:41.6308664","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:19:41 GMT
+      mise-correlation-id:
+      - 1ba121e5-d305-4232-a483-7b71caea4467
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"fcebe16b-3007-4197-b8e3-0b7d12880433":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"502f7eae-ee9c-412b-9d59-2ba3938c9986":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"308ba7a0-77fa-4fe0-9ccb-ae8b554cf65a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/468af3fa-7394-4093-b91b-9d5d952170e5/db5bd6e8-78b1-4a6e-8b4d-353519cb0781?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A19%3A42Z&sr=b&sp=r&sig=LLf1HHeBRWJDILIfenwMt5lA9XWgQLEkm79Cgb3OIFQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:19:42.3504951","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:19:23.925Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:19:38.015Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1575'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:19:42 GMT
+      mise-correlation-id:
+      - cc3a79a0-b73a-4c95-af19-3281f2ba18d7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:04.3966435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:04.3966435Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:46.7865681Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:46.7865681Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:59 GMT
+      - Mon, 30 Oct 2023 07:19:43 GMT
       etag:
-      - '"3c008224-0000-0100-0000-653eda5a0000"'
+      - '"3f006867-0000-0100-0000-653f58d90000"'
       expires:
       - '-1'
       pragma:
@@ -538,11 +538,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"fc5d4438-7ff3-4a46-858c-231697e4a3f1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"63c22fc5-1b0b-4d42-81e2-cbbb674ff2e7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fd8d5f11-df51-4d67-90d3-a7faeb04fd0a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/650349d7-5fc5-494a-834d-620f732e51d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A20%3A00Z&sr=b&sp=r&sig=szh2wh2VZ6gHUdmz3AL4uZ9FUOPIsR4B3OHA0p8AmUE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:20:00.7501866","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:19:40.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:19:53.713Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"fcebe16b-3007-4197-b8e3-0b7d12880433":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"502f7eae-ee9c-412b-9d59-2ba3938c9986":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"308ba7a0-77fa-4fe0-9ccb-ae8b554cf65a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/468af3fa-7394-4093-b91b-9d5d952170e5/db5bd6e8-78b1-4a6e-8b4d-353519cb0781?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A19%3A44Z&sr=b&sp=r&sig=PzQGMUgytodjXlK6uzDu9YxiGWC2kQ88vAL4lyfv2i8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:19:44.9070199","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:19:23.925Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:19:38.015Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:00 GMT
+      - Mon, 30 Oct 2023 07:19:44 GMT
       mise-correlation-id:
-      - 2f7e45d3-1061-45a3-b35b-dfe879131502
+      - 18fa2069-3393-4a38-8873-d39625482356
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:04.3966435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:04.3966435Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:46.7865681Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:46.7865681Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:02 GMT
+      - Mon, 30 Oct 2023 07:19:45 GMT
       etag:
-      - '"3c008224-0000-0100-0000-653eda5a0000"'
+      - '"3f006867-0000-0100-0000-653f58d90000"'
       expires:
       - '-1'
       pragma:
@@ -621,7 +621,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -631,9 +631,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Sun, 29 Oct 2023 22:20:03 GMT
+      - Mon, 30 Oct 2023 07:19:47 GMT
       mise-correlation-id:
-      - 4074fd8a-fd1f-4e15-9442-b341473f46dc
+      - 1ca9d9dc-b991-404e-a19d-aa8704b3f0e2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -656,7 +656,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:04.3966435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:04.3966435Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:46.7865681Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:46.7865681Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -665,9 +665,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:03 GMT
+      - Mon, 30 Oct 2023 07:19:48 GMT
       etag:
-      - '"3c008224-0000-0100-0000-653eda5a0000"'
+      - '"3f006867-0000-0100-0000-653f58d90000"'
       expires:
       - '-1'
       pragma:
@@ -697,7 +697,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+    uri: https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -711,9 +711,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:04 GMT
+      - Mon, 30 Oct 2023 07:19:50 GMT
       mise-correlation-id:
-      - a557b464-9a25-4399-8619-aa1f1eeb7518
+      - b963a0e9-fa12-4861-9fc5-2efeb9d15422
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,7 +736,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:04.3966435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:04.3966435Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:46.7865681Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:46.7865681Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -745,9 +745,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:06 GMT
+      - Mon, 30 Oct 2023 07:19:51 GMT
       etag:
-      - '"3c008224-0000-0100-0000-653eda5a0000"'
+      - '"3f006867-0000-0100-0000-653f58d90000"'
       expires:
       - '-1'
       pragma:
@@ -871,25 +871,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/39acc83b-5d18-4770-92ca-50f4297190a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A07Z&sr=b&sp=r&sig=vuoVIbsPabQsYePu8EPzk4EEm5rkJ4Y0i2oeO4kSPaY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:07.3649537","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/468af3fa-7394-4093-b91b-9d5d952170e5/e0e3b67c-9155-44ea-b4c5-ca95833a768d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A29%3A52Z&sr=b&sp=r&sig=Jds1sr68J9PcZXfDS%2FdOV2RqBwdAoMaj7eF5MjddNqw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:29:52.8561104","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:07 GMT
+      - Mon, 30 Oct 2023 07:19:52 GMT
       location:
-      - https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 217552c0-0dc3-422c-9c8c-3dc0b21c2333
+      - 5d76aa76-7149-4023-ac99-0ff9d411df99
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -909,23 +909,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/39acc83b-5d18-4770-92ca-50f4297190a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A07Z&sr=b&sp=r&sig=Ys6Lw9cx9CPiHX4OiUD14Y3fv3oMW6KL%2BnH2%2B4FwX1E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:07.6096462","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/468af3fa-7394-4093-b91b-9d5d952170e5/e0e3b67c-9155-44ea-b4c5-ca95833a768d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A29%3A53Z&sr=b&sp=r&sig=n7y1yIj3%2BlacBgTQfIAh4UGIDWEnlNyCBFsX9%2BwsS%2Fg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:29:53.1400248","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:07 GMT
+      - Mon, 30 Oct 2023 07:19:53 GMT
       mise-correlation-id:
-      - c5024617-13d2-4911-9e6c-ca5fa2256013
+      - 163267a6-4166-411d-8321-7022d0494753
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -945,10 +945,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/39acc83b-5d18-4770-92ca-50f4297190a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A12Z&sr=b&sp=r&sig=6piSJ5uA74FJVey8Y9M7%2FFtpNo2T5Zfp7Fukv1W0fGE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:12.8634445","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/468af3fa-7394-4093-b91b-9d5d952170e5/e0e3b67c-9155-44ea-b4c5-ca95833a768d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A29%3A58Z&sr=b&sp=r&sig=m7RxUa45rHQ2%2BISJ8jKK9ExelO9DYPeev8qBfW0LuSU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:29:58.4255277","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -959,9 +959,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:12 GMT
+      - Mon, 30 Oct 2023 07:19:58 GMT
       mise-correlation-id:
-      - 86e7c879-73de-4579-a163-ac1809087ce4
+      - 07e71837-2f3f-4f73-9275-bfd396c4a560
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -981,23 +981,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/39acc83b-5d18-4770-92ca-50f4297190a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A18Z&sr=b&sp=r&sig=CXBmvvID2ndhuQzAhT00qCvncYYS0qgP3RdAlM%2FwJY8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:18.181816","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/468af3fa-7394-4093-b91b-9d5d952170e5/e0e3b67c-9155-44ea-b4c5-ca95833a768d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A30%3A03Z&sr=b&sp=r&sig=KjlmyXP5IcJTqed%2FqyU7YFXpi3Ghry4Wbl2I5ytl6DA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:30:03.6850842","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:18 GMT
+      - Mon, 30 Oct 2023 07:20:03 GMT
       mise-correlation-id:
-      - 2ba0beff-e298-458b-834e-773803dc9740
+      - f5faea7c-3358-44f4-8b02-af79fd11a15e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1020,7 +1020,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:04.3966435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:04.3966435Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:46.7865681Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:46.7865681Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1029,9 +1029,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:18 GMT
+      - Mon, 30 Oct 2023 07:20:04 GMT
       etag:
-      - '"3c008224-0000-0100-0000-653eda5a0000"'
+      - '"3f006867-0000-0100-0000-653f58d90000"'
       expires:
       - '-1'
       pragma:
@@ -1061,10 +1061,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+    uri: https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/39acc83b-5d18-4770-92ca-50f4297190a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A19Z&sr=b&sp=r&sig=tuZZatkNheqcUG58KRtYRc0lsPbb5hfP%2FDHRtXvIJ3Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:19.8012877","validationStatus":"VALIDATION_INITIATED"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/468af3fa-7394-4093-b91b-9d5d952170e5/e0e3b67c-9155-44ea-b4c5-ca95833a768d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A30%3A05Z&sr=b&sp=r&sig=OoZNEfymNl%2BDEXCnZeHDGShqYXfkSuXSsrMWj1%2BhNhQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:30:05.4115262","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1075,9 +1075,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:19 GMT
+      - Mon, 30 Oct 2023 07:20:05 GMT
       mise-correlation-id:
-      - 5d68b6e1-6c6d-439c-8d18-037de4594453
+      - be3efb58-64e4-4071-be94-ca6cbc9faf8a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1100,7 +1100,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:04.3966435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:04.3966435Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:46.7865681Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:46.7865681Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1109,9 +1109,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:21 GMT
+      - Mon, 30 Oct 2023 07:20:06 GMT
       etag:
-      - '"3c008224-0000-0100-0000-653eda5a0000"'
+      - '"3f006867-0000-0100-0000-653f58d90000"'
       expires:
       - '-1'
       pragma:
@@ -1141,23 +1141,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8ec68d39-5891-4ef7-8958-6e6a64924774.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e19dcdd8-e44b-410b-860f-1875c696965f.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/39acc83b-5d18-4770-92ca-50f4297190a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A22Z&sr=b&sp=r&sig=f8y6oyi1spGY%2FWL13Aq8%2B1bqjg%2FIsMQ3aJh0rnDXqVI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:22.3305554","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/468af3fa-7394-4093-b91b-9d5d952170e5/e0e3b67c-9155-44ea-b4c5-ca95833a768d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A30%3A07Z&sr=b&sp=r&sig=jIcmSK1MF8F6LebduIhChTlYIsTIS6lmdYm0H0J4E2c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:30:07.3632809","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:22 GMT
+      - Mon, 30 Oct 2023 07:20:07 GMT
       mise-correlation-id:
-      - 4c467e3d-1b99-41a7-a49e-e0229d6c3fbe
+      - a4811146-23e8-4d0c-8740-d45b54c8612b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1177,7 +1177,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/366af8d6-6b9c-496c-a6bc-20208210226a/39acc83b-5d18-4770-92ca-50f4297190a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A22Z&sr=b&sp=r&sig=f8y6oyi1spGY%2FWL13Aq8%2B1bqjg%2FIsMQ3aJh0rnDXqVI%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/468af3fa-7394-4093-b91b-9d5d952170e5/e0e3b67c-9155-44ea-b4c5-ca95833a768d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A30%3A07Z&sr=b&sp=r&sig=jIcmSK1MF8F6LebduIhChTlYIsTIS6lmdYm0H0J4E2c%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -1250,17 +1250,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Sun, 29 Oct 2023 22:20:22 GMT
+      - Mon, 30 Oct 2023 07:20:07 GMT
       etag:
-      - '"0x8DBD8CD34FDAD5E"'
+      - '"0x8DBD9189C3DEA43"'
       last-modified:
-      - Sun, 29 Oct 2023 22:20:07 GMT
+      - Mon, 30 Oct 2023 07:19:52 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Sun, 29 Oct 2023 22:20:07 GMT
+      - Mon, 30 Oct 2023 07:19:52 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_list.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_list.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1030248Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1030248Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:39.3671168Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:39.3671168Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:16 GMT
+      - Sun, 29 Oct 2023 22:18:13 GMT
       etag:
-      - '"d300f131-0000-0100-0000-6537b78b0000"'
+      - '"3c00ef21-0000-0100-0000-653eda050000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:25:17 GMT
+      - Sun, 29 Oct 2023 22:18:16 GMT
       mise-correlation-id:
-      - 6af4bf80-fdfc-4458-b58d-37889bb83efa
+      - f1d2747b-6066-4049-864d-86332ec91c96
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"178f7c06-eb3d-4048-9356-41e5f7cc8c4e": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "89c0652b-eaf9-4eab-bd91-59ccab24a1d3":
+      {"passFailMetrics": {"ad21e576-a9b1-42ac-813c-f0693bd39bb9": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "1525c1cb-eead-4907-9238-69bae12cc67a":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "23b412f3-766b-4e3a-937f-116ef5b9a3ec": {"aggregate": "avg", "clientMetric":
+      "50"}, "ff649c1c-57b9-40e4-a6b6-bdc06a9d9236": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"178f7c06-eb3d-4048-9356-41e5f7cc8c4e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"89c0652b-eaf9-4eab-bd91-59ccab24a1d3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"23b412f3-766b-4e3a-937f-116ef5b9a3ec":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:17.837Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:17.837Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad21e576-a9b1-42ac-813c-f0693bd39bb9":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1525c1cb-eead-4907-9238-69bae12cc67a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff649c1c-57b9-40e4-a6b6-bdc06a9d9236":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.687Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:16.687Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:17 GMT
+      - Sun, 29 Oct 2023 22:18:16 GMT
       location:
-      - https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+      - https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 607be25b-6fa0-4c3c-b542-baee21ecb0f2
+      - 376a9b5f-6100-4cc9-8742-d799c5a8bb5d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
+    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:18 GMT
+      - Sun, 29 Oct 2023 22:18:16 GMT
       mise-correlation-id:
-      - 700c68f1-8278-4796-b9f7-758d58aa3d70
+      - 0dcdb243-93a0-4d0b-8f07-c5fc9d8e9d6b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f7cbca0d-956f-4e49-8f8e-9f69d6c53622/455223a4-72d5-4fd1-a732-833b8e87eb34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A19Z&sr=b&sp=r&sig=Fxk%2FyTKHQY0F5vQEhXS7U558CAnWyTjTFveSzoI20Z0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:19.6976114","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/142712db-4cf5-4196-b06e-8142bb4b6616/d1d6a9ff-720d-4243-a1fe-a656d62b7039?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A17Z&sr=b&sp=r&sig=g1irz8hZMAr9oxLKA99LeIFAb79sD3ap53xORVz9sk0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:17.6030572","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:19 GMT
+      - Sun, 29 Oct 2023 22:18:17 GMT
       location:
-      - https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - debaa930-712b-47a5-9eae-c1f47cd2de8b
+      - 5a476ff4-6bbd-4d41-8163-23ba4a86cfec
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,118 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f7cbca0d-956f-4e49-8f8e-9f69d6c53622/455223a4-72d5-4fd1-a732-833b8e87eb34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A20Z&sr=b&sp=r&sig=hNYrH8OJx68m0xopRjU0uFs%2FNLBf0bfnvk6rLLOtt6I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:20.0109437","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:25:20 GMT
-      mise-correlation-id:
-      - 7955fadd-72a6-48fe-95c4-cec048562a6c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f7cbca0d-956f-4e49-8f8e-9f69d6c53622/455223a4-72d5-4fd1-a732-833b8e87eb34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A25Z&sr=b&sp=r&sig=Wfkw%2BSgVBdZU0BKJyqDx0dxVNVnHtUo3oSMmHoFJPuY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:25.2743719","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:25:25 GMT
-      mise-correlation-id:
-      - 11d247f2-ddd1-4bdf-a50e-2358090a2b2b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f7cbca0d-956f-4e49-8f8e-9f69d6c53622/455223a4-72d5-4fd1-a732-833b8e87eb34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A31Z&sr=b&sp=r&sig=%2Bxcdvl4S3JClV8Jz5jTE6SXe6xWFgopjUP1CKLTRtGQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:31.3600235","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:25:31 GMT
-      mise-correlation-id:
-      - b1b62bba-a011-4aee-bdc5-4b5179780b8e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f7cbca0d-956f-4e49-8f8e-9f69d6c53622/455223a4-72d5-4fd1-a732-833b8e87eb34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A36Z&sr=b&sp=r&sig=EMiYtjbP1yQEzsjLe3cPgU1X%2FdvBCac0ApvJv54xhn0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:36.8616981","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/142712db-4cf5-4196-b06e-8142bb4b6616/d1d6a9ff-720d-4243-a1fe-a656d62b7039?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A17Z&sr=b&sp=r&sig=VjVSuZ7WuvnwZUyKDfVOoz6zOKmskilKXUg4Oytysz0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:17.8428202","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:36 GMT
+      - Sun, 29 Oct 2023 22:18:17 GMT
       mise-correlation-id:
-      - 13e20257-73cc-42b9-b9a5-2d512af80fe9
+      - 56242d31-e069-4011-bb59-12de804ba4d1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +349,132 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"178f7c06-eb3d-4048-9356-41e5f7cc8c4e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"89c0652b-eaf9-4eab-bd91-59ccab24a1d3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"23b412f3-766b-4e3a-937f-116ef5b9a3ec":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f7cbca0d-956f-4e49-8f8e-9f69d6c53622/455223a4-72d5-4fd1-a732-833b8e87eb34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A25%3A37Z&sr=b&sp=r&sig=iVx%2BkfaFP4n08Z0AMfS9Ef%2Br1RbjgT0qm0yD6NrzH10%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:25:37.1196853","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:17.837Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:33.8Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/142712db-4cf5-4196-b06e-8142bb4b6616/d1d6a9ff-720d-4243-a1fe-a656d62b7039?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A23Z&sr=b&sp=r&sig=CZQl0CIxcGC8SLieWN%2F1uV91QC3QLj6KQ83kG8zOni0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:23.0820538","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1577'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:37 GMT
+      - Sun, 29 Oct 2023 22:18:23 GMT
       mise-correlation-id:
-      - 0d453ff5-81aa-4efb-993f-4e059c188056
+      - a3f11b43-e769-4370-87af-1c8692720b98
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/142712db-4cf5-4196-b06e-8142bb4b6616/d1d6a9ff-720d-4243-a1fe-a656d62b7039?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A28Z&sr=b&sp=r&sig=YfLzrOAEqYgfy%2BprWKd1jkEfitlMXZdbbkOCkhuc0cE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:28.3308576","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:18:28 GMT
+      mise-correlation-id:
+      - 3f0b4949-2114-4bea-9b87-64b534979d59
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/142712db-4cf5-4196-b06e-8142bb4b6616/d1d6a9ff-720d-4243-a1fe-a656d62b7039?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A33Z&sr=b&sp=r&sig=a8Px0MKW4CntkdoDxu9zbkKTPMgd51ZePvPlCP5dq18%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:33.5850156","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '547'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:18:33 GMT
+      mise-correlation-id:
+      - 196f7db6-c7c7-496a-95cf-2e4923a0e56b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad21e576-a9b1-42ac-813c-f0693bd39bb9":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1525c1cb-eead-4907-9238-69bae12cc67a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff649c1c-57b9-40e4-a6b6-bdc06a9d9236":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/142712db-4cf5-4196-b06e-8142bb4b6616/d1d6a9ff-720d-4243-a1fe-a656d62b7039?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A18%3A33Z&sr=b&sp=r&sig=GqcsvKTqDVb6uXKv9bKVEQn14AYEom7I7BiJXXeZmm8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:18:33.8256354","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.687Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:31.893Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1575'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:18:33 GMT
+      mise-correlation-id:
+      - 60edd783-5ec4-40b9-97a1-aee136a974c9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1030248Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1030248Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:39.3671168Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:39.3671168Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:38 GMT
+      - Sun, 29 Oct 2023 22:18:34 GMT
       etag:
-      - '"d300f131-0000-0100-0000-6537b78b0000"'
+      - '"3c00ef21-0000-0100-0000-653eda050000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"178f7c06-eb3d-4048-9356-41e5f7cc8c4e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"89c0652b-eaf9-4eab-bd91-59ccab24a1d3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"23b412f3-766b-4e3a-937f-116ef5b9a3ec":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f7cbca0d-956f-4e49-8f8e-9f69d6c53622/455223a4-72d5-4fd1-a732-833b8e87eb34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A25%3A39Z&sr=b&sp=r&sig=Q7S43XHmhlLKgt2nTTXZQgePf9Fdo9FVy3t7GSVU0pA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:25:39.5198102","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:17.837Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:33.8Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ad21e576-a9b1-42ac-813c-f0693bd39bb9":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1525c1cb-eead-4907-9238-69bae12cc67a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff649c1c-57b9-40e4-a6b6-bdc06a9d9236":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/142712db-4cf5-4196-b06e-8142bb4b6616/d1d6a9ff-720d-4243-a1fe-a656d62b7039?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A18%3A35Z&sr=b&sp=r&sig=MC5CqHoIRv%2FJagrM0W9t1NW8Llnu0KivHXZDhczfKoM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:18:35.5727456","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.687Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:31.893Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1585'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:39 GMT
+      - Sun, 29 Oct 2023 22:18:35 GMT
       mise-correlation-id:
-      - f3fcb0ec-5655-48a9-bcd7-93bbec81c319
+      - 0dd1d0d7-28c9-47e1-b91e-583eb37933dc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1030248Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1030248Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:39.3671168Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:39.3671168Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:40 GMT
+      - Sun, 29 Oct 2023 22:18:36 GMT
       etag:
-      - '"d300f131-0000-0100-0000-6537b78b0000"'
+      - '"3c00ef21-0000-0100-0000-653eda050000"'
       expires:
       - '-1'
       pragma:
@@ -619,24 +619,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"178f7c06-eb3d-4048-9356-41e5f7cc8c4e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"89c0652b-eaf9-4eab-bd91-59ccab24a1d3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"23b412f3-766b-4e3a-937f-116ef5b9a3ec":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f7cbca0d-956f-4e49-8f8e-9f69d6c53622/455223a4-72d5-4fd1-a732-833b8e87eb34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A25%3A42Z&sr=b&sp=r&sig=3oOzj14LqICRodkTNvAWYYQNz5PZ4UUVCFXCOMBvMBQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:25:42.2112414","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:17.837Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:33.8Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ad21e576-a9b1-42ac-813c-f0693bd39bb9":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1525c1cb-eead-4907-9238-69bae12cc67a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff649c1c-57b9-40e4-a6b6-bdc06a9d9236":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/142712db-4cf5-4196-b06e-8142bb4b6616/d1d6a9ff-720d-4243-a1fe-a656d62b7039?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A18%3A38Z&sr=b&sp=r&sig=p4hKEZcgKcjhB6taLXRQLz0t8M1w2k6ayj1YDzajp6Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:18:38.0604823","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.687Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:31.893Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1585'
+      - '1587'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:25:42 GMT
+      - Sun, 29 Oct 2023 22:18:38 GMT
       mise-correlation-id:
-      - 9bfbe754-9066-4f16-a012-4312985567df
+      - 1e770c5f-221e-4bdf-ae3a-648fd059f364
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_list.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_list.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:53.4050986Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:53.4050986Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:55.8396895Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:55.8396895Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:27 GMT
+      - Fri, 13 Oct 2023 13:48:29 GMT
       etag:
-      - '"55002ba4-0000-0100-0000-6524512f0000"'
+      - '"d8011ea5-0000-0100-0000-65294a8d0000"'
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:15:28 GMT
+      - Fri, 13 Oct 2023 13:48:31 GMT
       mise-correlation-id:
-      - 3329027a-78f3-4643-a3db-4ed545e300e5
+      - 111c3624-cb1a-470b-b3ed-636defe6c62e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"db8b5d07-4d1b-4d49-b9d9-4fa309a49c88": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "f410da5c-0cb1-4110-9a19-618aee1388a8":
+      {"passFailMetrics": {"68aadb47-d177-4ea4-98cb-33b82b679c05": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "d33e9998-307a-41ec-a139-c49da0d559c8":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "dfff1f9d-05c0-49bc-ba02-2fb963e7a13f": {"aggregate": "avg", "clientMetric":
+      "50"}, "4d645dec-ee47-4b6d-8631-b65111db81ab": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -104,13 +104,13 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"db8b5d07-4d1b-4d49-b9d9-4fa309a49c88":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f410da5c-0cb1-4110-9a19-618aee1388a8":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"dfff1f9d-05c0-49bc-ba02-2fb963e7a13f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:29.587Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:29.587Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"68aadb47-d177-4ea4-98cb-33b82b679c05":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d33e9998-307a-41ec-a139-c49da0d559c8":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4d645dec-ee47-4b6d-8631-b65111db81ab":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:32.055Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:32.055Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:29 GMT
+      - Fri, 13 Oct 2023 13:48:32 GMT
       location:
-      - https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+      - https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 4e860f41-b2e7-487f-bd0f-18fba2815c6c
+      - 1dbd1044-5754-48d3-a760-e996d620a961
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -143,9 +143,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
+    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:29 GMT
+      - Fri, 13 Oct 2023 13:48:32 GMT
       mise-correlation-id:
-      - 99f6ef4e-a61e-4b33-8898-cec5dc12e695
+      - 75e3a82e-b2c2-4b46-82d9-3fe756559916
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -273,27 +273,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5248a7a4-986c-40d6-b21c-2afc234a06e4/1f4588f7-5eeb-44bd-9547-bb8c7ede30db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A31Z&sr=b&sp=r&sig=z3Z%2BU%2FM87CwxsXqTaNVBQpjKMSMgwDNSce86Dc7SHy0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:31.8619043","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bca57648-8b1e-4b81-89f8-bdd648fc5a80/258dc1aa-de1d-4aa7-8d5c-b0367006772c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A32Z&sr=b&sp=r&sig=%2FUb8Nhc2g5moTn98aZ%2FjPNiMlfL4Bm0k0M%2Bl%2BJ45xAQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:32.7790067","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '557'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:31 GMT
+      - Fri, 13 Oct 2023 13:48:32 GMT
       location:
-      - https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - c156e01a-c1fc-4711-9154-c988bcfcd1a6
+      - 38020e0a-7400-489d-b72a-aff21b7a3437
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -311,12 +311,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5248a7a4-986c-40d6-b21c-2afc234a06e4/1f4588f7-5eeb-44bd-9547-bb8c7ede30db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A32Z&sr=b&sp=r&sig=W%2BAKVrOY1dN4IIZ%2BP6dpqT0aFxc751w8anXGdA3tFNE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:32.6199459","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bca57648-8b1e-4b81-89f8-bdd648fc5a80/258dc1aa-de1d-4aa7-8d5c-b0367006772c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A33Z&sr=b&sp=r&sig=zelssRUYj55vaefEAjrsYrlBu%2FHUn1vUrYEXoXV%2BC84%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:33.0214984","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:32 GMT
+      - Fri, 13 Oct 2023 13:48:33 GMT
       mise-correlation-id:
-      - 03d56248-5a3c-4cd5-94e7-21967fb024e5
+      - c2a5d396-1202-4f77-ab9b-c241cf51d933
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -347,12 +347,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5248a7a4-986c-40d6-b21c-2afc234a06e4/1f4588f7-5eeb-44bd-9547-bb8c7ede30db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A38Z&sr=b&sp=r&sig=JPeOhkjdrNmJ%2BJrLBZClZqVsWMyQnq7UQsnkBj0nZPo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:38.1856651","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bca57648-8b1e-4b81-89f8-bdd648fc5a80/258dc1aa-de1d-4aa7-8d5c-b0367006772c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A38Z&sr=b&sp=r&sig=ysxi7nLz1r8J9laxwh5qdgDe3H6%2BJlKxbuoXp1hGLkY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:38.2676562","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:38 GMT
+      - Fri, 13 Oct 2023 13:48:38 GMT
       mise-correlation-id:
-      - 952e7fbd-7d04-4efd-a940-f70cdd5c865e
+      - 4afc20dc-f67d-43ee-96cd-74b5d9d7aaca
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -383,25 +383,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5248a7a4-986c-40d6-b21c-2afc234a06e4/1f4588f7-5eeb-44bd-9547-bb8c7ede30db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A43Z&sr=b&sp=r&sig=MC7QYIpyAsJGCWLEGM3%2Fg1fFIpxFXiYV1RLycy78eOM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:43.511747","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bca57648-8b1e-4b81-89f8-bdd648fc5a80/258dc1aa-de1d-4aa7-8d5c-b0367006772c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A43Z&sr=b&sp=r&sig=UM0hXvGca%2BuxhIHRNI59hMlqfbVVBsjmlkpwG4Ma0aE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:43.5237448","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:43 GMT
+      - Fri, 13 Oct 2023 13:48:43 GMT
       mise-correlation-id:
-      - 682b3b9e-00b3-466e-8150-846d17ca6d48
+      - d2361bb0-5897-433f-ae06-2da73f9337a5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -419,12 +419,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5248a7a4-986c-40d6-b21c-2afc234a06e4/1f4588f7-5eeb-44bd-9547-bb8c7ede30db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A48Z&sr=b&sp=r&sig=hyk9RX4x%2BgU4MWt2Ny7lJs2Yt7zc6ciaP4WNaKFujPs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:48.8469974","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bca57648-8b1e-4b81-89f8-bdd648fc5a80/258dc1aa-de1d-4aa7-8d5c-b0367006772c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A48Z&sr=b&sp=r&sig=fzrLr1akDpqty5kQHnzpoBeCecJdL93mTeq7e%2F0NS6k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:48.7484985","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:48 GMT
+      - Fri, 13 Oct 2023 13:48:48 GMT
       mise-correlation-id:
-      - a4ab893c-4ba2-45f7-9ba3-fec2506d99e2
+      - fa7a9a5f-7fac-4233-8016-0cace8c5a144
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -455,26 +455,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"db8b5d07-4d1b-4d49-b9d9-4fa309a49c88":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f410da5c-0cb1-4110-9a19-618aee1388a8":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"dfff1f9d-05c0-49bc-ba02-2fb963e7a13f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5248a7a4-986c-40d6-b21c-2afc234a06e4/1f4588f7-5eeb-44bd-9547-bb8c7ede30db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A15%3A49Z&sr=b&sp=r&sig=JOyHyvOTKkpyfLR4a8M2Hk7E8tqid50ErJ9crb2fSsA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:15:49.1639377","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:29.587Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:46.142Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"68aadb47-d177-4ea4-98cb-33b82b679c05":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d33e9998-307a-41ec-a139-c49da0d559c8":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4d645dec-ee47-4b6d-8631-b65111db81ab":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bca57648-8b1e-4b81-89f8-bdd648fc5a80/258dc1aa-de1d-4aa7-8d5c-b0367006772c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A48%3A49Z&sr=b&sp=r&sig=xiAVgF1qGljcwrWpUk%2FYU1QlR7zsPTlneuAm1cKAeM0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:48:49.0051428","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:32.055Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:45.988Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1575'
+      - '1577'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:49 GMT
+      - Fri, 13 Oct 2023 13:48:49 GMT
       mise-correlation-id:
-      - 5477eaaf-534b-42ac-9570-810acfc5127a
+      - 9bfafff9-603c-4c13-9e05-b143f19d68ef
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:53.4050986Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:53.4050986Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:55.8396895Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:55.8396895Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:50 GMT
+      - Fri, 13 Oct 2023 13:48:50 GMT
       etag:
-      - '"55002ba4-0000-0100-0000-6524512f0000"'
+      - '"d8011ea5-0000-0100-0000-65294a8d0000"'
       expires:
       - '-1'
       pragma:
@@ -536,13 +536,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"db8b5d07-4d1b-4d49-b9d9-4fa309a49c88":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f410da5c-0cb1-4110-9a19-618aee1388a8":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"dfff1f9d-05c0-49bc-ba02-2fb963e7a13f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5248a7a4-986c-40d6-b21c-2afc234a06e4/1f4588f7-5eeb-44bd-9547-bb8c7ede30db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A15%3A51Z&sr=b&sp=r&sig=Ukt2jAHusj1AQ4zsb8SE9gXtcNFqfDqys%2FzZBv%2Flbr8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:15:51.7046456","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:29.587Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:46.142Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"68aadb47-d177-4ea4-98cb-33b82b679c05":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d33e9998-307a-41ec-a139-c49da0d559c8":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4d645dec-ee47-4b6d-8631-b65111db81ab":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bca57648-8b1e-4b81-89f8-bdd648fc5a80/258dc1aa-de1d-4aa7-8d5c-b0367006772c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A48%3A51Z&sr=b&sp=r&sig=JfhTspTVXH1JFvGWJ4e87CdrglmcUBFJKDdVA%2F%2Fbx9I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:48:51.7972774","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:32.055Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:45.988Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:51 GMT
+      - Fri, 13 Oct 2023 13:48:51 GMT
       mise-correlation-id:
-      - dd4f1cfb-d241-478e-91d9-d095f5f933c8
+      - 6e4dc0dc-41f5-4b95-97d0-5a0fa072fdb8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:53.4050986Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:53.4050986Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:55.8396895Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:55.8396895Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:52 GMT
+      - Fri, 13 Oct 2023 13:48:52 GMT
       etag:
-      - '"55002ba4-0000-0100-0000-6524512f0000"'
+      - '"d8011ea5-0000-0100-0000-65294a8d0000"'
       expires:
       - '-1'
       pragma:
@@ -617,26 +617,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"db8b5d07-4d1b-4d49-b9d9-4fa309a49c88":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f410da5c-0cb1-4110-9a19-618aee1388a8":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"dfff1f9d-05c0-49bc-ba02-2fb963e7a13f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5248a7a4-986c-40d6-b21c-2afc234a06e4/1f4588f7-5eeb-44bd-9547-bb8c7ede30db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A15%3A54Z&sr=b&sp=r&sig=eJKQlXP%2BBt%2FmnSonzEQhZbPn0KqRStT6jzneT7yvt7k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:15:54.3710814","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:29.587Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:46.142Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"68aadb47-d177-4ea4-98cb-33b82b679c05":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d33e9998-307a-41ec-a139-c49da0d559c8":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4d645dec-ee47-4b6d-8631-b65111db81ab":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bca57648-8b1e-4b81-89f8-bdd648fc5a80/258dc1aa-de1d-4aa7-8d5c-b0367006772c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A48%3A53Z&sr=b&sp=r&sig=xHID2PPn2wsBkMYnhrvC7mnsl4IsLlQxtA%2BXCubET58%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:48:53.5522395","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:32.055Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:45.988Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1591'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:15:54 GMT
+      - Fri, 13 Oct 2023 13:48:53 GMT
       mise-correlation-id:
-      - d2989893-3b0d-410a-8443-5e4d7afd4e75
+      - 874cd5f7-d347-444c-ac23-d4ce737cdda1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_list.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_list.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:39.3671168Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:39.3671168Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:17:20.2635186Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:17:20.2635186Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"95f5d46d-1fb9-40ac-9397-0e0c13c28ebd.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:13 GMT
+      - Mon, 30 Oct 2023 07:17:55 GMT
       etag:
-      - '"3c00ef21-0000-0100-0000-653eda050000"'
+      - '"3f00b965-0000-0100-0000-653f58840000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://95f5d46d-1fb9-40ac-9397-0e0c13c28ebd.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:18:16 GMT
+      - Mon, 30 Oct 2023 07:17:58 GMT
       mise-correlation-id:
-      - f1d2747b-6066-4049-864d-86332ec91c96
+      - 3c554c46-eb7b-4600-a6c7-2868874a021e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"ad21e576-a9b1-42ac-813c-f0693bd39bb9": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "1525c1cb-eead-4907-9238-69bae12cc67a":
+      {"passFailMetrics": {"e2325267-6364-42b5-a748-6189cca70f93": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "93342bf0-881e-45d5-ba18-cea27685718b":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "ff649c1c-57b9-40e4-a6b6-bdc06a9d9236": {"aggregate": "avg", "clientMetric":
+      "50"}, "d0a629c3-f70f-41e7-847a-121f76ac2ae7": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://95f5d46d-1fb9-40ac-9397-0e0c13c28ebd.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad21e576-a9b1-42ac-813c-f0693bd39bb9":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1525c1cb-eead-4907-9238-69bae12cc67a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff649c1c-57b9-40e4-a6b6-bdc06a9d9236":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.687Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:16.687Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"e2325267-6364-42b5-a748-6189cca70f93":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"93342bf0-881e-45d5-ba18-cea27685718b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d0a629c3-f70f-41e7-847a-121f76ac2ae7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:17:58.527Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:17:58.527Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:16 GMT
+      - Mon, 30 Oct 2023 07:17:58 GMT
       location:
-      - https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+      - https://95f5d46d-1fb9-40ac-9397-0e0c13c28ebd.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 376a9b5f-6100-4cc9-8742-d799c5a8bb5d
+      - 4dca4ea6-f85d-444b-950b-30a3c1d5e980
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
+    uri: https://95f5d46d-1fb9-40ac-9397-0e0c13c28ebd.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:16 GMT
+      - Mon, 30 Oct 2023 07:17:59 GMT
       mise-correlation-id:
-      - 0dcdb243-93a0-4d0b-8f07-c5fc9d8e9d6b
+      - b1ee19a9-70b1-4a2d-ad6b-6ce5bab2bb37
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://95f5d46d-1fb9-40ac-9397-0e0c13c28ebd.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/142712db-4cf5-4196-b06e-8142bb4b6616/d1d6a9ff-720d-4243-a1fe-a656d62b7039?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A17Z&sr=b&sp=r&sig=g1irz8hZMAr9oxLKA99LeIFAb79sD3ap53xORVz9sk0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:17.6030572","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f07b5608-01ca-4655-baa7-3b99c90014ec/d035f81c-b665-4ca3-bc9e-2b4f5084cd9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A00Z&sr=b&sp=r&sig=KBP%2FhzJ3OSIBadwU5Ye0ETHNxBX3nBNE9aaHF2WHtqg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:00.5893629","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:17 GMT
+      - Mon, 30 Oct 2023 07:18:00 GMT
       location:
-      - https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://95f5d46d-1fb9-40ac-9397-0e0c13c28ebd.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 5a476ff4-6bbd-4d41-8163-23ba4a86cfec
+      - 2d40459e-638b-45c3-94a8-3c4652bbbfde
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://95f5d46d-1fb9-40ac-9397-0e0c13c28ebd.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/142712db-4cf5-4196-b06e-8142bb4b6616/d1d6a9ff-720d-4243-a1fe-a656d62b7039?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A17Z&sr=b&sp=r&sig=VjVSuZ7WuvnwZUyKDfVOoz6zOKmskilKXUg4Oytysz0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:17.8428202","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f07b5608-01ca-4655-baa7-3b99c90014ec/d035f81c-b665-4ca3-bc9e-2b4f5084cd9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A00Z&sr=b&sp=r&sig=exoXbi3zSF0MQ1OaM0AqNpQEsm4m%2FNvuMLCnJOsW3aY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:00.8318076","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:18:00 GMT
+      mise-correlation-id:
+      - d68bd651-751b-414f-8f19-1c3d8c60d61f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://95f5d46d-1fb9-40ac-9397-0e0c13c28ebd.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f07b5608-01ca-4655-baa7-3b99c90014ec/d035f81c-b665-4ca3-bc9e-2b4f5084cd9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A06Z&sr=b&sp=r&sig=bGw6GiheYCnSLNp8BvfZ6Y%2BCBjUnGh2%2BHeqAJ0kxjK0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:06.3563433","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:18:06 GMT
+      mise-correlation-id:
+      - 08d69c23-6a2b-4b4e-ae73-107ceb38a698
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://95f5d46d-1fb9-40ac-9397-0e0c13c28ebd.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f07b5608-01ca-4655-baa7-3b99c90014ec/d035f81c-b665-4ca3-bc9e-2b4f5084cd9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A11Z&sr=b&sp=r&sig=RAnxA46OIOfc9xocjREGYn3DCAPvn9yQnzLy3%2FJI5ng%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:11.607382","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '550'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:18:11 GMT
+      mise-correlation-id:
+      - d12abbc1-4b47-454f-bd25-9cc68386e103
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://95f5d46d-1fb9-40ac-9397-0e0c13c28ebd.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f07b5608-01ca-4655-baa7-3b99c90014ec/d035f81c-b665-4ca3-bc9e-2b4f5084cd9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A28%3A16Z&sr=b&sp=r&sig=Ih1cERg%2FFLkgZ76APs905YNt2BDt6W8gVSXJomOUBYY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:28:16.8688017","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:17 GMT
+      - Mon, 30 Oct 2023 07:18:16 GMT
       mise-correlation-id:
-      - 56242d31-e069-4011-bb59-12de804ba4d1
+      - 3845c825-96aa-458b-8667-171b8ded5312
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,132 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://95f5d46d-1fb9-40ac-9397-0e0c13c28ebd.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/142712db-4cf5-4196-b06e-8142bb4b6616/d1d6a9ff-720d-4243-a1fe-a656d62b7039?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A23Z&sr=b&sp=r&sig=CZQl0CIxcGC8SLieWN%2F1uV91QC3QLj6KQ83kG8zOni0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:23.0820538","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"e2325267-6364-42b5-a748-6189cca70f93":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"93342bf0-881e-45d5-ba18-cea27685718b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d0a629c3-f70f-41e7-847a-121f76ac2ae7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f07b5608-01ca-4655-baa7-3b99c90014ec/d035f81c-b665-4ca3-bc9e-2b4f5084cd9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A18%3A17Z&sr=b&sp=r&sig=bRzwtxsRPiAM1DXZfgsDcvEVApL8vtQ%2BrKwmqn0VXOA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:18:17.153355","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:17:58.527Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:18:13.277Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '1576'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:23 GMT
+      - Mon, 30 Oct 2023 07:18:18 GMT
       mise-correlation-id:
-      - a3f11b43-e769-4370-87af-1c8692720b98
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/142712db-4cf5-4196-b06e-8142bb4b6616/d1d6a9ff-720d-4243-a1fe-a656d62b7039?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A28Z&sr=b&sp=r&sig=YfLzrOAEqYgfy%2BprWKd1jkEfitlMXZdbbkOCkhuc0cE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:28.3308576","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:18:28 GMT
-      mise-correlation-id:
-      - 3f0b4949-2114-4bea-9b87-64b534979d59
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/142712db-4cf5-4196-b06e-8142bb4b6616/d1d6a9ff-720d-4243-a1fe-a656d62b7039?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A28%3A33Z&sr=b&sp=r&sig=a8Px0MKW4CntkdoDxu9zbkKTPMgd51ZePvPlCP5dq18%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:28:33.5850156","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '547'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:18:33 GMT
-      mise-correlation-id:
-      - 196f7db6-c7c7-496a-95cf-2e4923a0e56b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad21e576-a9b1-42ac-813c-f0693bd39bb9":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1525c1cb-eead-4907-9238-69bae12cc67a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff649c1c-57b9-40e4-a6b6-bdc06a9d9236":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/142712db-4cf5-4196-b06e-8142bb4b6616/d1d6a9ff-720d-4243-a1fe-a656d62b7039?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A18%3A33Z&sr=b&sp=r&sig=GqcsvKTqDVb6uXKv9bKVEQn14AYEom7I7BiJXXeZmm8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:18:33.8256354","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.687Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:31.893Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1575'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:18:33 GMT
-      mise-correlation-id:
-      - 60edd783-5ec4-40b9-97a1-aee136a974c9
+      - 5dce4b38-b573-4ca7-9b62-bc225a99116e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:39.3671168Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:39.3671168Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:17:20.2635186Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:17:20.2635186Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"95f5d46d-1fb9-40ac-9397-0e0c13c28ebd.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:34 GMT
+      - Mon, 30 Oct 2023 07:18:20 GMT
       etag:
-      - '"3c00ef21-0000-0100-0000-653eda050000"'
+      - '"3f00b965-0000-0100-0000-653f58840000"'
       expires:
       - '-1'
       pragma:
@@ -538,92 +538,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://95f5d46d-1fb9-40ac-9397-0e0c13c28ebd.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ad21e576-a9b1-42ac-813c-f0693bd39bb9":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1525c1cb-eead-4907-9238-69bae12cc67a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff649c1c-57b9-40e4-a6b6-bdc06a9d9236":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/142712db-4cf5-4196-b06e-8142bb4b6616/d1d6a9ff-720d-4243-a1fe-a656d62b7039?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A18%3A35Z&sr=b&sp=r&sig=MC5CqHoIRv%2FJagrM0W9t1NW8Llnu0KivHXZDhczfKoM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:18:35.5727456","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.687Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:31.893Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1589'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:18:35 GMT
-      mise-correlation-id:
-      - 0dd1d0d7-28c9-47e1-b91e-583eb37933dc
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:17:39.3671168Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:17:39.3671168Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '653'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:18:36 GMT
-      etag:
-      - '"3c00ef21-0000-0100-0000-653eda050000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://25459391-6c5a-43d2-a705-12f8f5eff340.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
-  response:
-    body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ad21e576-a9b1-42ac-813c-f0693bd39bb9":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1525c1cb-eead-4907-9238-69bae12cc67a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff649c1c-57b9-40e4-a6b6-bdc06a9d9236":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/142712db-4cf5-4196-b06e-8142bb4b6616/d1d6a9ff-720d-4243-a1fe-a656d62b7039?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A18%3A38Z&sr=b&sp=r&sig=p4hKEZcgKcjhB6taLXRQLz0t8M1w2k6ayj1YDzajp6Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:18:38.0604823","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:18:16.687Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:18:31.893Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"e2325267-6364-42b5-a748-6189cca70f93":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"93342bf0-881e-45d5-ba18-cea27685718b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d0a629c3-f70f-41e7-847a-121f76ac2ae7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f07b5608-01ca-4655-baa7-3b99c90014ec/d035f81c-b665-4ca3-bc9e-2b4f5084cd9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A18%3A21Z&sr=b&sp=r&sig=kJnq99ESOzeN6VKgzKAmLF8Y7o5NUX2oIJa3FCZB3yc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:18:21.3744235","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:17:58.527Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:18:13.277Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -634,9 +553,90 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:18:38 GMT
+      - Mon, 30 Oct 2023 07:18:21 GMT
       mise-correlation-id:
-      - 1e770c5f-221e-4bdf-ae3a-648fd059f364
+      - 774dba9f-cef9-48ff-8f55-697530264325
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:17:20.2635186Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:17:20.2635186Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"95f5d46d-1fb9-40ac-9397-0e0c13c28ebd.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '653'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:18:23 GMT
+      etag:
+      - '"3f00b965-0000-0100-0000-653f58840000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://95f5d46d-1fb9-40ac-9397-0e0c13c28ebd.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+  response:
+    body:
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"e2325267-6364-42b5-a748-6189cca70f93":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"93342bf0-881e-45d5-ba18-cea27685718b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d0a629c3-f70f-41e7-847a-121f76ac2ae7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f07b5608-01ca-4655-baa7-3b99c90014ec/d035f81c-b665-4ca3-bc9e-2b4f5084cd9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A18%3A23Z&sr=b&sp=r&sig=A84r%2Bm1gljhbrNbEcLGByLZ0jL8Wr85Hmatu2voZXfQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:18:23.8453367","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:17:58.527Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:18:13.277Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1589'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:18:23 GMT
+      mise-correlation-id:
+      - 98a528c8-2696-4ef3-b96d-d9c754c9296e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_list.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_list.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.7149684Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.7149684Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:53.4050986Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:53.4050986Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:08 GMT
+      - Mon, 09 Oct 2023 19:15:27 GMT
       etag:
-      - '"92015689-0000-0100-0000-652425830000"'
+      - '"55002ba4-0000-0100-0000-6524512f0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:09:09 GMT
+      - Mon, 09 Oct 2023 19:15:28 GMT
       mise-correlation-id:
-      - d7f57e18-a50a-463a-87ff-4a508cb9029a
+      - 3329027a-78f3-4643-a3db-4ed545e300e5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"9771131a-b612-4844-888f-41e102ed0254": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "c3416831-d285-4919-b7da-4145462d007e":
+      {"passFailMetrics": {"db8b5d07-4d1b-4d49-b9d9-4fa309a49c88": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "f410da5c-0cb1-4110-9a19-618aee1388a8":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "fabea672-1e46-4013-bf1b-014f31dc8465": {"aggregate": "avg", "clientMetric":
+      "50"}, "dfff1f9d-05c0-49bc-ba02-2fb963e7a13f": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9771131a-b612-4844-888f-41e102ed0254":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c3416831-d285-4919-b7da-4145462d007e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fabea672-1e46-4013-bf1b-014f31dc8465":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:09.729Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:09.729Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"db8b5d07-4d1b-4d49-b9d9-4fa309a49c88":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f410da5c-0cb1-4110-9a19-618aee1388a8":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"dfff1f9d-05c0-49bc-ba02-2fb963e7a13f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:29.587Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:29.587Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:09 GMT
+      - Mon, 09 Oct 2023 19:15:29 GMT
       location:
-      - https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+      - https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 1edcc032-bb32-44f4-bd4b-9d0266349a71
+      - 4e860f41-b2e7-487f-bd0f-18fba2815c6c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
+    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:10 GMT
+      - Mon, 09 Oct 2023 19:15:29 GMT
       mise-correlation-id:
-      - b555dddc-cda4-4a44-89eb-b74ca6c9ceda
+      - 99f6ef4e-a61e-4b33-8898-cec5dc12e695
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/17fa7f05-455e-4825-a629-8657b1af65aa/ac274e63-6a06-443d-9548-e4fe6991a665?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A10Z&sr=b&sp=r&sig=bE14wC%2BAKurkL%2FkmvKOiGefd41hpb7F%2BhdNWUUcIoA8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:10.6967512","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5248a7a4-986c-40d6-b21c-2afc234a06e4/1f4588f7-5eeb-44bd-9547-bb8c7ede30db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A31Z&sr=b&sp=r&sig=z3Z%2BU%2FM87CwxsXqTaNVBQpjKMSMgwDNSce86Dc7SHy0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:31.8619043","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:10 GMT
+      - Mon, 09 Oct 2023 19:15:31 GMT
       location:
-      - https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - e18a72d8-ce60-49d3-b99e-eab481544802
+      - c156e01a-c1fc-4711-9154-c988bcfcd1a6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/17fa7f05-455e-4825-a629-8657b1af65aa/ac274e63-6a06-443d-9548-e4fe6991a665?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A11Z&sr=b&sp=r&sig=Av4Yu%2FT%2Fpmk3gHtM0nPIDOou19E7VZ4AS%2FUij04J%2FiI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:11.0157477","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '557'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:09:11 GMT
-      mise-correlation-id:
-      - 9287b02f-e797-4d99-8b70-dad0428b85df
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/17fa7f05-455e-4825-a629-8657b1af65aa/ac274e63-6a06-443d-9548-e4fe6991a665?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A16Z&sr=b&sp=r&sig=FfHB4H05fzj2PhUG1dj2pVeVfBwvyhe9JjmZQtgHgos%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:16.3231513","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:09:16 GMT
-      mise-correlation-id:
-      - 7e024834-ac8d-4a73-8204-c09471d7f0f4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/17fa7f05-455e-4825-a629-8657b1af65aa/ac274e63-6a06-443d-9548-e4fe6991a665?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A21Z&sr=b&sp=r&sig=42p8CQvVFY6%2Bm1qMcXdf75t3oIWlq%2BT5ALeMp6dOXvI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:21.6498639","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5248a7a4-986c-40d6-b21c-2afc234a06e4/1f4588f7-5eeb-44bd-9547-bb8c7ede30db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A32Z&sr=b&sp=r&sig=W%2BAKVrOY1dN4IIZ%2BP6dpqT0aFxc751w8anXGdA3tFNE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:32.6199459","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:21 GMT
+      - Mon, 09 Oct 2023 19:15:32 GMT
       mise-correlation-id:
-      - f096f084-f262-4b24-972c-33ee845abb21
+      - 03d56248-5a3c-4cd5-94e7-21967fb024e5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,10 +349,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/17fa7f05-455e-4825-a629-8657b1af65aa/ac274e63-6a06-443d-9548-e4fe6991a665?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A26Z&sr=b&sp=r&sig=hmkd8%2BQNtenCTH2v5hxKEy3yCkjBJcHR3qvwVGrhaew%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:26.9741083","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5248a7a4-986c-40d6-b21c-2afc234a06e4/1f4588f7-5eeb-44bd-9547-bb8c7ede30db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A38Z&sr=b&sp=r&sig=JPeOhkjdrNmJ%2BJrLBZClZqVsWMyQnq7UQsnkBj0nZPo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:38.1856651","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:15:38 GMT
+      mise-correlation-id:
+      - 952e7fbd-7d04-4efd-a940-f70cdd5c865e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5248a7a4-986c-40d6-b21c-2afc234a06e4/1f4588f7-5eeb-44bd-9547-bb8c7ede30db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A43Z&sr=b&sp=r&sig=MC7QYIpyAsJGCWLEGM3%2Fg1fFIpxFXiYV1RLycy78eOM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:43.511747","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '550'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:15:43 GMT
+      mise-correlation-id:
+      - 682b3b9e-00b3-466e-8150-846d17ca6d48
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5248a7a4-986c-40d6-b21c-2afc234a06e4/1f4588f7-5eeb-44bd-9547-bb8c7ede30db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A25%3A48Z&sr=b&sp=r&sig=hyk9RX4x%2BgU4MWt2Ny7lJs2Yt7zc6ciaP4WNaKFujPs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:25:48.8469974","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:26 GMT
+      - Mon, 09 Oct 2023 19:15:48 GMT
       mise-correlation-id:
-      - 3ef5d832-12af-4bf5-b996-c709c20627f4
+      - a4ab893c-4ba2-45f7-9ba3-fec2506d99e2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9771131a-b612-4844-888f-41e102ed0254":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c3416831-d285-4919-b7da-4145462d007e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fabea672-1e46-4013-bf1b-014f31dc8465":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/17fa7f05-455e-4825-a629-8657b1af65aa/ac274e63-6a06-443d-9548-e4fe6991a665?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A09%3A27Z&sr=b&sp=r&sig=qXvmfBvVOid07nAusvNsTyQp%2FlFIZPwF0pC4OWtZ%2FS8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:09:27.2767993","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:09.729Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:23.019Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"db8b5d07-4d1b-4d49-b9d9-4fa309a49c88":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f410da5c-0cb1-4110-9a19-618aee1388a8":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"dfff1f9d-05c0-49bc-ba02-2fb963e7a13f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5248a7a4-986c-40d6-b21c-2afc234a06e4/1f4588f7-5eeb-44bd-9547-bb8c7ede30db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A15%3A49Z&sr=b&sp=r&sig=JOyHyvOTKkpyfLR4a8M2Hk7E8tqid50ErJ9crb2fSsA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:15:49.1639377","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:29.587Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:46.142Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1579'
+      - '1575'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:27 GMT
+      - Mon, 09 Oct 2023 19:15:49 GMT
       mise-correlation-id:
-      - 7032b105-0a34-4cc1-85ae-233a0ce9790b
+      - 5477eaaf-534b-42ac-9570-810acfc5127a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.7149684Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.7149684Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:53.4050986Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:53.4050986Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:28 GMT
+      - Mon, 09 Oct 2023 19:15:50 GMT
       etag:
-      - '"92015689-0000-0100-0000-652425830000"'
+      - '"55002ba4-0000-0100-0000-6524512f0000"'
       expires:
       - '-1'
       pragma:
@@ -538,11 +538,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"9771131a-b612-4844-888f-41e102ed0254":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c3416831-d285-4919-b7da-4145462d007e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fabea672-1e46-4013-bf1b-014f31dc8465":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/17fa7f05-455e-4825-a629-8657b1af65aa/ac274e63-6a06-443d-9548-e4fe6991a665?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A09%3A29Z&sr=b&sp=r&sig=qqr9NygLkj%2BeJCkvBZXbMwU%2BlfjVH1GiDZlxivEoI9k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:09:29.5461233","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:09.729Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:23.019Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"db8b5d07-4d1b-4d49-b9d9-4fa309a49c88":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f410da5c-0cb1-4110-9a19-618aee1388a8":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"dfff1f9d-05c0-49bc-ba02-2fb963e7a13f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5248a7a4-986c-40d6-b21c-2afc234a06e4/1f4588f7-5eeb-44bd-9547-bb8c7ede30db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A15%3A51Z&sr=b&sp=r&sig=Ukt2jAHusj1AQ4zsb8SE9gXtcNFqfDqys%2FzZBv%2Flbr8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:15:51.7046456","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:29.587Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:46.142Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:29 GMT
+      - Mon, 09 Oct 2023 19:15:51 GMT
       mise-correlation-id:
-      - 46c111e7-261c-4d21-9715-005d9841ff66
+      - dd4f1cfb-d241-478e-91d9-d095f5f933c8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.7149684Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.7149684Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:14:53.4050986Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:14:53.4050986Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:30 GMT
+      - Mon, 09 Oct 2023 19:15:52 GMT
       etag:
-      - '"92015689-0000-0100-0000-652425830000"'
+      - '"55002ba4-0000-0100-0000-6524512f0000"'
       expires:
       - '-1'
       pragma:
@@ -619,11 +619,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://0dba82c4-a17a-4864-b831-e41c8a927d67.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"9771131a-b612-4844-888f-41e102ed0254":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c3416831-d285-4919-b7da-4145462d007e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fabea672-1e46-4013-bf1b-014f31dc8465":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/17fa7f05-455e-4825-a629-8657b1af65aa/ac274e63-6a06-443d-9548-e4fe6991a665?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A09%3A31Z&sr=b&sp=r&sig=1Z%2FnZC0q42aF3bimD5%2FEPwtlWxU7S1vlnEKnnnVlKBM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:09:31.8050198","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:09.729Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:23.019Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"db8b5d07-4d1b-4d49-b9d9-4fa309a49c88":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f410da5c-0cb1-4110-9a19-618aee1388a8":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"dfff1f9d-05c0-49bc-ba02-2fb963e7a13f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5248a7a4-986c-40d6-b21c-2afc234a06e4/1f4588f7-5eeb-44bd-9547-bb8c7ede30db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A15%3A54Z&sr=b&sp=r&sig=eJKQlXP%2BBt%2FmnSonzEQhZbPn0KqRStT6jzneT7yvt7k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:15:54.3710814","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:15:29.587Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:15:46.142Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -634,9 +634,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:09:31 GMT
+      - Mon, 09 Oct 2023 19:15:54 GMT
       mise-correlation-id:
-      - 281a622a-9d67-4e09-995a-f538b6f9e7ac
+      - d2989893-3b0d-410a-8443-5e4d7afd4e75
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_list.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_list.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:08:16.6627579Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:08:16.6627579Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0b937915-2a09-497f-a204-8201508dbf19.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.7149684Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.7149684Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:08:54 GMT
+      - Mon, 09 Oct 2023 16:09:08 GMT
       etag:
-      - '"1a0a3997-0000-0100-0000-64af08320000"'
+      - '"92015689-0000-0100-0000-652425830000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0b937915-2a09-497f-a204-8201508dbf19.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:08:56 GMT
+      - Mon, 09 Oct 2023 16:09:09 GMT
       mise-correlation-id:
-      - 5dc56102-3b41-4dc2-979f-01d33746f8a8
+      - d7f57e18-a50a-463a-87ff-4a508cb9029a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -85,12 +85,12 @@ interactions:
 - request:
     body: '{"displayName": "CLI-Test", "description": "Test created from az load test
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
-      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "loadTestConfiguration":
+      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"985f4ce8-eb33-42de-82b3-8bf571e8b645": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "30a1eb4c-95bb-4281-9261-e70f12901841":
+      {"passFailMetrics": {"9771131a-b612-4844-888f-41e102ed0254": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "c3416831-d285-4919-b7da-4145462d007e":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "2771886a-cfec-4074-9e69-420079dc2d32": {"aggregate": "avg", "clientMetric":
+      "50"}, "fabea672-1e46-4013-bf1b-014f31dc8465": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -100,32 +100,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '768'
+      - '789'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://0b937915-2a09-497f-a204-8201508dbf19.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"985f4ce8-eb33-42de-82b3-8bf571e8b645":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"30a1eb4c-95bb-4281-9261-e70f12901841":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"2771886a-cfec-4074-9e69-420079dc2d32":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:08:56.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:08:56.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9771131a-b612-4844-888f-41e102ed0254":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c3416831-d285-4919-b7da-4145462d007e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fabea672-1e46-4013-bf1b-014f31dc8465":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:09.729Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:09.729Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1060'
+      - '1006'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:08:56 GMT
+      - Mon, 09 Oct 2023 16:09:09 GMT
       location:
-      - https://0b937915-2a09-497f-a204-8201508dbf19.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+      - https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - f3607875-ebc1-4a01-806e-275b047c54c4
+      - 1edcc032-bb32-44f4-bd4b-9d0266349a71
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0b937915-2a09-497f-a204-8201508dbf19.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
+    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:08:57 GMT
+      - Mon, 09 Oct 2023 16:09:10 GMT
       mise-correlation-id:
-      - c5f9916c-f172-43c1-ad77-c999cd845ec4
+      - b555dddc-cda4-4a44-89eb-b74ca6c9ceda
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://0b937915-2a09-497f-a204-8201508dbf19.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b4e9e0ac-b4a0-4a9d-b305-dd149e054a1f/12a67571-08b1-4478-9eb6-8d4d86a3bc38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A18%3A57Z&sr=b&sp=r&sig=gQJdGmwkMW%2BVJ6UKFuOw7nJZuaPV1H8eQBhVWGpsWrQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:18:57.6274808","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/17fa7f05-455e-4825-a629-8657b1af65aa/ac274e63-6a06-443d-9548-e4fe6991a665?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A10Z&sr=b&sp=r&sig=bE14wC%2BAKurkL%2FkmvKOiGefd41hpb7F%2BhdNWUUcIoA8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:10.6967512","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:08:57 GMT
+      - Mon, 09 Oct 2023 16:09:10 GMT
       location:
-      - https://0b937915-2a09-497f-a204-8201508dbf19.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 4e57a9ad-284d-4779-bd14-3c2dc09d62d6
+      - e18a72d8-ce60-49d3-b99e-eab481544802
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0b937915-2a09-497f-a204-8201508dbf19.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b4e9e0ac-b4a0-4a9d-b305-dd149e054a1f/12a67571-08b1-4478-9eb6-8d4d86a3bc38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A18%3A57Z&sr=b&sp=r&sig=WOacbgnckCl42P6NetxycIEHxJ3OEpeUZaaVd%2FAGUPE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:18:57.9970363","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/17fa7f05-455e-4825-a629-8657b1af65aa/ac274e63-6a06-443d-9548-e4fe6991a665?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A11Z&sr=b&sp=r&sig=Av4Yu%2FT%2Fpmk3gHtM0nPIDOou19E7VZ4AS%2FUij04J%2FiI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:11.0157477","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '557'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:08:57 GMT
+      - Mon, 09 Oct 2023 16:09:11 GMT
       mise-correlation-id:
-      - bf83330d-77ca-4287-b456-66720bf8b083
+      - 9287b02f-e797-4d99-8b70-dad0428b85df
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,46 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0b937915-2a09-497f-a204-8201508dbf19.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b4e9e0ac-b4a0-4a9d-b305-dd149e054a1f/12a67571-08b1-4478-9eb6-8d4d86a3bc38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A19%3A03Z&sr=b&sp=r&sig=My7yEBO1aLxU1GUZBL4B2PrJynFeiMldEWd3Z%2BJEAUk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:19:03.2714202","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:09:03 GMT
-      mise-correlation-id:
-      - 64748d33-fb78-44b9-ad17-3cd49dd3372e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0b937915-2a09-497f-a204-8201508dbf19.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b4e9e0ac-b4a0-4a9d-b305-dd149e054a1f/12a67571-08b1-4478-9eb6-8d4d86a3bc38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A19%3A08Z&sr=b&sp=r&sig=oATw4ymJkfzzcesYh45yXRRJ95neHgcDyQxLRTZJ9Tc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:19:08.5584222","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/17fa7f05-455e-4825-a629-8657b1af65aa/ac274e63-6a06-443d-9548-e4fe6991a665?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A16Z&sr=b&sp=r&sig=FfHB4H05fzj2PhUG1dj2pVeVfBwvyhe9JjmZQtgHgos%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:16.3231513","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:08 GMT
+      - Mon, 09 Oct 2023 16:09:16 GMT
       mise-correlation-id:
-      - 5d1ac507-0c1f-42b9-889e-53e0e6be8f7c
+      - 7e024834-ac8d-4a73-8204-c09471d7f0f4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0b937915-2a09-497f-a204-8201508dbf19.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b4e9e0ac-b4a0-4a9d-b305-dd149e054a1f/12a67571-08b1-4478-9eb6-8d4d86a3bc38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A19%3A13Z&sr=b&sp=r&sig=Hqi1GgW1u5%2Fg34RvvjajQcY3OSJVdXlQFW1V2OxG38M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:19:13.834239","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/17fa7f05-455e-4825-a629-8657b1af65aa/ac274e63-6a06-443d-9548-e4fe6991a665?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A21Z&sr=b&sp=r&sig=42p8CQvVFY6%2Bm1qMcXdf75t3oIWlq%2BT5ALeMp6dOXvI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:21.6498639","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '548'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:13 GMT
+      - Mon, 09 Oct 2023 16:09:21 GMT
       mise-correlation-id:
-      - ed453fb9-dcdd-40d6-9e00-b1c73b0b4819
+      - f096f084-f262-4b24-972c-33ee845abb21
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +421,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0b937915-2a09-497f-a204-8201508dbf19.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"985f4ce8-eb33-42de-82b3-8bf571e8b645":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"30a1eb4c-95bb-4281-9261-e70f12901841":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"2771886a-cfec-4074-9e69-420079dc2d32":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b4e9e0ac-b4a0-4a9d-b305-dd149e054a1f/12a67571-08b1-4478-9eb6-8d4d86a3bc38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A09%3A14Z&sr=b&sp=r&sig=r%2Fsea4QLnAuilwzI4OcajRmV4M2HSWpb4kOuJsS1YIY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:09:14.0946742","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:08:56.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:09:09.452Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/17fa7f05-455e-4825-a629-8657b1af65aa/ac274e63-6a06-443d-9548-e4fe6991a665?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A19%3A26Z&sr=b&sp=r&sig=hmkd8%2BQNtenCTH2v5hxKEy3yCkjBJcHR3qvwVGrhaew%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:19:26.9741083","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1631'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:14 GMT
+      - Mon, 09 Oct 2023 16:09:26 GMT
       mise-correlation-id:
-      - 8e9f9303-cefb-44e0-9a27-8f81eecd68e6
+      - 3ef5d832-12af-4bf5-b996-c709c20627f4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9771131a-b612-4844-888f-41e102ed0254":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c3416831-d285-4919-b7da-4145462d007e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fabea672-1e46-4013-bf1b-014f31dc8465":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/17fa7f05-455e-4825-a629-8657b1af65aa/ac274e63-6a06-443d-9548-e4fe6991a665?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A09%3A27Z&sr=b&sp=r&sig=qXvmfBvVOid07nAusvNsTyQp%2FlFIZPwF0pC4OWtZ%2FS8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:09:27.2767993","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:09.729Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:23.019Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1579'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:09:27 GMT
+      mise-correlation-id:
+      - 7032b105-0a34-4cc1-85ae-233a0ce9790b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:08:16.6627579Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:08:16.6627579Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0b937915-2a09-497f-a204-8201508dbf19.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.7149684Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.7149684Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:15 GMT
+      - Mon, 09 Oct 2023 16:09:28 GMT
       etag:
-      - '"1a0a3997-0000-0100-0000-64af08320000"'
+      - '"92015689-0000-0100-0000-652425830000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0b937915-2a09-497f-a204-8201508dbf19.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"985f4ce8-eb33-42de-82b3-8bf571e8b645":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"30a1eb4c-95bb-4281-9261-e70f12901841":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"2771886a-cfec-4074-9e69-420079dc2d32":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b4e9e0ac-b4a0-4a9d-b305-dd149e054a1f/12a67571-08b1-4478-9eb6-8d4d86a3bc38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A09%3A16Z&sr=b&sp=r&sig=hzYM5Ms12n63gafHX%2BOABwu4fjISGoRAFMTzhYSuENI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:09:16.3068952","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:08:56.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:09:09.452Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"9771131a-b612-4844-888f-41e102ed0254":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c3416831-d285-4919-b7da-4145462d007e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fabea672-1e46-4013-bf1b-014f31dc8465":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/17fa7f05-455e-4825-a629-8657b1af65aa/ac274e63-6a06-443d-9548-e4fe6991a665?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A09%3A29Z&sr=b&sp=r&sig=qqr9NygLkj%2BeJCkvBZXbMwU%2BlfjVH1GiDZlxivEoI9k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:09:29.5461233","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:09.729Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:23.019Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1643'
+      - '1591'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:16 GMT
+      - Mon, 09 Oct 2023 16:09:29 GMT
       mise-correlation-id:
-      - 3733afad-f900-4e02-8768-daf8e6d86ca6
+      - 46c111e7-261c-4d21-9715-005d9841ff66
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:08:16.6627579Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:08:16.6627579Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0b937915-2a09-497f-a204-8201508dbf19.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:08:33.7149684Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:08:33.7149684Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:16 GMT
+      - Mon, 09 Oct 2023 16:09:30 GMT
       etag:
-      - '"1a0a3997-0000-0100-0000-64af08320000"'
+      - '"92015689-0000-0100-0000-652425830000"'
       expires:
       - '-1'
       pragma:
@@ -619,24 +619,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0b937915-2a09-497f-a204-8201508dbf19.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://14404871-1e9d-4c49-adec-392df3a79a04.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"985f4ce8-eb33-42de-82b3-8bf571e8b645":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"30a1eb4c-95bb-4281-9261-e70f12901841":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"2771886a-cfec-4074-9e69-420079dc2d32":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b4e9e0ac-b4a0-4a9d-b305-dd149e054a1f/12a67571-08b1-4478-9eb6-8d4d86a3bc38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A09%3A17Z&sr=b&sp=r&sig=%2F6m1U9A6FDu1b8DxF4%2FEAN7L41O07p456WC7HtZT5G0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:09:17.8791243","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:08:56.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:09:09.452Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"9771131a-b612-4844-888f-41e102ed0254":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c3416831-d285-4919-b7da-4145462d007e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fabea672-1e46-4013-bf1b-014f31dc8465":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/17fa7f05-455e-4825-a629-8657b1af65aa/ac274e63-6a06-443d-9548-e4fe6991a665?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A09%3A31Z&sr=b&sp=r&sig=1Z%2FnZC0q42aF3bimD5%2FEPwtlWxU7S1vlnEKnnnVlKBM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:09:31.8050198","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:09:09.729Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:09:23.019Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1645'
+      - '1591'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:09:17 GMT
+      - Mon, 09 Oct 2023 16:09:31 GMT
       mise-correlation-id:
-      - a44f1391-8b64-493c-ad25-331d966d5961
+      - 281a622a-9d67-4e09-995a-f538b6f9e7ac
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_list.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_list.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.3865267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.3865267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1030248Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1030248Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:38 GMT
+      - Tue, 24 Oct 2023 12:25:16 GMT
       etag:
-      - '"75001c3a-0000-0100-0000-653044880000"'
+      - '"d300f131-0000-0100-0000-6537b78b0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:48:40 GMT
+      - Tue, 24 Oct 2023 12:25:17 GMT
       mise-correlation-id:
-      - 9fffef12-d819-438c-9fbd-8cb6c4273660
+      - 6af4bf80-fdfc-4458-b58d-37889bb83efa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"cc666694-ee54-4034-bb68-62b4aedbeafe": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "fdafabfd-1808-402a-a154-afeab9b90b32":
+      {"passFailMetrics": {"178f7c06-eb3d-4048-9356-41e5f7cc8c4e": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "89c0652b-eaf9-4eab-bd91-59ccab24a1d3":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "203d4072-1b95-46ed-9351-36c3da5498e8": {"aggregate": "avg", "clientMetric":
+      "50"}, "23b412f3-766b-4e3a-937f-116ef5b9a3ec": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cc666694-ee54-4034-bb68-62b4aedbeafe":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fdafabfd-1808-402a-a154-afeab9b90b32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"203d4072-1b95-46ed-9351-36c3da5498e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:41.416Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:41.416Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"178f7c06-eb3d-4048-9356-41e5f7cc8c4e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"89c0652b-eaf9-4eab-bd91-59ccab24a1d3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"23b412f3-766b-4e3a-937f-116ef5b9a3ec":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:17.837Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:17.837Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:41 GMT
+      - Tue, 24 Oct 2023 12:25:17 GMT
       location:
-      - https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+      - https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 0c3d0f41-a86d-4897-b482-7995c424526c
+      - 607be25b-6fa0-4c3c-b542-baee21ecb0f2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
+    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:41 GMT
+      - Tue, 24 Oct 2023 12:25:18 GMT
       mise-correlation-id:
-      - a171724a-2938-4023-9399-0b26a2a5b23c
+      - 700c68f1-8278-4796-b9f7-758d58aa3d70
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,10 +275,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8ef2c157-98cb-4f12-bf4e-c332960417d0/3d53686f-1cf1-4877-96ef-dfcd18cc0cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A42Z&sr=b&sp=r&sig=AE5WYxrGkoebp0mbnWcFuv1Ztg%2FZKLHInpXqB15a1ZE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:42.4286535","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f7cbca0d-956f-4e49-8f8e-9f69d6c53622/455223a4-72d5-4fd1-a732-833b8e87eb34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A19Z&sr=b&sp=r&sig=Fxk%2FyTKHQY0F5vQEhXS7U558CAnWyTjTFveSzoI20Z0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:19.6976114","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -289,11 +289,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:42 GMT
+      - Tue, 24 Oct 2023 12:25:19 GMT
       location:
-      - https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 10ddece7-a545-4c19-a2b3-064d4ac186f7
+      - debaa930-712b-47a5-9eae-c1f47cd2de8b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,46 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8ef2c157-98cb-4f12-bf4e-c332960417d0/3d53686f-1cf1-4877-96ef-dfcd18cc0cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A42Z&sr=b&sp=r&sig=hdfsavXD0lhyOWWYAPr4ztD2HQcjuSLcB8hBdf10bzQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:42.6706362","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:48:42 GMT
-      mise-correlation-id:
-      - 1e1ae0af-6e16-4831-bdad-f24dc76808bf
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8ef2c157-98cb-4f12-bf4e-c332960417d0/3d53686f-1cf1-4877-96ef-dfcd18cc0cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A47Z&sr=b&sp=r&sig=Jc%2FuRWgJuFoy7bmGh0cMqVLg7LgdiVJqNvmWP74bAPc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:47.9311394","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f7cbca0d-956f-4e49-8f8e-9f69d6c53622/455223a4-72d5-4fd1-a732-833b8e87eb34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A20Z&sr=b&sp=r&sig=hNYrH8OJx68m0xopRjU0uFs%2FNLBf0bfnvk6rLLOtt6I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:20.0109437","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:47 GMT
+      - Tue, 24 Oct 2023 12:25:20 GMT
       mise-correlation-id:
-      - 173dc641-35bb-4f6a-93e6-33a86705dce3
+      - 7955fadd-72a6-48fe-95c4-cec048562a6c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,10 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8ef2c157-98cb-4f12-bf4e-c332960417d0/3d53686f-1cf1-4877-96ef-dfcd18cc0cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A53Z&sr=b&sp=r&sig=kjk8V0zxmS493bXgPbU%2FJ5JxeXDDkrzFK460HXCcyf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:53.2132516","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f7cbca0d-956f-4e49-8f8e-9f69d6c53622/455223a4-72d5-4fd1-a732-833b8e87eb34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A25Z&sr=b&sp=r&sig=Wfkw%2BSgVBdZU0BKJyqDx0dxVNVnHtUo3oSMmHoFJPuY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:25.2743719","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:53 GMT
+      - Tue, 24 Oct 2023 12:25:25 GMT
       mise-correlation-id:
-      - 14dd3372-0e40-4bf2-aaa5-bffe2f485287
+      - 11d247f2-ddd1-4bdf-a50e-2358090a2b2b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,10 +385,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8ef2c157-98cb-4f12-bf4e-c332960417d0/3d53686f-1cf1-4877-96ef-dfcd18cc0cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A58Z&sr=b&sp=r&sig=lNfJrrE74eM5MRS%2Bep5oRsorBl8grH8fFFv01Lzrx5w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:58.5529261","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f7cbca0d-956f-4e49-8f8e-9f69d6c53622/455223a4-72d5-4fd1-a732-833b8e87eb34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A31Z&sr=b&sp=r&sig=%2Bxcdvl4S3JClV8Jz5jTE6SXe6xWFgopjUP1CKLTRtGQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:31.3600235","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:25:31 GMT
+      mise-correlation-id:
+      - b1b62bba-a011-4aee-bdc5-4b5179780b8e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f7cbca0d-956f-4e49-8f8e-9f69d6c53622/455223a4-72d5-4fd1-a732-833b8e87eb34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A35%3A36Z&sr=b&sp=r&sig=EMiYtjbP1yQEzsjLe3cPgU1X%2FdvBCac0ApvJv54xhn0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:35:36.8616981","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:58 GMT
+      - Tue, 24 Oct 2023 12:25:36 GMT
       mise-correlation-id:
-      - dc5204d4-217c-46ec-8368-91a9503f1328
+      - 13e20257-73cc-42b9-b9a5-2d512af80fe9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cc666694-ee54-4034-bb68-62b4aedbeafe":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fdafabfd-1808-402a-a154-afeab9b90b32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"203d4072-1b95-46ed-9351-36c3da5498e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8ef2c157-98cb-4f12-bf4e-c332960417d0/3d53686f-1cf1-4877-96ef-dfcd18cc0cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A48%3A58Z&sr=b&sp=r&sig=C3eWMmE0ZO9zbI%2BtAUQ%2FoRxcfozMrgp8x0K%2BaHGoxZ0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:48:58.8652186","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:41.416Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:55.277Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"178f7c06-eb3d-4048-9356-41e5f7cc8c4e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"89c0652b-eaf9-4eab-bd91-59ccab24a1d3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"23b412f3-766b-4e3a-937f-116ef5b9a3ec":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f7cbca0d-956f-4e49-8f8e-9f69d6c53622/455223a4-72d5-4fd1-a732-833b8e87eb34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A25%3A37Z&sr=b&sp=r&sig=iVx%2BkfaFP4n08Z0AMfS9Ef%2Br1RbjgT0qm0yD6NrzH10%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:25:37.1196853","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:17.837Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:33.8Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1581'
+      - '1577'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:48:58 GMT
+      - Tue, 24 Oct 2023 12:25:37 GMT
       mise-correlation-id:
-      - c6c8628d-76d2-4f1f-acb4-32c0217f18c7
+      - 0d453ff5-81aa-4efb-993f-4e059c188056
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.3865267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.3865267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1030248Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1030248Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:00 GMT
+      - Tue, 24 Oct 2023 12:25:38 GMT
       etag:
-      - '"75001c3a-0000-0100-0000-653044880000"'
+      - '"d300f131-0000-0100-0000-6537b78b0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"cc666694-ee54-4034-bb68-62b4aedbeafe":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fdafabfd-1808-402a-a154-afeab9b90b32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"203d4072-1b95-46ed-9351-36c3da5498e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8ef2c157-98cb-4f12-bf4e-c332960417d0/3d53686f-1cf1-4877-96ef-dfcd18cc0cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A49%3A01Z&sr=b&sp=r&sig=l40%2FyUnRfmrANBCs%2B3Y2rm4z2DMBVFN2MPgYjgIesyw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:49:01.1002842","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:41.416Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:55.277Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"178f7c06-eb3d-4048-9356-41e5f7cc8c4e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"89c0652b-eaf9-4eab-bd91-59ccab24a1d3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"23b412f3-766b-4e3a-937f-116ef5b9a3ec":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f7cbca0d-956f-4e49-8f8e-9f69d6c53622/455223a4-72d5-4fd1-a732-833b8e87eb34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A25%3A39Z&sr=b&sp=r&sig=Q7S43XHmhlLKgt2nTTXZQgePf9Fdo9FVy3t7GSVU0pA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:25:39.5198102","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:17.837Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:33.8Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1591'
+      - '1585'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:01 GMT
+      - Tue, 24 Oct 2023 12:25:39 GMT
       mise-correlation-id:
-      - 901d9a4e-864a-4cfd-95b9-4ad06cf6f6e3
+      - f3fcb0ec-5655-48a9-bcd7-93bbec81c319
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.3865267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.3865267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:24:42.1030248Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:24:42.1030248Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:02 GMT
+      - Tue, 24 Oct 2023 12:25:40 GMT
       etag:
-      - '"75001c3a-0000-0100-0000-653044880000"'
+      - '"d300f131-0000-0100-0000-6537b78b0000"'
       expires:
       - '-1'
       pragma:
@@ -619,24 +619,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://776eebc6-d67d-4fb4-9e9a-ae31b35331a7.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"cc666694-ee54-4034-bb68-62b4aedbeafe":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fdafabfd-1808-402a-a154-afeab9b90b32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"203d4072-1b95-46ed-9351-36c3da5498e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8ef2c157-98cb-4f12-bf4e-c332960417d0/3d53686f-1cf1-4877-96ef-dfcd18cc0cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A49%3A03Z&sr=b&sp=r&sig=9bfizA%2B56SpXwakQxDv9oFQJwCNaTEgX2NddJvimb2w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:49:03.2941948","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:41.416Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:55.277Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"178f7c06-eb3d-4048-9356-41e5f7cc8c4e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"89c0652b-eaf9-4eab-bd91-59ccab24a1d3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"23b412f3-766b-4e3a-937f-116ef5b9a3ec":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f7cbca0d-956f-4e49-8f8e-9f69d6c53622/455223a4-72d5-4fd1-a732-833b8e87eb34?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A25%3A42Z&sr=b&sp=r&sig=3oOzj14LqICRodkTNvAWYYQNz5PZ4UUVCFXCOMBvMBQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:25:42.2112414","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:25:17.837Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:25:33.8Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1589'
+      - '1585'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:49:03 GMT
+      - Tue, 24 Oct 2023 12:25:42 GMT
       mise-correlation-id:
-      - ef23da19-b346-4ed7-af7b-8996eaf4668c
+      - 9bfbe754-9066-4f16-a012-4312985567df
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_list.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_list.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:55.8396895Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:55.8396895Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.3865267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.3865267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:29 GMT
+      - Wed, 18 Oct 2023 20:48:38 GMT
       etag:
-      - '"d8011ea5-0000-0100-0000-65294a8d0000"'
+      - '"75001c3a-0000-0100-0000-653044880000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:48:31 GMT
+      - Wed, 18 Oct 2023 20:48:40 GMT
       mise-correlation-id:
-      - 111c3624-cb1a-470b-b3ed-636defe6c62e
+      - 9fffef12-d819-438c-9fbd-8cb6c4273660
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"68aadb47-d177-4ea4-98cb-33b82b679c05": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "d33e9998-307a-41ec-a139-c49da0d559c8":
+      {"passFailMetrics": {"cc666694-ee54-4034-bb68-62b4aedbeafe": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "fdafabfd-1808-402a-a154-afeab9b90b32":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "4d645dec-ee47-4b6d-8631-b65111db81ab": {"aggregate": "avg", "clientMetric":
+      "50"}, "203d4072-1b95-46ed-9351-36c3da5498e8": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"68aadb47-d177-4ea4-98cb-33b82b679c05":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d33e9998-307a-41ec-a139-c49da0d559c8":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4d645dec-ee47-4b6d-8631-b65111db81ab":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:32.055Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:32.055Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cc666694-ee54-4034-bb68-62b4aedbeafe":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fdafabfd-1808-402a-a154-afeab9b90b32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"203d4072-1b95-46ed-9351-36c3da5498e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:41.416Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:41.416Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:32 GMT
+      - Wed, 18 Oct 2023 20:48:41 GMT
       location:
-      - https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+      - https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 1dbd1044-5754-48d3-a760-e996d620a961
+      - 0c3d0f41-a86d-4897-b482-7995c424526c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
+    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:32 GMT
+      - Wed, 18 Oct 2023 20:48:41 GMT
       mise-correlation-id:
-      - 75e3a82e-b2c2-4b46-82d9-3fe756559916
+      - a171724a-2938-4023-9399-0b26a2a5b23c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bca57648-8b1e-4b81-89f8-bdd648fc5a80/258dc1aa-de1d-4aa7-8d5c-b0367006772c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A32Z&sr=b&sp=r&sig=%2FUb8Nhc2g5moTn98aZ%2FjPNiMlfL4Bm0k0M%2Bl%2BJ45xAQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:32.7790067","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8ef2c157-98cb-4f12-bf4e-c332960417d0/3d53686f-1cf1-4877-96ef-dfcd18cc0cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A42Z&sr=b&sp=r&sig=AE5WYxrGkoebp0mbnWcFuv1Ztg%2FZKLHInpXqB15a1ZE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:42.4286535","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '557'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:32 GMT
+      - Wed, 18 Oct 2023 20:48:42 GMT
       location:
-      - https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 38020e0a-7400-489d-b72a-aff21b7a3437
+      - 10ddece7-a545-4c19-a2b3-064d4ac186f7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,118 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bca57648-8b1e-4b81-89f8-bdd648fc5a80/258dc1aa-de1d-4aa7-8d5c-b0367006772c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A33Z&sr=b&sp=r&sig=zelssRUYj55vaefEAjrsYrlBu%2FHUn1vUrYEXoXV%2BC84%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:33.0214984","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:48:33 GMT
-      mise-correlation-id:
-      - c2a5d396-1202-4f77-ab9b-c241cf51d933
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bca57648-8b1e-4b81-89f8-bdd648fc5a80/258dc1aa-de1d-4aa7-8d5c-b0367006772c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A38Z&sr=b&sp=r&sig=ysxi7nLz1r8J9laxwh5qdgDe3H6%2BJlKxbuoXp1hGLkY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:38.2676562","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:48:38 GMT
-      mise-correlation-id:
-      - 4afc20dc-f67d-43ee-96cd-74b5d9d7aaca
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bca57648-8b1e-4b81-89f8-bdd648fc5a80/258dc1aa-de1d-4aa7-8d5c-b0367006772c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A43Z&sr=b&sp=r&sig=UM0hXvGca%2BuxhIHRNI59hMlqfbVVBsjmlkpwG4Ma0aE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:43.5237448","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:48:43 GMT
-      mise-correlation-id:
-      - d2361bb0-5897-433f-ae06-2da73f9337a5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bca57648-8b1e-4b81-89f8-bdd648fc5a80/258dc1aa-de1d-4aa7-8d5c-b0367006772c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T13%3A58%3A48Z&sr=b&sp=r&sig=fzrLr1akDpqty5kQHnzpoBeCecJdL93mTeq7e%2F0NS6k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T13:58:48.7484985","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8ef2c157-98cb-4f12-bf4e-c332960417d0/3d53686f-1cf1-4877-96ef-dfcd18cc0cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A42Z&sr=b&sp=r&sig=hdfsavXD0lhyOWWYAPr4ztD2HQcjuSLcB8hBdf10bzQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:42.6706362","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:48 GMT
+      - Wed, 18 Oct 2023 20:48:42 GMT
       mise-correlation-id:
-      - fa7a9a5f-7fac-4233-8016-0cace8c5a144
+      - 1e1ae0af-6e16-4831-bdad-f24dc76808bf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +349,132 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"68aadb47-d177-4ea4-98cb-33b82b679c05":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d33e9998-307a-41ec-a139-c49da0d559c8":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4d645dec-ee47-4b6d-8631-b65111db81ab":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bca57648-8b1e-4b81-89f8-bdd648fc5a80/258dc1aa-de1d-4aa7-8d5c-b0367006772c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A48%3A49Z&sr=b&sp=r&sig=xiAVgF1qGljcwrWpUk%2FYU1QlR7zsPTlneuAm1cKAeM0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:48:49.0051428","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:32.055Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:45.988Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8ef2c157-98cb-4f12-bf4e-c332960417d0/3d53686f-1cf1-4877-96ef-dfcd18cc0cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A47Z&sr=b&sp=r&sig=Jc%2FuRWgJuFoy7bmGh0cMqVLg7LgdiVJqNvmWP74bAPc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:47.9311394","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1577'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:49 GMT
+      - Wed, 18 Oct 2023 20:48:47 GMT
       mise-correlation-id:
-      - 9bfafff9-603c-4c13-9e05-b143f19d68ef
+      - 173dc641-35bb-4f6a-93e6-33a86705dce3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8ef2c157-98cb-4f12-bf4e-c332960417d0/3d53686f-1cf1-4877-96ef-dfcd18cc0cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A53Z&sr=b&sp=r&sig=kjk8V0zxmS493bXgPbU%2FJ5JxeXDDkrzFK460HXCcyf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:53.2132516","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:48:53 GMT
+      mise-correlation-id:
+      - 14dd3372-0e40-4bf2-aaa5-bffe2f485287
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8ef2c157-98cb-4f12-bf4e-c332960417d0/3d53686f-1cf1-4877-96ef-dfcd18cc0cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T20%3A58%3A58Z&sr=b&sp=r&sig=lNfJrrE74eM5MRS%2Bep5oRsorBl8grH8fFFv01Lzrx5w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T20:58:58.5529261","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:48:58 GMT
+      mise-correlation-id:
+      - dc5204d4-217c-46ec-8368-91a9503f1328
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cc666694-ee54-4034-bb68-62b4aedbeafe":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fdafabfd-1808-402a-a154-afeab9b90b32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"203d4072-1b95-46ed-9351-36c3da5498e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8ef2c157-98cb-4f12-bf4e-c332960417d0/3d53686f-1cf1-4877-96ef-dfcd18cc0cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A48%3A58Z&sr=b&sp=r&sig=C3eWMmE0ZO9zbI%2BtAUQ%2FoRxcfozMrgp8x0K%2BaHGoxZ0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:48:58.8652186","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:41.416Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:55.277Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1581'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:48:58 GMT
+      mise-correlation-id:
+      - c6c8628d-76d2-4f1f-acb4-32c0217f18c7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:55.8396895Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:55.8396895Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.3865267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.3865267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:50 GMT
+      - Wed, 18 Oct 2023 20:49:00 GMT
       etag:
-      - '"d8011ea5-0000-0100-0000-65294a8d0000"'
+      - '"75001c3a-0000-0100-0000-653044880000"'
       expires:
       - '-1'
       pragma:
@@ -538,11 +538,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"68aadb47-d177-4ea4-98cb-33b82b679c05":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d33e9998-307a-41ec-a139-c49da0d559c8":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4d645dec-ee47-4b6d-8631-b65111db81ab":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bca57648-8b1e-4b81-89f8-bdd648fc5a80/258dc1aa-de1d-4aa7-8d5c-b0367006772c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A48%3A51Z&sr=b&sp=r&sig=JfhTspTVXH1JFvGWJ4e87CdrglmcUBFJKDdVA%2F%2Fbx9I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:48:51.7972774","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:32.055Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:45.988Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"cc666694-ee54-4034-bb68-62b4aedbeafe":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fdafabfd-1808-402a-a154-afeab9b90b32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"203d4072-1b95-46ed-9351-36c3da5498e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8ef2c157-98cb-4f12-bf4e-c332960417d0/3d53686f-1cf1-4877-96ef-dfcd18cc0cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A49%3A01Z&sr=b&sp=r&sig=l40%2FyUnRfmrANBCs%2B3Y2rm4z2DMBVFN2MPgYjgIesyw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:49:01.1002842","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:41.416Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:55.277Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:51 GMT
+      - Wed, 18 Oct 2023 20:49:01 GMT
       mise-correlation-id:
-      - 6e4dc0dc-41f5-4b95-97d0-5a0fa072fdb8
+      - 901d9a4e-864a-4cfd-95b9-4ad06cf6f6e3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:47:55.8396895Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:47:55.8396895Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:48:05.3865267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:48:05.3865267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:52 GMT
+      - Wed, 18 Oct 2023 20:49:02 GMT
       etag:
-      - '"d8011ea5-0000-0100-0000-65294a8d0000"'
+      - '"75001c3a-0000-0100-0000-653044880000"'
       expires:
       - '-1'
       pragma:
@@ -619,11 +619,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4eef40fe-f131-47f4-a8b9-13031970ff98.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://560d845a-8efa-48fd-bd93-b69b4d1416e1.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"68aadb47-d177-4ea4-98cb-33b82b679c05":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d33e9998-307a-41ec-a139-c49da0d559c8":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4d645dec-ee47-4b6d-8631-b65111db81ab":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bca57648-8b1e-4b81-89f8-bdd648fc5a80/258dc1aa-de1d-4aa7-8d5c-b0367006772c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A48%3A53Z&sr=b&sp=r&sig=xHID2PPn2wsBkMYnhrvC7mnsl4IsLlQxtA%2BXCubET58%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:48:53.5522395","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:48:32.055Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:48:45.988Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"cc666694-ee54-4034-bb68-62b4aedbeafe":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fdafabfd-1808-402a-a154-afeab9b90b32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"203d4072-1b95-46ed-9351-36c3da5498e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8ef2c157-98cb-4f12-bf4e-c332960417d0/3d53686f-1cf1-4877-96ef-dfcd18cc0cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A49%3A03Z&sr=b&sp=r&sig=9bfizA%2B56SpXwakQxDv9oFQJwCNaTEgX2NddJvimb2w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:49:03.2941948","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:48:41.416Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:48:55.277Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -634,9 +634,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:48:53 GMT
+      - Wed, 18 Oct 2023 20:49:03 GMT
       mise-correlation-id:
-      - 874cd5f7-d347-444c-ac23-d4ce737cdda1
+      - ef23da19-b346-4ed7-af7b-8996eaf4668c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_create.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_create.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:39.6895752Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:39.6895752Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:11.2483666Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:11.2483666Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:13 GMT
+      - Tue, 24 Oct 2023 12:28:45 GMT
       etag:
-      - '"7500814e-0000-0100-0000-6530455d0000"'
+      - '"d300e23b-0000-0100-0000-6537b85d0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:52:15 GMT
+      - Tue, 24 Oct 2023 12:28:46 GMT
       mise-correlation-id:
-      - 6f18756c-5d53-4308-80de-136943c584ab
+      - 6a0b93b3-621e-4261-9da1-b8c72d0578b8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"7018876b-209f-4eb1-a306-e3e4667da02e": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":
+      {"passFailMetrics": {"27c55f6c-f4e3-4744-b037-69ccbd54175c": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "361a7b92-7112-4c75-a437-d85b4e4e033d": {"aggregate": "avg", "clientMetric":
+      "50"}, "60818291-485b-469b-9ea4-310d3594f2cc": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:52:15.644Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:15.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:47.456Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:47.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:15 GMT
+      - Tue, 24 Oct 2023 12:28:47 GMT
       location:
-      - https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+      - https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - b04e388f-cb3e-4a8b-b4db-7d9832a8a1b9
+      - 4e651766-a475-4b22-a45a-70984d8df109
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:15 GMT
+      - Tue, 24 Oct 2023 12:28:47 GMT
       mise-correlation-id:
-      - e453eab2-e2d6-4e12-8d5e-c90dc56cfc4a
+      - 31d9594d-f08a-4288-ae24-ef2df25c9382
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A16Z&sr=b&sp=r&sig=3p955hry2oK4h2GNX2PEIQaGmsqCCBpJOw71wzvB164%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:16.6049881","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A48Z&sr=b&sp=r&sig=wWoBHmCEXHPTK4ceKP0FN5e4pt50KsT%2FpeKCdGUuDCA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:48.7667662","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:16 GMT
+      - Tue, 24 Oct 2023 12:28:48 GMT
       location:
-      - https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 463bf8b7-474d-4d4c-8b85-48ea540e8dff
+      - 5b3dff14-3b83-44ae-93f1-797d55c42419
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A16Z&sr=b&sp=r&sig=fr0Ge%2BqiLAFrlvkZu8%2Be0uVs%2FuIg1T56%2BzoXE0Mewkk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:16.8506924","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A49Z&sr=b&sp=r&sig=QSgurHDccw38YNvhpLULUhnmp19j6ccqc1LGLHW1WrQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:49.0137122","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '557'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:16 GMT
+      - Tue, 24 Oct 2023 12:28:49 GMT
       mise-correlation-id:
-      - d806a315-f160-43f0-b992-92fd2558aec6
+      - 10a770af-c500-418b-a2ee-04f4c9338f61
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,10 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A22Z&sr=b&sp=r&sig=F%2BbCZcaZSlwBBu1d2AdFh3QcLBR2fpb%2FtvP93rxDwKE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:22.1104866","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A54Z&sr=b&sp=r&sig=A6y3e9dgzPiHks%2BuBS9GOPSgscirytgwUox4FVjf%2Frg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:54.2645366","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:22 GMT
+      - Tue, 24 Oct 2023 12:28:54 GMT
       mise-correlation-id:
-      - 8101f79b-848a-49e6-aff5-ac7b191a9912
+      - e0759d67-0a4a-434a-9d6b-0b37056eafef
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A27Z&sr=b&sp=r&sig=GYpTsn%2F%2BQG0OaqCQpX5oc030CHjVr%2F4IplJ%2Fg4Bq0oM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:27.3692148","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A59Z&sr=b&sp=r&sig=RfPwYsXIs7pbu1VImY4R%2FQxNRb6Gl%2Fl4pJDwxRT4k3g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:59.5348721","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '557'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:27 GMT
+      - Tue, 24 Oct 2023 12:28:59 GMT
       mise-correlation-id:
-      - b4a4c96e-e823-4a60-97d0-9e09392dc535
+      - 562c6a6d-3e7c-4f5a-a30d-2c4de3914dde
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A32Z&sr=b&sp=r&sig=qSbmH9XRqDorKGxRTYETRFE73wIP0nmLthYgzhUqpT8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:32.6546761","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A04Z&sr=b&sp=r&sig=hjd62qNJj31z88FiEUIrjw8svVegH%2BqpnGh2ZvRW4dY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:04.8095264","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:32 GMT
+      - Tue, 24 Oct 2023 12:29:04 GMT
       mise-correlation-id:
-      - 576857dc-466a-4e46-8653-3a7df4bfca7c
+      - ca348fd4-53d8-4ed7-8cee-2aa2025bb9d3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A32Z&sr=b&sp=r&sig=XZf5xvgoCBZox%2BR0bES6Kh%2BtGgPtcVNYw9c2JMNACfQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:32.905597","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:52:15.644Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:29.781Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A05Z&sr=b&sp=r&sig=jAS%2Ff4SIYCuXMR7Znk0vWQ8CtSluQ1s2BXYtzc6DkVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:05.0943153","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:47.456Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:01.909Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1580'
+      - '1579'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:32 GMT
+      - Tue, 24 Oct 2023 12:29:05 GMT
       mise-correlation-id:
-      - 611c44ce-2e76-4414-9ead-8c37e0517e2d
+      - c2fbbc01-5d30-49a9-a6a9-08fe87849e13
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:39.6895752Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:39.6895752Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:11.2483666Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:11.2483666Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:32 GMT
+      - Tue, 24 Oct 2023 12:29:05 GMT
       etag:
-      - '"7500814e-0000-0100-0000-6530455d0000"'
+      - '"d300e23b-0000-0100-0000-6537b85d0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A35Z&sr=b&sp=r&sig=ckejjZ8kj%2FzMYQ44dd%2FNQh4MocblaPKsXBmlTx4mXak%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:35.4500707","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:52:15.644Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:29.781Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A07Z&sr=b&sp=r&sig=ho%2BbCX9g3FgkCfvvu5A3Fv7JXV4AYU0ghjys5uXZpqU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:07.5966382","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:47.456Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:01.909Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1593'
+      - '1591'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:35 GMT
+      - Tue, 24 Oct 2023 12:29:07 GMT
       mise-correlation-id:
-      - eba0626c-8e7c-4bcc-a8b5-fe3e00360fe2
+      - 9d3ebd50-ede4-4a07-9a02-0bcedb9eee14
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:39.6895752Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:39.6895752Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:11.2483666Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:11.2483666Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:36 GMT
+      - Tue, 24 Oct 2023 12:29:09 GMT
       etag:
-      - '"7500814e-0000-0100-0000-6530455d0000"'
+      - '"d300e23b-0000-0100-0000-6537b85d0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:52:37 GMT
+      - Tue, 24 Oct 2023 12:29:10 GMT
       mise-correlation-id:
-      - ae4712c8-ea81-49f2-bed3-249ae6b00492
+      - 4e340de6-44e7-48b0-b921-a2b629cdea96
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -664,25 +664,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A38Z&sr=b&sp=r&sig=k5R1KoiIzw6cHmRxb77%2BYhfSs%2B71yZAe%2FYKgcJ3qgjs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:38.7595792","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A38Z&sr=b&sp=r&sig=EV1sqi%2B1IY6sRIDhuuhVURqVJzYu%2BNzvMwLPRkpH9w0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:38.759409","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A38Z&sr=b&sp=r&sig=9VBHw3nkE5q3cSsvoqSgu%2B2o2MYZ1t%2B%2F5B16BAE9qO4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:38.7596033","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:38.686Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A10Z&sr=b&sp=r&sig=KubJy0Gm%2B6yzgycUtsqelHE9cRis7VhHArRR6VYNEOc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:10.8663909","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A10Z&sr=b&sp=r&sig=KPM7znU6sKXMJOcLlh7JDFImIp9PdcN%2B8SK0UBFvMdY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:10.8662634","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A10Z&sr=b&sp=r&sig=2CLEgmKxSAQ1RKrhhiGVgCg6xooW%2FraTA4UsGQfOUlE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:10.8664356","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:10.772Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3214'
+      - '3205'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:38 GMT
+      - Tue, 24 Oct 2023 12:29:11 GMT
       location:
-      - https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+      - https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - e43cef5a-6b89-44ac-a631-6fdb3bfe82c1
+      - f8ae06f9-7836-4e73-9300-7ce77dfc4630
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -702,23 +702,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A39Z&sr=b&sp=r&sig=TjAHSbB4TZKGxrG9EExMTwKssw7rBP67BTywW9yeNSo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:39.2026536","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A39Z&sr=b&sp=r&sig=SHMWPjtkVhXVlT2qo3infbSmPF%2F75gJCBhFLDOVUnME%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:39.2025708","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A39Z&sr=b&sp=r&sig=cR7ae9sTH6r6gnEpO9VQulj3tSI0Y7P%2FhKwiOZOdG8E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:39.2026683","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"NOTSTARTED","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.088Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A11Z&sr=b&sp=r&sig=AqwbuG1WtO4xilmbUBZxCFFzTb2yiA2pllcbRvyCp%2FA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:11.3398955","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A11Z&sr=b&sp=r&sig=1gQ6wmMN436fkWj%2FqMZSkGCRB0N3V7JVTz9b%2BavnSPE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:11.3398288","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A11Z&sr=b&sp=r&sig=ntj14H3hcWLuJst8Rgr6zhANx6Wx8WVUJjN7kd1fYOM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:11.3399108","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:10.772Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3248'
+      - '3205'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:39 GMT
+      - Tue, 24 Oct 2023 12:29:11 GMT
       mise-correlation-id:
-      - 0b1a0c54-a890-4868-a779-7a8a1ce49200
+      - 96d93ccb-38d1-416d-bf63-61668e2f902d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -738,190 +738,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A44Z&sr=b&sp=r&sig=7UAHZalBLkCTEawrpSFuYKH5mS6U6TBGlICFF76Jh4U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:44.5406923","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A44Z&sr=b&sp=r&sig=OGb93t7zpXoAe9CZvUzMA6kVc9nEyBJmhANp3UNdyEg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:44.5405837","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A44Z&sr=b&sp=r&sig=grW7aC4aoeQuvBo%2Fm11Hl69Vt8VJQCN2XVmH2YJ2QkA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:44.5407153","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.265Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3248'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:52:44 GMT
-      mise-correlation-id:
-      - f7b08f8c-4181-41de-a838-e5a72d7f96c8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A49Z&sr=b&sp=r&sig=cpoiiBVgSKEFN62EFTb%2Fpsy9sfJ2Dcht5ZZe2F%2Bej%2FA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:49.8498227","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A49Z&sr=b&sp=r&sig=pYNtqyYn74nf3T2YUPhz1fpC0RrYy4R20qPhM8g%2FLqc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:49.8497563","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A49Z&sr=b&sp=r&sig=9jMdghvV3AveaL2Wdbqmrfp2SB5GTz3qAnY1eQBQdWs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:49.8498375","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.265Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3254'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:52:49 GMT
-      mise-correlation-id:
-      - b398d669-572c-42fd-b813-44480daa4560
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A55Z&sr=b&sp=r&sig=EOupyJsMgQZ3cU4p%2Fp5gPLRLYFLZm8payKUP%2BqeYqow%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:55.2064033","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A55Z&sr=b&sp=r&sig=KF8NAWWWHtRfUGup90%2BgoVZ9%2BL62Q8nliATzDnh4pyQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:55.2062989","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A55Z&sr=b&sp=r&sig=C%2FVFXoRmcgdcVTee6A7FB%2Bmfi6UVePetWQ6quOa1sc0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:55.2064271","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.265Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3258'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:52:55 GMT
-      mise-correlation-id:
-      - 3183e6b6-2dae-4c85-b7f9-9b035bff7ccd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A00Z&sr=b&sp=r&sig=RdTdbnOiOpnsDE8vtzasnKeb%2BAE9%2BjNIXePxbxc3pmU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:00.5124085","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A00Z&sr=b&sp=r&sig=jVR9UExVn%2FQrZUT4iqNoWiZWxC8f40ughAVEBJduY1c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:00.5123114","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A00Z&sr=b&sp=r&sig=uAtXsYV%2BbMeJBlxn%2BSJc%2BGNFP5%2B4Q4eo5VkQIS103Xo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:00.5124362","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.265Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3260'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:00 GMT
-      mise-correlation-id:
-      - d42169d6-cb6c-460f-b85e-2482b39daa34
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A05Z&sr=b&sp=r&sig=aKk8kKLvL0xT6IxudnJhFZxQ%2B105kukwGA08QcX6NWc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:05.8388902","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A05Z&sr=b&sp=r&sig=cIHwobPSrwBxuNDlJdiCOuLu6ZP4wcDQ5liRcwJ%2B8T4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:05.8387985","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A05Z&sr=b&sp=r&sig=27GeVXbUghKrllBLtiiuojnxYsMP9Tg3WZGE7p6pHCY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:05.8389052","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.265Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3250'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:05 GMT
-      mise-correlation-id:
-      - a4b7c752-5ae9-4157-808a-d09a40df46b2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A11Z&sr=b&sp=r&sig=Yf%2FQiyqFQKfugJcWmOyChSKy%2BX23J6TwDzI1DZeD9Lc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:11.1595499","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A11Z&sr=b&sp=r&sig=zIhsU1zYjVu6zV1ihPTXZbrZ9Jm2Zy1ZKv7rXiVjxv8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:11.1594765","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A11Z&sr=b&sp=r&sig=ja4lpcEKa3ATgKwAEB4g0MoYn8wEyK%2FSGCW9iYYaBkE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:11.1595636","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.265Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A16Z&sr=b&sp=r&sig=USOWviktUlZplpRVhAT6sPV0gdC0p5oF41IkLUmbuPM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:16.6130141","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A16Z&sr=b&sp=r&sig=X0HK9JFcf%2Bm4anJjP3E9WEr2kJyfa2DTO7vArX9oTHM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:16.6129461","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A16Z&sr=b&sp=r&sig=IxaFhp1LUwfo3%2FpGXO%2BjSvGklWu36okUuJKKpWzvDFA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:16.6130274","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:11.997Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -932,9 +752,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:11 GMT
+      - Tue, 24 Oct 2023 12:29:16 GMT
       mise-correlation-id:
-      - b6c2d0d3-2097-4307-9231-882d1dcedd4c
+      - a9ab5784-18eb-437e-908b-c945f044f26e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -954,23 +774,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A16Z&sr=b&sp=r&sig=uvK%2Fm%2Ft5Ju3%2BJbZ3HSTi0necnI5OKLDKany%2FJV%2FcdFM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:16.506986","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A16Z&sr=b&sp=r&sig=3nJQYMw8UNWDJe0pxYLQEkh9T1UKI1ehqZFj%2FxKXidI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:16.5069206","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A16Z&sr=b&sp=r&sig=gaiFTzfUbsygoNlpDhzBpw5LC9tVBrhpoSC3EvdxuJ4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:16.5070003","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.265Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A21Z&sr=b&sp=r&sig=Y67MehXFCOXkIHPwT3BZtGYaRbT%2BokAXQrY3v7jaSiI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:21.8651162","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A21Z&sr=b&sp=r&sig=mKPyux%2FQkxaymtuaRGnuIOMBvHqBFbNsbnMD16izjm0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:21.8649612","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A21Z&sr=b&sp=r&sig=Qgx0TGoHVHEer%2F9GQsPj2BQC98vQfGYByNhImrX2cjs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:21.8651388","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:11.997Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3257'
+      - '3252'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:16 GMT
+      - Tue, 24 Oct 2023 12:29:21 GMT
       mise-correlation-id:
-      - b7fcde98-e65f-44af-9fc9-0473772461f3
+      - 140a646b-d10d-4b68-bdc5-c68f8c86379b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -990,10 +810,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A21Z&sr=b&sp=r&sig=aDbb%2BDEx%2FkA2U9JRNOLCPY4qYSKezffIdBWqdPHLWgk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:21.7813832","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A21Z&sr=b&sp=r&sig=9WeOozHccDbakVLApDBqXPJn3DBkZXNiTuCmkbdmls0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:21.7813087","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A21Z&sr=b&sp=r&sig=P93gDWI2IPR3%2Fc7eSQlmws35scjiKSigH3O2ZPl%2Fhr4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:21.7813973","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.265Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A27Z&sr=b&sp=r&sig=dHSZCX1IOALfeheFywIszUvz%2FNYirm9wky14oddQaQ8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:27.199941","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A27Z&sr=b&sp=r&sig=UNB2k2en3O2Kbb7qHudrTuuDYA0mW%2FlWssKgbDmfvGQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:27.1998652","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A27Z&sr=b&sp=r&sig=BggihFtcFAXcMkTPX5z8FgJiTBv7OS53CnTaBxN7Gsc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:27.199955","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:11.997Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3248'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:29:27 GMT
+      mise-correlation-id:
+      - d0aa1c4f-d29d-4465-8367-ee0710146ca7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A32Z&sr=b&sp=r&sig=H0yV6T1Eq3okd9ECYgkud3sObDMpdTkmfK48bFLvaIk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:32.8793333","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A32Z&sr=b&sp=r&sig=IO4f7Ma%2FEhS2RS2aLglJVyCUsX19sAxIFvsEQ6RXuaM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:32.8792648","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A32Z&sr=b&sp=r&sig=Ct10WPdGyrCX1COG%2BayNYcC4NcD%2B8Y39DiX0fIAl%2BmA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:32.8793473","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:11.997Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1004,9 +860,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:21 GMT
+      - Tue, 24 Oct 2023 12:29:32 GMT
       mise-correlation-id:
-      - 4e633ff5-6d65-4167-89ca-085bdb1ccaca
+      - 1f6c62ab-6c6a-4446-8ba6-7e08d77a7141
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1026,658 +882,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A27Z&sr=b&sp=r&sig=D7LLjx2Ty4Xp0esZaK9%2FHdMcPeNc7Q2hhfaHk%2FzyYL8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:27.0526656","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A27Z&sr=b&sp=r&sig=UQIkxh59c8NhwxhCWtvU834IrZYEB9JM6wFPZLAENDk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:27.0525625","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A27Z&sr=b&sp=r&sig=fzOQIV%2FmpvHUzgsgOh6Yj4hTQBW1L6SXXgXT3InL2uM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:27.0526797","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"CONFIGURING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.747Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3251'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:27 GMT
-      mise-correlation-id:
-      - d8bb3dc8-e2fa-46a7-90ce-b436343bc163
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A32Z&sr=b&sp=r&sig=Vb9JKP3pNK7PQackMjIJcWfLNBszskjyT1mUIpq0Opg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:32.3161457","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A32Z&sr=b&sp=r&sig=9Ox%2BKrYDCGdVNS8ZwLRcTVrTrhDLGtU0rinOXIFSeNI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:32.3160712","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A32Z&sr=b&sp=r&sig=qxnI%2FCWPpq1UDimkITDxc44gwW45QueTFFxiS0lcznQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:32.3161598","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3247'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:32 GMT
-      mise-correlation-id:
-      - 35b9f7a1-9a7e-43ed-85f2-0cd092fd48fc
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A37Z&sr=b&sp=r&sig=kIbgL6FiV2Y99kaoBdL69gmG%2BDrsg98mLe2KFXbyC%2F8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:37.5820444","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A37Z&sr=b&sp=r&sig=1TgljL3hj33cx%2F%2BFR3gzVBJsFdVCfA%2FxjiNbTHHy58w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:37.5819763","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A37Z&sr=b&sp=r&sig=gAP%2FRge%2BWTa6w%2B0Ijfrtn2UreF1PJp5U4LoJkgz1YQw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:37.5820588","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3259'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:37 GMT
-      mise-correlation-id:
-      - f49dd872-040b-4c17-90cb-0b4b829be95d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A42Z&sr=b&sp=r&sig=IiakPGjASxdRbEc1T%2FXwJVKmekZohRlXPv59ukQbg2g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:42.8767613","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A42Z&sr=b&sp=r&sig=qeRcgJSiHtcKDo9dPQFmoMW3QsT5vdwxdEs2rh4O9xI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:42.8766523","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A42Z&sr=b&sp=r&sig=kOPNgoA8CY6JEuXXzpig9vstNU%2FaClyfHxUsVSNqLiw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:42.8767845","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3247'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:42 GMT
-      mise-correlation-id:
-      - b18caf8a-a61e-4187-bffe-f6c9452f765c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A48Z&sr=b&sp=r&sig=nINhQ20nAaeG6ObntQ%2FFtv7fkgta%2BoYc8XCqDBtZzJA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:48.1788861","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A48Z&sr=b&sp=r&sig=sCo37RYYRw6W0P1gqiVocoF2g6G6ahawAyEsAOW1E94%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:48.1787676","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A48Z&sr=b&sp=r&sig=hfoaO7CwFRRlawrk1YP62RIcCJWt0dHYx8dH93VTVbU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:48.1789104","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3247'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:48 GMT
-      mise-correlation-id:
-      - bb8ec0a3-ba81-4097-a31b-1a81b36d58f9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A53Z&sr=b&sp=r&sig=D1hCJQUfjxL0o3enbs7xxtW4peUwBEMTjrpxOxW079E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:53.4653756","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A53Z&sr=b&sp=r&sig=GZaUQWfA7CPBKlUHK4xExd5f0Iz2FTOKcwodQINsy7E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:53.4652957","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A53Z&sr=b&sp=r&sig=SAmh2N3DMZXjiEkB%2FQ%2FOjohQSZCmndIRgx4SzvZLPq0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:53.4653897","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3247'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:53 GMT
-      mise-correlation-id:
-      - 44e6f47f-082a-4643-8191-83e9bb4feaca
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A58Z&sr=b&sp=r&sig=95mncOH2%2FYGsP619QRTHOEuBsv%2FDXdmHWQioHJbOeyw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:58.8022711","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A58Z&sr=b&sp=r&sig=7qs%2FDDfVyJt1MOC9VmQQx8FJUC6i2VUy%2FsvOVuDY7no%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:58.8021146","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A58Z&sr=b&sp=r&sig=qv6ROtB2HUlV01%2BIIVbSFnwIsaTIDS6kbMnDnACN3Gg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:58.8023006","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3253'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:58 GMT
-      mise-correlation-id:
-      - 17dfe3cf-0726-4706-a200-9bd970729803
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A04Z&sr=b&sp=r&sig=k%2FqJ8W3qOHamxCSz%2FBtslWZe6KI8hOb23Z4MX2vccig%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:04.0754424","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A04Z&sr=b&sp=r&sig=59LHs3XnqaNULDCLf9ZuRCqDDNnVYpKICn%2F%2BM5TVyEk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:04.0753308","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A04Z&sr=b&sp=r&sig=qui5QN05tmlV9n3rhfG0pEwLlBVQ5t0pb%2FKiPBqETVo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:04.0754674","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3253'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:04 GMT
-      mise-correlation-id:
-      - b08a3006-1579-4916-b320-727f74017f12
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A09Z&sr=b&sp=r&sig=%2F3ipJHd2cxLtSVZ2QqLYOmOpSXBMLq0j2PWCfAtegd4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:09.3618118","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A09Z&sr=b&sp=r&sig=XhkTabmpFrzPk1pyD5YEfZkcrzHd93EHH7I8C4KvoSo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:09.3617068","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A09Z&sr=b&sp=r&sig=FFfhD4lMRXVrD2UyUrsTFAIFmmOKKmUX1B3zcKRztNI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:09.3618378","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3245'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:09 GMT
-      mise-correlation-id:
-      - 5095be26-a570-43fe-9654-865c6a03a914
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A14Z&sr=b&sp=r&sig=M2kfq04xfX05VNKm2Hk4%2FBxlCvDi82xiVJ%2B2yjl6OqA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:14.6592686","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A14Z&sr=b&sp=r&sig=SoQ2KpRHStMM9y6CegKCZLoMltRtXVlzXjpCUyPzwxU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:14.6591835","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A14Z&sr=b&sp=r&sig=tZ1%2Bkcj0pEBeZH9ifIYOH3qJNoYQ6vaFxUMmRMkpMZw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:14.659287","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3248'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:14 GMT
-      mise-correlation-id:
-      - 4f35f346-d67b-4a40-b32b-888241a99c22
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A19Z&sr=b&sp=r&sig=aWz6eWTt%2BH22jlP0ikL0T2AlnvRlY4gDeiWq9OsDln8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:19.986015","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A19Z&sr=b&sp=r&sig=WnshXUQBVnJw8XSO4HMIFFlct%2FDwKOqi1hxxL5ZFVeA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:19.9859405","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A19Z&sr=b&sp=r&sig=VGaVvLMEnGPS3aTBKWbS3QB4fEPeoYGRcBpTipKv38w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:19.9860291","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3246'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:19 GMT
-      mise-correlation-id:
-      - 08c2f42f-dd9b-45ec-a5a1-cc38f0446e7a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A25Z&sr=b&sp=r&sig=A8zQPWe56LX%2F8%2B2Ah98ZjBQ21%2FBbORCPML8nQYL6H5k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:25.2643554","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A25Z&sr=b&sp=r&sig=kNHegWWG7zhjdQtVjuPgWl0vyDPskTW%2BNasMyCpatyU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:25.2642848","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A25Z&sr=b&sp=r&sig=IH8dOF5awRGIMB92i3izi%2FttvRYyCvjVW7s%2FL4CWa8g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:25.26437","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3253'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:25 GMT
-      mise-correlation-id:
-      - c03baf40-4911-4334-8a8a-1411200b6ba3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A30Z&sr=b&sp=r&sig=W3bFtDppqk9pD7zQ58YE0kIoMVJAwhezCwHSf4tvofE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:30.5416497","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A30Z&sr=b&sp=r&sig=v%2FcKHTW%2BwNTrgoctaCNsr3b7%2FV5gS2DzZ78SG5p8e%2Bg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:30.5415802","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A30Z&sr=b&sp=r&sig=LSc10Xv1xeLjSvHaleXt8R%2FI4h0rl%2BZntEic318biQo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:30.5416645","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3255'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:30 GMT
-      mise-correlation-id:
-      - 8d0897d7-3262-4c9d-bf1d-70e5608b869b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A36Z&sr=b&sp=r&sig=hySkBLTESgPJtLjshNArFxpLajiFb8fB1zgU%2FAjgWBY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:36.7009447","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A36Z&sr=b&sp=r&sig=QSrVjef9QwvRFe7%2BxNRvgfb2avwvtFs9IDai10K2VnU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:36.7008727","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A36Z&sr=b&sp=r&sig=ZN4%2BQ%2BEsJAQ0xWhP1e2qFi92fdikpfYx0N9OTBgJlxg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:36.7009589","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3251'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:36 GMT
-      mise-correlation-id:
-      - 2e23929e-b3f8-4f9e-bd83-4ba2c1d19d6d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A42Z&sr=b&sp=r&sig=9GqosRNOokbAS6sVId1v0uD3LWQCF8O0b7SM3xriJao%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:42.0148017","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A42Z&sr=b&sp=r&sig=5wOfsRgLLDTdByQdjKQxHyJUTla3F%2Ff0HsKUOYsu8LQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:42.0147228","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A42Z&sr=b&sp=r&sig=nR2Q38e%2BltYf7s5Q5yX%2B7rZOPdVXmUsb5gI0zj36UC0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:42.014816","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3248'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:42 GMT
-      mise-correlation-id:
-      - faf30478-f427-477f-a966-3f0078d96cc9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A47Z&sr=b&sp=r&sig=fAnlw1L18wAaxROR0ANIXSLTkRIbTe9Gbomo22z1KBw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:47.3396104","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A47Z&sr=b&sp=r&sig=0gU%2BtHi%2FwFSYX0ltODCgrEPYhrPztBx%2FkfpIw0gWcWE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:47.3395264","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A47Z&sr=b&sp=r&sig=c0vVrgKyY2OuX4%2BXITC9IuqFXSb34gbqbvi6UAyo7gI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:47.3396322","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3251'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:47 GMT
-      mise-correlation-id:
-      - e748da22-40e0-4917-ad54-bcf5e29d2496
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A52Z&sr=b&sp=r&sig=vbv%2FDxrQxJkjHa855UJIQE7WFwjZ9ryL%2Fhaqv45fiFQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:52.6586157","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A52Z&sr=b&sp=r&sig=2nSnpuQTDxwqV26O%2Ba6Hp38YKr1%2Fj9RvtGNj7Pt%2BMas%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:52.6585271","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A52Z&sr=b&sp=r&sig=XjAHa6DWQoQl7O1sghdPqhr5tTTS%2BeMJVqYDcThq0U0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:52.6586294","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3255'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:52 GMT
-      mise-correlation-id:
-      - fcfafd90-c7a8-43e8-a4e6-318452ff8d91
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A57Z&sr=b&sp=r&sig=pcIZpD7aiJ%2Fo1fQEKDtvebX85a%2F5hRFm%2B%2Bf6zzM0o18%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:57.9632506","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A57Z&sr=b&sp=r&sig=vdcG5fLqnDI3qzONXNW59Mb5fJA35HqRlLIqR5KVfBI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:57.9631765","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A57Z&sr=b&sp=r&sig=GRnkYuU9O5RQJuW67YaPIUH1mikJ63fhn5hTrjY3AP4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:57.9632655","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3251'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:57 GMT
-      mise-correlation-id:
-      - 430d5d94-54a3-47bb-93c8-56a1da582b83
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A03Z&sr=b&sp=r&sig=JasLxc%2F4z%2FU62vk9bduos8Nwra2FKWkfGcS1EBldcYE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:03.557568","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A03Z&sr=b&sp=r&sig=gFjaXepTsp8MUuayejFdY8nSXMbPFS2zFI9Slzq%2FhCE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:03.5574637","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A03Z&sr=b&sp=r&sig=YoDHHsRJXLRwwcF2oaybFsTbXz04kTjAlWkCR%2BkANuU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:03.5575854","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A38Z&sr=b&sp=r&sig=IT31i7MYFHdkNKAxa07ALQEh%2ByPrkFGse%2FIZYeoZlWk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:38.1335797","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A38Z&sr=b&sp=r&sig=twYmfifRqzjyxedR6JpS22aG9ckITEumw3Hiqmu4Qgo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:38.133509","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A38Z&sr=b&sp=r&sig=mjKZKlC8J10wqimRai6MGibBHD5BlaeX%2FLctXgPijkk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:38.133595","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:11.997Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1688,9 +896,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:03 GMT
+      - Tue, 24 Oct 2023 12:29:38 GMT
       mise-correlation-id:
-      - 4d6c1668-e4c5-43e4-a3cc-aec98bc69be3
+      - e7bf6623-0e2e-40ba-a039-faf7c920277b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1710,23 +918,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A08Z&sr=b&sp=r&sig=6bXhtwuIwsg8mYKIBZAV63OppLtCtZbj4ihlscPHuAs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:08.9202701","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A08Z&sr=b&sp=r&sig=syoBCjSjuzyDQYomtM1FIU919nGxnIZ4GsP6p7CCH2k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:08.9202007","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A08Z&sr=b&sp=r&sig=F3vmW3JIycoi2h%2FWomyT68xzbCp8YPXrcY%2Fds30%2FApY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:08.9202844","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A43Z&sr=b&sp=r&sig=cImVe3DfVvTfRduqTUJmSdM8RpHmvHHaD40kBFpcfxk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:43.4842552","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A43Z&sr=b&sp=r&sig=4ntOsqm0CkBrKC4J0g54df2TxNt5tpdS3b0SScDsyH4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:43.4841873","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A43Z&sr=b&sp=r&sig=LnfpSB%2FED1OQPhoch4GeBZaFZmOLwpnQLFUPbYpr4NE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:43.4842689","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:11.997Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3249'
+      - '3248'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:08 GMT
+      - Tue, 24 Oct 2023 12:29:43 GMT
       mise-correlation-id:
-      - 26bc009d-ce4b-4997-b018-521212e53041
+      - 04d20a5c-e35b-48e3-92f7-7484bb902653
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1746,10 +954,262 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A14Z&sr=b&sp=r&sig=G1MlhyrawO67kho6h%2BDU7P3rIfjVazfj23XnoqdF4GA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:14.1765174","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A14Z&sr=b&sp=r&sig=ntmBfKvVl5iT59L6VP8LpUZkDBnISQ4thbqdM%2F16uqo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:14.1763968","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A14Z&sr=b&sp=r&sig=zSPccjkPghQ%2FkBa9K%2FHZHeuZ5KVN5%2FyyRzn0zPUaoBM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:14.1765394","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A48Z&sr=b&sp=r&sig=JSnQtVJEM1pgq%2FGuq1Ke19dhzsvRssUTwDTpssN3gJE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:48.7708878","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A48Z&sr=b&sp=r&sig=t3pSYaJBiLVonlzNA03Hi5g%2Fv%2BRPL8oIHkRJz%2FeOGcI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:48.7708214","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A48Z&sr=b&sp=r&sig=nveMWlL6JGEABLIUuE2q5DSn%2BacrcB9dbYQBUMCrzbs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:48.7709023","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:11.997Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3256'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:29:48 GMT
+      mise-correlation-id:
+      - 88177697-4e47-43dc-a3f5-97e1fa5d6ea2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A54Z&sr=b&sp=r&sig=Nt95m1173v%2BpoFfvAwCOQgCZvHJitmWUQDBN%2FeBZTEE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:54.1390815","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A54Z&sr=b&sp=r&sig=%2B3kF3%2B75t7bbDkGwlmnRVUSVabIlXgbP2X7IMEfIoZA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:54.1390087","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A54Z&sr=b&sp=r&sig=Xx0FjqxggTEpIe0jj9unmxH1kzwcdO0HXiG%2FtHtgBqA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:54.1390963","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:11.997Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3256'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:29:54 GMT
+      mise-correlation-id:
+      - bc662ff6-78b2-45e5-9606-8ecf32291cbe
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A59Z&sr=b&sp=r&sig=UWeryib7NeH7v9L3mMlGQEyrspwrZfM1znkJq6FtTMo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:59.458533","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A59Z&sr=b&sp=r&sig=3x%2B19ScacxkDIA8mjY1phh60Rfl8lNADXyUn1YlONC8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:59.4584535","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A59Z&sr=b&sp=r&sig=qZ%2BI%2FQ25mEm886bT%2BhyO%2BY4%2BM8sJRegXqBQ6LbbqN7w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:59.4585469","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"CONFIGURING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.702Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3256'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:29:59 GMT
+      mise-correlation-id:
+      - 8a47a39a-9a2c-4fd8-94e1-bfb7abc4a427
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A05Z&sr=b&sp=r&sig=9chh2C3Dj1hQx6zndWCRcI%2BKp7oKoVui%2Fj4zntkLcUo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:05.1116794","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A05Z&sr=b&sp=r&sig=mcJrkhQjDroefTlbDN98cDuRfNb%2F3kuikz6f4izAUCw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:05.1115538","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A05Z&sr=b&sp=r&sig=MybXN1MIUSCg6DbhR7lq2V0bH5GyZGSUwCvA%2FkmHupQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:05.1117092","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3251'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:05 GMT
+      mise-correlation-id:
+      - 2a38c161-a56a-40a6-9d28-6b0ff7dc8612
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A10Z&sr=b&sp=r&sig=SX92kjEzyjRVBr0T4mDXawwZzSs0a8Knaje%2FIpNaHN8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:10.387646","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A10Z&sr=b&sp=r&sig=m6uIehj9gi%2B05MeGeiBpAOTUQiBU9KtzCb2EaWaURVY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:10.3875646","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A10Z&sr=b&sp=r&sig=hMqEehIMxXCLeKs27u56WNA9%2B15Xqg%2BX4gjGDFfsGlE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:10.3876628","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3250'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:10 GMT
+      mise-correlation-id:
+      - d650a8c6-6fd3-45ec-9f38-dc8ad9a2506a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A15Z&sr=b&sp=r&sig=bV0bTNBGNAgpYkKbsdf8wDb4nbAk0PgdwHMVDjE9vHE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:15.6794543","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A15Z&sr=b&sp=r&sig=44gtimqt6EpnsPcm%2B%2FK989mDh%2FbTSbjOYT%2FkgHj5j8E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:15.6793791","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A15Z&sr=b&sp=r&sig=%2FXZuwRjpgrI0ugup0pCMtfNuK3bLGtcEJeQRb%2FOIIkY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:15.679469","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3254'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:15 GMT
+      mise-correlation-id:
+      - f85942d2-789a-486b-b080-57a8025149cc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A20Z&sr=b&sp=r&sig=zEKS1T0M8BQUDqnulHMVJmUmILE1hBjBOBLW0ZzlnWM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:20.9782188","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A20Z&sr=b&sp=r&sig=8w9qcW6zJHBOBGHnsvpWdxUgHh45lqJL3qxBAJvHCME%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:20.9781322","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A20Z&sr=b&sp=r&sig=apqD1GrJnt1ehN2ADweqX9KnSAKWnlslV6qQe%2BbhNX0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:20.9782401","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3245'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:20 GMT
+      mise-correlation-id:
+      - f62c7568-4b7c-4f40-afa6-4ba8504c786c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A26Z&sr=b&sp=r&sig=Rm8tTLvNk6QQIgfARdXxbxP7eKz5DQN0hbpYnIFFg7Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:26.3705813","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A26Z&sr=b&sp=r&sig=4HvkjB%2BxG9lScrg5Ul5yGZo93rzAcnDiITT%2BJ%2F9hi04%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:26.3704805","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A26Z&sr=b&sp=r&sig=HY%2BmBJ%2FNZqRLCL4vXqpFuVuBgl4EuUb9Buz53FbanYs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:26.3705997","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1760,9 +1220,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:14 GMT
+      - Tue, 24 Oct 2023 12:30:26 GMT
       mise-correlation-id:
-      - 55f6977d-8023-43cd-b68d-4a95e2d57f34
+      - b445bb79-6a96-427a-8897-47bf88aae2ee
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1782,10 +1242,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A19Z&sr=b&sp=r&sig=TysKtgMl0UyZVWIdxyBT4ZvWoqcI3BxDOCTKPrv6FGg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:19.4853108","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A19Z&sr=b&sp=r&sig=nLbPRQ5Qbqx%2FSJGtM2pF598TJmXy%2BwEmZBzufnh0HMg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:19.4852069","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A19Z&sr=b&sp=r&sig=d2LBjrjHaVn6TosteasOuj7gKy9%2FnF0owwxxHdBmi6U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:19.4853339","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A31Z&sr=b&sp=r&sig=oAf5K9Cmqt%2B21SnIyT%2F7sS93wo92oeiW52M63cNDP4g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:31.7216915","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A31Z&sr=b&sp=r&sig=vJx8p0%2F1cdeDZWSwRb513BFiH1KTE38m2eJD0KUgSFg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:31.7216231","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A31Z&sr=b&sp=r&sig=YqkcB3Nor9d20EHaDpW80Ua1j06QHCOPSKEI83nJzQE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:31.7217066","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1796,9 +1256,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:19 GMT
+      - Tue, 24 Oct 2023 12:30:31 GMT
       mise-correlation-id:
-      - 0798978a-ff84-4516-a358-a847089de8e0
+      - 7ab9340c-8e35-4b73-81ea-3346b3bc2bfc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1818,23 +1278,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A24Z&sr=b&sp=r&sig=g7TKUX%2FsWWJ8HCQENW7mYG%2FQ0I6RktdqBqLpu1mpjVM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:24.796174","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A24Z&sr=b&sp=r&sig=2W5OgdrxkhpQhaeVcA6jt40atv%2Bab7nfexl75RIk3rU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:24.7960335","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A24Z&sr=b&sp=r&sig=m1mSLSHJaKCjVTOCyJbCM98SxDVqfZmfsWrY%2Bn%2BrqLk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:24.7961974","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-18T20:52:39.088Z","endDateTime":"2023-10-18T20:55:21.879Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:23.62Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A36Z&sr=b&sp=r&sig=SnmPGE6Bg13W7NIO7ESwF7gSarJD5vuU%2F4POdwNhhUw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:36.9891763","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A36Z&sr=b&sp=r&sig=jO2fLEp3as55wrcDKaCypY2EuKJVLFgfjY0mOGpfF4k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:36.9891078","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A36Z&sr=b&sp=r&sig=o%2BV3VSddCzGl4kvEoC13SWZU6wdVsiqUv%2FT7e9iTt1w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:36.9891905","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3287'
+      - '3249'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:24 GMT
+      - Tue, 24 Oct 2023 12:30:36 GMT
       mise-correlation-id:
-      - 135b17e4-c8a6-4d21-a27a-a23b5134002e
+      - 86529646-cc41-4beb-9f94-fe80e18846fd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1852,37 +1312,29 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:39.6895752Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:39.6895752Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A42Z&sr=b&sp=r&sig=CORUI3AIotfPToC%2FQaEGgCwjDv%2FkRwhgTa7PROVNxKo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:42.2704661","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A42Z&sr=b&sp=r&sig=Yn7ful1oNmXso6GGki4nu%2FJb0iNMWvI3A5BSL7V2saU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:42.2703801","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A42Z&sr=b&sp=r&sig=FZ1Ssdg8klEuqmAjrLJkDa0MMLx9EQpzWLY94zG9zFQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:42.2704884","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
-      cache-control:
-      - no-cache
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
       content-length:
-      - '690'
+      - '3249'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:25 GMT
-      etag:
-      - '"7500814e-0000-0100-0000-6530455d0000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
+      - Tue, 24 Oct 2023 12:30:42 GMT
+      mise-correlation-id:
+      - ac6a88d8-91d6-4ce8-a236-96e0963c962b
       strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
+      - max-age=15724800; includeSubDomains
       x-content-type-options:
       - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
     status:
       code: 200
       message: OK
@@ -1898,10 +1350,478 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A26Z&sr=b&sp=r&sig=RshwP8%2Brk%2BI6z1djQBlRemGC1O%2BNJ3XjPAoNu%2BwdgHI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:26.9411456","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A26Z&sr=b&sp=r&sig=92XF5gbmxcQ8Rj%2BFtaee40oOH8FOVFmu1DO1NCwBxwY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:26.9410657","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A26Z&sr=b&sp=r&sig=9%2BNEvCrAucr9hEtGICxX70b6q4li81eUEPNkVeSsRZ4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:26.9411647","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-18T20:52:39.088Z","endDateTime":"2023-10-18T20:55:21.879Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:23.62Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A47Z&sr=b&sp=r&sig=LADzU3cHYK2KAKzr9gMj36iYvVmNXuZVyYUmW4F8%2FQM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:47.5642369","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A47Z&sr=b&sp=r&sig=xyCdeOuVeMEApgVEf4xf4%2BryNW3bvdP2sb2UCwlRojU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:47.5641688","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A47Z&sr=b&sp=r&sig=t9TfAHZcF4I4iMGdRqC5Wd6bPjPwFtv88O2InaqC2E0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:47.5642505","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3247'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:47 GMT
+      mise-correlation-id:
+      - ed589be6-624c-4533-bbf3-1c42340cb8b7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A52Z&sr=b&sp=r&sig=I12Ghl%2BS59JBtMtNRRTCFKZd68jxu7mVs2BcnExY4kc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:52.8265227","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A52Z&sr=b&sp=r&sig=OSnlEq6EDQXbB5jqplza4dI5qrOXVeDc%2BK%2BKxDa2LmA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:52.8264389","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A52Z&sr=b&sp=r&sig=lhGfRU0f2EkPCUR%2FwWEQnEqn4Q6O%2FacuWooAzDqjg8I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:52.8265381","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3253'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:52 GMT
+      mise-correlation-id:
+      - 0d4b407c-3e65-4b3a-a25f-8eb444c170c8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A58Z&sr=b&sp=r&sig=%2BJxW2r03u%2Fmqj2HyoVo3mfRJu3ubDzZP%2BNb4kut16cQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:58.4962713","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A58Z&sr=b&sp=r&sig=%2FfuQQUNNrX3WB8epW4WGsSYJw0ZJ3QryA9xDGHBZQhg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:58.4961833","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A58Z&sr=b&sp=r&sig=e138rjpSj47%2BeM%2F4hiOJSy%2BUo0JMu7vl8p6OtzCsz9o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:58.4962924","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3257'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:58 GMT
+      mise-correlation-id:
+      - 834e70f7-a966-4a5c-b546-23c9490652dc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A03Z&sr=b&sp=r&sig=Hky45OGyoGiTMYjWaVtvfHE5msExF%2Bsu1Z%2Fp%2F%2BED8dk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:03.7794522","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A03Z&sr=b&sp=r&sig=BQVuPIsPO5DDKNdLT58ZCa%2BekuudFrNquy6eZTpPXao%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:03.7793812","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A03Z&sr=b&sp=r&sig=YjllfmIz%2FzMSYTt9lQwzlaG%2FmWVfEVyFvH3TEpBh0gg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:03.7794664","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3257'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:03 GMT
+      mise-correlation-id:
+      - 350aa062-93ea-4115-8e81-d0703229ef9e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A09Z&sr=b&sp=r&sig=CPCA7EvJ1VxJVsMii6N0UESTR%2Bo3JKZDGWGhExg6Y%2Bo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:09.0521707","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A09Z&sr=b&sp=r&sig=WWBo0TIntvHECX5f2BfHip5SrAnNgp7N6CB7yu%2FETWM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:09.0520768","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A09Z&sr=b&sp=r&sig=tWiJR%2FLBfQS9YpGotF0gKx51vaQd6BK3z3e4SYx2KZk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:09.052194","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3250'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:09 GMT
+      mise-correlation-id:
+      - a737cb27-24a7-48d2-8842-5b3f72c66287
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A14Z&sr=b&sp=r&sig=k5QvgPyYf5HFvw6qrR98LB%2F9dae7JB68VvCrurUtDo0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:14.354957","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A14Z&sr=b&sp=r&sig=Nf8qaeDeIqQdarf70TcY5yLXMT8zH2LXai98UnThs4I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:14.3548808","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A14Z&sr=b&sp=r&sig=nKJkcM0K%2BaE3FDsknZgjAzkaGb56G%2FbOL4Vr8%2FjybGY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:14.3549739","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3250'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:14 GMT
+      mise-correlation-id:
+      - 63c48e85-0f5c-4e11-9682-0e05f72d5192
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A19Z&sr=b&sp=r&sig=3mloBzZEr6B99QjwT4qpGuQJF4pihHtjTbFZ8KmptsU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:19.6410117","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A19Z&sr=b&sp=r&sig=FhO7iG4uTDn29m9jh4VFkZrsliS%2FxMigDP8bOubkMUU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:19.6409249","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A19Z&sr=b&sp=r&sig=ijMi4UxMJ5d0JGcC1GgfwoW54eRwMIEfmc%2BTL0p6rb0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:19.6410343","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3247'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:19 GMT
+      mise-correlation-id:
+      - 5485c8bf-e92d-4d4e-89e1-5eda88c3db31
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A25Z&sr=b&sp=r&sig=IlsVlhWYZ6NM9upN55tc6TUuKkl2JloCfx%2FV4ChBuco%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:25.8905345","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A25Z&sr=b&sp=r&sig=7aUmKm1NYKEU9lGpjBoEucLMfblTyXnO%2BWPSnlpolTc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:25.8904577","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A25Z&sr=b&sp=r&sig=ofWiQ0Mync09bdcEK%2BcpjfdrETPVDwtPMtfF1NGwKYc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:25.8905492","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3249'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:25 GMT
+      mise-correlation-id:
+      - daf8d9f5-0d32-4ff2-b10b-54c2f5b6a6cd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A31Z&sr=b&sp=r&sig=W97Wxu3w9UT6cQvg8SnUOsfX970Yk95bSHxTwpp5fYU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:31.2161344","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A31Z&sr=b&sp=r&sig=IVtvdMHnSXP2748R181rLhFh8TEP0ffG%2FssgF0xtvRg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:31.21602","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A31Z&sr=b&sp=r&sig=%2FPifLT4kkBk%2B9JNNgfwKj02LfIZ2Jhvg%2Fz3h8%2BbOmjA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:31.2161605","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3251'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:31 GMT
+      mise-correlation-id:
+      - 8a49a645-148b-4864-b2b5-c2192c38fc66
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A36Z&sr=b&sp=r&sig=NMsqPjXT9OD3LhZKH8ZtYg1NZq4m0JC94GnHaEnMA%2F4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:36.5271456","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A36Z&sr=b&sp=r&sig=sj%2F88hXocnPU9zKYjEyscjGW2CE9kjnWWgdKCJkV%2B54%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:36.5270752","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A36Z&sr=b&sp=r&sig=UjSYbxAHFas%2FKb9WbTd7ZshqY5CiVyOADEo4OJ5XLWU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:36.5271602","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3251'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:36 GMT
+      mise-correlation-id:
+      - 6a7abdbb-e38b-4a5e-bdc8-6a43f23ca650
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A41Z&sr=b&sp=r&sig=K7a1FAQ5EmGoatg3eCg77FScXZ%2BxdWyo4NCmcrtolUw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:41.8594374","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A41Z&sr=b&sp=r&sig=pukQbMPzuUC9ouEOuYFVmoJqolgP9jPxdd74zyqzZYE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:41.8593526","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A41Z&sr=b&sp=r&sig=CCcQgRYbQbD6E2ENkdHSsvisb9jYT618NDZGryqgsgM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:41.8594597","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3245'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:41 GMT
+      mise-correlation-id:
+      - 200160bd-347a-476d-9a79-109d3d6c4284
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A47Z&sr=b&sp=r&sig=R4MVUWopIUFgI3fW5KPtBpdEb97pIdvOE9c9Vz945S0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:47.1161768","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A47Z&sr=b&sp=r&sig=59Lb6BauUJsgiLANCIi943On1M85APGuvbUjZCQ2ilw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:47.1161022","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A47Z&sr=b&sp=r&sig=OFWZdg186kDtPk7gK0tqqKU%2B0Mqc1aWvSitzi6XIyVA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:47.1161924","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3245'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:47 GMT
+      mise-correlation-id:
+      - b86f673f-1927-4fb4-b6d9-af498c74506c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A52Z&sr=b&sp=r&sig=4R0%2Be640J%2F7uNRTnlu71hFSvHP0dzJFD98cz%2BnRQWH8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:52.4241345","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A52Z&sr=b&sp=r&sig=JLyIkKhwHBD48p5p3FJCKzkAlEYhAtSWokeSPojul%2Fg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:52.4240488","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A52Z&sr=b&sp=r&sig=NeYUs5oKpbuyzyOKXHdS3GsJemAd87wtpu921hPurQI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:52.4241497","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3251'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:52 GMT
+      mise-correlation-id:
+      - 1680ca35-b487-46ec-b926-6216dc2a4f71
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A57Z&sr=b&sp=r&sig=5AHC3zs1hVuW6noN55%2BK0aBcMDGLR8lJ2Yg5c9kn1uk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:57.8369763","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A57Z&sr=b&sp=r&sig=bxC%2B3pN5gtWbOmeQHZSkpqTa%2BcO%2B31UEEchmYMp6E8A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:57.8369095","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A57Z&sr=b&sp=r&sig=jMuf%2BHvTKgM1MvepYn8i058chQz0nvmaRm5%2Fo52OjAA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:57.8369905","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-24T12:29:11.794Z","endDateTime":"2023-10-24T12:31:55.06Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:31:56.807Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1912,9 +1832,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:26 GMT
+      - Tue, 24 Oct 2023 12:31:57 GMT
       mise-correlation-id:
-      - 184e8911-a590-45d8-8c17-76c5109a8e94
+      - 9054c6f1-2959-4bb4-bc9b-abf6d66111e5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1937,7 +1857,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:39.6895752Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:39.6895752Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:11.2483666Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:11.2483666Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1946,9 +1866,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:27 GMT
+      - Tue, 24 Oct 2023 12:31:59 GMT
       etag:
-      - '"7500814e-0000-0100-0000-6530455d0000"'
+      - '"d300e23b-0000-0100-0000-6537b85d0000"'
       expires:
       - '-1'
       pragma:
@@ -1978,23 +1898,103 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A29Z&sr=b&sp=r&sig=%2FE5Wxw%2F%2BLuGNvp6d0aVVC3UtvEa2Rc2DHIxfiAyZIPc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:29.3019492","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A29Z&sr=b&sp=r&sig=j%2Bqgg%2FpuxHre%2FpOMz04J6tLo4wxAmeOMx1LUL4kmPJI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:29.3018577","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A29Z&sr=b&sp=r&sig=fIBI%2BFcCgsmDqZn8%2FHzAkrCwHwYY1WCp33tKbdhbqFY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:29.3019718","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-18T20:52:39.088Z","endDateTime":"2023-10-18T20:55:21.879Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:23.62Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A00Z&sr=b&sp=r&sig=WLXJ5MMr86dJ2noulzrDp3sOHYAj%2BvFLIMjAuB9o9GQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:00.2865177","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A00Z&sr=b&sp=r&sig=6s6dKwHN9HZWQGyhPVsmJHap%2FpzaSXQY3hG0jWxrFf4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:00.2864154","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A00Z&sr=b&sp=r&sig=4a0tAKJSX1%2BO%2B0mW8crlYUBQ2O0VJzzc6m6QCdawmHw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:00.2865402","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-24T12:29:11.794Z","endDateTime":"2023-10-24T12:31:55.06Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:31:56.807Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3294'
+      - '3286'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:29 GMT
+      - Tue, 24 Oct 2023 12:32:00 GMT
       mise-correlation-id:
-      - c9a8b9df-0d10-449d-991a-79986c524d1b
+      - 965d2f07-1b29-444c-b586-50ba260bed7d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:11.2483666Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:11.2483666Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:32:01 GMT
+      etag:
+      - '"d300e23b-0000-0100-0000-6537b85d0000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A02Z&sr=b&sp=r&sig=Jn3ZzcnEWK82rS4QQeisqwmxZ5LRxfxkZywXe6iR5qU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:02.9352502","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A02Z&sr=b&sp=r&sig=zxyGZDSziHORkCHSb7z%2FCWGm7tGf35uQhBV8vTl7V2g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:02.9351757","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A02Z&sr=b&sp=r&sig=w7cTj1%2Bm5gVfhxhhS9yyrUJc9UNSR4I%2BQ4ErDWdBKek%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:02.935264","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-24T12:29:11.794Z","endDateTime":"2023-10-24T12:31:55.06Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:31:56.807Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3283'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:32:02 GMT
+      mise-correlation-id:
+      - b58e4272-3717-4cf2-abfe-c9eb0f2a68cd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_create.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_create.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:44.1306584Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:44.1306584Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:02.4219126Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:02.4219126Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:18 GMT
+      - Mon, 30 Oct 2023 07:21:35 GMT
       etag:
-      - '"3c00ad27-0000-0100-0000-653edabe0000"'
+      - '"3f00836a-0000-0100-0000-653f595f0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:21:19 GMT
+      - Mon, 30 Oct 2023 07:21:37 GMT
       mise-correlation-id:
-      - b1f3d013-1d9a-42a9-bce5-3636d4c5f7bf
+      - ba60e4bd-bdd1-4a66-a1d4-823bc9aff1e8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"dda1905b-f02d-4f3b-85d8-b09f307a348f": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "f46ebd85-3b86-4296-b63e-f9bb751d380a":
+      {"passFailMetrics": {"83b6a7ba-6955-456a-8782-ec747e59328e": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "a6430162-af4b-4349-8b20-76d49268b24e":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "3ed39a8e-2b5f-413f-b17e-437ddf203435": {"aggregate": "avg", "clientMetric":
+      "50"}, "8740175b-e23b-46c5-9682-c02564078871": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:19.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:19.868Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:21:38.433Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:21:38.433Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:19 GMT
+      - Mon, 30 Oct 2023 07:21:38 GMT
       location:
-      - https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+      - https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - e4a582ea-557b-4b2d-9082-f5f515d95078
+      - a23d8fa1-6db6-4be0-b953-419e2743c281
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:20 GMT
+      - Mon, 30 Oct 2023 07:21:38 GMT
       mise-correlation-id:
-      - 51f14d07-6eaa-4ebe-98a7-039bddf455dc
+      - f829023b-1298-4353-bc7a-16eb8821d179
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A20Z&sr=b&sp=r&sig=v3gwEzYCTHMX%2FUQLxjzdo5t91EcD8lrXEqr3%2FVXQjPs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:20.7847772","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A39Z&sr=b&sp=r&sig=Kw3EYLtTliyjsNbVzOtsU4PEBSKDMCdDPps4RxeKUqw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:39.9458135","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:20 GMT
+      - Mon, 30 Oct 2023 07:21:39 GMT
       location:
-      - https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 49e7b3d5-ee6e-4dee-9e11-f7cf8a289677
+      - ea281105-73a2-46e1-9c93-7200f1f23b1d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A21Z&sr=b&sp=r&sig=25WlEUr8gcQnFxQAFLEMqkzUuFLFTPGiF6m91mkTRaE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:21.0213365","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A40Z&sr=b&sp=r&sig=eStDMXpv2yO%2FXXOLpQ1rcNm7CcxCrxI2E4GaYINdbwQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:40.2254785","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:21 GMT
+      - Mon, 30 Oct 2023 07:21:40 GMT
       mise-correlation-id:
-      - 96fcde5c-f042-49e7-9056-fb8d35befc38
+      - c2e41a1c-d601-4b36-b4aa-505060ff6f3e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,10 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A26Z&sr=b&sp=r&sig=EdUOOXqTORZ5etN40EyW8hYdFWC6rlFvMcEup18YJbM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:26.2687926","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A45Z&sr=b&sp=r&sig=IEaJ7vCNGMBBaS4hAaBrJAb66ITGcOMHsaSHkAuVS5k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:45.4920081","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:26 GMT
+      - Mon, 30 Oct 2023 07:21:45 GMT
       mise-correlation-id:
-      - e07cebf5-22a2-4791-95ef-1bff3bcadd22
+      - 475179c1-ec18-478c-8029-978d2c32acf8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,10 +385,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A31Z&sr=b&sp=r&sig=deC0zX%2FC4UjXbF7M%2FaZWCv1VCo9kPtSfef1ZLaz3jvU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:31.5238975","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A50Z&sr=b&sp=r&sig=HwQzy45%2BSsw%2FiBggOix5qF%2BwTcEiqCzx7zcy6emjhmM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:50.7628818","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '555'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:21:50 GMT
+      mise-correlation-id:
+      - 003a2cda-dd40-47c6-9c98-a6613d5ba9ab
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A56Z&sr=b&sp=r&sig=OUmtZsj3PfgTMSsV30aq%2B3yCI%2B0Pyie4Y7N7wHu%2F2WM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:56.0927438","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:31 GMT
+      - Mon, 30 Oct 2023 07:21:56 GMT
       mise-correlation-id:
-      - bdeaa36f-1e3b-4184-8b2c-aaae168a8c90
+      - d4bd0f67-5165-4f5e-90af-dfb49471793e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,47 +457,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A36Z&sr=b&sp=r&sig=KqMJF9kLAudtanZFRAIBl7IeqV%2FrNFORtPJmKtBrODI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:36.7855727","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:21:36 GMT
-      mise-correlation-id:
-      - 59dacbbb-3c1a-42aa-91d8-7f3255244548
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A37Z&sr=b&sp=r&sig=QoyQ2tk9KOCZKCEz0tegmQEmGeWkOtzW4tQtwMINT%2BQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:37.0378001","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:19.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:34.624Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A21%3A56Z&sr=b&sp=r&sig=far%2F1ovXLqxQP9WplCUFvYAUN8bxzOA2H2ZUePOtZkw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:21:56.3946199","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:21:38.433Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:21:54.386Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,9 +472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:37 GMT
+      - Mon, 30 Oct 2023 07:21:56 GMT
       mise-correlation-id:
-      - 16476148-4f98-4560-98ab-820a889d3ed2
+      - 30f8cd60-5872-4e24-a41d-27b1935e5a59
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:44.1306584Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:44.1306584Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:02.4219126Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:02.4219126Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:38 GMT
+      - Mon, 30 Oct 2023 07:21:57 GMT
       etag:
-      - '"3c00ad27-0000-0100-0000-653edabe0000"'
+      - '"3f00836a-0000-0100-0000-653f595f0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A39Z&sr=b&sp=r&sig=nykJ7T%2BIqOy172izmpIEox%2BKrUJV5NYav0%2F5IKtxJik%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:39.1772576","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:19.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:34.624Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A21%3A59Z&sr=b&sp=r&sig=v1uqbZ1uF2Cowxj7MA1ZNQ3YfgLwGKbmITSTtOajlo8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:21:59.0583396","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:21:38.433Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:21:54.386Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1595'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:39 GMT
+      - Mon, 30 Oct 2023 07:21:59 GMT
       mise-correlation-id:
-      - 9971ce7b-fd41-4297-be6b-412f5618832e
+      - eb576f8a-79c2-4e40-9b0f-9f4f551ba5cf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:44.1306584Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:44.1306584Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:02.4219126Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:02.4219126Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:39 GMT
+      - Mon, 30 Oct 2023 07:22:00 GMT
       etag:
-      - '"3c00ad27-0000-0100-0000-653edabe0000"'
+      - '"3f00836a-0000-0100-0000-653f595f0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:21:41 GMT
+      - Mon, 30 Oct 2023 07:22:01 GMT
       mise-correlation-id:
-      - fb7c4dcc-b8da-48b4-bad2-89508574bbba
+      - 1141889c-1278-4475-93b9-351c4eb4251d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -664,25 +664,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A43Z&sr=b&sp=r&sig=6%2B6RtrSAvp0s2Guj7Tjw1ZkjwTBM7AuzJPDMRCzfqnk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:21:43.2381699","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A43Z&sr=b&sp=r&sig=AGUdlE43kgM78Z7nENZj7R4cJkPvmgDQGOl23PWbOPg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:43.2380687","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A43Z&sr=b&sp=r&sig=wuVX7HNadfJKtSSxftPkkFHZ%2FAOg8wgON1%2B6AzM8ip0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:21:43.2382185","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:43.155Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A02Z&sr=b&sp=r&sig=b%2BMGZZNe3pyUlvVueUVh4uOwWIsmqOFrc9cLTVRVj2k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:02.4718753","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A02Z&sr=b&sp=r&sig=hMpIkb%2FkEMWXInr1d94jLcHBDwvSpXcJ09axXpOc%2FxE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:02.4717689","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A02Z&sr=b&sp=r&sig=6pxXg08kgUxhfC0%2FUw0zlHI9%2BbafYpXCaI%2F41miwuqw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:02.4719011","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:02.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3204'
+      - '3211'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:43 GMT
+      - Mon, 30 Oct 2023 07:22:02 GMT
       location:
-      - https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+      - https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 01515c03-9a10-4b3e-b537-a33b2faff68c
+      - 0b3d283c-455f-407a-bc21-e088abbd7109
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -702,46 +702,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A44Z&sr=b&sp=r&sig=9%2BulmHqEc%2BhB82KzUYEl3M5H%2Bw8mrAq8jOkUjopfRyY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:21:44.5079973","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A44Z&sr=b&sp=r&sig=CN0dE2ZGBLTfDHQSqgA%2FsWsVGqwoWcLfwJT830ZE5ZE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:44.5079043","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A44Z&sr=b&sp=r&sig=srh94OkCxa87zvb%2BH59TWhVzQCpdztz5EEsWNqmuIrM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:21:44.5080183","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:43.933Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3255'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:21:44 GMT
-      mise-correlation-id:
-      - 4c7ef968-2227-4a52-b7bf-f6a3fb239a87
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A50Z&sr=b&sp=r&sig=05SCTPCpyqcZol%2F%2FSmvePnfdJ0rfdJEY4umFJQJaLUU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:21:50.1340556","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A50Z&sr=b&sp=r&sig=G1KcQ71%2BJ9pycpjW%2BaplhfdgiTJ6yYuDmJ265D9rQOE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:50.133967","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A50Z&sr=b&sp=r&sig=0eWFTN%2FL1D7G4lyS0gEHH5N5yGxBV5QODS9t4B9YRgo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:21:50.1340774","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:43.933Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A02Z&sr=b&sp=r&sig=8QQq%2FQ0Wco%2B1eFPdW8Kdi8Uyp57NVM7%2Bt8%2BlNN6Fveo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:02.9187018","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A02Z&sr=b&sp=r&sig=OodlBthikJuKJo0T7aSoX1vgjVUtSwjWn3tzQNHedxA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:02.9186075","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A02Z&sr=b&sp=r&sig=PZLBd62aG0OY6uP7pV1Bejo1pXJOcqWCTeK%2FhrcDLqc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:02.9187162","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"NOTSTARTED","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:02.807Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -752,9 +716,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:50 GMT
+      - Mon, 30 Oct 2023 07:22:02 GMT
       mise-correlation-id:
-      - 9faa557d-80b7-4c0f-9149-a5adc13f5252
+      - 03dd149d-e0a5-4c5f-8050-176e48b3558e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -774,10 +738,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A55Z&sr=b&sp=r&sig=BT8Rd5fbNU7PcM1Oa7oK1JzSGgQi01cusf9nsjI2EoU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:21:55.3946991","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A55Z&sr=b&sp=r&sig=gPp6%2BknZKat1v2b5XqALgXPSt9diQw0tG7fZpAfSzFM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:55.3946076","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A55Z&sr=b&sp=r&sig=%2FNSnYMz8MPYhe0VoJ7gBBK8hWfVOCAgiMkEWraOvJxs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:21:55.3947208","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:43.933Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A08Z&sr=b&sp=r&sig=bPKftbf2uccjRja2ZGIBZdA2mzEnmBv%2B2HQ6GYuDUiw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:08.2803102","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A08Z&sr=b&sp=r&sig=t48mqwgaN8abzd01h8eQ7CE49S6K4joBmSL1krrjAz4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:08.2802404","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A08Z&sr=b&sp=r&sig=pyL9R6GA88ZnpuFQAzjknav7OdytPwBAKlr9v%2FBT9uM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:08.2803253","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:02.94Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -788,9 +752,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:55 GMT
+      - Mon, 30 Oct 2023 07:22:08 GMT
       mise-correlation-id:
-      - d8b98193-c43e-465c-9ad4-9114d58f61d2
+      - d68e15b3-71b2-476f-9471-fd41c0877173
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -810,82 +774,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A01Z&sr=b&sp=r&sig=qoHVO4QtvSH4m8ShVklJI4uiF9deDng93xSxKcgf4BM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:01.6940644","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A01Z&sr=b&sp=r&sig=l2XIYWYEILEL9gJwxcBeo%2BRkEuOY40bSCuimRr%2FTzz8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:01.6939937","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A01Z&sr=b&sp=r&sig=njrEasBNmsJ9dWhmROGVd8fBRE1JAzKRQqgi9yKFkKk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:01.6940788","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:43.933Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3249'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:22:01 GMT
-      mise-correlation-id:
-      - 9cf1bd33-3573-492b-af75-78f2a61fe58a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A06Z&sr=b&sp=r&sig=BgKeDCOKvp%2F%2FGJH8jxRRfCS4l6SsfEBpROmxTkz1QPk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:06.9661149","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A06Z&sr=b&sp=r&sig=NOYPWArNk5utUiP0MPCT%2Bcr92p6%2BKsrmNOSWpFb7UvY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:06.966044","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A06Z&sr=b&sp=r&sig=UbdDU9tEC2KxWJvkz8kDrRvIUMI8xC%2Fm8eX86y83bLk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:06.9661293","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:43.933Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3254'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:22:06 GMT
-      mise-correlation-id:
-      - 3edb172c-1150-45f8-b477-004390a6e87e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A12Z&sr=b&sp=r&sig=jsTB8Kpd5YQUNg0EzS0I2dAXCLyKAAYSX3vV1ytkJAI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:12.2637264","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A12Z&sr=b&sp=r&sig=RlhA75S%2BSokxLySFGWRZvxE6H7Ff5Dk%2BygfyGicgVQA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:12.2636565","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A12Z&sr=b&sp=r&sig=3Jmu4HU3O5gCbWTGbbmB8N%2BJbvXfmQDHoV8Jk2I%2FZFI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:12.2637411","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:43.933Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A13Z&sr=b&sp=r&sig=iLkSp51l65RLIMLeMI9iKZeDYBAh4BlbfHzAjf90lL0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:13.6070067","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A13Z&sr=b&sp=r&sig=DRFn%2FmK%2FlwlSARTaWCCGDoS1AG6XRsFDHokBXKIy0MQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:13.6069007","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A13Z&sr=b&sp=r&sig=A9%2BSopLON6qGwi%2B8b6PdaB3S5hQiNecR7cJWarHxc1Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:13.6070338","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:02.94Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -896,9 +788,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:12 GMT
+      - Mon, 30 Oct 2023 07:22:13 GMT
       mise-correlation-id:
-      - 364d7e52-11f0-4dcd-8a99-2030420f84e0
+      - b5712172-cd80-466f-b899-0df138ce3d2b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -918,46 +810,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A17Z&sr=b&sp=r&sig=%2FZv5yZLTt1%2FrZyVLJOBgCJTgPCNN259AGNGita8lEiw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:17.8632316","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A17Z&sr=b&sp=r&sig=VWn3QR9kMYjTl1Lh4r0s0UBy5dwxV%2BK9CyyC%2Bdzt%2FbI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:17.8631599","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A17Z&sr=b&sp=r&sig=A%2BzZ7aS0Exe23xOeIvqVIkvTUMn3F43UpbMp5VvyqDM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:17.863248","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:43.933Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3256'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:22:17 GMT
-      mise-correlation-id:
-      - 0a003070-ed60-4a5a-ae9e-62a32fb0df8d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A23Z&sr=b&sp=r&sig=ieBbyJ478RhZjhjH3zL%2Bl5%2FQCW%2Fl1I0tuTsmxC5nMFY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:23.1285562","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A23Z&sr=b&sp=r&sig=ZQGWz1%2BBo9hIXj1H0Lxfxug3SqG4jwe0XODwMvuOnVQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:23.1284671","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A23Z&sr=b&sp=r&sig=LcBZxp%2BWO5y7pDcMrNqTRT7JyvkfAqcK0eSCcOdRVsc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:23.1285774","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:43.933Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A18Z&sr=b&sp=r&sig=%2Bp3Va4YhB2xohsFdpjFVlExBKnAPpoPkA%2Bu7%2B4gPbtQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:18.9218067","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A18Z&sr=b&sp=r&sig=lMwd4EJ2f6pDCLHS2umn7S%2Fvn8P1uSsEIDHLK0S32j8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:18.9217156","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A18Z&sr=b&sp=r&sig=u81JjvHQY%2BEmh11mH2GpBnizQapu4Z3PpEnaEzrlqew%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:18.9218325","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:02.94Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -968,9 +824,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:23 GMT
+      - Mon, 30 Oct 2023 07:22:18 GMT
       mise-correlation-id:
-      - ca50860a-7f68-4575-8db9-f5dbd12d7cc3
+      - 815e6b01-2598-4ad3-a603-7695bc933c22
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -990,23 +846,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A28Z&sr=b&sp=r&sig=hhWPRv8m4RSaOlN3W3Yu%2FA0yUB%2B6NgdtZRlXXjJ9h8k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:28.5062541","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A28Z&sr=b&sp=r&sig=V2nuHZPROqGDBCif%2B3yud4F%2FZgQIn4Gun1EeM4JY1Yc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:28.5061605","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A28Z&sr=b&sp=r&sig=QZKwFcH852AHCuKf3BniE4VrCUZWySJyvxnoJzS6V9s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:28.5062761","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"CONFIGURING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:25.266Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A24Z&sr=b&sp=r&sig=eC73xm4VEEJ1rwy9H7cklcZcy819g%2BIYbj2RcWpyW44%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:24.214486","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A24Z&sr=b&sp=r&sig=VKfEvI6yqbfsPY%2BHQvnnMfudPfLTrrPztMu1GvfASwo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:24.2144176","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A24Z&sr=b&sp=r&sig=frJe1PPMmEuuC3%2FAp36AXAS8meAEIqAyLLxfJLHY3hc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:24.214502","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:02.94Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3252'
+      - '3249'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:28 GMT
+      - Mon, 30 Oct 2023 07:22:24 GMT
       mise-correlation-id:
-      - 18a19be6-4b0a-483f-bf97-051d235a9a54
+      - 628feb8a-1c5c-4c09-93a0-f2f4a3f6d4cd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1026,23 +882,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A33Z&sr=b&sp=r&sig=sBHJ%2BsGpN%2Fnq8l1%2B4q9zANmBryAc%2B6nxBZXhL4LXr84%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:33.7640338","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A33Z&sr=b&sp=r&sig=reu4lKuJ%2FufgB5F6vjyHodGvcrU17u8B%2FNwfjayt9qE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:33.7639519","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A33Z&sr=b&sp=r&sig=pOyL0CsKcIRWOFBH1Bbpm3huhVRyxYJLdVeQ%2BKGwF9U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:33.7641725","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A29Z&sr=b&sp=r&sig=Vm4LC%2FuHFiNKF4JAMy6AuUvh6syDTf3Hu6TLnwKng7k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:29.4772767","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A29Z&sr=b&sp=r&sig=qWHcNXFlokxwq7LpBohtRmuQwN6iHGKSX5IWH12GuhY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:29.477198","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A29Z&sr=b&sp=r&sig=cUNCiV1JMO5nXgTBYlh7pyVk83TKQ7%2F3J53B42cC3Ic%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:29.4772923","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:02.94Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3256'
+      - '3248'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:33 GMT
+      - Mon, 30 Oct 2023 07:22:29 GMT
       mise-correlation-id:
-      - 13dc90b2-678c-4ab9-afed-892a070ebd30
+      - 4825537a-9b94-43f2-a758-10c1ec0ba104
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1062,82 +918,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A39Z&sr=b&sp=r&sig=22s7vu5QltbgewDVfxRB5nCDnVT8immUyDxFwmp6Zyk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:39.0269624","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A39Z&sr=b&sp=r&sig=Vm5hA3ioO9Hb2rWn%2FBqP000TENhSGC%2F8J4WzDlhBH4g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:39.0268815","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A39Z&sr=b&sp=r&sig=0AeGf%2B1cxKB6BPQa2Py6HxXudqobYLla%2Bg02fAEPZGI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:39.0269764","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3250'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:22:39 GMT
-      mise-correlation-id:
-      - 5729d8e1-eab9-497c-b330-0992e6d1644d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A44Z&sr=b&sp=r&sig=On2Mk7ej4R2JgS5C%2FFJZ8%2BrcwN%2BRuk2y93ej%2FW44ICY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:44.3293162","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A44Z&sr=b&sp=r&sig=FqU0hyGh4xcsQwY%2FVyv6CmAhz0fngm0VST60d3klUxw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:44.3292477","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A44Z&sr=b&sp=r&sig=WkEp7ziUMbruqpM9XDKC%2BUpskZ7%2F13IRo%2BkJ7yKfYXI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:44.3293307","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3258'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:22:44 GMT
-      mise-correlation-id:
-      - 7cf8ecc5-ae5c-4b11-80eb-ba495bcc9df9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A49Z&sr=b&sp=r&sig=WayL9VYPQS65ZB0xgQEtx3GSFyQBt2oy4z34aS13%2BCw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:49.6944345","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A49Z&sr=b&sp=r&sig=h%2Fgt%2BQ4KOE00Zmyxv8meU7loudw56o9V9juEMZZ%2FkzA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:49.6943428","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A49Z&sr=b&sp=r&sig=hQwtf2qy20VPBIUAVBX7HHRU7M3b3FuQvamJuI6arhE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:49.6944574","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A34Z&sr=b&sp=r&sig=6wIOcKfakwtH6bvCsf8ym0yh6ew0b3ueHC11h8R1L5U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:34.7304248","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A34Z&sr=b&sp=r&sig=RuuU8WD3H431WI6lpgaysKAgC7T5Rzxq1iW7WqidMto%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:34.7303403","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A34Z&sr=b&sp=r&sig=U%2F5MshLxRxMblCjMXXheI%2BxmHiQgoi%2FglGo0fdiZYxA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:34.730446","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:02.94Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1148,9 +932,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:49 GMT
+      - Mon, 30 Oct 2023 07:22:34 GMT
       mise-correlation-id:
-      - e3a80478-0250-4e8b-bbe2-1d5c9a6e711e
+      - 7159b24b-83f7-4756-acea-4893c6dc691a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1170,118 +954,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A55Z&sr=b&sp=r&sig=%2FT9IVyss3GSlGQYXR%2BCkWhRCjvAYp%2Bxo0aqRL3cQUEg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:55.061783","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A55Z&sr=b&sp=r&sig=8BudesILAu0m8RbHWP0bO5kZHUksN%2BfV%2FapOC543G2Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:55.0616981","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A55Z&sr=b&sp=r&sig=fCx5VDd9WHGXKGF6FT75s5a4GqvJ3Ce6HuRFKEaqYBc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:55.0617972","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3251'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:22:55 GMT
-      mise-correlation-id:
-      - 87158358-4cce-45aa-8795-7225e1839971
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A00Z&sr=b&sp=r&sig=i8rBQk%2BZIigc3tx0AsRHe%2FCkw7V9o8qxoCb7gPDVPiQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:00.3124417","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A00Z&sr=b&sp=r&sig=i3%2Ffjrg0wIG1Oi7y%2FTceMx0myriIwYSxKbmSeTQAfmc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:00.312373","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A00Z&sr=b&sp=r&sig=uUDWZl0GDs8rM3%2BlJ5UY9lRbbzNBJlJU1kyail8M5k4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:00.3124564","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3251'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:00 GMT
-      mise-correlation-id:
-      - f193777e-b1cf-42e0-bcc9-63355e89efcb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A05Z&sr=b&sp=r&sig=ievwjCx%2FVW%2FcUyVJCyCh7%2FwQ3gQc9CuOwKg0qcX6qKQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:05.5963881","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A05Z&sr=b&sp=r&sig=CIRFB8Y265HDE%2BsZiU57onsCnyB4TeRH4rX%2Fv5g9c5Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:05.5963152","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A05Z&sr=b&sp=r&sig=lTDITOmS6y%2BYHSDM3XGW2158l9opHmbidb25p9MHonc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:05.5964042","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3254'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:05 GMT
-      mise-correlation-id:
-      - 21d078fb-6474-47c1-8e18-3b78a1b1612a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A10Z&sr=b&sp=r&sig=TIkLT7dOOEng9iZqpZ0b9n%2F9Hf1Qx0Y1Gf%2FEuIr5SYM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:10.921073","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A10Z&sr=b&sp=r&sig=MlpejBJoD5iqc59ch49u%2Bg36HrFmUOKvSwtHeRkEd3w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:10.9209767","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A10Z&sr=b&sp=r&sig=qZippZ22hNdp7mtt5MQrpz5WkzXoSTdwbHkRUnpqyyE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:10.9210998","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A40Z&sr=b&sp=r&sig=fedIhmLw949FS1sAB2REFkF37v2EmNL3LQ7VSzeGFxg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:40.0169603","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A40Z&sr=b&sp=r&sig=H3m4jorLuurKYvc%2Backfpgz8rILh7vF0C13Od8J8k70%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:40.0168536","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A40Z&sr=b&sp=r&sig=peJKhcWZEu5EeEjL9eCTwpuj2VIUAbnKIZ8MuPOqYQo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:40.0169811","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:02.94Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1292,9 +968,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:10 GMT
+      - Mon, 30 Oct 2023 07:22:40 GMT
       mise-correlation-id:
-      - 136dc81f-4c1a-4382-8e92-c6071e064616
+      - 59433f71-85d8-4f54-bcd1-3a99729b1891
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1314,23 +990,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A16Z&sr=b&sp=r&sig=Niwpu%2B359y3zu0GgXC7VKSMUru%2BMTs4nqkZ3sHF%2FWWg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:16.2456123","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A16Z&sr=b&sp=r&sig=vojQfZyqA%2FRzYSTnUzERRYBo8zVYdxqaxqPKUzTwWuE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:16.245507","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A16Z&sr=b&sp=r&sig=GGHLUCk5nQGHt3WiJV8JT8jzJxFcVDHKs8LVypkeObg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:16.2456378","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A45Z&sr=b&sp=r&sig=AWB%2BbcqYRS7smykdcAxlsN%2FXS2yG8ENxbL7BYVR0b7Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:45.3462346","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A45Z&sr=b&sp=r&sig=hUmtvEUVY8nWYo4Z6O%2BtrS1IfVpsJzoye0oNUWgxAjQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:45.3461511","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A45Z&sr=b&sp=r&sig=mYFRF%2F4FpTj8d%2FE4Uh6k5tzW9odCSG0xqCpKZXbBRxk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:45.3462573","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:02.94Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3249'
+      - '3255'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:16 GMT
+      - Mon, 30 Oct 2023 07:22:45 GMT
       mise-correlation-id:
-      - f6616b8e-5f4d-4dea-acf3-6f33e8bf69d5
+      - 234424ad-e3a4-4f07-b1c1-0cb10b7da542
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1350,46 +1026,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A21Z&sr=b&sp=r&sig=g%2BXiqz%2F7LBWpbXW7x75A2fi%2B85bSIyK7Kw%2B1eIKWghM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:21.5859668","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A21Z&sr=b&sp=r&sig=0DvqQefcgPmf%2Bt1a4soRoYjGtwMBhPqfKVu1WrPFXvo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:21.5858915","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A21Z&sr=b&sp=r&sig=eadynicSD8PLW%2FJg1VyHWC3F%2BctQUA%2B6wOgIqwAr7k8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:21.5859815","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3258'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:21 GMT
-      mise-correlation-id:
-      - 7d62e305-096d-417e-9e94-ed929c2145ae
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A26Z&sr=b&sp=r&sig=lOIgISu95DpzhxGtqgEo44H%2F6xpluhTFHfDxNAG9Dq8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:26.8405073","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A26Z&sr=b&sp=r&sig=dZQGcHgIbQyaeYiH1x3CoSvhrGcBp7iypVW%2FVickr6Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:26.8404167","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A26Z&sr=b&sp=r&sig=Kjl%2BvcNzuVU5mh%2BaMr3ywBBhB0VhGrWvdcqOHLxBTO4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:26.8405333","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A50Z&sr=b&sp=r&sig=6v8oy8mpAgubPWOFPoS1MDikxAwdHKqcw0P%2Bh7AQMDY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:50.6725841","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A50Z&sr=b&sp=r&sig=071SsvhmjucMXhJd0IZAxyMIzEJ3jsYFTAaY5jXBhUA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:50.6724919","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A50Z&sr=b&sp=r&sig=zI%2FkUzooMZTJbqoHU1X23Sb6HwL8rptr6%2FLUQMUU3CQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:50.672603","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"CONFIGURING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:48.239Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1400,9 +1040,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:26 GMT
+      - Mon, 30 Oct 2023 07:22:50 GMT
       mise-correlation-id:
-      - 6f8cc4fd-6913-42d3-afa1-51df692a1dbf
+      - 894b99ba-8e84-4576-b0a5-be70fd1ee97a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1422,23 +1062,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A32Z&sr=b&sp=r&sig=16R%2F8bQjV2bTJF5I76ZgL4GKIB1tk5%2BnqXNv3p78l9g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:32.1237751","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A32Z&sr=b&sp=r&sig=OmxzDzDHm4%2BkdROKAdgs9SR5H0o25CQagW7zhTkJKBg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:32.1237054","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A32Z&sr=b&sp=r&sig=KQ16af0o2r6AIzzLrMJ0JUJpAd%2FnIeYP5L85RnjR5Q0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:32.1237891","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A55Z&sr=b&sp=r&sig=IXQT6N8WWkK1kIMjWLQHZ93dBocEaQwr%2BWFvZ1CYHDI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:55.9875816","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A55Z&sr=b&sp=r&sig=bP3NwmIuUH4fcP2%2FwmM9navab3vufBz2YUv9kVmrvQY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:55.9874864","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A55Z&sr=b&sp=r&sig=%2BSZB84Bl7lTCTGsLq9GnLC%2BomDY9jLI37fFTXiVf1q4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:55.9876024","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3250'
+      - '3251'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:32 GMT
+      - Mon, 30 Oct 2023 07:22:56 GMT
       mise-correlation-id:
-      - a04e9ee5-4780-491b-a186-9641a0c77526
+      - fd4beffc-ea8c-4752-90bd-398c728e3e6d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1458,10 +1098,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A37Z&sr=b&sp=r&sig=EkbV2ZOgxpOQ26BGBQx%2F4UuvRChrr%2FN31zLwD1Y4QPE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:37.373139","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A37Z&sr=b&sp=r&sig=aAQRupn50EQO%2B1b21m7bZk02x4aROUZs22dPDMT%2FNIE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:37.3730657","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A37Z&sr=b&sp=r&sig=%2BE6Fy2gd1TcQ%2B1sNLgJtXEUvbprqkz892MKFYg0CxwI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:37.3731532","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A01Z&sr=b&sp=r&sig=r17IoMEdhrsROLTbVI9juxz9Jg7hcPWCmrxA6%2FY3ku8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:01.3141594","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A01Z&sr=b&sp=r&sig=VRys%2BRFL%2FneP5IMxgRH3bDXFWcww7rqkDh9Ulv20mT0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:01.3140613","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A01Z&sr=b&sp=r&sig=FGPCd%2BQrs1AgxHMyPKYcVh7oc%2BB6cHQY2AY7U8ugit0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:01.3141826","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1472,9 +1112,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:37 GMT
+      - Mon, 30 Oct 2023 07:23:01 GMT
       mise-correlation-id:
-      - 3106a25e-3460-489f-9dd4-0a1b336b3b23
+      - c318b700-5eb6-4dcf-a1e3-1abbe9e48410
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1494,23 +1134,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A42Z&sr=b&sp=r&sig=ig8cqi8Nt%2FBP4YibfEhr%2BWAhW55vYPUr7Jr4i%2FDIPis%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:42.6718794","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A42Z&sr=b&sp=r&sig=0x%2BoGn7L7F9HW5Ert355euyPbjqRhefx3R3T4vXGjko%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:42.6718073","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A42Z&sr=b&sp=r&sig=KEzxH0GTOSj9FDXivyFdKtu3fiya4mt%2B0miJTVYJAMg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:42.6718937","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A06Z&sr=b&sp=r&sig=qLEfDfBssOZxoWdsfcF2eP0lMvomh5ukOvcIXQjBsgk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:06.6406013","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A06Z&sr=b&sp=r&sig=eXIMnbpJAHK8aCJmlnCqjfdkxcaY8khVNFded%2BlGa%2F4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:06.6405118","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A06Z&sr=b&sp=r&sig=haROzOvC1hd5GMqpVxI%2BqBpVUCMguqtFPuC%2BD1Ekwuk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:06.6406253","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3252'
+      - '3251'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:42 GMT
+      - Mon, 30 Oct 2023 07:23:06 GMT
       mise-correlation-id:
-      - a552077e-3042-4c89-841d-884873fd213a
+      - c35a7df8-8b9f-4bd7-b635-350d05a56a66
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1530,23 +1170,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A48Z&sr=b&sp=r&sig=VBhLysxFbJDEu0GHbjPoQ1M%2Fd%2B5oujcsLFKquSGy66c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:48.0066777","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A48Z&sr=b&sp=r&sig=9jUNTy9ck0eAeWNUOET9LjJkwhj%2Fc0CkVgVjVsEYyb4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:48.0066081","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A48Z&sr=b&sp=r&sig=zoZI%2BPk4yxSVJn97n%2FeAWfLBm0oNNhIaqThM0DnrFXY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:48.0066918","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A11Z&sr=b&sp=r&sig=0qKsg8iXzixFmB%2FWzL7njIqs%2B4UVvAAz41r2gmkhNdk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:11.9080204","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A11Z&sr=b&sp=r&sig=Pw6PiHP42xTnVsupSwL%2FULGv%2B2krtaJicWYktR1vwVs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:11.9079431","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A11Z&sr=b&sp=r&sig=mxYou3zWyxxtkpsA0ViEF8xeaE%2Bjit5ZKwVrrXmxNyc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:11.9080381","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3252'
+      - '3253'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:48 GMT
+      - Mon, 30 Oct 2023 07:23:11 GMT
       mise-correlation-id:
-      - 277e4ce3-d269-4f2d-9530-0b6fbbbedbd2
+      - e79cf4ae-bc89-471f-9e67-b331a2d247ea
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1566,23 +1206,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A53Z&sr=b&sp=r&sig=UNYGNllPxqabZEY4z7GG4w%2BF%2Fw10vCvX8IMZrDGFfqY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:53.6115406","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A53Z&sr=b&sp=r&sig=qZVh5GWDyOLUx3ua99%2Bd6ySgug08%2FsqgC6poem2MEAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:53.6114718","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A53Z&sr=b&sp=r&sig=P1UiAUzmZny%2FtD1oMAclOljGcxM7%2Bo9q0TDQnE1UAmM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:53.6115551","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A17Z&sr=b&sp=r&sig=kXi%2F1RthCwTMrLhLb9JvqtmrKWLJCTzkkJmLw%2FHHszw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:17.1790935","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A17Z&sr=b&sp=r&sig=f%2BM8SASnJlsLswDmC5ih985FSgcQ17stvnr0h%2FZ3ouw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:17.1790031","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A17Z&sr=b&sp=r&sig=kUL6%2Fb2jUTibvwGSZEF3itwCzEMzTipvUlyuheXsh%2Bw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:17.1791164","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3254'
+      - '3255'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:53 GMT
+      - Mon, 30 Oct 2023 07:23:17 GMT
       mise-correlation-id:
-      - 0607c3ce-4f1e-4b62-b953-93dce17a0cef
+      - 62cb6aa2-730f-4c95-817a-cd67a0229a1f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1602,46 +1242,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A59Z&sr=b&sp=r&sig=eduLrW6%2BD1Bl2BHFZrrNFPKdSn4jludt6ijDlFI33sY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:59.2233695","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A59Z&sr=b&sp=r&sig=F74jK671xa3refvd4ov63Sf%2FdgqS1dYlgrkGVY4nWkk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:59.2232957","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A59Z&sr=b&sp=r&sig=G1S0LNvkpgksW2PPcX7ozL74JMp2CIKv1a4c4LoIH%2Fg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:59.2233826","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3248'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:59 GMT
-      mise-correlation-id:
-      - 1c78abd3-d533-4935-80f4-6e9d3b7ca492
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A04Z&sr=b&sp=r&sig=G4oUl977WGf9jjVJeo7xa%2F%2F9I9KaaMBrvjW3naWBBPw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:04.4764349","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A04Z&sr=b&sp=r&sig=nEvAn60vtGgFBrzAJxLfwwfjlGF%2FWHSZBpb8S532ti4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:04.4763544","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A04Z&sr=b&sp=r&sig=fguC40YVxiVMSHwl9lX0z%2BIYmeQ5C5IkzsRIHnDmKow%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:04.476449","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A22Z&sr=b&sp=r&sig=A2p%2FoaCVyMVxLulB7XXmF3zATjbl1wBjzNwZyWkKsGc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:22.5130267","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A22Z&sr=b&sp=r&sig=X2BSpAkIjv8efFFLP0brHOOPZ5VJxTIFf5Rdp4Jjca8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:22.5129597","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A22Z&sr=b&sp=r&sig=dvxz7P%2FoCN0isiCsXPIroqrFb9%2B7lryi0QjiFudYe90%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:22.5130411","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1652,9 +1256,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:04 GMT
+      - Mon, 30 Oct 2023 07:23:22 GMT
       mise-correlation-id:
-      - bea971e6-5425-4f69-885a-27a2d7fadd81
+      - a212dec5-bbd6-4f7d-916d-5d525c454ac9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1674,23 +1278,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A09Z&sr=b&sp=r&sig=Cwfl640CPLXZzpmEMnmLit17f1BFwdtvqyijOBuDF6o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:09.7315354","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A09Z&sr=b&sp=r&sig=UDbVAPTBoQEL8jU2WYyXpYVJO63ych1axruc9abJdGQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:09.7314316","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A09Z&sr=b&sp=r&sig=yMftaMtx1qL%2BXAeH6s0B3Giz6tOUg8h0m8ZHuD0W7us%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:09.7315598","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A27Z&sr=b&sp=r&sig=EPoeQQA7%2Bqy8fpH5YDJlFKjoHFfw3hUDrPHdV6IisQA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:27.7824804","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A27Z&sr=b&sp=r&sig=4CGTXfU42ys3dvLTXX9PxE6Hp8uYsiqmej615%2B6LYWc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:27.7824138","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A27Z&sr=b&sp=r&sig=DxUgtha%2BD4aL010xH0qSwowXnJN9m3ZL6mWhMspG4wY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:27.7824949","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3244'
+      - '3249'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:09 GMT
+      - Mon, 30 Oct 2023 07:23:27 GMT
       mise-correlation-id:
-      - 75ea6081-bb66-45ea-bf9b-00cab51b9465
+      - 78744c22-51c1-48ea-9683-85a5961f3fcc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1710,10 +1314,154 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A14Z&sr=b&sp=r&sig=dsU67kpdM%2FblI56%2BTZYVl82xxk1lUMg513RB620n6J8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:14.9857899","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A14Z&sr=b&sp=r&sig=ohnXUmxa7vC8A0pI0%2F2aB5NVUJuaCYptHpSU1AjVFfU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:14.9857023","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A14Z&sr=b&sp=r&sig=Ux%2BLdQ%2F1TYfDFpZTBB98u2%2BXU4lB139ZXi4LqSpgO%2BM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:14.9858109","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A33Z&sr=b&sp=r&sig=bQ6C4VxNSj2tgYdVIt%2Bj9vN0hd7653UjJ6m7EDkVtqU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:33.0635713","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A33Z&sr=b&sp=r&sig=nBcW0BRP1AUUgbBGC74qXcbpfClpYpy24T4kBhJqgfU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:33.0635044","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A33Z&sr=b&sp=r&sig=QWOU8yhyoVfjxJZnB%2FEwv5d3SczFUE0YDMcYyZcKbcw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:33.0635869","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3247'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:33 GMT
+      mise-correlation-id:
+      - 1351112e-884e-4a4c-b8b7-ba5f1a33116f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A38Z&sr=b&sp=r&sig=9GbAi98z2dlOUhyCIKyvWUS0o77NtwKTaz%2FCqMAgxUc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:38.3849035","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A38Z&sr=b&sp=r&sig=g665JZWsNmT7p84AAbhM%2BxWCvpThFhmcYBfKgui%2BsoA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:38.3848054","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A38Z&sr=b&sp=r&sig=qhDhzwi%2FkGIfUxySMUdNLUE3GJpHOK9gV2pM8KPRU0w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:38.3849307","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3251'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:38 GMT
+      mise-correlation-id:
+      - 5a79a3f7-a5ab-4ae7-8fd9-97a81e9c1bd8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A44Z&sr=b&sp=r&sig=NFVK226zRRRvMmcl3YHgDrbPiWMLTMxA3tb4fEfXqWE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:44.0059179","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A44Z&sr=b&sp=r&sig=r11zPLETU0rfOyrfv4Y5pHrdl6o2GBX0ikTnr0hP2v4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:44.0058455","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A44Z&sr=b&sp=r&sig=7o9N923O6PSaXi5%2BAxccZBMXJTyoNM5gc5yNGYfHp1g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:44.0059317","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3245'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:44 GMT
+      mise-correlation-id:
+      - 81bcf1ad-54c7-4044-9595-aab2a835d2e2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A49Z&sr=b&sp=r&sig=U0Eb7skidJRnNMsVLPHh%2FceuUKcH%2BK1NySLwrJMYVE0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:49.3474541","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A49Z&sr=b&sp=r&sig=H2dZat%2BJEdX3iR9OWBCs79B%2F3gGGEXuEIxihE%2Bmqkts%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:49.3473552","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A49Z&sr=b&sp=r&sig=2YhToyUGdH37NfPx5neVXsYSOTwx8J%2B9hJVehGvt6vk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:49.347482","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3254'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:49 GMT
+      mise-correlation-id:
+      - ecfb1088-336c-4946-80c4-cb396a6253ed
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A54Z&sr=b&sp=r&sig=uJERaS7Ym%2BtIO2TWuq8C%2Fm8PLV7zET4ksRA31gOXnOI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:54.6978418","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A54Z&sr=b&sp=r&sig=HI%2BbpBobhLVzkOaBJzLWc%2Bk%2B9LUV4VGdXzALTcutAjU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:54.6977572","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A54Z&sr=b&sp=r&sig=XYdBC56%2Fi3U%2BvLp0MPnTW5VXg9iqYspEXqkIeUt0rHo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:54.697867","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1724,9 +1472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:14 GMT
+      - Mon, 30 Oct 2023 07:23:54 GMT
       mise-correlation-id:
-      - 3a20a10f-523e-40c2-b9a2-bec790749125
+      - 6027cea9-4043-485b-9706-a385810795f1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1746,10 +1494,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A20Z&sr=b&sp=r&sig=FmSC6uZyVkVd6nRusBSgLAteWsoTBT48%2FSSqci8dba8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:20.2567671","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A20Z&sr=b&sp=r&sig=uk7J%2F2ntHPCN5H6qgDCgyLjH7TQdnTMF9L76AW1Cffg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:20.2566739","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A20Z&sr=b&sp=r&sig=wo7dJz5BscFuO%2F0rAqU92M8axdyRwIWnAtISXrofeKE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:20.2567907","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A00Z&sr=b&sp=r&sig=LLONbWDcpmDKGhm0%2BGGQmwm7swnNtwPwbDckZ0Xsn5A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:00.1705009","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A00Z&sr=b&sp=r&sig=LshMuczI7hWg0usGQ36pNUtbYu04%2Fe5hy7r2FVdpyUc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:00.1704279","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A00Z&sr=b&sp=r&sig=7sXkJASsHB7Daj6GQKTzP8tVLcQnEfVtzZD9wg%2FVD5g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:00.1705154","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3249'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:00 GMT
+      mise-correlation-id:
+      - b3613848-1781-47c4-a70d-e0df36a2ce14
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A05Z&sr=b&sp=r&sig=JWzvXYtCBK%2Fq4xy7fBof4EjBG%2Bv%2B2VenbjAMIPQ%2BGcM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:05.5428181","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A05Z&sr=b&sp=r&sig=4syJuiHcY32GzShujNq1M4Kp6dB8Scdtw89SNcpdqJk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:05.5427452","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A05Z&sr=b&sp=r&sig=hfdTO9ZALLGjUuleupYahf1UkDLyv4Znccr9l3Pee34%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:05.5428333","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3251'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:05 GMT
+      mise-correlation-id:
+      - 023fe35e-5fb9-4b48-bb57-dd755abc7004
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A10Z&sr=b&sp=r&sig=86MAVCJ98LkR17VC%2Ffrb7TAJxMEcnerJx492d5mdDvI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:10.8492885","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A10Z&sr=b&sp=r&sig=Q5httnzNGLcYnTUjE7qiK4x%2FkF1hsCOZGZhcvCkWlWw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:10.8492098","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A10Z&sr=b&sp=r&sig=Wzp9CnXVxXE6HwDukXHvHYNdeFJaljW9xwLy%2FZydLdc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:10.8493023","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3249'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:10 GMT
+      mise-correlation-id:
+      - d06ddfdb-cba4-4370-bf9f-af6628005ef8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A16Z&sr=b&sp=r&sig=kLIPpk03X5bi4l6ky3sgQMy9Oqw9pv0qKn8SaEmuZYQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:16.185299","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A16Z&sr=b&sp=r&sig=oMsJ4MDy0k8A1gZiJeOgOQIv%2BqGUxaJars2B0TkGwpo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:16.1852242","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A16Z&sr=b&sp=r&sig=EyW1W1bj48t%2F61gbXQ%2BU0Ymn7p8L9jSu8UAHtt6ZpR4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:16.1853131","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1760,9 +1616,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:20 GMT
+      - Mon, 30 Oct 2023 07:24:16 GMT
       mise-correlation-id:
-      - 8754665f-e4ee-4bcb-90b5-3a5a667c6087
+      - eea16c7d-302e-4196-a9a5-0e40259a9739
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1782,23 +1638,203 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A25Z&sr=b&sp=r&sig=szsCs88E1AXYe1Dk3uIRW5SC%2Byk6vs%2Bh8z743KfTBGw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:25.513665","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A25Z&sr=b&sp=r&sig=wYslShif4MPMnp%2FwJFHLhCJ3cTteDXm8WAHAKTG1r8Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:25.5135568","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A25Z&sr=b&sp=r&sig=Y2oIhestfJDJwf8Qgi456engpiKjqeDug8jia2oW64M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:25.5136804","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-29T22:21:43.696Z","endDateTime":"2023-10-29T22:24:21.171Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:24:22.53Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A21Z&sr=b&sp=r&sig=86Wvpor0334z9h%2FqpA74KqWLzLVCzeOWeBxh8tRfkm0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:21.509224","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A21Z&sr=b&sp=r&sig=n4vFmVhPrxkqLBCY2%2Br9a2f7mmIh0%2BmAJhQiGR8rYDY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:21.5091349","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A21Z&sr=b&sp=r&sig=O6tXa4KRusDaGVDbYf662kcXRSD%2BJv8G5f4LaU%2FAzzQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:21.509246","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3282'
+      - '3251'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:25 GMT
+      - Mon, 30 Oct 2023 07:24:21 GMT
       mise-correlation-id:
-      - 9ffdc97f-c893-4b9e-afce-c5bde5c29038
+      - c8515d56-dbe1-4ae7-9024-4f749419b530
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A26Z&sr=b&sp=r&sig=V6SGoO33MbHDF1QQH0gmlb22QvFe%2BSUli8kMixoPDJY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:26.7771391","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A26Z&sr=b&sp=r&sig=6ROMrthriBEWrfI77pDMp2dXLx6fHiHDHuSciN4Zf3M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:26.7770719","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A26Z&sr=b&sp=r&sig=OLJtqBLHQecHSlIWiJMKMxWSy9gu90i5mhycZfxWNEU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:26.7771533","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3245'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:26 GMT
+      mise-correlation-id:
+      - afc0fee8-fb5a-4349-b745-cf572b90b4f2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A32Z&sr=b&sp=r&sig=0PtmFERCZ5Uh31NDnSWMF63wIgev4kUaOM1qRavK6yo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:32.0402545","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A32Z&sr=b&sp=r&sig=MgzZ%2FnVZTH8NdssyffUojiafkjbRZYdlXvIWRWOMl7g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:32.0401821","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A32Z&sr=b&sp=r&sig=DZZoX4250Z2ezu%2BesD%2FZ05vq21n%2B4ySK6VjxHNsnaJo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:32.0402685","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3251'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:32 GMT
+      mise-correlation-id:
+      - 6ff09e1c-a70b-4d51-98ad-da6b5ee03893
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A37Z&sr=b&sp=r&sig=y4qUwOvpy0Ud8dx%2FT78bp22Q%2F%2BYAO6q54P5dRVszXlo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:37.3008477","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A37Z&sr=b&sp=r&sig=2nlyZxOI0WbiMDvGmiG1vZxdnFCijeU0%2BDP1xeSDUnk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:37.3007809","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A37Z&sr=b&sp=r&sig=UHFF1sSjnR%2F%2FEC8OukNThvWyqgp3vs2NRVmVuAyzrjE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:37.3008619","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3255'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:37 GMT
+      mise-correlation-id:
+      - 77de3646-7448-4e09-84ca-82b0ccfd58b2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A42Z&sr=b&sp=r&sig=6QvaBnfzEGBSpUFONzUeByad5jCU4eNjplIKU94IET8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:42.6088173","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A42Z&sr=b&sp=r&sig=kbX7tjIMYE5dAPZTh8uTid0BzxwvDQNqMIBNoqxBbaY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:42.6087441","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A42Z&sr=b&sp=r&sig=ZRtzFGpQ1N1JwlbTEfRdt93BD%2FHFK7YvhYZidvLshZw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:42.6088321","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-30T07:22:02.807Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.353Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3245'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:42 GMT
+      mise-correlation-id:
+      - d7478412-a075-4fda-b78a-3c7841f8f82f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A47Z&sr=b&sp=r&sig=MK6uDpt6Tf4L6dUweJJ7tb6rjau%2FqyJKL9DvwQPNs78%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:47.9381656","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A47Z&sr=b&sp=r&sig=Xbk3%2B4FY%2F%2F%2Bfb%2B1c40Zk3JZ8HYz%2FyA8POM9nNfvXlqo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:47.9380969","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A47Z&sr=b&sp=r&sig=%2B0S4zIZhRuvU8lOLQBlt2%2BhVZlOTwnTfX8Tdt5kVZtE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:47.9381801","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-30T07:22:02.807Z","endDateTime":"2023-10-30T07:24:44.924Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:24:47.549Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3297'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:47 GMT
+      mise-correlation-id:
+      - 7b6ba782-863b-48f9-ba95-6ea69657642e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1821,7 +1857,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:44.1306584Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:44.1306584Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:02.4219126Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:02.4219126Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1830,9 +1866,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:26 GMT
+      - Mon, 30 Oct 2023 07:24:49 GMT
       etag:
-      - '"3c00ad27-0000-0100-0000-653edabe0000"'
+      - '"3f00836a-0000-0100-0000-653f595f0000"'
       expires:
       - '-1'
       pragma:
@@ -1862,23 +1898,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A27Z&sr=b&sp=r&sig=xuBmZ8Sj4X%2B5yL3qWIl5tdMA1ERxT2kdLre6RGgVe%2F0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:27.6292608","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A27Z&sr=b&sp=r&sig=ornLl7GmxsvuRErBsVkEet4Zjh6n2kAuV3FiyLZM3iA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:27.6291584","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A27Z&sr=b&sp=r&sig=newLcsMTfWOY6T4ZHLELFzFXF9Xi%2BQg%2FirU8ZoKMnlk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:27.6292759","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-29T22:21:43.696Z","endDateTime":"2023-10-29T22:24:21.171Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:24:22.53Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A50Z&sr=b&sp=r&sig=aR7%2BtS75qeYfFI%2FT18ifaw1u%2BpuRksNPyR5OqLFnrVU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:50.4754529","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A50Z&sr=b&sp=r&sig=ZVL%2B8T%2FomeYURVG9816MvQi9NZX0yFx5xj81OdaT9c0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:50.4753867","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A50Z&sr=b&sp=r&sig=91HvalpZirV6Zg2PvjCaD%2FRLZLWVd2nOyipRJGGQaTs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:50.4754676","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-30T07:22:02.807Z","endDateTime":"2023-10-30T07:24:44.924Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:24:47.549Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3285'
+      - '3291'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:27 GMT
+      - Mon, 30 Oct 2023 07:24:50 GMT
       mise-correlation-id:
-      - ac25d5a9-a07b-484e-b2c3-e39f57aa2502
+      - 08be14f0-a5f5-4fbd-a94d-ceb016aa34c8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1901,7 +1937,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:44.1306584Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:44.1306584Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:02.4219126Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:02.4219126Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1910,9 +1946,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:28 GMT
+      - Mon, 30 Oct 2023 07:24:51 GMT
       etag:
-      - '"3c00ad27-0000-0100-0000-653edabe0000"'
+      - '"3f00836a-0000-0100-0000-653f595f0000"'
       expires:
       - '-1'
       pragma:
@@ -1942,23 +1978,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://15c59b70-38ec-46be-81f8-e04102692932.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A29Z&sr=b&sp=r&sig=DIHzMb1UUpm%2Bxd5cZipPAuqf1blxwizSc3demzI6vnc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:29.7855984","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A29Z&sr=b&sp=r&sig=IaaZeXUL43TinUVT8LkZ2Rd5yIcZLStM4Do0%2FQxLX5o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:29.7855297","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A29Z&sr=b&sp=r&sig=aEogQ%2F0%2FoXSkCj7bihFy0E5uMFVzU%2FYbGWFf%2BQvBtdA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:29.7856148","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/8623bf12-7f28-431d-bfb1-1057dbfd5615_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A29Z&sr=b&sp=r&sig=H0tXFEbxuChu4rAUJ7ZBvvH5THfeH8aL3vpqGfHXls0%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:29.7856303","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/8623bf12-7f28-431d-bfb1-1057dbfd5615_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A29Z&sr=b&sp=r&sig=SNJP7WPhgznCx1j9GXrBAD9jf%2FXZi3Sgp0DhMdgGero%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:29.7856468","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-29T22:21:43.696Z","endDateTime":"2023-10-29T22:24:21.171Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:24:28.815Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"83b6a7ba-6955-456a-8782-ec747e59328e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6430162-af4b-4349-8b20-76d49268b24e":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8740175b-e23b-46c5-9682-c02564078871":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/559d1c4f-3c72-44eb-ba52-77a505cec535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A53Z&sr=b&sp=r&sig=vR0mn6hqfjEXPU6%2BClJK5UdDievnbbptZjT2pNTa8XI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:53.1497425","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/6e6b78bf-6ea1-4937-a547-f10c044c9f24?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A53Z&sr=b&sp=r&sig=1HCRajE1E1Yk6QamRo5XtllJiP0ZqAYxBTvEouMFJd0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:53.1496731","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/540dc01f-94f3-47ba-9a01-fcbbad6d15e1/069b3480-2933-43b3-a484-a9b0f0db6680?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A53Z&sr=b&sp=r&sig=%2BadtMDuPyrqVjKnbSrdpsOM4%2FZmNixTHw%2Bo1Mj4si%2BE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:53.1497566","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-30T07:22:02.807Z","endDateTime":"2023-10-30T07:24:44.924Z","executedDateTime":"2023-10-30T07:22:02.104Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-30T07:22:02.383Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:24:47.549Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4451'
+      - '3289'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:29 GMT
+      - Mon, 30 Oct 2023 07:24:53 GMT
       mise-correlation-id:
-      - e8141acf-4964-49a6-b3a6-a0b09e3f71b2
+      - b5c0f0c2-ba01-4667-9741-7ff22558e5cf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_create.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_create.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:26.2350862Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:26.2350862Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:35.5623435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:35.5623435Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:00 GMT
+      - Fri, 13 Oct 2023 13:52:11 GMT
       etag:
-      - '"5600b814-0000-0100-0000-652452040000"'
+      - '"d8014ceb-0000-0100-0000-65294b6a0000"'
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:19:01 GMT
+      - Fri, 13 Oct 2023 13:52:13 GMT
       mise-correlation-id:
-      - 6701ea33-f621-4a70-9bc9-697888fbbfe0
+      - aa97b8a0-a97e-4879-9869-b46b76d68e9c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"7eafd8ff-0693-4dda-8561-41deeb0eeb7c": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":
+      {"passFailMetrics": {"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "62171b6e-0d63-4366-b7bb-e961f9997a09":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "92ba572e-89da-4757-b0df-a6d5ddc50e43": {"aggregate": "avg", "clientMetric":
+      "50"}, "b7453971-1907-402e-a251-49d002301c4a": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -104,13 +104,13 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:01.836Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:01.836Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:13.691Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:13.691Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:01 GMT
+      - Fri, 13 Oct 2023 13:52:13 GMT
       location:
-      - https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+      - https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - d6407df9-7e8a-499f-8b46-e69200dee37a
+      - 6928ec35-133c-4654-bc65-589287527f35
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -143,9 +143,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:02 GMT
+      - Fri, 13 Oct 2023 13:52:13 GMT
       mise-correlation-id:
-      - f07cb74e-7cfa-4303-8e0b-6997ba36f2bf
+      - 893de3f3-3b9c-4e2f-80c6-f127f10f7626
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -273,27 +273,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A03Z&sr=b&sp=r&sig=1DAhF3MZ8qurLC%2BVOieejnwRhzJXb2%2Bln35DLEomRwo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:03.2982942","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A14Z&sr=b&sp=r&sig=Vc9fwLvA0ytvarQSpooNtIx6U3A3B74aj3f73RvPAWI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:14.4511192","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:03 GMT
+      - Fri, 13 Oct 2023 13:52:14 GMT
       location:
-      - https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 13491897-b45e-4e8c-8d26-4d7417321d34
+      - 430b87de-19bd-431c-991f-18e12aea5586
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -311,12 +311,48 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A03Z&sr=b&sp=r&sig=1DAhF3MZ8qurLC%2BVOieejnwRhzJXb2%2Bln35DLEomRwo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:03.6011739","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A14Z&sr=b&sp=r&sig=sg%2Bp6YKOAU%2Fm61H0%2FkuWr9vUwj8XkEhZ5eJZYXecews%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:14.7190711","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '555'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:52:14 GMT
+      mise-correlation-id:
+      - a2c37b80-8eeb-40b7-9038-72c06e61383b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A19Z&sr=b&sp=r&sig=sGL0JT273Y5A0Dp%2BjD476GSUaAWQ2O7ubUi%2BtLvor1Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:19.9671608","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:03 GMT
+      - Fri, 13 Oct 2023 13:52:19 GMT
       mise-correlation-id:
-      - 8fc55b0d-1635-4a87-9b8d-4f124618cb39
+      - af2b0602-1ce7-40db-bbc0-6474f709db02
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -347,48 +383,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A08Z&sr=b&sp=r&sig=PWXkgJrhuHrfMjW3Y9yW%2Bg2bjmy8cQ6qeh47OLmF5Js%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:08.9220881","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:19:08 GMT
-      mise-correlation-id:
-      - 3b17b3a2-9955-4e0b-9461-a47b6a95c744
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A14Z&sr=b&sp=r&sig=UtDCHqOJeIjaHJ9DS0QF6CNoXdy6Jh7RzeS6GKZbmxM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:14.1934386","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A25Z&sr=b&sp=r&sig=gnfWwdPRmqargl0Ji2lPXloiDnymA7tDg36ESJNvFQ0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:25.2258825","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:14 GMT
+      - Fri, 13 Oct 2023 13:52:25 GMT
       mise-correlation-id:
-      - a0cf8924-ae52-4f95-962a-2058179583bb
+      - 3fc643f8-96eb-4ae8-8157-6a6f32fac657
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -419,25 +419,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A19Z&sr=b&sp=r&sig=iF2LlzP2iJmMpwXIBdmZT7140wIN9Xnehiigpib01FE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:19.4817897","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A30Z&sr=b&sp=r&sig=tz0MF5Nb%2BghDkPjiWlkbOGjeW4EqlEGXmQLuE9JFHK0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:30.5041616","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:19 GMT
+      - Fri, 13 Oct 2023 13:52:30 GMT
       mise-correlation-id:
-      - 8f148375-c557-4c21-bcec-5dd8141e791f
+      - f9827615-296d-4a47-ada9-610d55bd094a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -455,13 +455,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A19Z&sr=b&sp=r&sig=JJ741TKYklUSWiwHCLlg8VCOWJmgznCPqYFamQDDFFA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:19.7826347","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:01.836Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:18.386Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A30Z&sr=b&sp=r&sig=L6snAWhvhcNdUdfP4hkozP5kLI02DtRwLm7bDrSC0SA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:30.7539678","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:13.691Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:27.761Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,9 +472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:19 GMT
+      - Fri, 13 Oct 2023 13:52:30 GMT
       mise-correlation-id:
-      - 42f6a0b3-0a8b-499b-981a-9439909bb043
+      - b50dc1f0-9f00-4cfa-89e3-8358fa7cd046
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:26.2350862Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:26.2350862Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:35.5623435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:35.5623435Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:21 GMT
+      - Fri, 13 Oct 2023 13:52:31 GMT
       etag:
-      - '"5600b814-0000-0100-0000-652452040000"'
+      - '"d8014ceb-0000-0100-0000-65294b6a0000"'
       expires:
       - '-1'
       pragma:
@@ -536,26 +536,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A22Z&sr=b&sp=r&sig=nv5OpbiySoS67RD8AWTHDru6Ef%2FWg9flaR%2BGGVbnEU0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:22.2457858","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:01.836Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:18.386Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A33Z&sr=b&sp=r&sig=BqyX1P8zHDJqUkmKJECU8iSiBLS6t44JAwi06uP4EO0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:33.2139599","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:13.691Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:27.761Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1593'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:22 GMT
+      - Fri, 13 Oct 2023 13:52:33 GMT
       mise-correlation-id:
-      - 1782e304-9aec-4c55-8c08-2874d8d77c33
+      - 71cad844-0097-498e-8cb9-cc8042880766
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:26.2350862Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:26.2350862Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:35.5623435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:35.5623435Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:23 GMT
+      - Fri, 13 Oct 2023 13:52:34 GMT
       etag:
-      - '"5600b814-0000-0100-0000-652452040000"'
+      - '"d8014ceb-0000-0100-0000-65294b6a0000"'
       expires:
       - '-1'
       pragma:
@@ -617,9 +617,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:19:24 GMT
+      - Fri, 13 Oct 2023 13:52:35 GMT
       mise-correlation-id:
-      - d7310c02-81aa-4604-a49a-978837783c65
+      - 3e6083ec-495b-4124-a334-edfbd0916b63
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,27 +662,27 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A25Z&sr=b&sp=r&sig=r9EF8%2FD6g%2BilfwWPnNIyrIiSp3xvEIR6yPQdLgz%2FHTY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:25.6614784","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A25Z&sr=b&sp=r&sig=BWYfFXfc5%2Fu6Dndd9u4f7NWfHG8MQJLFj5ycdaQkZRY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:25.6613491","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A25Z&sr=b&sp=r&sig=aoM9rbodpIyue%2F3Ey76Mru2FdeomIAd0ZLCI5p0JEgM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:25.6615387","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:25.589Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A36Z&sr=b&sp=r&sig=hcVfHOSZoW%2FHPxzGztjtCPuQF4je%2FMdJLDYAQUOJ3Ls%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:36.5754903","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A36Z&sr=b&sp=r&sig=pu5a8xpvijL8A7p9ky8indvzh5hVe1e0WWib98HkYqw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:36.5753928","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A36Z&sr=b&sp=r&sig=PTuHEEpc%2BIdF4mQMc%2BbnVK5BgbiorRF6IT7hX%2Fp%2B3U8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:36.5755183","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:36.504Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3209'
+      - '3211'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:25 GMT
+      - Fri, 13 Oct 2023 13:52:36 GMT
       location:
-      - https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+      - https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - fe7693da-b0d6-4076-8117-f8d6119c82de
+      - f46691db-a76e-46a1-ba98-20876ae0f713
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,25 +700,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A26Z&sr=b&sp=r&sig=yHJITbnMldR5Cmj1yIxS405%2Br2pTtgIWcSBwd7vXl88%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:26.5688268","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A26Z&sr=b&sp=r&sig=D2eFGkW888ZVwtJ6dkEcSeab1VBOx3CxBrM6gKq8%2BnU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:26.5687568","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A26Z&sr=b&sp=r&sig=SiluhJIpZjuGGkRCii7LPG8qc4cjUnX78Y8WSsjD5Wg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:26.5688434","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:25.589Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A37Z&sr=b&sp=r&sig=lUnuBM7nZBLyGy%2FQGoJA1lVc%2B7Zpc3CFpPcOu5y4i78%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:37.0170076","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A37Z&sr=b&sp=r&sig=0TOF4qNvdt3S3QwNoeo3wVzNgDf%2BOHFYexUsFGpLlOY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:37.0168977","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A37Z&sr=b&sp=r&sig=ycQt8LAKIjYIdOS7lKN69jniM8bbih7R0lHQa8BLUvU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:37.0170338","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"NOTSTARTED","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:36.886Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3203'
+      - '3250'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:26 GMT
+      - Fri, 13 Oct 2023 13:52:37 GMT
       mise-correlation-id:
-      - 06e2f8c5-f079-42fb-b03d-0b08cf060d88
+      - 166cc80f-8fe5-49b4-a088-cce216340a70
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,25 +736,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A31Z&sr=b&sp=r&sig=zyY0tQwZ7AiyqFnUdCawAOJbatFAr3oyY1jHBe1FN5s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:31.8809159","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A31Z&sr=b&sp=r&sig=d2Ix6bY%2BMueypsh2KnWOa7b2%2FJtpgMI2wdFtt5SexXU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:31.8808444","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A31Z&sr=b&sp=r&sig=Mge0AVBxVUrKXXVNVGQOoga42z9WEFXRyRpsNk%2Fc8EU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:31.8809303","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:26.936Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A42Z&sr=b&sp=r&sig=EaTPpZwnDYp%2BRpmCUtxh2Ny%2Bopmw0R9DJ1YOZG3GXu4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:42.2892961","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A42Z&sr=b&sp=r&sig=F0VzCzqt3%2Bjj%2FREdmWUQmlNlkT24fnv1QP0GllnlGrM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:42.2892278","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A42Z&sr=b&sp=r&sig=L8bmdsyaAXRjufAQDoQboM5wARP0TWJMgFCBC9t7mjg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:42.2893103","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:37.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3252'
+      - '3254'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:31 GMT
+      - Fri, 13 Oct 2023 13:52:42 GMT
       mise-correlation-id:
-      - 5f5d0636-04d1-4fa1-a51e-790dc86e61ce
+      - 594fe710-789c-4f12-8e89-3629d9100fa1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,25 +772,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A37Z&sr=b&sp=r&sig=w%2BMGY6ov2VAsUBnx%2B6gE5UaugnSR5e1HtL%2BIK1UWz%2B0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:37.2507723","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A37Z&sr=b&sp=r&sig=u4HYcNGdES1hv2GWwjVDQ7vWKxuLO9tuEbB0MK%2FxxTc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:37.2506868","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A37Z&sr=b&sp=r&sig=Kd%2BVAfNstG7yxUq3Cglb4LwDHSTzDI2npR%2BZHSaT61A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:37.2507894","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:26.936Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A47Z&sr=b&sp=r&sig=aKou3adyChJ9Qf%2BaO%2FAdRel4adJWgbyLnwOCZSdABGM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:47.5746486","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A47Z&sr=b&sp=r&sig=8UoM4XtxxKpaHDdSRIM2bhfnT1LH4lWuW6REAqfpm00%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:47.5745632","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A47Z&sr=b&sp=r&sig=bNBXmmLl%2BMX34x0Wstrl0IbgGhlCon%2FO%2BUl4vAxyeTs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:47.5746701","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:37.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3260'
+      - '3256'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:37 GMT
+      - Fri, 13 Oct 2023 13:52:47 GMT
       mise-correlation-id:
-      - 8538f03e-f72a-4f0e-b95a-e697af70daf6
+      - 90299d9a-e82f-4723-87a2-fca453c7bd6c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,25 +808,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A42Z&sr=b&sp=r&sig=C3ByVuh%2BIjAeK%2Bv%2B2MImG36%2FcvOY5SSSGQaJxcsQrDY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:42.5194763","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A42Z&sr=b&sp=r&sig=PY5Z%2BBuslGl2xeMLsx%2BsSXBIDQj%2B8BDxgAUBQn7bteA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:42.5193804","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A42Z&sr=b&sp=r&sig=u29tY3qQG95ELhiA3Zxd7FLwP2oCUZT8Ru2WiXwy4Y4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:42.5195005","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:26.936Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A52Z&sr=b&sp=r&sig=QLOjRet8u%2Bs7yClOhUHPlJ5KGFWBzONWxOb%2BiKXPVzM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:52.8909935","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A52Z&sr=b&sp=r&sig=8JoM0xmH25lDC3hquzP2miYy4RRgISrT9j768%2FC7%2Fgc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:52.8908863","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A52Z&sr=b&sp=r&sig=q%2FhTpSS4h3BFaBn5FkIQxZ8eYWCRo0oGQqcU2sfuhuE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:52.8910163","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:37.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3260'
+      - '3256'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:42 GMT
+      - Fri, 13 Oct 2023 13:52:52 GMT
       mise-correlation-id:
-      - d6942c5a-1b87-432f-9c0c-5bd1fd0efdac
+      - 3b7e0c16-9396-4aab-a095-533c868d3756
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,12 +844,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A47Z&sr=b&sp=r&sig=OGLG3%2BcA%2BYDZm%2BLXl6BqthmyuNWZ4ay6j6AtMhb9Zlg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:47.8117559","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A47Z&sr=b&sp=r&sig=UNxaWRAH6FsBxeOLRlTaA5GDzPw2ZM%2Fm9YBTB5KIcJU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:47.811542","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A47Z&sr=b&sp=r&sig=6iM320F26NnKTdu5KIzNhiqiL%2BHR93kCifVDT2hrwXo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:47.8117867","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:26.936Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A58Z&sr=b&sp=r&sig=bbG22twIQQR7n8fbrlnuG8Im%2Fr5fxe%2FqoFLNuIsn7rM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:58.194134","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A58Z&sr=b&sp=r&sig=7%2BXVwAwLACvKoqgDCvj4gLoSk7AklUE2I6bC6kd9x5M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:58.1940369","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A58Z&sr=b&sp=r&sig=ocM8G2D9NCTcZrq9CqK4oF%2Frdqs8Nr7A5cHzXwAF%2BwM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:58.1941554","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:37.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -860,9 +860,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:47 GMT
+      - Fri, 13 Oct 2023 13:52:58 GMT
       mise-correlation-id:
-      - 60e7a74b-2fd0-458c-a7d1-ac39d5f2463b
+      - 03cd0015-373e-4c40-9584-a28ed912786d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -880,25 +880,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A53Z&sr=b&sp=r&sig=Qd5DrQIfZPp4%2FRoSg%2BkcqJcE%2FrtNlMxtlymuYyWE0sI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:53.1141173","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A53Z&sr=b&sp=r&sig=CqjkJTCP6N5kBiP91OviOygez%2BbBhRg5n7G8%2BkCdAyU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:53.1140142","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A53Z&sr=b&sp=r&sig=8Tsm%2FaAbguRLev8CMuQijtBvenMG1xQhrguspAsNl9I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:53.1141394","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:26.936Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A03Z&sr=b&sp=r&sig=e2KuW0mL3SPB38pvl0GN32p4uqwVV48sxGFtmrVI8G4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:03.440584","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A03Z&sr=b&sp=r&sig=vSJdDnfEYfWKjos7bsiJ0Cprxp7%2F7pZE0aopaFxh%2FhY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:03.4404664","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A03Z&sr=b&sp=r&sig=maSZFc%2BRkhVza6XrNZiCfCF%2FNiIA4l0mh%2FcjyOIw%2BzQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:03.4406068","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:37.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3258'
+      - '3257'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:53 GMT
+      - Fri, 13 Oct 2023 13:53:03 GMT
       mise-correlation-id:
-      - ca6a83bc-1b2a-4f29-b4ea-de521b0f2233
+      - 5fc63fd3-550b-4022-beb8-729ab3aa698a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -916,12 +916,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A58Z&sr=b&sp=r&sig=F86pVT2Jo8Jnn8D2l5621NQ6CAAnonJs0l4lT8v9WIY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:58.3943442","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A58Z&sr=b&sp=r&sig=uBycrD4gQg5JBgclH530E5qWXBQuwkKqvpHVpxqRMVk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:58.3942762","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A58Z&sr=b&sp=r&sig=rkKk6D8mQg9pMSks86cPnwlO0p9u%2Fa5Tu%2F978%2BvFq8k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:58.3943593","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:26.936Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A08Z&sr=b&sp=r&sig=FTQ27WYeGb0YjDjn6Hxk9kR95koqBDUAIiLFt0deyYs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:08.7752335","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A08Z&sr=b&sp=r&sig=1kNla6J62PJXZ4YkBkXyFv%2Fi9xpj9p6RNVQvYs7CdX4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:08.7751341","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A08Z&sr=b&sp=r&sig=0aFSxIGkJAsR6FHJhfrcXPOz92dt%2Bfk10qSbzwRA%2FDM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:08.7752577","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:37.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -932,9 +932,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:58 GMT
+      - Fri, 13 Oct 2023 13:53:08 GMT
       mise-correlation-id:
-      - 474bdf39-a78d-4529-8430-d5c7939ce733
+      - a3c825d0-3fd1-48e8-ad22-cc14e43c3784
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -952,25 +952,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A03Z&sr=b&sp=r&sig=CZTLSAG9W51SIK23BuIR1Az7npE%2BPB8auWD1pAYHRX4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:03.7090459","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A03Z&sr=b&sp=r&sig=oTfdeRArJJsc7Xmd56NGsvKT%2FUYixSyQC6BIUQT3wzA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:03.708957","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A03Z&sr=b&sp=r&sig=QpMneEcJ2tmMpM3Tiy0REF9ZbO9HzoQ1IIXKj%2BxWvVE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:03.7090672","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:26.936Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A14Z&sr=b&sp=r&sig=6Cv4SaQLrt51oWrb5wj%2FXuMIRGvcZDWTqH7HHzpVH8o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:14.0138897","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A14Z&sr=b&sp=r&sig=QsJn0HzCLMPVErkDRnGOUXeE5TNN6BR%2Fws8PGNvAC%2Bc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:14.0138006","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A14Z&sr=b&sp=r&sig=YCgH0oXoiCmUbspZk6BQEuzoOqRgQjqTvTPGBTrBfU8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:14.0139064","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:37.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3251'
+      - '3252'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:03 GMT
+      - Fri, 13 Oct 2023 13:53:14 GMT
       mise-correlation-id:
-      - 9a10da3b-d06c-4132-8fdf-cd5a054cfcc2
+      - b104b835-35e0-4ca8-ab33-ae50b773e5b0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -988,25 +988,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A09Z&sr=b&sp=r&sig=14kAKSxk0bLW9BZ40wxdS6cFADsvdU8yv5LJ62Oyp14%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:09.0841769","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A09Z&sr=b&sp=r&sig=io24fd8dVJJfMTtextZCqa9AMpY%2FCfNoNXEHJxFPy2Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:09.0840723","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A09Z&sr=b&sp=r&sig=wMNvUHxPz6TuaDP7oPQXFlZRNwD%2Bi0%2F4JIox4srGeoE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:09.0842036","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"CONFIGURING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:08.599Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A19Z&sr=b&sp=r&sig=GzPqwoO6eLgSU2J8f12j5H5KKGQnZxhyNY%2FmmBS%2FBQs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:19.3260399","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A19Z&sr=b&sp=r&sig=fJfuf5mnRX6B8Iu1sMNggpkK8MGRfLl0t3RpbF%2BfguQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:19.3259388","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A19Z&sr=b&sp=r&sig=AYbbr6%2FGOQW9CQ8iFdJXzB2%2BEc43bxLJwjg5d3IwQ7U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:19.3260556","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:37.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3251'
+      - '3256'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:09 GMT
+      - Fri, 13 Oct 2023 13:53:19 GMT
       mise-correlation-id:
-      - 00a43e74-c335-4c67-8611-e320483775ed
+      - 1b2cf731-6278-4364-b05b-596b8032bbc4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1024,12 +1024,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=nDx1Lv6H7BxsYWlW7dDowlzPFcX%2B0DIWu6udevGFHa0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:14.3825908","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=J78NPHaHFdDUVUVSd33ETrfMekq%2FCeSlc1ZWdLR%2F0U0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:14.38252","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=25r0XRQI5yDUNg6qWb2fc1MoASe%2FPfFDD1G04KGFtJE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:14.3826048","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A24Z&sr=b&sp=r&sig=JeJjLpfJkk2oUZzWCjkjfm0KbxO%2FMQxP8NoUsc74kAI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:24.5754717","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A24Z&sr=b&sp=r&sig=FiXi7cWCOdQo9Db8yuGQTV3nXhCvpLzYORgoctb1Otk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:24.5754012","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A24Z&sr=b&sp=r&sig=%2BTio3mHa1C7dyexaFy70jLSNPgm9SefKl3lwOo8kvk8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:24.5754857","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"CONFIGURING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:23.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1040,9 +1040,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:14 GMT
+      - Fri, 13 Oct 2023 13:53:24 GMT
       mise-correlation-id:
-      - 78c52154-07e2-49a2-a926-2f1869268b65
+      - f9de5b76-94db-411f-9ff8-1cea83b01651
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,372 +1060,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A19Z&sr=b&sp=r&sig=wNVPVKnKO60Qe4Fn8jX%2FASOD6EtoN%2Bz8zLtoRutZV0E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:19.773071","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A19Z&sr=b&sp=r&sig=g%2BtmtyXkYQOrwH9xWsfr0BQbWzUPXt7V2Ht5vovcD20%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:19.7729876","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A19Z&sr=b&sp=r&sig=5sWYikJIvzt9kcudBsWx5lpM%2BMhESJOC8pwcxrrUNrg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:19.7730854","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3250'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:19 GMT
-      mise-correlation-id:
-      - b47b3da0-0415-4e2e-a040-fa50c0d14fff
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A25Z&sr=b&sp=r&sig=UZXh14D3bJ2RvRsP%2F8eeR6396nxmooxmF5AUnH6tfCI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:25.1164634","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A25Z&sr=b&sp=r&sig=JFOOWUKAIp68zZWIprMas7I3hjdnsUNmnnfK4vxn1Hw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:25.1163771","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A25Z&sr=b&sp=r&sig=99OVNGJafsJwbCVPezN6SHxMv2YMRjOK4Bc6KSoTWFo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:25.1164839","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3245'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:25 GMT
-      mise-correlation-id:
-      - 720abfee-0eb7-4079-b132-fc9b30db0e2b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A30Z&sr=b&sp=r&sig=UD24NmqbBZZCaoyy8if3kjCkJSXMQ%2BP7h1sQjvaI51E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:30.4011526","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A30Z&sr=b&sp=r&sig=Z9XpsMt5wPGaRXy6UNOR7MyIWHje5SRAd3Xh5RAMVqo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:30.4010729","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A30Z&sr=b&sp=r&sig=r2CJ2MhjjIf8sPaRUHftHizhjf6lvokQIePBRneBvuI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:30.4011691","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3245'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:30 GMT
-      mise-correlation-id:
-      - bfd551e9-841d-47bf-a6f9-a6339f6fd19f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A35Z&sr=b&sp=r&sig=Is6nGZr5uy3zVTNzVte6S4eCEvJQX3hqy3Av37b3xaU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:35.786187","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A35Z&sr=b&sp=r&sig=NpaWXPLLp6d0SBetHNiXLTiKUkqxDDGwLKj8%2BunT83Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:35.7861173","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A35Z&sr=b&sp=r&sig=czEK%2BjcF%2BnK8NXjdXSnri7w70%2BHYRRefaHhv81y%2Bmxs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:35.7862055","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3252'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:35 GMT
-      mise-correlation-id:
-      - 91d7bf17-2e52-433f-91d8-02fa8e0beeab
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A41Z&sr=b&sp=r&sig=BR3fBEt9YPTfDgYbcqZ7ZGWIChs3uI7N2MGjOlcBGUo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:41.0697667","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A41Z&sr=b&sp=r&sig=MvpYxpiz%2FK%2FbkFwhPb4HeeYFlc1GQ6doxgixNdNYZGI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:41.0696919","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A41Z&sr=b&sp=r&sig=lDeJAH4PQZ8Fihu9vl3hNNN%2BF2KbTngnGCOiz9aX9oE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:41.0697806","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3249'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:41 GMT
-      mise-correlation-id:
-      - 57ad51f7-3df0-4929-ab31-55a319ae8fca
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A46Z&sr=b&sp=r&sig=rjshGAjQoV4JSVtZ27%2BpHGquL95iCUKmg7WsHTMzt74%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:46.4412504","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A46Z&sr=b&sp=r&sig=gGuENa9Bh9klNX2jFg7IkDIH7%2BbQZeVSXueLMxYyMHE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:46.441175","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A46Z&sr=b&sp=r&sig=%2ByEwJWZsysiMqPO3LwwlmmC7BSyUxZHvfEeddpB7IGA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:46.4412676","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3248'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:46 GMT
-      mise-correlation-id:
-      - 4ab9f6db-bc44-4771-b831-1e74d9d43030
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A51Z&sr=b&sp=r&sig=ARO5a%2BldyZP1zSbeVZa2vcRNRU5a%2BoJp5iRKcoN6ep0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:51.7385109","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A51Z&sr=b&sp=r&sig=nSjOD1buYsEygAZLHN6qT858k94qQsaVhLeHowAYUJs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:51.738413","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A51Z&sr=b&sp=r&sig=QKcQiKrjKb2Ur0LRB1Z%2FKgw%2BfvCxgkidKw1ak%2BF6J3M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:51.7385501","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3252'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:51 GMT
-      mise-correlation-id:
-      - ae68892f-afe8-47c3-b38e-79e802ffdb6e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A57Z&sr=b&sp=r&sig=myGEesoRceTva0xk3O2zZdBD%2FZzvPecQd8pmsz2X%2Fbo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:57.139847","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A57Z&sr=b&sp=r&sig=gj6M60gxXSz0w1Rpkz3DtK2WD%2BThQ%2B8pC9VPftmBz90%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:57.138989","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A57Z&sr=b&sp=r&sig=0dRTNpfHfTEbq6tUuMjn1yJdR2eRA3G4oIAEsD20v5I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:57.139876","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3248'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:57 GMT
-      mise-correlation-id:
-      - 9f9c926b-bdc5-4249-a04e-2dccb3e56897
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A02Z&sr=b&sp=r&sig=%2BnH4rVjN2NH7r6R4MHyuE5lKJa3NuM%2BKzvIFFeRSvzs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:02.422162","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A02Z&sr=b&sp=r&sig=HBrQgpWGCMr6LwC%2BLeTGwNXrjttShUxFEcBpPm5FtzU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:02.4220716","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A02Z&sr=b&sp=r&sig=%2FqlzC%2Bl5uDnprY8NX72FCHQK3dMFsWdxuAPzD21aH%2BU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:02.4221847","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3254'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:02 GMT
-      mise-correlation-id:
-      - 9234daf0-0015-45f6-af55-b47561f3f308
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A07Z&sr=b&sp=r&sig=FzlSJe%2Bt7dYB1w41wXhw5f%2Fx2pyLfvMu%2BGXhCHPQqHQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:07.7216076","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A07Z&sr=b&sp=r&sig=2MYL2fsQAqUmuzFtZCqQGScLWqclGkU%2BYtoc9%2BLhBGo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:07.7215189","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A07Z&sr=b&sp=r&sig=jfxgbLFzDo8VH7Cj7nFhHv%2FCwef3D5l4EX84EemjJsA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:07.721628","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3254'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:07 GMT
-      mise-correlation-id:
-      - c9b792b5-4c1a-4728-bcb6-29b975edd5eb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A13Z&sr=b&sp=r&sig=wTenftXHj%2Fgkhv64t9HtD2zECBqjukPQVJQEo%2FhzgFE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:13.0501687","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A13Z&sr=b&sp=r&sig=hZBmHqSevlp4S2IwsRef9RWpdts0QPVnjJdUy5fCGcM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:13.0500832","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A13Z&sr=b&sp=r&sig=CR%2FdHDe2yOaIuXOQU%2FGF6OXJkzuCnmKRZ3sd193cEkU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:13.0501923","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A29Z&sr=b&sp=r&sig=w%2Fedi2yapuU1LBi7nguUOPCO3NnVR7Qs3isuuES%2Bnnc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:29.8818848","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A29Z&sr=b&sp=r&sig=WJqTyyUGBZbGY7OXnyPr91piH7DniBWjM3wbg9qe%2BIo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:29.8817742","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A29Z&sr=b&sp=r&sig=r9CyDBEhgo7J4h81dSff6aBI6tH%2F1D1qgnNl6xuLVP8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:29.8819106","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1436,9 +1076,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:21:13 GMT
+      - Fri, 13 Oct 2023 13:53:29 GMT
       mise-correlation-id:
-      - 9ec28964-c880-4db7-b6d3-cd61e0e65848
+      - 3ff7a75c-ed82-4e4c-a183-2b1fca6f0910
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1456,25 +1096,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A18Z&sr=b&sp=r&sig=fXPJB4SolkdOYYBC%2BWBtsaBsaB5hpIBJWa4%2Fqw0HGSk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:18.4020508","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A18Z&sr=b&sp=r&sig=k3mLt4oNP%2FjFBb63Yffsz2OMi5yq7ES%2B5o7r3KvtLFc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:18.4019606","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A18Z&sr=b&sp=r&sig=%2BLhykluWHBlZaJUHuOHQEcQuYILVG2gBNKtzmde7TCI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:18.4020733","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A35Z&sr=b&sp=r&sig=ULpep%2BFqJQUdeBRGm22UC1rk3OJRvoOIb5Upoo4SEB4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:35.1444235","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A35Z&sr=b&sp=r&sig=zJvmtY4%2BWA5nlHAh4gVEXf42eRyTW0vR5LNfrMzy9Lk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:35.1443404","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A35Z&sr=b&sp=r&sig=3P48JCwIpQzbvxckyIAnZS%2BvrV4iOOybZsUvg9xUHng%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:35.1444418","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3253'
+      - '3249'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:21:18 GMT
+      - Fri, 13 Oct 2023 13:53:35 GMT
       mise-correlation-id:
-      - f82d4ebb-ab36-4eac-aa2b-3409872a01bc
+      - ed25a665-fbb3-4c44-9afa-62b8f0d3ab4a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1492,12 +1132,228 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A23Z&sr=b&sp=r&sig=yEp3dmV3xiQaEoECQZLcX5UFMvBnm31Zbe0CQpTsMCs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:23.6757764","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A23Z&sr=b&sp=r&sig=WxawaM5Vwat0aGQdNXWsD50H23WbJCaJVpUA92VvKlI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:23.6756826","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A23Z&sr=b&sp=r&sig=REIszPnoUQmLifqdpegB8xr%2BK0YMrIfDGbCfWjr5zqk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:23.6757993","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A40Z&sr=b&sp=r&sig=RUm57aMOvK6gBsiEB%2BoPOPtjx5o1tZg27ytsvCoGM5M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:40.4078544","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A40Z&sr=b&sp=r&sig=rDR%2FrKhPhv2qL2Fogk073mMoc4IBsP4Wq9pm4PaB69w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:40.4077704","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A40Z&sr=b&sp=r&sig=l72Vopub78pINCSeBHrJbw1tcZdZU7UySz%2F1HxNG82I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:40.4078687","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3249'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:40 GMT
+      mise-correlation-id:
+      - a300724e-5a3c-471d-9c83-15fa7c8f1000
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A45Z&sr=b&sp=r&sig=ikKKrJuczWew0mUfTS4eTCQEshsnd4LO055btD5gfvw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:45.674115","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A45Z&sr=b&sp=r&sig=g94DsByICE8Ts%2BaTXdgLRHVBEmENIIJ%2Bm2soSWo5xdE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:45.6740233","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A45Z&sr=b&sp=r&sig=d5tVaa5jZ%2Bjk8VfEqlW8YpzW492IjUNcmGRPapRZwNA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:45.6741391","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3248'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:45 GMT
+      mise-correlation-id:
+      - 4b242372-277a-40fe-8d7d-4cdc4aa0dbab
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A50Z&sr=b&sp=r&sig=Sk5wKbho46kJzI8i8l8kX91l%2BjP%2BOL8AKuuuKSKof78%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:50.9219597","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A50Z&sr=b&sp=r&sig=IECdDV2oHy1j3SJUXjaJ1DzVEG3eVwrJwdmmK0ENw9I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:50.921863","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A50Z&sr=b&sp=r&sig=Uce3bwvm9hxH4DWTMKgDazyLnJ6FN%2Bkx8%2FvO5%2F0EvtE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:50.9219859","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3252'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:50 GMT
+      mise-correlation-id:
+      - 9de973b4-f80f-4e69-ad18-08d045be1589
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A56Z&sr=b&sp=r&sig=hOr9D%2F0e5snyA%2FcJqp9VjkujMrwnz%2FE%2BQDaeI78d348%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:56.1938129","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A56Z&sr=b&sp=r&sig=e%2BrWdwNCC3AIbqiswlh9JWGfcHEBeZl4aGJQ%2F2AmMQE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:56.1937428","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A56Z&sr=b&sp=r&sig=ZR2y9zJ7kE1eNmj0332HvUnjo%2FtvteaG47ELr3lIjTA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:56.1938277","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3257'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:56 GMT
+      mise-correlation-id:
+      - d0926e02-8ed5-4e81-a2d4-60a12fdf5da1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A01Z&sr=b&sp=r&sig=jbvWT%2B7o1tGtE0tq3Jpc8huZGUXUEeidK62TAiTDVJI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:01.5318243","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A01Z&sr=b&sp=r&sig=9473%2B3EdYw5J7Q8JGqQ9nyRQn90Fh2aLT2%2FN5B9xIhI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:01.5317367","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A01Z&sr=b&sp=r&sig=2CguxDJL42CgAYhTcVhXkSA4IEeIburdg9pAiOw%2BbPY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:01.5318496","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3251'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:01 GMT
+      mise-correlation-id:
+      - 9122e1d7-981b-4382-a637-98229a98490b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A06Z&sr=b&sp=r&sig=HCD6HB6SnY%2B9KmUsRnYocpt7q%2BXZDKWedYNsXFZN6Wg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:06.8378418","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A06Z&sr=b&sp=r&sig=YD2juGclermRVi8N7p9VvFtnDlETVwbfhDvp9joKM4Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:06.8377504","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A06Z&sr=b&sp=r&sig=v3Qj%2FvCajXwtYYFfPj6wMlFJl9P6%2FkTtMU2okJqFHwA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:06.8378631","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3251'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:06 GMT
+      mise-correlation-id:
+      - bc2cb212-43e8-4a8a-af91-df80fe84a511
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A12Z&sr=b&sp=r&sig=hDouDWXvUbhcA2iXzjmnFjszkpdkr2UTN2Pl2gz3oqM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:12.1463594","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A12Z&sr=b&sp=r&sig=jXieg4PghlLgxzwsm9tDqtfpiVz01kIDjsGARjAx%2BS0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:12.1462925","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A12Z&sr=b&sp=r&sig=IdDsaRS4f3g9tifkbwHKIZh3gSdjDOBEOBCIpMijiY8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:12.1463734","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1508,9 +1364,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:21:23 GMT
+      - Fri, 13 Oct 2023 13:54:12 GMT
       mise-correlation-id:
-      - a93725db-4930-4321-8c24-ddbf0e0d3007
+      - 42f255bb-7afc-4f85-9e4e-b22a0f3d103e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1528,12 +1384,120 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A28Z&sr=b&sp=r&sig=NLTLtfaI2qRPg6kdcFLiVjoel9iFvgevBs%2F6t7qgr0w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:28.9984533","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A28Z&sr=b&sp=r&sig=Ew7emDaJvAYM%2FbvWh8RC9ODJpnVOVFqWH88WVy59QXI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:28.9983936","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A28Z&sr=b&sp=r&sig=%2F6%2B0qUf9NPo%2B1ZSduLEFQyYcUJXo1xg18bxlIFCWrio%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:28.9984711","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A17Z&sr=b&sp=r&sig=5kgwUptWGjsyPWYDwjp1uW9QM5nsP1pspieSNUpji1w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:17.4149125","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A17Z&sr=b&sp=r&sig=g4urf7AWCA9rqEXx4E3reF5tGbKL3hI%2B0jhWCyoKhfw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:17.4148315","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A17Z&sr=b&sp=r&sig=DARlA8KgIITcd1IiCha6ek4vOfvysg9jhxWD2D0g1cI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:17.4149297","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3245'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:17 GMT
+      mise-correlation-id:
+      - 0f89a037-4f2e-4c57-985c-9e728c97fe00
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A23Z&sr=b&sp=r&sig=%2F84aT%2FV9Q04BQfii8JrMYTcuS7u%2B3DWJR6DmgBL77Vc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:23.075724","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A23Z&sr=b&sp=r&sig=wKihH20AnMQSy5rVwxU2aqaqbg5kJ%2BHr0msF%2FBp2NEU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:23.0756058","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A23Z&sr=b&sp=r&sig=Y7y47WHrINP4ZhXAq0KM4Fhx3Ad6ypmz7lu8ncEfeVI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:23.0757466","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3252'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:23 GMT
+      mise-correlation-id:
+      - 650ce1e3-8eef-49be-9441-4b4f14dd79e4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A28Z&sr=b&sp=r&sig=Ec2noGlaL%2BigGhqB%2Bi7i%2BipdI7i812D%2BlApPAZ%2FDsRs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:28.3404054","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A28Z&sr=b&sp=r&sig=Di2uin%2By8qWNgcfd7xX2KTJ5mOJ1P9Cfbr8ygmiLEvw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:28.3403329","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A28Z&sr=b&sp=r&sig=WAefGyozwYySIK8FloIPD%2F4CuZrW%2BSCNjvu36XmIYXo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:28.3404195","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3259'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:28 GMT
+      mise-correlation-id:
+      - d1cb564b-1461-46e1-a2ca-4c6b3b26d869
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A33Z&sr=b&sp=r&sig=e6DSIfyx6E94Cnf9xn%2FiB1xYoPkgt2k5JRZOPPEd60k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:33.6080096","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A33Z&sr=b&sp=r&sig=tWNQr%2Fp2MnJym92kxMUofNd8bDdmMLEJbxUnuLx1li4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:33.6079366","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A33Z&sr=b&sp=r&sig=qSPFz3gHWNcWwhIFhlXuE%2BJVlbX2WLbr1cn%2F%2Bq9vgHk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:33.6080233","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1544,9 +1508,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:21:28 GMT
+      - Fri, 13 Oct 2023 13:54:33 GMT
       mise-correlation-id:
-      - 228c162b-72d7-4ec1-88fa-3e252bac6dd2
+      - e15c5902-df52-4453-a34e-7b4ced81229d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,25 +1528,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A34Z&sr=b&sp=r&sig=9n%2B7Dp4q%2FzE0q7%2Bk3zLyPRFo%2BkTaaSkpjnXiEy9SXv0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:34.2831179","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A34Z&sr=b&sp=r&sig=ICtUc2S0EiE2rBsbjpP57OON7P86%2FyNPLAiFxJZIF3g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:34.2830207","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A34Z&sr=b&sp=r&sig=RaFW%2Bfnf8HAR74XuZO0ctTAA%2BPM7mV%2B%2BAwBQ57uSJSc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:34.2831373","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A38Z&sr=b&sp=r&sig=XGDSlwUTgxK5J8fTPjupTEPiWfTbLws60YmdhfUfy3w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:38.9122168","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A38Z&sr=b&sp=r&sig=UexmsP5VcsTOyG0C9LsmrMiCNY%2Foy68tv891VUGudvI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:38.9121436","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A38Z&sr=b&sp=r&sig=o0%2BvVdvbsk90VrFYzfnxMO2ka9dyW4zSQS5m9w4szk8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:38.9122325","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3261'
+      - '3247'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:21:34 GMT
+      - Fri, 13 Oct 2023 13:54:38 GMT
       mise-correlation-id:
-      - 6cc3dc71-d26a-4d9d-b1f4-25b9ed1a375e
+      - d3b98e26-f0c8-420a-b534-2f3e9299b6b1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,25 +1564,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A39Z&sr=b&sp=r&sig=J7oZ7pLKuiETBleKzlhwzvzqTpxqNYd7kS5YAgB92D0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:39.5533645","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A39Z&sr=b&sp=r&sig=ehaQK1RcbU3ETdY1ksJ7J0c8nXtzaMs1GhTcF0VXv04%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:39.5532979","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A39Z&sr=b&sp=r&sig=YvvKXUmlK25DFT5EjfKKXaw1f1iZXqSXscHokwFA3XI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:39.5533801","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A44Z&sr=b&sp=r&sig=fP%2BHG5LeL0Wo2f80gihhp%2BTia%2BEj7kJtrCXbiIkzsms%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:44.2281147","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A44Z&sr=b&sp=r&sig=G7XroimTd3t1dVSB1ywJxkW5WHl1ZSo5DjAX4uerWAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:44.2280168","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A44Z&sr=b&sp=r&sig=knmxWxR9LeqqWbLfs6n8a5LRLWtZmAb0KkQoNLawH5Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:44.2281294","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3243'
+      - '3249'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:21:39 GMT
+      - Fri, 13 Oct 2023 13:54:44 GMT
       mise-correlation-id:
-      - a0496518-f6b0-4313-83a3-8493d873891f
+      - 3fa3ddbd-3baa-4aac-b2cb-9415ab5af2b6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,25 +1600,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A44Z&sr=b&sp=r&sig=4GJr4dQvj%2BzUOEnDu0SRF2yI70EfWGvHQDuZcu%2Bpp%2FE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:44.8690285","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A44Z&sr=b&sp=r&sig=bQWSbetyGyk1yWQZEXXHZHQr%2BpeU1Ww3PUWAXhrnDlc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:44.8689629","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A44Z&sr=b&sp=r&sig=8EcAsM9A2h6Atjyci0mp66N7KvH7Ox9zRWNXswfpSzo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:44.869044","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A49Z&sr=b&sp=r&sig=kGRNacyOrV0hWndO0MKXi7UpvCLsd2nHIJWP2TbEvfg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:49.471402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A49Z&sr=b&sp=r&sig=%2FVDEtPsjFVVbp4ufiofF%2FHmto9ayx%2FNoC9zrJcwbXB0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:49.4713385","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A49Z&sr=b&sp=r&sig=f%2FahcHqMCbkdQDYwP86IwAl%2B%2BGhqw35IXeynwgAylWk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:49.4714164","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3250'
+      - '3254'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:21:44 GMT
+      - Fri, 13 Oct 2023 13:54:49 GMT
       mise-correlation-id:
-      - 8cf5612a-56a0-4e7b-9568-81fd210be314
+      - 508b9a06-f9b5-4150-a7f9-899803134dd9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,25 +1636,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A50Z&sr=b&sp=r&sig=8idhqPx%2BxNESAt8%2BJFx7O%2BOcAQHxj8ltU1mrsok6t5M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:50.1281631","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A50Z&sr=b&sp=r&sig=t3zRsfaqoGPqeLZDnoFPt9NhPLkeUlzJNeYG%2BAvEu1g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:50.1280676","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A50Z&sr=b&sp=r&sig=OXDOK%2FX0Rtvg53pgb2FqOcOocjjFA1VhBVwMdQYHdz0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:50.1281773","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A54Z&sr=b&sp=r&sig=gg7SOuewdlRQIO8xCFAn38EoLbrEPgcWIcDnXaeKhv8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:54.6972158","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A54Z&sr=b&sp=r&sig=81xMxd4ENw04kWRehvIuqBn0u%2BDFmvwqDBpcyf5b2rc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:54.6971151","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A54Z&sr=b&sp=r&sig=vaVUfhQh2lsMpQPC4Wa6Mnn%2BR34ouYE3gVpJ6IPQIT4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:54.6972372","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3253'
+      - '3247'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:21:50 GMT
+      - Fri, 13 Oct 2023 13:54:54 GMT
       mise-correlation-id:
-      - 640f3bf8-b7bc-4fe8-b379-c1dbc94bc523
+      - 7714031f-72a9-4019-8345-de035c854506
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,48 +1672,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A55Z&sr=b&sp=r&sig=EHnwECcjyhNfa5sCJlvVQIUNOfh%2BNcW3ipALCjLfVk4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:55.417523","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A55Z&sr=b&sp=r&sig=08v072bmdnpvPjyWzoZScpkSzWeQfhBFWczfbr9gRzg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:55.4174454","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A55Z&sr=b&sp=r&sig=27R73FyPwYc%2B7Bc3uuy%2BDR6V4%2BEMFwf1pehN5qTHNG4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:55.4175393","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3250'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:55 GMT
-      mise-correlation-id:
-      - d563e78b-937c-4390-955c-8205b9f63c81
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A00Z&sr=b&sp=r&sig=XQTxTwKa7cLIt9XEroclIgPC45G%2B5ZUSPw%2BWTWVK%2FaA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:00.6671996","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A00Z&sr=b&sp=r&sig=DIMuBao3gt%2FlxopAcgieh08PnRKbedmezdUrPupQSzg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:00.6671297","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A00Z&sr=b&sp=r&sig=WiI%2FIDqHqP1aGNdpLA9cPdzWPzQnOSomSMQggaagrJE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:00.6672158","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A59Z&sr=b&sp=r&sig=uXij4X1VYEZEb1P3OnFUtPmU5gF9jcnOk8i%2Fp01Vig4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:59.9357663","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A59Z&sr=b&sp=r&sig=HqJrnANcsCCt%2BAgTpMj0IZj4gMl983R5wa3lAk%2B26E4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:59.9356989","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A59Z&sr=b&sp=r&sig=Ddk4HTqQU%2Bgifxu52fzDLF1Ts8iRKh25Xl9JYd%2FV8Xc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:59.9357806","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1760,9 +1688,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:00 GMT
+      - Fri, 13 Oct 2023 13:54:59 GMT
       mise-correlation-id:
-      - 95785046-51b3-4362-95a7-991a60ce6cc4
+      - ac8c0e47-39f0-4fb3-b6cc-9b7423c79009
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,25 +1708,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A05Z&sr=b&sp=r&sig=XXJZD1cq03R7s9Sf%2FzU82wCkNtDq%2F2op8T%2BFYiDZGm0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:05.9270334","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A05Z&sr=b&sp=r&sig=chDOBZzFnKY4PXZtJ96%2FYgSEpNZbtKXCKaVtDZoKSBg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:05.9269448","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A05Z&sr=b&sp=r&sig=Jz9S6B3F3miOPfEwJ4R6PySBuqFynDtDuF2L%2BqGVJIM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:05.9270517","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A05Z&sr=b&sp=r&sig=f1lIf6uW18a6%2B3eTI12n%2B1MZ1HNEuwfDd6mrvx6BIp4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:05.1858316","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A05Z&sr=b&sp=r&sig=7mWsYoSTIhEXZwoV%2BwYlWJgTbVsOPWCZ7lKIL48bk0E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:05.1857625","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A05Z&sr=b&sp=r&sig=D3dITvTIJcCJ1aCcwGjMV8AezdauRRJQjHWNGprGgyM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:05.1858462","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3253'
+      - '3249'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:05 GMT
+      - Fri, 13 Oct 2023 13:55:05 GMT
       mise-correlation-id:
-      - 2e154cc4-ac11-4125-8490-3baff9123081
+      - 782e979f-9869-46fa-a51c-f60d90286301
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1816,25 +1744,133 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A11Z&sr=b&sp=r&sig=T1Wz9hxeOfygeO%2Fq%2BMxhFnblwcAB%2BzeCha4OuX1Fesw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:11.2026651","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A11Z&sr=b&sp=r&sig=M8Be%2BZOU6dvTHaUitsB12eGHZ9n6JZYgXLH7Nj7m0mw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:11.2025333","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A11Z&sr=b&sp=r&sig=yC430Xm8LGz1dn%2BG9TA%2BZ3ji9sj9hBW%2FrF0aaX9UI2I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:11.2026945","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-09T19:19:26.768Z","endDateTime":"2023-10-09T19:22:07.723Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:09.753Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A10Z&sr=b&sp=r&sig=IOfRHehwivaO2DoACuqXloD0wV62FsL21qNA9ptUOeA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:10.4333637","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A10Z&sr=b&sp=r&sig=kqnF0Vy4eocnizhi4oSi0V6KHlHISBTOTt0zEGfNpoo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:10.4332848","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A10Z&sr=b&sp=r&sig=9bKOvRxps01SoyGeiSZWdzu%2BvGl0zBoSPzc1uqdtDnY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:10.4333822","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3293'
+      - '3245'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:11 GMT
+      - Fri, 13 Oct 2023 13:55:10 GMT
       mise-correlation-id:
-      - 93396aee-6038-4b6c-8e51-0114b6dc9553
+      - d5f4a6b6-df60-4614-aa0d-cb5c51e89af7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A15Z&sr=b&sp=r&sig=5jagUYfwsQjVStyhjVwrWATKmbMTDK0E0MwUf3RgtnI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:15.6829349","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A15Z&sr=b&sp=r&sig=yS7WcpFhBSC6JMU297KFD%2BdP2pE5Mtv%2BDBEDisB7AHs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:15.682851","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A15Z&sr=b&sp=r&sig=Hw9KEdfMaVPJC4zs3lbkE2q4AOiMcZgih0ob%2F8PSq7k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:15.6829517","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3248'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:15 GMT
+      mise-correlation-id:
+      - 3a333a67-c661-4d41-918a-e4fdfa5770a3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A21Z&sr=b&sp=r&sig=UARJPyoUgTP%2FhggAOG8EdOdv5dYqUkpgsf%2BY7%2FDyK6Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:21.0230702","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A21Z&sr=b&sp=r&sig=rXsEL7f52Sxia1DKwzzE8LA0JUzacLFzTPVjF627Xms%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:21.0229932","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A21Z&sr=b&sp=r&sig=AsT0P26p6sPlirwDKS81xvGG8w3avrxqolgGHV9BHuE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:21.0230889","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3249'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:21 GMT
+      mise-correlation-id:
+      - 39c995bd-ff03-41b7-a409-b2e07d6c2472
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A27Z&sr=b&sp=r&sig=45Qu%2FKMULcwEl6Z8gLDKzGtOm68L6BJXFm6PCsuk5B4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:27.0992413","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A27Z&sr=b&sp=r&sig=DbgJ%2FoMfRLHhDX%2FJx3S%2Fnh%2F0yKM%2BpfnHRa9x87c0mMw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:27.0991559","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A27Z&sr=b&sp=r&sig=StEnfSjEMviCjlFhG8EJ1k8vT2Vi5y%2Ff%2FhDEHBaGs7A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:27.0992597","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-13T13:52:36.886Z","endDateTime":"2023-10-13T13:55:23.624Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:25.351Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3295'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:27 GMT
+      mise-correlation-id:
+      - 51dafe23-d2be-48ce-b7c7-487906d660bd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1857,7 +1893,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:26.2350862Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:26.2350862Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:35.5623435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:35.5623435Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1866,9 +1902,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:12 GMT
+      - Fri, 13 Oct 2023 13:55:28 GMT
       etag:
-      - '"5600b814-0000-0100-0000-652452040000"'
+      - '"d8014ceb-0000-0100-0000-65294b6a0000"'
       expires:
       - '-1'
       pragma:
@@ -1896,25 +1932,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A13Z&sr=b&sp=r&sig=1FG6SrdCxbBaNimYWHNznAgl5rmfOSuren26hJ83odA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:13.4749725","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A13Z&sr=b&sp=r&sig=ye39ihzhjdYk8nppQCq6skPztjZRQEXZbFAdBpQm8g4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:13.4749043","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A13Z&sr=b&sp=r&sig=%2BoKhmP%2FL8jhTm90QgLQOElCWyl2gRRxbgs1bKeUAns0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:13.4749869","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-09T19:19:26.768Z","endDateTime":"2023-10-09T19:22:07.723Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:09.753Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A29Z&sr=b&sp=r&sig=e%2BwTurwOuF7pwn6DDAOlJ2X3vNd1k1JvOVnPZPQCYYM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:29.4656308","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A29Z&sr=b&sp=r&sig=YCa2cEnmMwmr2XY4Bk0lNtunkXLxqOx7LMqUQCtMNF8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:29.4655567","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A29Z&sr=b&sp=r&sig=mm37L8%2Fn%2FSev%2BgrU5xNfjHixIYI%2Bb4UKSEFwEkvmAS8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:29.4656442","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-13T13:52:36.886Z","endDateTime":"2023-10-13T13:55:23.624Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:25.351Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3283'
+      - '3289'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:13 GMT
+      - Fri, 13 Oct 2023 13:55:29 GMT
       mise-correlation-id:
-      - a967310e-34fb-4d54-b40a-21b92ac234c5
+      - 46a7330e-9c53-44fc-a0cb-2f01295af397
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1937,7 +1973,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:26.2350862Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:26.2350862Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:35.5623435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:35.5623435Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1946,9 +1982,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:14 GMT
+      - Fri, 13 Oct 2023 13:55:30 GMT
       etag:
-      - '"5600b814-0000-0100-0000-652452040000"'
+      - '"d8014ceb-0000-0100-0000-65294b6a0000"'
       expires:
       - '-1'
       pragma:
@@ -1976,25 +2012,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A15Z&sr=b&sp=r&sig=%2BXXrau8Zs%2FoYqnuhRfiyovsbz8eG2FQ%2BLo9s1fL9NmU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:15.7120699","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A15Z&sr=b&sp=r&sig=f9B0Vt%2B5EUOY%2B5YT0SyjOoGDJIA7VbyD9acWRaU5rMM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:15.7119739","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A15Z&sr=b&sp=r&sig=VxlE6o0TkJFp9b8tSg%2F3IUqGOat24jScCSSqU0AG5c8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:15.7120923","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-09T19:19:26.768Z","endDateTime":"2023-10-09T19:22:07.723Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:09.753Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A32Z&sr=b&sp=r&sig=4w9cbBk8czKoWN3jAIMWfR2dx5AtDXCY%2FJ8dcIBvdws%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:32.0839705","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A32Z&sr=b&sp=r&sig=Mbo7K5EZnXEXgh2JC9da1kmP3tlYYg7Ehlf%2Fn2KlIn0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:32.0839003","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A32Z&sr=b&sp=r&sig=QxWY8FTP5WKoK3KrBLY0ktBgFu16%2F9LhXFvuDJ0dPKM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:32.0839857","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-13T13:52:36.886Z","endDateTime":"2023-10-13T13:55:23.624Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:25.351Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3291'
+      - '3285'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:15 GMT
+      - Fri, 13 Oct 2023 13:55:32 GMT
       mise-correlation-id:
-      - 62823244-4e8a-4cf8-99db-3affdf7e0065
+      - 4184dade-591a-4192-86db-1751b48217e9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_create.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_create.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:35.5623435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:35.5623435Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:39.6895752Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:39.6895752Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:11 GMT
+      - Wed, 18 Oct 2023 20:52:13 GMT
       etag:
-      - '"d8014ceb-0000-0100-0000-65294b6a0000"'
+      - '"7500814e-0000-0100-0000-6530455d0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:52:13 GMT
+      - Wed, 18 Oct 2023 20:52:15 GMT
       mise-correlation-id:
-      - aa97b8a0-a97e-4879-9869-b46b76d68e9c
+      - 6f18756c-5d53-4308-80de-136943c584ab
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "62171b6e-0d63-4366-b7bb-e961f9997a09":
+      {"passFailMetrics": {"7018876b-209f-4eb1-a306-e3e4667da02e": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "b7453971-1907-402e-a251-49d002301c4a": {"aggregate": "avg", "clientMetric":
+      "50"}, "361a7b92-7112-4c75-a437-d85b4e4e033d": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:13.691Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:13.691Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:52:15.644Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:15.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:13 GMT
+      - Wed, 18 Oct 2023 20:52:15 GMT
       location:
-      - https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+      - https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 6928ec35-133c-4654-bc65-589287527f35
+      - b04e388f-cb3e-4a8b-b4db-7d9832a8a1b9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:13 GMT
+      - Wed, 18 Oct 2023 20:52:15 GMT
       mise-correlation-id:
-      - 893de3f3-3b9c-4e2f-80c6-f127f10f7626
+      - e453eab2-e2d6-4e12-8d5e-c90dc56cfc4a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,10 +275,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A14Z&sr=b&sp=r&sig=Vc9fwLvA0ytvarQSpooNtIx6U3A3B74aj3f73RvPAWI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:14.4511192","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A16Z&sr=b&sp=r&sig=3p955hry2oK4h2GNX2PEIQaGmsqCCBpJOw71wzvB164%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:16.6049881","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -289,11 +289,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:14 GMT
+      - Wed, 18 Oct 2023 20:52:16 GMT
       location:
-      - https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 430b87de-19bd-431c-991f-18e12aea5586
+      - 463bf8b7-474d-4d4c-8b85-48ea540e8dff
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A14Z&sr=b&sp=r&sig=sg%2Bp6YKOAU%2Fm61H0%2FkuWr9vUwj8XkEhZ5eJZYXecews%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:14.7190711","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A16Z&sr=b&sp=r&sig=fr0Ge%2BqiLAFrlvkZu8%2Be0uVs%2FuIg1T56%2BzoXE0Mewkk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:16.8506924","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '557'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:14 GMT
+      - Wed, 18 Oct 2023 20:52:16 GMT
       mise-correlation-id:
-      - a2c37b80-8eeb-40b7-9038-72c06e61383b
+      - d806a315-f160-43f0-b992-92fd2558aec6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,10 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A19Z&sr=b&sp=r&sig=sGL0JT273Y5A0Dp%2BjD476GSUaAWQ2O7ubUi%2BtLvor1Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:19.9671608","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A22Z&sr=b&sp=r&sig=F%2BbCZcaZSlwBBu1d2AdFh3QcLBR2fpb%2FtvP93rxDwKE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:22.1104866","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:19 GMT
+      - Wed, 18 Oct 2023 20:52:22 GMT
       mise-correlation-id:
-      - af2b0602-1ce7-40db-bbc0-6474f709db02
+      - 8101f79b-848a-49e6-aff5-ac7b191a9912
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A25Z&sr=b&sp=r&sig=gnfWwdPRmqargl0Ji2lPXloiDnymA7tDg36ESJNvFQ0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:25.2258825","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A27Z&sr=b&sp=r&sig=GYpTsn%2F%2BQG0OaqCQpX5oc030CHjVr%2F4IplJ%2Fg4Bq0oM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:27.3692148","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '557'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:25 GMT
+      - Wed, 18 Oct 2023 20:52:27 GMT
       mise-correlation-id:
-      - 3fc643f8-96eb-4ae8-8157-6a6f32fac657
+      - b4a4c96e-e823-4a60-97d0-9e09392dc535
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A30Z&sr=b&sp=r&sig=tz0MF5Nb%2BghDkPjiWlkbOGjeW4EqlEGXmQLuE9JFHK0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:30.5041616","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A32Z&sr=b&sp=r&sig=qSbmH9XRqDorKGxRTYETRFE73wIP0nmLthYgzhUqpT8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:32.6546761","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:30 GMT
+      - Wed, 18 Oct 2023 20:52:32 GMT
       mise-correlation-id:
-      - f9827615-296d-4a47-ada9-610d55bd094a
+      - 576857dc-466a-4e46-8653-3a7df4bfca7c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A30Z&sr=b&sp=r&sig=L6snAWhvhcNdUdfP4hkozP5kLI02DtRwLm7bDrSC0SA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:30.7539678","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:13.691Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:27.761Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A32Z&sr=b&sp=r&sig=XZf5xvgoCBZox%2BR0bES6Kh%2BtGgPtcVNYw9c2JMNACfQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:32.905597","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:52:15.644Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:29.781Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1577'
+      - '1580'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:30 GMT
+      - Wed, 18 Oct 2023 20:52:32 GMT
       mise-correlation-id:
-      - b50dc1f0-9f00-4cfa-89e3-8358fa7cd046
+      - 611c44ce-2e76-4414-9ead-8c37e0517e2d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:35.5623435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:35.5623435Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:39.6895752Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:39.6895752Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:31 GMT
+      - Wed, 18 Oct 2023 20:52:32 GMT
       etag:
-      - '"d8014ceb-0000-0100-0000-65294b6a0000"'
+      - '"7500814e-0000-0100-0000-6530455d0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A33Z&sr=b&sp=r&sig=BqyX1P8zHDJqUkmKJECU8iSiBLS6t44JAwi06uP4EO0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:33.2139599","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:13.691Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:27.761Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A35Z&sr=b&sp=r&sig=ckejjZ8kj%2FzMYQ44dd%2FNQh4MocblaPKsXBmlTx4mXak%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:35.4500707","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:52:15.644Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:29.781Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1589'
+      - '1593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:33 GMT
+      - Wed, 18 Oct 2023 20:52:35 GMT
       mise-correlation-id:
-      - 71cad844-0097-498e-8cb9-cc8042880766
+      - eba0626c-8e7c-4bcc-a8b5-fe3e00360fe2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:35.5623435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:35.5623435Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:39.6895752Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:39.6895752Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:34 GMT
+      - Wed, 18 Oct 2023 20:52:36 GMT
       etag:
-      - '"d8014ceb-0000-0100-0000-65294b6a0000"'
+      - '"7500814e-0000-0100-0000-6530455d0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:52:35 GMT
+      - Wed, 18 Oct 2023 20:52:37 GMT
       mise-correlation-id:
-      - 3e6083ec-495b-4124-a334-edfbd0916b63
+      - ae4712c8-ea81-49f2-bed3-249ae6b00492
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -664,25 +664,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A36Z&sr=b&sp=r&sig=hcVfHOSZoW%2FHPxzGztjtCPuQF4je%2FMdJLDYAQUOJ3Ls%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:36.5754903","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A36Z&sr=b&sp=r&sig=pu5a8xpvijL8A7p9ky8indvzh5hVe1e0WWib98HkYqw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:36.5753928","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A36Z&sr=b&sp=r&sig=PTuHEEpc%2BIdF4mQMc%2BbnVK5BgbiorRF6IT7hX%2Fp%2B3U8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:36.5755183","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:36.504Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A38Z&sr=b&sp=r&sig=k5R1KoiIzw6cHmRxb77%2BYhfSs%2B71yZAe%2FYKgcJ3qgjs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:38.7595792","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A38Z&sr=b&sp=r&sig=EV1sqi%2B1IY6sRIDhuuhVURqVJzYu%2BNzvMwLPRkpH9w0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:38.759409","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A38Z&sr=b&sp=r&sig=9VBHw3nkE5q3cSsvoqSgu%2B2o2MYZ1t%2B%2F5B16BAE9qO4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:38.7596033","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:38.686Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3211'
+      - '3214'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:36 GMT
+      - Wed, 18 Oct 2023 20:52:38 GMT
       location:
-      - https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+      - https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - f46691db-a76e-46a1-ba98-20876ae0f713
+      - e43cef5a-6b89-44ac-a631-6fdb3bfe82c1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -702,10 +702,190 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A37Z&sr=b&sp=r&sig=lUnuBM7nZBLyGy%2FQGoJA1lVc%2B7Zpc3CFpPcOu5y4i78%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:37.0170076","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A37Z&sr=b&sp=r&sig=0TOF4qNvdt3S3QwNoeo3wVzNgDf%2BOHFYexUsFGpLlOY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:37.0168977","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A37Z&sr=b&sp=r&sig=ycQt8LAKIjYIdOS7lKN69jniM8bbih7R0lHQa8BLUvU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:37.0170338","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"NOTSTARTED","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:36.886Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A39Z&sr=b&sp=r&sig=TjAHSbB4TZKGxrG9EExMTwKssw7rBP67BTywW9yeNSo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:39.2026536","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A39Z&sr=b&sp=r&sig=SHMWPjtkVhXVlT2qo3infbSmPF%2F75gJCBhFLDOVUnME%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:39.2025708","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A39Z&sr=b&sp=r&sig=cR7ae9sTH6r6gnEpO9VQulj3tSI0Y7P%2FhKwiOZOdG8E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:39.2026683","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"NOTSTARTED","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.088Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3248'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:52:39 GMT
+      mise-correlation-id:
+      - 0b1a0c54-a890-4868-a779-7a8a1ce49200
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A44Z&sr=b&sp=r&sig=7UAHZalBLkCTEawrpSFuYKH5mS6U6TBGlICFF76Jh4U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:44.5406923","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A44Z&sr=b&sp=r&sig=OGb93t7zpXoAe9CZvUzMA6kVc9nEyBJmhANp3UNdyEg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:44.5405837","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A44Z&sr=b&sp=r&sig=grW7aC4aoeQuvBo%2Fm11Hl69Vt8VJQCN2XVmH2YJ2QkA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:44.5407153","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.265Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3248'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:52:44 GMT
+      mise-correlation-id:
+      - f7b08f8c-4181-41de-a838-e5a72d7f96c8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A49Z&sr=b&sp=r&sig=cpoiiBVgSKEFN62EFTb%2Fpsy9sfJ2Dcht5ZZe2F%2Bej%2FA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:49.8498227","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A49Z&sr=b&sp=r&sig=pYNtqyYn74nf3T2YUPhz1fpC0RrYy4R20qPhM8g%2FLqc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:49.8497563","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A49Z&sr=b&sp=r&sig=9jMdghvV3AveaL2Wdbqmrfp2SB5GTz3qAnY1eQBQdWs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:49.8498375","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.265Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3254'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:52:49 GMT
+      mise-correlation-id:
+      - b398d669-572c-42fd-b813-44480daa4560
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A55Z&sr=b&sp=r&sig=EOupyJsMgQZ3cU4p%2Fp5gPLRLYFLZm8payKUP%2BqeYqow%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:55.2064033","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A55Z&sr=b&sp=r&sig=KF8NAWWWHtRfUGup90%2BgoVZ9%2BL62Q8nliATzDnh4pyQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:55.2062989","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A55Z&sr=b&sp=r&sig=C%2FVFXoRmcgdcVTee6A7FB%2Bmfi6UVePetWQ6quOa1sc0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:55.2064271","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.265Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3258'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:52:55 GMT
+      mise-correlation-id:
+      - 3183e6b6-2dae-4c85-b7f9-9b035bff7ccd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A00Z&sr=b&sp=r&sig=RdTdbnOiOpnsDE8vtzasnKeb%2BAE9%2BjNIXePxbxc3pmU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:00.5124085","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A00Z&sr=b&sp=r&sig=jVR9UExVn%2FQrZUT4iqNoWiZWxC8f40ughAVEBJduY1c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:00.5123114","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A00Z&sr=b&sp=r&sig=uAtXsYV%2BbMeJBlxn%2BSJc%2BGNFP5%2B4Q4eo5VkQIS103Xo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:00.5124362","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.265Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3260'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:00 GMT
+      mise-correlation-id:
+      - d42169d6-cb6c-460f-b85e-2482b39daa34
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A05Z&sr=b&sp=r&sig=aKk8kKLvL0xT6IxudnJhFZxQ%2B105kukwGA08QcX6NWc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:05.8388902","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A05Z&sr=b&sp=r&sig=cIHwobPSrwBxuNDlJdiCOuLu6ZP4wcDQ5liRcwJ%2B8T4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:05.8387985","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A05Z&sr=b&sp=r&sig=27GeVXbUghKrllBLtiiuojnxYsMP9Tg3WZGE7p6pHCY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:05.8389052","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.265Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -716,9 +896,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:37 GMT
+      - Wed, 18 Oct 2023 20:53:05 GMT
       mise-correlation-id:
-      - 166cc80f-8fe5-49b4-a088-cce216340a70
+      - a4b7c752-5ae9-4157-808a-d09a40df46b2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -738,10 +918,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A42Z&sr=b&sp=r&sig=EaTPpZwnDYp%2BRpmCUtxh2Ny%2Bopmw0R9DJ1YOZG3GXu4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:42.2892961","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A42Z&sr=b&sp=r&sig=F0VzCzqt3%2Bjj%2FREdmWUQmlNlkT24fnv1QP0GllnlGrM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:42.2892278","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A42Z&sr=b&sp=r&sig=L8bmdsyaAXRjufAQDoQboM5wARP0TWJMgFCBC9t7mjg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:42.2893103","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:37.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A11Z&sr=b&sp=r&sig=Yf%2FQiyqFQKfugJcWmOyChSKy%2BX23J6TwDzI1DZeD9Lc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:11.1595499","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A11Z&sr=b&sp=r&sig=zIhsU1zYjVu6zV1ihPTXZbrZ9Jm2Zy1ZKv7rXiVjxv8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:11.1594765","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A11Z&sr=b&sp=r&sig=ja4lpcEKa3ATgKwAEB4g0MoYn8wEyK%2FSGCW9iYYaBkE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:11.1595636","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.265Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3252'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:11 GMT
+      mise-correlation-id:
+      - b6c2d0d3-2097-4307-9231-882d1dcedd4c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A16Z&sr=b&sp=r&sig=uvK%2Fm%2Ft5Ju3%2BJbZ3HSTi0necnI5OKLDKany%2FJV%2FcdFM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:16.506986","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A16Z&sr=b&sp=r&sig=3nJQYMw8UNWDJe0pxYLQEkh9T1UKI1ehqZFj%2FxKXidI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:16.5069206","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A16Z&sr=b&sp=r&sig=gaiFTzfUbsygoNlpDhzBpw5LC9tVBrhpoSC3EvdxuJ4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:16.5070003","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.265Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3257'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:16 GMT
+      mise-correlation-id:
+      - b7fcde98-e65f-44af-9fc9-0473772461f3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A21Z&sr=b&sp=r&sig=aDbb%2BDEx%2FkA2U9JRNOLCPY4qYSKezffIdBWqdPHLWgk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:21.7813832","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A21Z&sr=b&sp=r&sig=9WeOozHccDbakVLApDBqXPJn3DBkZXNiTuCmkbdmls0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:21.7813087","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A21Z&sr=b&sp=r&sig=P93gDWI2IPR3%2Fc7eSQlmws35scjiKSigH3O2ZPl%2Fhr4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:21.7813973","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:39.265Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -752,9 +1004,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:42 GMT
+      - Wed, 18 Oct 2023 20:53:21 GMT
       mise-correlation-id:
-      - 594fe710-789c-4f12-8e89-3629d9100fa1
+      - 4e633ff5-6d65-4167-89ca-085bdb1ccaca
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -774,298 +1026,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A47Z&sr=b&sp=r&sig=aKou3adyChJ9Qf%2BaO%2FAdRel4adJWgbyLnwOCZSdABGM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:47.5746486","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A47Z&sr=b&sp=r&sig=8UoM4XtxxKpaHDdSRIM2bhfnT1LH4lWuW6REAqfpm00%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:47.5745632","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A47Z&sr=b&sp=r&sig=bNBXmmLl%2BMX34x0Wstrl0IbgGhlCon%2FO%2BUl4vAxyeTs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:47.5746701","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:37.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3256'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:52:47 GMT
-      mise-correlation-id:
-      - 90299d9a-e82f-4723-87a2-fca453c7bd6c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A52Z&sr=b&sp=r&sig=QLOjRet8u%2Bs7yClOhUHPlJ5KGFWBzONWxOb%2BiKXPVzM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:52.8909935","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A52Z&sr=b&sp=r&sig=8JoM0xmH25lDC3hquzP2miYy4RRgISrT9j768%2FC7%2Fgc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:52.8908863","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A52Z&sr=b&sp=r&sig=q%2FhTpSS4h3BFaBn5FkIQxZ8eYWCRo0oGQqcU2sfuhuE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:52.8910163","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:37.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3256'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:52:52 GMT
-      mise-correlation-id:
-      - 3b7e0c16-9396-4aab-a095-533c868d3756
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A58Z&sr=b&sp=r&sig=bbG22twIQQR7n8fbrlnuG8Im%2Fr5fxe%2FqoFLNuIsn7rM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:58.194134","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A58Z&sr=b&sp=r&sig=7%2BXVwAwLACvKoqgDCvj4gLoSk7AklUE2I6bC6kd9x5M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:58.1940369","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A58Z&sr=b&sp=r&sig=ocM8G2D9NCTcZrq9CqK4oF%2Frdqs8Nr7A5cHzXwAF%2BwM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:52:58.1941554","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:37.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3255'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:52:58 GMT
-      mise-correlation-id:
-      - 03cd0015-373e-4c40-9584-a28ed912786d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A03Z&sr=b&sp=r&sig=e2KuW0mL3SPB38pvl0GN32p4uqwVV48sxGFtmrVI8G4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:03.440584","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A03Z&sr=b&sp=r&sig=vSJdDnfEYfWKjos7bsiJ0Cprxp7%2F7pZE0aopaFxh%2FhY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:03.4404664","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A03Z&sr=b&sp=r&sig=maSZFc%2BRkhVza6XrNZiCfCF%2FNiIA4l0mh%2FcjyOIw%2BzQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:03.4406068","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:37.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3257'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:03 GMT
-      mise-correlation-id:
-      - 5fc63fd3-550b-4022-beb8-729ab3aa698a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A08Z&sr=b&sp=r&sig=FTQ27WYeGb0YjDjn6Hxk9kR95koqBDUAIiLFt0deyYs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:08.7752335","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A08Z&sr=b&sp=r&sig=1kNla6J62PJXZ4YkBkXyFv%2Fi9xpj9p6RNVQvYs7CdX4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:08.7751341","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A08Z&sr=b&sp=r&sig=0aFSxIGkJAsR6FHJhfrcXPOz92dt%2Bfk10qSbzwRA%2FDM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:08.7752577","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:37.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3252'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:08 GMT
-      mise-correlation-id:
-      - a3c825d0-3fd1-48e8-ad22-cc14e43c3784
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A14Z&sr=b&sp=r&sig=6Cv4SaQLrt51oWrb5wj%2FXuMIRGvcZDWTqH7HHzpVH8o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:14.0138897","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A14Z&sr=b&sp=r&sig=QsJn0HzCLMPVErkDRnGOUXeE5TNN6BR%2Fws8PGNvAC%2Bc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:14.0138006","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A14Z&sr=b&sp=r&sig=YCgH0oXoiCmUbspZk6BQEuzoOqRgQjqTvTPGBTrBfU8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:14.0139064","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:37.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3252'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:14 GMT
-      mise-correlation-id:
-      - b104b835-35e0-4ca8-ab33-ae50b773e5b0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A19Z&sr=b&sp=r&sig=GzPqwoO6eLgSU2J8f12j5H5KKGQnZxhyNY%2FmmBS%2FBQs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:19.3260399","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A19Z&sr=b&sp=r&sig=fJfuf5mnRX6B8Iu1sMNggpkK8MGRfLl0t3RpbF%2BfguQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:19.3259388","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A19Z&sr=b&sp=r&sig=AYbbr6%2FGOQW9CQ8iFdJXzB2%2BEc43bxLJwjg5d3IwQ7U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:19.3260556","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:37.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3256'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:19 GMT
-      mise-correlation-id:
-      - 1b2cf731-6278-4364-b05b-596b8032bbc4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A24Z&sr=b&sp=r&sig=JeJjLpfJkk2oUZzWCjkjfm0KbxO%2FMQxP8NoUsc74kAI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:24.5754717","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A24Z&sr=b&sp=r&sig=FiXi7cWCOdQo9Db8yuGQTV3nXhCvpLzYORgoctb1Otk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:24.5754012","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A24Z&sr=b&sp=r&sig=%2BTio3mHa1C7dyexaFy70jLSNPgm9SefKl3lwOo8kvk8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:24.5754857","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"CONFIGURING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:23.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3249'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:24 GMT
-      mise-correlation-id:
-      - f9de5b76-94db-411f-9ff8-1cea83b01651
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A29Z&sr=b&sp=r&sig=w%2Fedi2yapuU1LBi7nguUOPCO3NnVR7Qs3isuuES%2Bnnc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:29.8818848","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A29Z&sr=b&sp=r&sig=WJqTyyUGBZbGY7OXnyPr91piH7DniBWjM3wbg9qe%2BIo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:29.8817742","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A29Z&sr=b&sp=r&sig=r9CyDBEhgo7J4h81dSff6aBI6tH%2F1D1qgnNl6xuLVP8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:29.8819106","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A27Z&sr=b&sp=r&sig=D7LLjx2Ty4Xp0esZaK9%2FHdMcPeNc7Q2hhfaHk%2FzyYL8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:27.0526656","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A27Z&sr=b&sp=r&sig=UQIkxh59c8NhwxhCWtvU834IrZYEB9JM6wFPZLAENDk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:27.0525625","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A27Z&sr=b&sp=r&sig=fzOQIV%2FmpvHUzgsgOh6Yj4hTQBW1L6SXXgXT3InL2uM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:27.0526797","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"CONFIGURING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.747Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1076,9 +1040,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:29 GMT
+      - Wed, 18 Oct 2023 20:53:27 GMT
       mise-correlation-id:
-      - 3ff7a75c-ed82-4e4c-a183-2b1fca6f0910
+      - d8bb3dc8-e2fa-46a7-90ce-b436343bc163
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1098,23 +1062,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A35Z&sr=b&sp=r&sig=ULpep%2BFqJQUdeBRGm22UC1rk3OJRvoOIb5Upoo4SEB4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:35.1444235","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A35Z&sr=b&sp=r&sig=zJvmtY4%2BWA5nlHAh4gVEXf42eRyTW0vR5LNfrMzy9Lk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:35.1443404","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A35Z&sr=b&sp=r&sig=3P48JCwIpQzbvxckyIAnZS%2BvrV4iOOybZsUvg9xUHng%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:35.1444418","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A32Z&sr=b&sp=r&sig=Vb9JKP3pNK7PQackMjIJcWfLNBszskjyT1mUIpq0Opg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:32.3161457","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A32Z&sr=b&sp=r&sig=9Ox%2BKrYDCGdVNS8ZwLRcTVrTrhDLGtU0rinOXIFSeNI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:32.3160712","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A32Z&sr=b&sp=r&sig=qxnI%2FCWPpq1UDimkITDxc44gwW45QueTFFxiS0lcznQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:32.3161598","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3249'
+      - '3247'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:35 GMT
+      - Wed, 18 Oct 2023 20:53:32 GMT
       mise-correlation-id:
-      - ed25a665-fbb3-4c44-9afa-62b8f0d3ab4a
+      - 35b9f7a1-9a7e-43ed-85f2-0cd092fd48fc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1134,334 +1098,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A40Z&sr=b&sp=r&sig=RUm57aMOvK6gBsiEB%2BoPOPtjx5o1tZg27ytsvCoGM5M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:40.4078544","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A40Z&sr=b&sp=r&sig=rDR%2FrKhPhv2qL2Fogk073mMoc4IBsP4Wq9pm4PaB69w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:40.4077704","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A40Z&sr=b&sp=r&sig=l72Vopub78pINCSeBHrJbw1tcZdZU7UySz%2F1HxNG82I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:40.4078687","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3249'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:40 GMT
-      mise-correlation-id:
-      - a300724e-5a3c-471d-9c83-15fa7c8f1000
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A45Z&sr=b&sp=r&sig=ikKKrJuczWew0mUfTS4eTCQEshsnd4LO055btD5gfvw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:45.674115","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A45Z&sr=b&sp=r&sig=g94DsByICE8Ts%2BaTXdgLRHVBEmENIIJ%2Bm2soSWo5xdE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:45.6740233","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A45Z&sr=b&sp=r&sig=d5tVaa5jZ%2Bjk8VfEqlW8YpzW492IjUNcmGRPapRZwNA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:45.6741391","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3248'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:45 GMT
-      mise-correlation-id:
-      - 4b242372-277a-40fe-8d7d-4cdc4aa0dbab
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A50Z&sr=b&sp=r&sig=Sk5wKbho46kJzI8i8l8kX91l%2BjP%2BOL8AKuuuKSKof78%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:50.9219597","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A50Z&sr=b&sp=r&sig=IECdDV2oHy1j3SJUXjaJ1DzVEG3eVwrJwdmmK0ENw9I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:50.921863","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A50Z&sr=b&sp=r&sig=Uce3bwvm9hxH4DWTMKgDazyLnJ6FN%2Bkx8%2FvO5%2F0EvtE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:50.9219859","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3252'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:50 GMT
-      mise-correlation-id:
-      - 9de973b4-f80f-4e69-ad18-08d045be1589
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A56Z&sr=b&sp=r&sig=hOr9D%2F0e5snyA%2FcJqp9VjkujMrwnz%2FE%2BQDaeI78d348%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:56.1938129","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A56Z&sr=b&sp=r&sig=e%2BrWdwNCC3AIbqiswlh9JWGfcHEBeZl4aGJQ%2F2AmMQE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:56.1937428","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A56Z&sr=b&sp=r&sig=ZR2y9zJ7kE1eNmj0332HvUnjo%2FtvteaG47ELr3lIjTA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:56.1938277","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3257'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:56 GMT
-      mise-correlation-id:
-      - d0926e02-8ed5-4e81-a2d4-60a12fdf5da1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A01Z&sr=b&sp=r&sig=jbvWT%2B7o1tGtE0tq3Jpc8huZGUXUEeidK62TAiTDVJI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:01.5318243","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A01Z&sr=b&sp=r&sig=9473%2B3EdYw5J7Q8JGqQ9nyRQn90Fh2aLT2%2FN5B9xIhI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:01.5317367","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A01Z&sr=b&sp=r&sig=2CguxDJL42CgAYhTcVhXkSA4IEeIburdg9pAiOw%2BbPY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:01.5318496","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3251'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:01 GMT
-      mise-correlation-id:
-      - 9122e1d7-981b-4382-a637-98229a98490b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A06Z&sr=b&sp=r&sig=HCD6HB6SnY%2B9KmUsRnYocpt7q%2BXZDKWedYNsXFZN6Wg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:06.8378418","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A06Z&sr=b&sp=r&sig=YD2juGclermRVi8N7p9VvFtnDlETVwbfhDvp9joKM4Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:06.8377504","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A06Z&sr=b&sp=r&sig=v3Qj%2FvCajXwtYYFfPj6wMlFJl9P6%2FkTtMU2okJqFHwA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:06.8378631","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3251'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:06 GMT
-      mise-correlation-id:
-      - bc2cb212-43e8-4a8a-af91-df80fe84a511
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A12Z&sr=b&sp=r&sig=hDouDWXvUbhcA2iXzjmnFjszkpdkr2UTN2Pl2gz3oqM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:12.1463594","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A12Z&sr=b&sp=r&sig=jXieg4PghlLgxzwsm9tDqtfpiVz01kIDjsGARjAx%2BS0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:12.1462925","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A12Z&sr=b&sp=r&sig=IdDsaRS4f3g9tifkbwHKIZh3gSdjDOBEOBCIpMijiY8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:12.1463734","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3245'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:12 GMT
-      mise-correlation-id:
-      - 42f255bb-7afc-4f85-9e4e-b22a0f3d103e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A17Z&sr=b&sp=r&sig=5kgwUptWGjsyPWYDwjp1uW9QM5nsP1pspieSNUpji1w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:17.4149125","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A17Z&sr=b&sp=r&sig=g4urf7AWCA9rqEXx4E3reF5tGbKL3hI%2B0jhWCyoKhfw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:17.4148315","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A17Z&sr=b&sp=r&sig=DARlA8KgIITcd1IiCha6ek4vOfvysg9jhxWD2D0g1cI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:17.4149297","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3245'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:17 GMT
-      mise-correlation-id:
-      - 0f89a037-4f2e-4c57-985c-9e728c97fe00
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A23Z&sr=b&sp=r&sig=%2F84aT%2FV9Q04BQfii8JrMYTcuS7u%2B3DWJR6DmgBL77Vc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:23.075724","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A23Z&sr=b&sp=r&sig=wKihH20AnMQSy5rVwxU2aqaqbg5kJ%2BHr0msF%2FBp2NEU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:23.0756058","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A23Z&sr=b&sp=r&sig=Y7y47WHrINP4ZhXAq0KM4Fhx3Ad6ypmz7lu8ncEfeVI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:23.0757466","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3252'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:23 GMT
-      mise-correlation-id:
-      - 650ce1e3-8eef-49be-9441-4b4f14dd79e4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A28Z&sr=b&sp=r&sig=Ec2noGlaL%2BigGhqB%2Bi7i%2BipdI7i812D%2BlApPAZ%2FDsRs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:28.3404054","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A28Z&sr=b&sp=r&sig=Di2uin%2By8qWNgcfd7xX2KTJ5mOJ1P9Cfbr8ygmiLEvw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:28.3403329","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A28Z&sr=b&sp=r&sig=WAefGyozwYySIK8FloIPD%2F4CuZrW%2BSCNjvu36XmIYXo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:28.3404195","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A37Z&sr=b&sp=r&sig=kIbgL6FiV2Y99kaoBdL69gmG%2BDrsg98mLe2KFXbyC%2F8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:37.5820444","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A37Z&sr=b&sp=r&sig=1TgljL3hj33cx%2F%2BFR3gzVBJsFdVCfA%2FxjiNbTHHy58w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:37.5819763","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A37Z&sr=b&sp=r&sig=gAP%2FRge%2BWTa6w%2B0Ijfrtn2UreF1PJp5U4LoJkgz1YQw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:37.5820588","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1472,9 +1112,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:54:28 GMT
+      - Wed, 18 Oct 2023 20:53:37 GMT
       mise-correlation-id:
-      - d1cb564b-1461-46e1-a2ca-4c6b3b26d869
+      - f49dd872-040b-4c17-90cb-0b4b829be95d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1494,46 +1134,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A33Z&sr=b&sp=r&sig=e6DSIfyx6E94Cnf9xn%2FiB1xYoPkgt2k5JRZOPPEd60k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:33.6080096","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A33Z&sr=b&sp=r&sig=tWNQr%2Fp2MnJym92kxMUofNd8bDdmMLEJbxUnuLx1li4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:33.6079366","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A33Z&sr=b&sp=r&sig=qSPFz3gHWNcWwhIFhlXuE%2BJVlbX2WLbr1cn%2F%2Bq9vgHk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:33.6080233","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3253'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:33 GMT
-      mise-correlation-id:
-      - e15c5902-df52-4453-a34e-7b4ced81229d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A38Z&sr=b&sp=r&sig=XGDSlwUTgxK5J8fTPjupTEPiWfTbLws60YmdhfUfy3w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:38.9122168","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A38Z&sr=b&sp=r&sig=UexmsP5VcsTOyG0C9LsmrMiCNY%2Foy68tv891VUGudvI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:38.9121436","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A38Z&sr=b&sp=r&sig=o0%2BvVdvbsk90VrFYzfnxMO2ka9dyW4zSQS5m9w4szk8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:38.9122325","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A42Z&sr=b&sp=r&sig=IiakPGjASxdRbEc1T%2FXwJVKmekZohRlXPv59ukQbg2g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:42.8767613","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A42Z&sr=b&sp=r&sig=qeRcgJSiHtcKDo9dPQFmoMW3QsT5vdwxdEs2rh4O9xI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:42.8766523","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A42Z&sr=b&sp=r&sig=kOPNgoA8CY6JEuXXzpig9vstNU%2FaClyfHxUsVSNqLiw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:42.8767845","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1544,9 +1148,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:54:38 GMT
+      - Wed, 18 Oct 2023 20:53:42 GMT
       mise-correlation-id:
-      - d3b98e26-f0c8-420a-b534-2f3e9299b6b1
+      - b18caf8a-a61e-4187-bffe-f6c9452f765c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1566,82 +1170,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A44Z&sr=b&sp=r&sig=fP%2BHG5LeL0Wo2f80gihhp%2BTia%2BEj7kJtrCXbiIkzsms%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:44.2281147","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A44Z&sr=b&sp=r&sig=G7XroimTd3t1dVSB1ywJxkW5WHl1ZSo5DjAX4uerWAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:44.2280168","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A44Z&sr=b&sp=r&sig=knmxWxR9LeqqWbLfs6n8a5LRLWtZmAb0KkQoNLawH5Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:44.2281294","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3249'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:44 GMT
-      mise-correlation-id:
-      - 3fa3ddbd-3baa-4aac-b2cb-9415ab5af2b6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A49Z&sr=b&sp=r&sig=kGRNacyOrV0hWndO0MKXi7UpvCLsd2nHIJWP2TbEvfg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:49.471402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A49Z&sr=b&sp=r&sig=%2FVDEtPsjFVVbp4ufiofF%2FHmto9ayx%2FNoC9zrJcwbXB0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:49.4713385","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A49Z&sr=b&sp=r&sig=f%2FahcHqMCbkdQDYwP86IwAl%2B%2BGhqw35IXeynwgAylWk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:49.4714164","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3254'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:49 GMT
-      mise-correlation-id:
-      - 508b9a06-f9b5-4150-a7f9-899803134dd9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A54Z&sr=b&sp=r&sig=gg7SOuewdlRQIO8xCFAn38EoLbrEPgcWIcDnXaeKhv8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:54.6972158","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A54Z&sr=b&sp=r&sig=81xMxd4ENw04kWRehvIuqBn0u%2BDFmvwqDBpcyf5b2rc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:54.6971151","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A54Z&sr=b&sp=r&sig=vaVUfhQh2lsMpQPC4Wa6Mnn%2BR34ouYE3gVpJ6IPQIT4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:54.6972372","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A48Z&sr=b&sp=r&sig=nINhQ20nAaeG6ObntQ%2FFtv7fkgta%2BoYc8XCqDBtZzJA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:48.1788861","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A48Z&sr=b&sp=r&sig=sCo37RYYRw6W0P1gqiVocoF2g6G6ahawAyEsAOW1E94%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:48.1787676","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A48Z&sr=b&sp=r&sig=hfoaO7CwFRRlawrk1YP62RIcCJWt0dHYx8dH93VTVbU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:48.1789104","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1652,9 +1184,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:54:54 GMT
+      - Wed, 18 Oct 2023 20:53:48 GMT
       mise-correlation-id:
-      - 7714031f-72a9-4019-8345-de035c854506
+      - bb8ec0a3-ba81-4097-a31b-1a81b36d58f9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1674,10 +1206,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A59Z&sr=b&sp=r&sig=uXij4X1VYEZEb1P3OnFUtPmU5gF9jcnOk8i%2Fp01Vig4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:59.9357663","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A59Z&sr=b&sp=r&sig=HqJrnANcsCCt%2BAgTpMj0IZj4gMl983R5wa3lAk%2B26E4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:59.9356989","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A59Z&sr=b&sp=r&sig=Ddk4HTqQU%2Bgifxu52fzDLF1Ts8iRKh25Xl9JYd%2FV8Xc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:59.9357806","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A53Z&sr=b&sp=r&sig=D1hCJQUfjxL0o3enbs7xxtW4peUwBEMTjrpxOxW079E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:53.4653756","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A53Z&sr=b&sp=r&sig=GZaUQWfA7CPBKlUHK4xExd5f0Iz2FTOKcwodQINsy7E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:53.4652957","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A53Z&sr=b&sp=r&sig=SAmh2N3DMZXjiEkB%2FQ%2FOjohQSZCmndIRgx4SzvZLPq0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:53.4653897","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3247'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:53 GMT
+      mise-correlation-id:
+      - 44e6f47f-082a-4643-8191-83e9bb4feaca
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A58Z&sr=b&sp=r&sig=95mncOH2%2FYGsP619QRTHOEuBsv%2FDXdmHWQioHJbOeyw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:58.8022711","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A58Z&sr=b&sp=r&sig=7qs%2FDDfVyJt1MOC9VmQQx8FJUC6i2VUy%2FsvOVuDY7no%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:58.8021146","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A58Z&sr=b&sp=r&sig=qv6ROtB2HUlV01%2BIIVbSFnwIsaTIDS6kbMnDnACN3Gg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:58.8023006","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1688,9 +1256,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:54:59 GMT
+      - Wed, 18 Oct 2023 20:53:58 GMT
       mise-correlation-id:
-      - ac8c0e47-39f0-4fb3-b6cc-9b7423c79009
+      - 17dfe3cf-0726-4706-a200-9bd970729803
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1710,23 +1278,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A05Z&sr=b&sp=r&sig=f1lIf6uW18a6%2B3eTI12n%2B1MZ1HNEuwfDd6mrvx6BIp4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:05.1858316","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A05Z&sr=b&sp=r&sig=7mWsYoSTIhEXZwoV%2BwYlWJgTbVsOPWCZ7lKIL48bk0E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:05.1857625","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A05Z&sr=b&sp=r&sig=D3dITvTIJcCJ1aCcwGjMV8AezdauRRJQjHWNGprGgyM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:05.1858462","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A04Z&sr=b&sp=r&sig=k%2FqJ8W3qOHamxCSz%2FBtslWZe6KI8hOb23Z4MX2vccig%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:04.0754424","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A04Z&sr=b&sp=r&sig=59LHs3XnqaNULDCLf9ZuRCqDDNnVYpKICn%2F%2BM5TVyEk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:04.0753308","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A04Z&sr=b&sp=r&sig=qui5QN05tmlV9n3rhfG0pEwLlBVQ5t0pb%2FKiPBqETVo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:04.0754674","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3249'
+      - '3253'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:05 GMT
+      - Wed, 18 Oct 2023 20:54:04 GMT
       mise-correlation-id:
-      - 782e979f-9869-46fa-a51c-f60d90286301
+      - b08a3006-1579-4916-b320-727f74017f12
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1746,10 +1314,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A10Z&sr=b&sp=r&sig=IOfRHehwivaO2DoACuqXloD0wV62FsL21qNA9ptUOeA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:10.4333637","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A10Z&sr=b&sp=r&sig=kqnF0Vy4eocnizhi4oSi0V6KHlHISBTOTt0zEGfNpoo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:10.4332848","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A10Z&sr=b&sp=r&sig=9bKOvRxps01SoyGeiSZWdzu%2BvGl0zBoSPzc1uqdtDnY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:10.4333822","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A09Z&sr=b&sp=r&sig=%2F3ipJHd2cxLtSVZ2QqLYOmOpSXBMLq0j2PWCfAtegd4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:09.3618118","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A09Z&sr=b&sp=r&sig=XhkTabmpFrzPk1pyD5YEfZkcrzHd93EHH7I8C4KvoSo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:09.3617068","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A09Z&sr=b&sp=r&sig=FFfhD4lMRXVrD2UyUrsTFAIFmmOKKmUX1B3zcKRztNI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:09.3618378","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1760,9 +1328,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:10 GMT
+      - Wed, 18 Oct 2023 20:54:09 GMT
       mise-correlation-id:
-      - d5f4a6b6-df60-4614-aa0d-cb5c51e89af7
+      - 5095be26-a570-43fe-9654-865c6a03a914
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1782,10 +1350,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A15Z&sr=b&sp=r&sig=5jagUYfwsQjVStyhjVwrWATKmbMTDK0E0MwUf3RgtnI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:15.6829349","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A15Z&sr=b&sp=r&sig=yS7WcpFhBSC6JMU297KFD%2BdP2pE5Mtv%2BDBEDisB7AHs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:15.682851","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A15Z&sr=b&sp=r&sig=Hw9KEdfMaVPJC4zs3lbkE2q4AOiMcZgih0ob%2F8PSq7k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:15.6829517","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A14Z&sr=b&sp=r&sig=M2kfq04xfX05VNKm2Hk4%2FBxlCvDi82xiVJ%2B2yjl6OqA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:14.6592686","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A14Z&sr=b&sp=r&sig=SoQ2KpRHStMM9y6CegKCZLoMltRtXVlzXjpCUyPzwxU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:14.6591835","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A14Z&sr=b&sp=r&sig=tZ1%2Bkcj0pEBeZH9ifIYOH3qJNoYQ6vaFxUMmRMkpMZw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:14.659287","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1796,9 +1364,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:15 GMT
+      - Wed, 18 Oct 2023 20:54:14 GMT
       mise-correlation-id:
-      - 3a333a67-c661-4d41-918a-e4fdfa5770a3
+      - 4f35f346-d67b-4a40-b32b-888241a99c22
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1818,10 +1386,334 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A21Z&sr=b&sp=r&sig=UARJPyoUgTP%2FhggAOG8EdOdv5dYqUkpgsf%2BY7%2FDyK6Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:21.0230702","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A21Z&sr=b&sp=r&sig=rXsEL7f52Sxia1DKwzzE8LA0JUzacLFzTPVjF627Xms%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:21.0229932","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A21Z&sr=b&sp=r&sig=AsT0P26p6sPlirwDKS81xvGG8w3avrxqolgGHV9BHuE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:21.0230889","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-13T13:52:36.886Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:28.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A19Z&sr=b&sp=r&sig=aWz6eWTt%2BH22jlP0ikL0T2AlnvRlY4gDeiWq9OsDln8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:19.986015","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A19Z&sr=b&sp=r&sig=WnshXUQBVnJw8XSO4HMIFFlct%2FDwKOqi1hxxL5ZFVeA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:19.9859405","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A19Z&sr=b&sp=r&sig=VGaVvLMEnGPS3aTBKWbS3QB4fEPeoYGRcBpTipKv38w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:19.9860291","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3246'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:19 GMT
+      mise-correlation-id:
+      - 08c2f42f-dd9b-45ec-a5a1-cc38f0446e7a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A25Z&sr=b&sp=r&sig=A8zQPWe56LX%2F8%2B2Ah98ZjBQ21%2FBbORCPML8nQYL6H5k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:25.2643554","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A25Z&sr=b&sp=r&sig=kNHegWWG7zhjdQtVjuPgWl0vyDPskTW%2BNasMyCpatyU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:25.2642848","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A25Z&sr=b&sp=r&sig=IH8dOF5awRGIMB92i3izi%2FttvRYyCvjVW7s%2FL4CWa8g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:25.26437","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3253'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:25 GMT
+      mise-correlation-id:
+      - c03baf40-4911-4334-8a8a-1411200b6ba3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A30Z&sr=b&sp=r&sig=W3bFtDppqk9pD7zQ58YE0kIoMVJAwhezCwHSf4tvofE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:30.5416497","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A30Z&sr=b&sp=r&sig=v%2FcKHTW%2BwNTrgoctaCNsr3b7%2FV5gS2DzZ78SG5p8e%2Bg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:30.5415802","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A30Z&sr=b&sp=r&sig=LSc10Xv1xeLjSvHaleXt8R%2FI4h0rl%2BZntEic318biQo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:30.5416645","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3255'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:30 GMT
+      mise-correlation-id:
+      - 8d0897d7-3262-4c9d-bf1d-70e5608b869b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A36Z&sr=b&sp=r&sig=hySkBLTESgPJtLjshNArFxpLajiFb8fB1zgU%2FAjgWBY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:36.7009447","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A36Z&sr=b&sp=r&sig=QSrVjef9QwvRFe7%2BxNRvgfb2avwvtFs9IDai10K2VnU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:36.7008727","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A36Z&sr=b&sp=r&sig=ZN4%2BQ%2BEsJAQ0xWhP1e2qFi92fdikpfYx0N9OTBgJlxg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:36.7009589","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3251'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:36 GMT
+      mise-correlation-id:
+      - 2e23929e-b3f8-4f9e-bd83-4ba2c1d19d6d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A42Z&sr=b&sp=r&sig=9GqosRNOokbAS6sVId1v0uD3LWQCF8O0b7SM3xriJao%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:42.0148017","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A42Z&sr=b&sp=r&sig=5wOfsRgLLDTdByQdjKQxHyJUTla3F%2Ff0HsKUOYsu8LQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:42.0147228","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A42Z&sr=b&sp=r&sig=nR2Q38e%2BltYf7s5Q5yX%2B7rZOPdVXmUsb5gI0zj36UC0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:42.014816","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3248'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:42 GMT
+      mise-correlation-id:
+      - faf30478-f427-477f-a966-3f0078d96cc9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A47Z&sr=b&sp=r&sig=fAnlw1L18wAaxROR0ANIXSLTkRIbTe9Gbomo22z1KBw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:47.3396104","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A47Z&sr=b&sp=r&sig=0gU%2BtHi%2FwFSYX0ltODCgrEPYhrPztBx%2FkfpIw0gWcWE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:47.3395264","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A47Z&sr=b&sp=r&sig=c0vVrgKyY2OuX4%2BXITC9IuqFXSb34gbqbvi6UAyo7gI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:47.3396322","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3251'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:47 GMT
+      mise-correlation-id:
+      - e748da22-40e0-4917-ad54-bcf5e29d2496
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A52Z&sr=b&sp=r&sig=vbv%2FDxrQxJkjHa855UJIQE7WFwjZ9ryL%2Fhaqv45fiFQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:52.6586157","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A52Z&sr=b&sp=r&sig=2nSnpuQTDxwqV26O%2Ba6Hp38YKr1%2Fj9RvtGNj7Pt%2BMas%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:52.6585271","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A52Z&sr=b&sp=r&sig=XjAHa6DWQoQl7O1sghdPqhr5tTTS%2BeMJVqYDcThq0U0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:52.6586294","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3255'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:52 GMT
+      mise-correlation-id:
+      - fcfafd90-c7a8-43e8-a4e6-318452ff8d91
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A57Z&sr=b&sp=r&sig=pcIZpD7aiJ%2Fo1fQEKDtvebX85a%2F5hRFm%2B%2Bf6zzM0o18%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:57.9632506","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A57Z&sr=b&sp=r&sig=vdcG5fLqnDI3qzONXNW59Mb5fJA35HqRlLIqR5KVfBI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:57.9631765","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A57Z&sr=b&sp=r&sig=GRnkYuU9O5RQJuW67YaPIUH1mikJ63fhn5hTrjY3AP4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:57.9632655","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3251'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:57 GMT
+      mise-correlation-id:
+      - 430d5d94-54a3-47bb-93c8-56a1da582b83
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A03Z&sr=b&sp=r&sig=JasLxc%2F4z%2FU62vk9bduos8Nwra2FKWkfGcS1EBldcYE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:03.557568","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A03Z&sr=b&sp=r&sig=gFjaXepTsp8MUuayejFdY8nSXMbPFS2zFI9Slzq%2FhCE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:03.5574637","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A03Z&sr=b&sp=r&sig=YoDHHsRJXLRwwcF2oaybFsTbXz04kTjAlWkCR%2BkANuU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:03.5575854","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3250'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:03 GMT
+      mise-correlation-id:
+      - 4d6c1668-e4c5-43e4-a3cc-aec98bc69be3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A08Z&sr=b&sp=r&sig=6bXhtwuIwsg8mYKIBZAV63OppLtCtZbj4ihlscPHuAs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:08.9202701","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A08Z&sr=b&sp=r&sig=syoBCjSjuzyDQYomtM1FIU919nGxnIZ4GsP6p7CCH2k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:08.9202007","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A08Z&sr=b&sp=r&sig=F3vmW3JIycoi2h%2FWomyT68xzbCp8YPXrcY%2Fds30%2FApY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:08.9202844","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1832,9 +1724,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:21 GMT
+      - Wed, 18 Oct 2023 20:55:08 GMT
       mise-correlation-id:
-      - 39c995bd-ff03-41b7-a409-b2e07d6c2472
+      - 26bc009d-ce4b-4997-b018-521212e53041
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1854,23 +1746,95 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A27Z&sr=b&sp=r&sig=45Qu%2FKMULcwEl6Z8gLDKzGtOm68L6BJXFm6PCsuk5B4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:27.0992413","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A27Z&sr=b&sp=r&sig=DbgJ%2FoMfRLHhDX%2FJx3S%2Fnh%2F0yKM%2BpfnHRa9x87c0mMw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:27.0991559","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A27Z&sr=b&sp=r&sig=StEnfSjEMviCjlFhG8EJ1k8vT2Vi5y%2Ff%2FhDEHBaGs7A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:27.0992597","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-13T13:52:36.886Z","endDateTime":"2023-10-13T13:55:23.624Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:25.351Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A14Z&sr=b&sp=r&sig=G1MlhyrawO67kho6h%2BDU7P3rIfjVazfj23XnoqdF4GA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:14.1765174","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A14Z&sr=b&sp=r&sig=ntmBfKvVl5iT59L6VP8LpUZkDBnISQ4thbqdM%2F16uqo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:14.1763968","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A14Z&sr=b&sp=r&sig=zSPccjkPghQ%2FkBa9K%2FHZHeuZ5KVN5%2FyyRzn0zPUaoBM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:14.1765394","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3295'
+      - '3253'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:27 GMT
+      - Wed, 18 Oct 2023 20:55:14 GMT
       mise-correlation-id:
-      - 51dafe23-d2be-48ce-b7c7-487906d660bd
+      - 55f6977d-8023-43cd-b68d-4a95e2d57f34
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A19Z&sr=b&sp=r&sig=TysKtgMl0UyZVWIdxyBT4ZvWoqcI3BxDOCTKPrv6FGg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:19.4853108","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A19Z&sr=b&sp=r&sig=nLbPRQ5Qbqx%2FSJGtM2pF598TJmXy%2BwEmZBzufnh0HMg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:19.4852069","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A19Z&sr=b&sp=r&sig=d2LBjrjHaVn6TosteasOuj7gKy9%2FnF0owwxxHdBmi6U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:19.4853339","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-18T20:52:39.088Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:28.661Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3249'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:19 GMT
+      mise-correlation-id:
+      - 0798978a-ff84-4516-a358-a847089de8e0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A24Z&sr=b&sp=r&sig=g7TKUX%2FsWWJ8HCQENW7mYG%2FQ0I6RktdqBqLpu1mpjVM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:24.796174","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A24Z&sr=b&sp=r&sig=2W5OgdrxkhpQhaeVcA6jt40atv%2Bab7nfexl75RIk3rU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:24.7960335","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A24Z&sr=b&sp=r&sig=m1mSLSHJaKCjVTOCyJbCM98SxDVqfZmfsWrY%2Bn%2BrqLk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:24.7961974","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-18T20:52:39.088Z","endDateTime":"2023-10-18T20:55:21.879Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:23.62Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3287'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:24 GMT
+      mise-correlation-id:
+      - 135b17e4-c8a6-4d21-a27a-a23b5134002e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1893,7 +1857,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:35.5623435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:35.5623435Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:39.6895752Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:39.6895752Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1902,9 +1866,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:28 GMT
+      - Wed, 18 Oct 2023 20:55:25 GMT
       etag:
-      - '"d8014ceb-0000-0100-0000-65294b6a0000"'
+      - '"7500814e-0000-0100-0000-6530455d0000"'
       expires:
       - '-1'
       pragma:
@@ -1934,23 +1898,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A29Z&sr=b&sp=r&sig=e%2BwTurwOuF7pwn6DDAOlJ2X3vNd1k1JvOVnPZPQCYYM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:29.4656308","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A29Z&sr=b&sp=r&sig=YCa2cEnmMwmr2XY4Bk0lNtunkXLxqOx7LMqUQCtMNF8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:29.4655567","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A29Z&sr=b&sp=r&sig=mm37L8%2Fn%2FSev%2BgrU5xNfjHixIYI%2Bb4UKSEFwEkvmAS8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:29.4656442","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-13T13:52:36.886Z","endDateTime":"2023-10-13T13:55:23.624Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:25.351Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A26Z&sr=b&sp=r&sig=RshwP8%2Brk%2BI6z1djQBlRemGC1O%2BNJ3XjPAoNu%2BwdgHI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:26.9411456","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A26Z&sr=b&sp=r&sig=92XF5gbmxcQ8Rj%2BFtaee40oOH8FOVFmu1DO1NCwBxwY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:26.9410657","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A26Z&sr=b&sp=r&sig=9%2BNEvCrAucr9hEtGICxX70b6q4li81eUEPNkVeSsRZ4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:26.9411647","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-18T20:52:39.088Z","endDateTime":"2023-10-18T20:55:21.879Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:23.62Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3289'
+      - '3290'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:29 GMT
+      - Wed, 18 Oct 2023 20:55:26 GMT
       mise-correlation-id:
-      - 46a7330e-9c53-44fc-a0cb-2f01295af397
+      - 184e8911-a590-45d8-8c17-76c5109a8e94
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1973,7 +1937,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:51:35.5623435Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:51:35.5623435Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:39.6895752Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:39.6895752Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1982,9 +1946,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:30 GMT
+      - Wed, 18 Oct 2023 20:55:27 GMT
       etag:
-      - '"d8014ceb-0000-0100-0000-65294b6a0000"'
+      - '"7500814e-0000-0100-0000-6530455d0000"'
       expires:
       - '-1'
       pragma:
@@ -2014,23 +1978,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b6a787e0-de53-4d4e-be95-4bd5c8afb10d.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://57487ead-0ac2-4a2f-9792-4bd1ebb0ae76.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1365d5ca-2ebc-4bea-81c4-661a1f5ed2f0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"62171b6e-0d63-4366-b7bb-e961f9997a09":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b7453971-1907-402e-a251-49d002301c4a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/cd37a910-8232-4956-bdab-0269fc265826?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A32Z&sr=b&sp=r&sig=4w9cbBk8czKoWN3jAIMWfR2dx5AtDXCY%2FJ8dcIBvdws%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:32.0839705","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/1d1c7569-af65-483f-9af2-b6e2a70da4bb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A32Z&sr=b&sp=r&sig=Mbo7K5EZnXEXgh2JC9da1kmP3tlYYg7Ehlf%2Fn2KlIn0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:32.0839003","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/96bb3c11-9185-46f4-b4f1-a5ec2ffbf1f5/39cb1d23-e818-4e0b-98fd-8fef4fe1de42?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A32Z&sr=b&sp=r&sig=QxWY8FTP5WKoK3KrBLY0ktBgFu16%2F9LhXFvuDJ0dPKM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:32.0839857","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-13T13:52:36.886Z","endDateTime":"2023-10-13T13:55:23.624Z","executedDateTime":"2023-10-13T13:52:36.225Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-13T13:52:36.504Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:25.351Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7018876b-209f-4eb1-a306-e3e4667da02e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"23f7e9bb-341c-41ae-8d3b-eb86fcbb3018":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"361a7b92-7112-4c75-a437-d85b4e4e033d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/fa004022-dcf7-4927-a2a9-f798433bbcd9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A29Z&sr=b&sp=r&sig=%2FE5Wxw%2F%2BLuGNvp6d0aVVC3UtvEa2Rc2DHIxfiAyZIPc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:29.3019492","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/88ed4ac0-eff9-4edd-aeb3-0bed21e3011b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A29Z&sr=b&sp=r&sig=j%2Bqgg%2FpuxHre%2FpOMz04J6tLo4wxAmeOMx1LUL4kmPJI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:29.3018577","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/4b354339-d03a-448e-84b5-066d392069b9/ab279df7-73fc-439d-b5fe-f36b5c973300?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A29Z&sr=b&sp=r&sig=fIBI%2BFcCgsmDqZn8%2FHzAkrCwHwYY1WCp33tKbdhbqFY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:29.3019718","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-18T20:52:39.088Z","endDateTime":"2023-10-18T20:55:21.879Z","executedDateTime":"2023-10-18T20:52:38.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-18T20:52:38.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:23.62Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3285'
+      - '3294'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:32 GMT
+      - Wed, 18 Oct 2023 20:55:29 GMT
       mise-correlation-id:
-      - 4184dade-591a-4192-86db-1751b48217e9
+      - c9a8b9df-0d10-449d-991a-79986c524d1b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_create.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_create.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:12:30.1446438Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:12:30.1446438Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:58.1750771Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:58.1750771Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:04 GMT
+      - Mon, 09 Oct 2023 16:12:32 GMT
       etag:
-      - '"1a0a09c2-0000-0100-0000-64af092f0000"'
+      - '"9201a5ad-0000-0100-0000-652426500000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:13:05 GMT
+      - Mon, 09 Oct 2023 16:12:33 GMT
       mise-correlation-id:
-      - 3bdcd7d8-f922-49d2-ba68-308bb6e50111
+      - ef473bca-4a9d-4bb2-90f5-8cd0bc9fb10d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -85,12 +85,12 @@ interactions:
 - request:
     body: '{"displayName": "CLI-Test", "description": "Test created from az load test
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
-      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "loadTestConfiguration":
+      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "bdc1ebb5-0fab-424c-843b-910d78388102":
+      {"passFailMetrics": {"6fc89fb4-6bf3-4564-a707-4dd60502f3da": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "1b6bee86-72d8-405e-b03f-958dbd3cbd77":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "ecee81e4-63ea-4b5f-859b-dcbc0554feb8": {"aggregate": "avg", "clientMetric":
+      "50"}, "e58845ea-8f94-42a4-a2a9-c74a435b7bd4": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -100,32 +100,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '768'
+      - '789'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"bdc1ebb5-0fab-424c-843b-910d78388102":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"ecee81e4-63ea-4b5f-859b-dcbc0554feb8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:13:05.768Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:05.768Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:33.634Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:33.634Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1062'
+      - '1008'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:05 GMT
+      - Mon, 09 Oct 2023 16:12:33 GMT
       location:
-      - https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+      - https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 3cbbf443-0d98-4a62-8b7d-38a43711fd43
+      - 5931128c-fa3b-4228-b3de-7bd8539fa810
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:06 GMT
+      - Mon, 09 Oct 2023 16:12:33 GMT
       mise-correlation-id:
-      - f0712dc3-9b2f-4fa5-aa0e-6da56256a7bd
+      - 292599a2-aa21-4594-a13f-7c7ab0c8447e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A23%3A06Z&sr=b&sp=r&sig=6YSkvohxnOdWaIDRghkleAdkHX88I3Ec52hPEORIZJ8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:23:06.7879664","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A34Z&sr=b&sp=r&sig=%2Ff5NXM6EYfy6U6GJF2humuXun65QDoJg2aHTmfNQ90A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:34.5558875","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:06 GMT
+      - Mon, 09 Oct 2023 16:12:34 GMT
       location:
-      - https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 8da8495a-9da6-468e-939c-0d2e985e0f2d
+      - a1662b82-6195-4503-9df1-26270a51c59f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A23%3A07Z&sr=b&sp=r&sig=UXh1r7kyUuixdFngo3eAEzOXNdAbZ00MYivPtGfRyrE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:23:07.1544897","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A34Z&sr=b&sp=r&sig=k1BZuaCwVjZwJkhpzlXor%2Fpcam0SA5Xj2uQNmVEHkv8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:34.8417345","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:07 GMT
+      - Mon, 09 Oct 2023 16:12:34 GMT
       mise-correlation-id:
-      - c23eda6e-50ce-4dba-ab82-f1171b6fdb33
+      - bb750f23-fca2-4566-958d-5e92025b8f13
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A23%3A20Z&sr=b&sp=r&sig=wyjpk9jWKxbRsvM2%2Ff4cPuIRI4g3pbp%2Bbbkp2yNuwcY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:23:20.248813","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A40Z&sr=b&sp=r&sig=zYnjPeheV%2BtA0PnanYwexZOKKAEJhNtw06PSbJmAwqs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:40.1253507","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:20 GMT
+      - Mon, 09 Oct 2023 16:12:40 GMT
       mise-correlation-id:
-      - 4d77342c-83ac-46ef-86f1-ce3517b08da7
+      - 33bba84b-2f21-4096-95d8-6575f5c9687a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,24 +385,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"bdc1ebb5-0fab-424c-843b-910d78388102":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"ecee81e4-63ea-4b5f-859b-dcbc0554feb8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A20Z&sr=b&sp=r&sig=wdTR2V0zbjpBSDPA35c1Baaa0rgQGQZXAv9FROJHflQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:20.7446567","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:13:05.768Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:18.788Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A45Z&sr=b&sp=r&sig=xqvO5GggRe31pQFfeQ5hN36RfI49bzwLnXIOVO1QUzg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:45.397448","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1631'
+      - '548'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:20 GMT
+      - Mon, 09 Oct 2023 16:12:45 GMT
       mise-correlation-id:
-      - 0d927099-4f70-4797-81b9-a7c72f94bca0
+      - d6c31ac7-9bbb-4773-a1a3-3308dbf33144
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A50Z&sr=b&sp=r&sig=otSjz1OC7BA185eull0FS45p8Ee2lrsLEIvDz6Gta3M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:50.6902824","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '547'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:12:50 GMT
+      mise-correlation-id:
+      - 0b43ec69-8456-41d6-a878-f85f0f50e78c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A50Z&sr=b&sp=r&sig=tyWs3j15pmXyrzK7glkxA311FEBJJb6J22UYupOmfec%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:50.9482923","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:33.634Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:48.302Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1577'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:12:50 GMT
+      mise-correlation-id:
+      - eb371f93-9d96-455c-9ae9-f4d01297cf86
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -425,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:12:30.1446438Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:12:30.1446438Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:58.1750771Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:58.1750771Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -434,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:22 GMT
+      - Mon, 09 Oct 2023 16:12:51 GMT
       etag:
-      - '"1a0a09c2-0000-0100-0000-64af092f0000"'
+      - '"9201a5ad-0000-0100-0000-652426500000"'
       expires:
       - '-1'
       pragma:
@@ -466,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"bdc1ebb5-0fab-424c-843b-910d78388102":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"ecee81e4-63ea-4b5f-859b-dcbc0554feb8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A24Z&sr=b&sp=r&sig=9lATL1U%2BJr9njtARQfCxHxejjvEVUceLfdHVBlWeMdQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:24.342266","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:13:05.768Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:18.788Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A52Z&sr=b&sp=r&sig=cUTDPBFiiBA87Ch3sTWcfD5flcDRvLKNGmjbJYtS0g8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:52.5080627","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:33.634Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:48.302Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1644'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:24 GMT
+      - Mon, 09 Oct 2023 16:12:52 GMT
       mise-correlation-id:
-      - c9184a7f-bd07-49c8-956c-fd140430bc27
+      - 7864806c-5b44-43f8-94b8-69d0e30a8546
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -506,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:12:30.1446438Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:12:30.1446438Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:58.1750771Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:58.1750771Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -515,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:25 GMT
+      - Mon, 09 Oct 2023 16:12:53 GMT
       etag:
-      - '"1a0a09c2-0000-0100-0000-64af092f0000"'
+      - '"9201a5ad-0000-0100-0000-652426500000"'
       expires:
       - '-1'
       pragma:
@@ -547,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -560,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:13:26 GMT
+      - Mon, 09 Oct 2023 16:12:54 GMT
       mise-correlation-id:
-      - e35240a0-54d9-47ac-82ba-f8b0d9e413b8
+      - 95c315f0-e053-46fe-a068-d05eee1d52fe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -592,25 +664,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"bdc1ebb5-0fab-424c-843b-910d78388102":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"ecee81e4-63ea-4b5f-859b-dcbc0554feb8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/52b8fa8f-631b-42a1-8533-ef94241933e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A27Z&sr=b&sp=r&sig=v69Z92w7p%2FSPofQFDGu1drWwQ1EIRYd1uSF3ze7KuXU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:27.5109589","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A27Z&sr=b&sp=r&sig=hHQz6hWQ1AizUoKODWj00nEWgUbkAp3v1fVQSb5hrPQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:27.5107409","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/499912f4-3c0f-42a6-92e1-a34cb52bd42f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A27Z&sr=b&sp=r&sig=wMBngCAG1m4Bplyi6EVASVgsPHCYFIg2PRL74XOWe4Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:27.5109818","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-07-12T20:13:27.361Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-07-12T20:13:28.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:28.868Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A56Z&sr=b&sp=r&sig=Jfzsz%2BO2jP6Gh%2B9VnfKBlz32HB0Fcnabqw0W7lbQQaU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:12:56.1385709","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A56Z&sr=b&sp=r&sig=puenNnmPPdCD4ci%2F9Pou%2BEb5v8R7eICg%2BoSmgU%2FrjmE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:56.1384696","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A56Z&sr=b&sp=r&sig=QzwXRfiQxeLTWJV3LoutXRg02f6fwFehUwAyhAUBVhU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:12:56.1385914","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:56.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3273'
+      - '3209'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:28 GMT
+      - Mon, 09 Oct 2023 16:12:56 GMT
       location:
-      - https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+      - https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 9f2285f0-fd3a-4461-939b-38f7ee03ce31
+      - c2e4b8c7-b24f-4262-b25d-5421161d66a4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -630,23 +702,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"bdc1ebb5-0fab-424c-843b-910d78388102":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"ecee81e4-63ea-4b5f-859b-dcbc0554feb8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/52b8fa8f-631b-42a1-8533-ef94241933e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A29Z&sr=b&sp=r&sig=eqx4MoAdptvjX9FHPdyGCz1gS%2FUi0seUVXvtGj88qFE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:29.2630689","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A29Z&sr=b&sp=r&sig=z%2BB%2FVU5bG2Ckkq%2BM1Be1%2FVpyXdeDffpnJ2fqtwnvB1o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:29.2629814","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/499912f4-3c0f-42a6-92e1-a34cb52bd42f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A29Z&sr=b&sp=r&sig=vLXLvvhjegk3cH8rAE9YyKK988BA9UYEh5pcuzQ0lMg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:29.2630942","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-07-12T20:13:27.361Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-07-12T20:13:28.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:28.868Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A56Z&sr=b&sp=r&sig=Gc1ZO9qxga8Kzx9Sz3YSZcl6tiXWE4oqH0HmmNJ1hWQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:12:56.646986","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A56Z&sr=b&sp=r&sig=vWYbjwZNmIvKgg6kEWjEKltfD7TeBcuNhWM5%2F7msKss%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:56.6468801","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A56Z&sr=b&sp=r&sig=s5e1f1SiKMsrTqQNLUqMI%2F9Lg7xhCaJm7NMjPwTU18w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:12:56.6470103","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:56.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3281'
+      - '3200'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:29 GMT
+      - Mon, 09 Oct 2023 16:12:56 GMT
       mise-correlation-id:
-      - 32ed7716-2078-4e6e-960e-0206a5496940
+      - 432dbba5-1677-4cc8-b73f-60714528dec0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -666,23 +738,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"bdc1ebb5-0fab-424c-843b-910d78388102":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"ecee81e4-63ea-4b5f-859b-dcbc0554feb8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/52b8fa8f-631b-42a1-8533-ef94241933e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A34Z&sr=b&sp=r&sig=YU3za4G5Kj5jGUzv78gNVEkl169Z9MvNzu%2Bjycu%2Fy5I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:34.5904401","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A34Z&sr=b&sp=r&sig=Av4fLb3J8y0jb9RZk1C09H74M30fErkXxVph3JTE5%2B4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:34.5903701","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/499912f4-3c0f-42a6-92e1-a34cb52bd42f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A34Z&sr=b&sp=r&sig=K28yq59kTHgJTh1nUBcmqUCeMpE9QKdd4lA8PkOnsQU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:34.5904541","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:29.812Z","executedDateTime":"2023-07-12T20:13:27.361Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-07-12T20:13:28.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:30.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A01Z&sr=b&sp=r&sig=CxKlovJpaQj1r9YD6mMB66XbIuVbUkPIyh0wI0WdniM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:01.9938911","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A01Z&sr=b&sp=r&sig=nSk7LdY7psXUJNY53eTFNLWg%2FjOjfyYrv5HeqYmnJSw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:01.993791","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A01Z&sr=b&sp=r&sig=pimboEHbCjoWXD6qVOiN6mqKoPK7rwMznQFf87TcKqw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:01.9939111","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:57.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3324'
+      - '3245'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:34 GMT
+      - Mon, 09 Oct 2023 16:13:01 GMT
       mise-correlation-id:
-      - 86ccc86e-c1dd-4b52-9a42-623cd0efd6cc
+      - 6328bd8f-b254-4d81-99aa-86778b6eac85
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -702,23 +774,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"bdc1ebb5-0fab-424c-843b-910d78388102":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"ecee81e4-63ea-4b5f-859b-dcbc0554feb8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/52b8fa8f-631b-42a1-8533-ef94241933e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A39Z&sr=b&sp=r&sig=%2Bxjdk15mwA5IbJk57SIIDWce8VGIDRusCkZrgdIZ92k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:39.875042","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A39Z&sr=b&sp=r&sig=Vglducjtu2xFtJo6qVPf7IQzv4qK3O2bfmT%2BVYo452A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:39.8749729","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/499912f4-3c0f-42a6-92e1-a34cb52bd42f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A39Z&sr=b&sp=r&sig=qphtDtB%2B%2FyDzlBGvLgzmB9ue1%2BhYKZaoElfbzQGz4rU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:39.8750559","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:29.812Z","executedDateTime":"2023-07-12T20:13:27.361Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-07-12T20:13:28.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:30.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A07Z&sr=b&sp=r&sig=sCbeXqtJs312XpAFRKrjgel0qmzpVdYpvr2LrCUWi0s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:07.2694345","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A07Z&sr=b&sp=r&sig=bmJV0t5PAq1I2Mf0USNY2qJZn%2BOIC2UnFrY5rPHDbPQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:07.2693298","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A07Z&sr=b&sp=r&sig=GmcibNZ%2Bp4GT1AgIYpRc9clTJCsMPJzkA%2BukePLwXME%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:07.2694601","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:57.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3327'
+      - '3250'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:39 GMT
+      - Mon, 09 Oct 2023 16:13:07 GMT
       mise-correlation-id:
-      - e65d8b62-61f2-4be6-9d0a-1f90f28dd258
+      - 57109860-3ef0-4637-8f3e-03ddd5536ff9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -738,23 +810,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"bdc1ebb5-0fab-424c-843b-910d78388102":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"ecee81e4-63ea-4b5f-859b-dcbc0554feb8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/52b8fa8f-631b-42a1-8533-ef94241933e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A45Z&sr=b&sp=r&sig=5ydesyQNJIhM3nUrfwQN7awDz1MLYVDVcITqNNEWQlQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:45.1811831","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A45Z&sr=b&sp=r&sig=7aaDpeP%2FP2TKKaQp7auLm%2FzbhoCiD2dXIBeSlGbWh4I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:45.1811173","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/499912f4-3c0f-42a6-92e1-a34cb52bd42f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A45Z&sr=b&sp=r&sig=05AMR4cmuL6ZXix5SQs%2Broiske91lLZiIzVd4snEl5Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:45.181197","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:29.812Z","executedDateTime":"2023-07-12T20:13:27.361Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-07-12T20:13:28.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:30.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A12Z&sr=b&sp=r&sig=CALDRH64M4A7m0BZgJ8jOR6Wt%2F2NsuGr9zUQUBKn9IM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:12.5904772","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A12Z&sr=b&sp=r&sig=0H9QkRsLmVb9j1%2FqSAqa1pnZkz96ty7AUxSzEUMdmLY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:12.5903806","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A12Z&sr=b&sp=r&sig=p77MsFtzXk5vScQL32rbqpwOtbzmz7ialY%2F%2FbuFko5k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:12.590492","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:57.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3323'
+      - '3251'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:45 GMT
+      - Mon, 09 Oct 2023 16:13:12 GMT
       mise-correlation-id:
-      - b5d114df-6da1-4808-9a4a-64d5dc13f90d
+      - 62aade8e-6de0-4d15-af50-51fdd829c4fe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -774,23 +846,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"bdc1ebb5-0fab-424c-843b-910d78388102":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"ecee81e4-63ea-4b5f-859b-dcbc0554feb8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/52b8fa8f-631b-42a1-8533-ef94241933e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A50Z&sr=b&sp=r&sig=1HpkuSGxcYVxoJpSRvg3V9xdONpK509f6IeLDPBuq1g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:50.4797271","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A50Z&sr=b&sp=r&sig=A8cPVq%2BiGvaoogwaFm7yFv%2FzMa2abGKRVla61xddFm4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:50.4796358","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/499912f4-3c0f-42a6-92e1-a34cb52bd42f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A50Z&sr=b&sp=r&sig=E0nEH2073xxm0BKjvs9FTsVpuJZjO5Q0Ubcs51byMlA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:50.4797514","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:29.812Z","executedDateTime":"2023-07-12T20:13:27.361Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-07-12T20:13:28.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:30.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A17Z&sr=b&sp=r&sig=Jrgh2dFZB7A4iu36qlX8L0ooHVhG%2BbDUAiGKgFQBu9I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:17.8698317","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A17Z&sr=b&sp=r&sig=i8ZSmMPihz4IvQa64oE8vwtdiNF9mCAsD9eI3i1F%2FR8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:17.8697417","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A17Z&sr=b&sp=r&sig=3WGiK%2BrrTy4NfpXtaGfOp5rcylsGjJzlD0b1Nz1cOgw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:17.8698492","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:57.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3322'
+      - '3250'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:50 GMT
+      - Mon, 09 Oct 2023 16:13:17 GMT
       mise-correlation-id:
-      - 6358035f-e28c-4ea8-abd7-98ea61019236
+      - fa59633a-b8b2-42e8-9cd3-771607a34a71
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -810,23 +882,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"bdc1ebb5-0fab-424c-843b-910d78388102":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"ecee81e4-63ea-4b5f-859b-dcbc0554feb8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/52b8fa8f-631b-42a1-8533-ef94241933e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A55Z&sr=b&sp=r&sig=NwrgLCBhL2IUA0I5k8LylhhuvNGQGj5ilfkhlSqaAeQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:55.7759753","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A55Z&sr=b&sp=r&sig=7HUKwJ1yC5hDUqjhPbUA0cXrDB95zxsFw5pzDGjuTLU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:55.7758905","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/499912f4-3c0f-42a6-92e1-a34cb52bd42f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A55Z&sr=b&sp=r&sig=P01ENQoX%2BCn%2BPJeFI%2F5hqEEfM2%2BO47zAYOEI7csn4aM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:55.7759927","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:29.812Z","executedDateTime":"2023-07-12T20:13:27.361Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-07-12T20:13:28.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:30.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A23Z&sr=b&sp=r&sig=k0WGI122%2BXXioelh0J%2FR%2B0u1WrVyjKBI2CZuoRhPNmk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:23.1681506","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A23Z&sr=b&sp=r&sig=UaYh2gYdsI%2F1ySI1Xn84oQbsl5RF6iB4OIAWualvbgE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:23.1680543","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A23Z&sr=b&sp=r&sig=LaswzNVcSePnONWnNX9ww4OPtPewWUb2W3hsNJs4t%2Fk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:23.1681733","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:57.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3326'
+      - '3254'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:55 GMT
+      - Mon, 09 Oct 2023 16:13:23 GMT
       mise-correlation-id:
-      - 57b5d85b-581d-4b96-a715-1bb3ad60bbc7
+      - b8c187ad-0c45-4a55-ac53-eaadb5d126f0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -846,23 +918,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"bdc1ebb5-0fab-424c-843b-910d78388102":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"ecee81e4-63ea-4b5f-859b-dcbc0554feb8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/52b8fa8f-631b-42a1-8533-ef94241933e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A01Z&sr=b&sp=r&sig=E%2BB3y1IJ2%2FjUtFoaWaXwFVRejoFuFHg3x7SlPAkrBps%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:01.1035477","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A01Z&sr=b&sp=r&sig=1ang7dA94wYtKXR6K35NlwZEPV32CqLSitwQfIJJMfw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:01.1034837","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/499912f4-3c0f-42a6-92e1-a34cb52bd42f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A01Z&sr=b&sp=r&sig=GYdZmJWwJXfJSZJJ4%2BFb1BhuGQtP0xitKUNfI87qb88%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:01.103562","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:29.812Z","executedDateTime":"2023-07-12T20:13:27.361Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-07-12T20:13:28.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:30.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A28Z&sr=b&sp=r&sig=gJnsHHiqm40%2BS2OTQfcjUKqIhNTCZxADZm8sPzn7B1Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:28.440104","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A28Z&sr=b&sp=r&sig=BHH0LsntJt9arhHHz%2BJq7kObyUWRrGcV%2BdqoJAFhJhM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:28.4400008","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A28Z&sr=b&sp=r&sig=FhgqXVv1IMdE%2FdSVSFR9uknAkG2qGmYaEYp9jKVipoE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:28.4401328","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:57.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3323'
+      - '3251'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:01 GMT
+      - Mon, 09 Oct 2023 16:13:28 GMT
       mise-correlation-id:
-      - ff74347b-776d-4e8b-94de-da621dc39c55
+      - ed73c38c-b7d4-47a5-afbe-80c034093121
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -882,23 +954,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"bdc1ebb5-0fab-424c-843b-910d78388102":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"ecee81e4-63ea-4b5f-859b-dcbc0554feb8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/52b8fa8f-631b-42a1-8533-ef94241933e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A06Z&sr=b&sp=r&sig=os3KEf%2B%2BZoSAOH5RNChiapYT%2BpXH26rqgZBn4x7BIcA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:06.5462621","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A06Z&sr=b&sp=r&sig=ORLYAp2gFZJgvE8OHHeeZiuvUqQlC3zGVdncjDhKaQE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:06.5461949","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/499912f4-3c0f-42a6-92e1-a34cb52bd42f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A06Z&sr=b&sp=r&sig=zevjPl972%2BzHnR%2Bcw9MmezdsEXEeM4sNGaeFrCPVQh8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:06.5462773","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:29.812Z","executedDateTime":"2023-07-12T20:13:27.361Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-07-12T20:13:28.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:30.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A33Z&sr=b&sp=r&sig=5ROm8Ihca3S54s69prDw4XcfRU3Vv8ImlrV8A2rZN8I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:33.7131811","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A33Z&sr=b&sp=r&sig=YpMaLWGIQBmgS%2BaYpgJsCvusL1nzwzxxIGKyiXqw3qQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:33.7131076","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A33Z&sr=b&sp=r&sig=a%2F6Dl%2Bl1WzgRYH9zIzQIwTwQ6Kyp9FfOC0QXIhosJgw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:33.7131979","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:57.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3328'
+      - '3250'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:06 GMT
+      - Mon, 09 Oct 2023 16:13:33 GMT
       mise-correlation-id:
-      - bd812382-2a9f-4c88-941b-1bcc7b84b37c
+      - d8054ee3-9538-4a38-927d-e119998b2373
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -918,23 +990,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"bdc1ebb5-0fab-424c-843b-910d78388102":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"ecee81e4-63ea-4b5f-859b-dcbc0554feb8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/52b8fa8f-631b-42a1-8533-ef94241933e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A12Z&sr=b&sp=r&sig=SxN2ii5tsn7Y%2FD3tnNlY1I9nyf3RrrbOn9QLBPp65os%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:12.0721103","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A12Z&sr=b&sp=r&sig=KScwocvL%2FM%2BNaLvUyagFkkPBVnZzZWkVHrZqxh%2BoI2E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:12.0720453","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/499912f4-3c0f-42a6-92e1-a34cb52bd42f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A12Z&sr=b&sp=r&sig=U4I%2F%2B0uMQsIfpok9l1AnuIc1HUaXDYOYGmPQuc20B%2F4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:12.0721246","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"CONFIGURING","startDateTime":"2023-07-12T20:13:29.812Z","executedDateTime":"2023-07-12T20:13:27.361Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-07-12T20:13:28.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:10.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A38Z&sr=b&sp=r&sig=V2mLTRNVSLUIMowXfgl%2FGxCr2E3xgsV2KXD%2BGXAh3Qs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:38.9892217","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A38Z&sr=b&sp=r&sig=fifJo47NYUc6gUiqJcD2fTGPlrtfq5p8a%2F2ItuaukDw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:38.9891343","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A38Z&sr=b&sp=r&sig=5ll7RgtWCS1vHEFTKx3D6UDG75VE72PHA507pML44Ro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:38.9892401","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:57.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3331'
+      - '3250'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:12 GMT
+      - Mon, 09 Oct 2023 16:13:38 GMT
       mise-correlation-id:
-      - 4402ab8d-e106-4c4e-b26a-e896fc48fd02
+      - 306a209f-f03c-4077-af33-f3dfbdecaa88
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -954,23 +1026,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"bdc1ebb5-0fab-424c-843b-910d78388102":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"ecee81e4-63ea-4b5f-859b-dcbc0554feb8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/52b8fa8f-631b-42a1-8533-ef94241933e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A17Z&sr=b&sp=r&sig=asSR7pVclJG62UWhdDQkLQbS6Unbo9u1kH7jMiIaHXc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:17.5221263","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A17Z&sr=b&sp=r&sig=5ZJQeaLR9%2BveQYK6kUeMB9FZ%2BWrcVVv4JEJIjSyKTdU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:17.5220587","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/499912f4-3c0f-42a6-92e1-a34cb52bd42f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A17Z&sr=b&sp=r&sig=VJPPwZAgoXxsXSgEJP719s5QyqJhqF7246yJhDBvCbI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:17.5221412","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-07-12T20:13:29.812Z","executedDateTime":"2023-07-12T20:13:27.361Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-07-12T20:13:28.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:14.225Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A44Z&sr=b&sp=r&sig=PK1%2F5dbr%2FmI34ngnvXKJ2Lrg43H3n7NEp1TwlNnSc7U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:44.6572963","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A44Z&sr=b&sp=r&sig=U7ZMrvwthAvqXm%2FdukHDKIM5a8YXaOhSmIAYneFBASc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:44.6572009","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A44Z&sr=b&sp=r&sig=tvP5LbfPwjWizPx2oh85teXJl153uf83o1I01uVWky0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:44.6573201","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"CONFIGURING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:40.787Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3319'
+      - '3250'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:17 GMT
+      - Mon, 09 Oct 2023 16:13:44 GMT
       mise-correlation-id:
-      - 18348c8f-ea6b-418c-be44-4906317f0726
+      - 54761a0f-6c6c-4a44-a64a-845992e4d09c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -990,23 +1062,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"bdc1ebb5-0fab-424c-843b-910d78388102":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"ecee81e4-63ea-4b5f-859b-dcbc0554feb8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/52b8fa8f-631b-42a1-8533-ef94241933e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A24Z&sr=b&sp=r&sig=TvTwW0Sp12dLRuKj0U%2FJ7WhH4sPjuJe0GJ%2Fo892MwwQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:24.0151217","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A24Z&sr=b&sp=r&sig=2xj8k06Gvd%2BJmM73Qc7RP0ydZU1BLNDpVLFcczwLG7I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:24.0150577","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/499912f4-3c0f-42a6-92e1-a34cb52bd42f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A24Z&sr=b&sp=r&sig=L%2FewmPWEyxiT0v6yD80jlLntmxeILl8tsVWYvRZIPl4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:24.0151353","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-07-12T20:13:29.812Z","executedDateTime":"2023-07-12T20:13:27.361Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-07-12T20:13:28.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:14.225Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A49Z&sr=b&sp=r&sig=lpat77um69dojaAVIG2yUtTLhcc2tHlU1KGlkDDDqF8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:49.9386201","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A49Z&sr=b&sp=r&sig=CrOMXXfL3KmxC1lvPsC2BlHluaxCsJNFSL%2BJPDFeEaA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:49.9385395","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A49Z&sr=b&sp=r&sig=a0JKzVgeoTQ3Vo3y4Wm64M%2FFI8qMVOrjfAoj2mqcUjk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:49.9386416","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3323'
+      - '3244'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:24 GMT
+      - Mon, 09 Oct 2023 16:13:49 GMT
       mise-correlation-id:
-      - 6c463ce4-76cd-4cbe-8aca-4ad36637bb68
+      - 3e3d61a3-4bf9-420c-831c-1dd41eeb0f3d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1026,23 +1098,707 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"bdc1ebb5-0fab-424c-843b-910d78388102":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"ecee81e4-63ea-4b5f-859b-dcbc0554feb8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/52b8fa8f-631b-42a1-8533-ef94241933e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A31Z&sr=b&sp=r&sig=58PgjW60dK3S5%2FaeQ5xhEZ6Ykfk0aMCKj%2B2IM%2FiGT7w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:31.6009501","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A31Z&sr=b&sp=r&sig=wkYekS8av9S40O7wMR5DJiif3geLNHbquU0xRnjXE8U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:31.6008558","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/499912f4-3c0f-42a6-92e1-a34cb52bd42f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A31Z&sr=b&sp=r&sig=BrZkRGY68otA4kpS3Onb18yuBVZfhtlJxW5XdTfxFbE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:31.6009678","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-07-12T20:13:29.812Z","endDateTime":"2023-07-12T20:14:24.534Z","executedDateTime":"2023-07-12T20:13:27.361Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-07-12T20:13:28.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:26.028Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A55Z&sr=b&sp=r&sig=%2FvNw3Y23Bi0IG2oFOCwlH4kRwa%2B4h3avmgg5xZYAwVQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:55.2226281","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A55Z&sr=b&sp=r&sig=gA0msrKV1M7vd5VfwXHPm43KrFV%2F5ziuCX8RAXBRtu4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:55.2225531","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A55Z&sr=b&sp=r&sig=%2BVcE%2F6yjI5zn%2B9XlzXx%2B1529z9%2FBH4Zv%2BeTP%2BgidbS8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:55.2226445","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3357'
+      - '3260'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:31 GMT
+      - Mon, 09 Oct 2023 16:13:55 GMT
       mise-correlation-id:
-      - a1914365-6396-4752-ac75-547eaaa09286
+      - e29ea4db-4874-4f8e-9eeb-6daab285d675
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A01Z&sr=b&sp=r&sig=yLWvSMYi0bsQH%2FnHDFoAd5%2FORnwo1CreNtPI33Tp44A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:01.172817","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A01Z&sr=b&sp=r&sig=nTUtNyZAj9jhPWyARt4MbuufRn7vFd7MtJXeq9HP9p8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:01.1727144","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A01Z&sr=b&sp=r&sig=yvjF08dgrXRF%2BlMHERq2IjLVOXzg9KGfPXaWMa%2FHC48%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:01.1728419","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3247'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:01 GMT
+      mise-correlation-id:
+      - a9b580af-c66f-4d3a-ab13-bd61d752f2b3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A06Z&sr=b&sp=r&sig=1GPjJJTiZi0uDQmjlJ5jMBz1sn0XnJ52GuNvKH6xz7A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:06.460126","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A06Z&sr=b&sp=r&sig=TOy9Y%2FL9o4fp0oV%2BzKRXRkOYBzN7acXzV0GQQoNpkdA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:06.4600594","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A06Z&sr=b&sp=r&sig=lc9CxLXhhhzeH3IVElj9e07ngPIOtS4oInnUrkE6wPA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:06.4601424","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3243'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:06 GMT
+      mise-correlation-id:
+      - 0232b963-43bd-4d1e-8f65-24fe0a47503d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A11Z&sr=b&sp=r&sig=kX9lyYWccJf5oIXmyIZltK6Q%2Bq9fDokqaKFzp1GMDME%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:11.737244","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A11Z&sr=b&sp=r&sig=pRl%2B4%2FPGwIPeMGaQ73wGvOnWG3ynTnmZJ5mmYVvZgek%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:11.7371579","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A11Z&sr=b&sp=r&sig=MMSdkXro9rX%2BvGzMgcnNi84OeCcio8ikpbpixji6Sig%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:11.7372657","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3247'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:11 GMT
+      mise-correlation-id:
+      - cf441c64-9309-43b4-933d-c14ca67e7322
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A17Z&sr=b&sp=r&sig=SxM4TEsWw8LXO%2FY4SgVG8Ya9X8FfNjToMfXHR3NVUDw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:17.0055986","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A17Z&sr=b&sp=r&sig=%2FQ8iPXwMF2cu1oBezFkvhNcUv730o0zdnCXJAsaKD0s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:17.0055284","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A17Z&sr=b&sp=r&sig=wic6NLbLcVfQUSXRslE6W4A97cKXfQlAbbgKRkShYiw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:17.0056124","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3244'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:17 GMT
+      mise-correlation-id:
+      - 7cdfd148-fb6e-4437-988b-14d94f10fb78
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A22Z&sr=b&sp=r&sig=LMq9uBhmJpDNoS1CRbVTZF2E71uISKo6mY%2BnD0apx0M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:22.2777558","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A22Z&sr=b&sp=r&sig=DLOHhJ1GjdKGFFLnVBRZX%2FE3mc9O4EK2p1qTFvwwCBM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:22.277661","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A22Z&sr=b&sp=r&sig=oo%2BSGJ5%2FqBdFb1o%2FrDeJqvxc05Dg2M9CP7mppPD8fko%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:22.2777719","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3249'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:22 GMT
+      mise-correlation-id:
+      - d4192ebe-bcaf-4157-a75a-653862b946b9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A27Z&sr=b&sp=r&sig=YlL9NnzZsC1fyLj7B%2FRrlc%2F5Nm2X%2BXuAB%2FuVQwUDnic%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:27.5553872","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A27Z&sr=b&sp=r&sig=732ry1LX8kD6sWuqJWpiICSkwr9jki7%2BNB%2BMgvSnDdI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:27.5552925","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A27Z&sr=b&sp=r&sig=4gF%2FtbUL0AXTA9Xzwhu2z4iLB8pTT2WVeWFbiuE05dM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:27.5554099","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3254'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:27 GMT
+      mise-correlation-id:
+      - d956ce17-74cc-45ee-9e63-37a5ec5f4018
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A32Z&sr=b&sp=r&sig=Qmo4MavlsaY8kIDqkeI7u0qHMNZqHGhI7pRSrMgNfu8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:32.8290379","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A32Z&sr=b&sp=r&sig=21H3ZUpZCfp1T1q%2BKJ7DfZTZhfgY3A2gOlk%2FJodsUBs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:32.8289715","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A32Z&sr=b&sp=r&sig=LpVxh8lpAvCQxhhVi7XQ7qmRT9mErv8nuqVFXT5FatY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:32.8290521","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3244'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:32 GMT
+      mise-correlation-id:
+      - dd61f02c-ab0c-4a06-8f15-25decd8f6037
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A38Z&sr=b&sp=r&sig=mlBWv%2Be0kzRclXnbfB0zcEQWhUCt9H4tpv0tzuRnhuo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:38.1248209","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A38Z&sr=b&sp=r&sig=vPxu2ypww8Ql0ZbI2lHFHSzcu%2BYlQs3%2Bq%2BYEdW6m220%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:38.1247529","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A38Z&sr=b&sp=r&sig=tzV4jIBXwEgGPM5Abw8PdoUK%2BitcJlP%2BZmF0NKfuE8o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:38.1248356","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3252'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:38 GMT
+      mise-correlation-id:
+      - 0197265e-c77d-4d9a-a2ad-20115501d101
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A43Z&sr=b&sp=r&sig=BLHz8IKBnSpE53QFMKZUyCe7WS9v9ne1P%2Fk1%2FCZyPkM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:43.4010565","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A43Z&sr=b&sp=r&sig=moxPtoaMko2vjVn3%2FVIaxdOue3nr9VTy1tt4pLi5vdA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:43.4009659","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A43Z&sr=b&sp=r&sig=c8UKtkmfCHLcy%2FlTgSrRPkkcvLF8oFJ%2BDXm1zJ6wFWc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:43.4010777","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3250'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:43 GMT
+      mise-correlation-id:
+      - 06e8b3f2-2f38-47bb-a104-d91a5c11584b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A48Z&sr=b&sp=r&sig=rwetN1ObckSCtxsU9JO5ofG3Lv5Yruo5IxDbuiS1894%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:48.6789935","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A48Z&sr=b&sp=r&sig=ZZDqp0jPRZK9UnQuOkjXj2vI91IXA8ONCjQRuP1aFSo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:48.6789128","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A48Z&sr=b&sp=r&sig=Ch0jC0wiRgBjgCxLyuKPa0wZ%2BIXFQmEzY7b3HsxWuYg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:48.6790133","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3242'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:48 GMT
+      mise-correlation-id:
+      - 258c26db-6ca5-4a61-9f78-55e851fbfc1c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A54Z&sr=b&sp=r&sig=fLsfSyqQUnURSjDQ7Ck0jU5nrAZvVTARZKuOgRS2MXw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:54.4761267","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A54Z&sr=b&sp=r&sig=aOhkpG6%2Fu4wVJQ2O%2FpAc%2BHJCdU2oJKSSNqE6ulwbKO0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:54.476031","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A54Z&sr=b&sp=r&sig=NtFnwKoAlfSQThoL9TsXqcYpyIn6l7QgJ1dBGnNaPUA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:54.4761511","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3245'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:54 GMT
+      mise-correlation-id:
+      - 60e4f314-6b1f-4bb2-b9f0-128d6909e353
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A59Z&sr=b&sp=r&sig=QYxCCBpl7ZeXp3W%2B2eAPwpaV23%2F2o4jtx%2FWTzi1TCwI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:59.7413727","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A59Z&sr=b&sp=r&sig=dzffxArueyoSdOcwSjLJAC%2BbxRJEhypRQnJI9FolGQY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:59.7412805","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A59Z&sr=b&sp=r&sig=ygiFDBWv1CWA38sBqNJe0tIKV85g5Pxho8exW3rEE3s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:59.7413948","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3248'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:59 GMT
+      mise-correlation-id:
+      - 70ad66f4-5668-4eaa-a034-963a855cc6a2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A05Z&sr=b&sp=r&sig=pSiSN4m%2BFEo8olGt0XBIwqY720YQs8hRhqdDjqsH%2FxU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:05.0269895","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A05Z&sr=b&sp=r&sig=EeECyYY5477yzmmWpZjVPLjUqemU8CXiPX58O7mUQgc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:05.0269083","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A05Z&sr=b&sp=r&sig=%2FOdLhvGKRbQlQIEJysZbDZo22rzvnoJllBo9zT2JiqU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:05.0270097","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3246'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:05 GMT
+      mise-correlation-id:
+      - 6f0347be-046e-4828-a34d-e5d61496adba
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A10Z&sr=b&sp=r&sig=8BiXzcGwrrbanKmOoUmNvFTiQ1Fp0YsgrtowVqfUiMs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:10.8564747","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A10Z&sr=b&sp=r&sig=uwfq5W5n5h98P8KqXw6gzguWR24YR7u0I1P8tNTvUuI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:10.8564103","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A10Z&sr=b&sp=r&sig=afRMH5DdGal1ehs4CIExMXjP3hx%2Bt5YpmIA63YLgCkY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:10.8564887","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3242'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:10 GMT
+      mise-correlation-id:
+      - be7e57ae-e4c8-4905-907a-67dd6924a03b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A16Z&sr=b&sp=r&sig=Vth8SPHuIEynrcDcwAEMFhUO7%2BYpUFSEGYRv5HvmfpU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:16.1191143","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A16Z&sr=b&sp=r&sig=FA4uBhjrIyXWVtxUzMrnl9FzoMpJ%2BiyGHgye4qzX0N0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:16.1190476","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A16Z&sr=b&sp=r&sig=BGaZeMPRZ0ONUOYju1u3H0%2FQ5Ua73VmMxG5%2FKf9U%2BoU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:16.1191294","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3250'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:16 GMT
+      mise-correlation-id:
+      - e9d6de9e-caf4-4a38-a4a8-fefc51b1e99f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A21Z&sr=b&sp=r&sig=FPJftY5mE3vYdEaiNIEjlXqfeTAV%2BcepTsSMGeO0yek%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:21.4093533","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A21Z&sr=b&sp=r&sig=NShsyeR3RNCmdyI7%2F9aVgVpuiJBv8mKxHGG9z79DKL8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:21.4092435","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A21Z&sr=b&sp=r&sig=qiK%2FDtCjrKqqYz5NFxvgv0k2j78S9YJGTHkCLpIln68%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:21.4093716","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3246'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:21 GMT
+      mise-correlation-id:
+      - e101c3e6-8f01-4960-adc6-a30e6fe5fdb2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A26Z&sr=b&sp=r&sig=b3QTDdCWjdUDkl8htb8CTjcnkCOoc6QyYwuZfbYhQwA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:26.6822405","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A26Z&sr=b&sp=r&sig=8GbHotK0Ue2CV511dxb8Tl4evVVYgMFEOKLlv5v7jgw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:26.6821578","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A26Z&sr=b&sp=r&sig=BCSVxrBJITlA6mBORGXrcibsVS5gXqp9L6CPjvUpfsE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:26.6822619","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3240'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:26 GMT
+      mise-correlation-id:
+      - b6a806fa-7a1a-4836-9d34-1bddd7cfd0e9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A31Z&sr=b&sp=r&sig=nZI%2BcZvzCCIUM%2FEP360Id9YqojygW3hUhjxc4f2KmP8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:31.9552764","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A31Z&sr=b&sp=r&sig=U0vgWzTbnerkxv5KgAV%2BGtUXGiZrJpBYhu2Fvpv%2FRKM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:31.9552091","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A31Z&sr=b&sp=r&sig=uIdbux%2BXRnpLMB%2Birm%2BZfmHkf%2FCOdqq%2BfiZKyeraBAs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:31.9552903","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3258'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:31 GMT
+      mise-correlation-id:
+      - b4d0b64f-7289-484f-93bd-7cb9d38c8919
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A37Z&sr=b&sp=r&sig=tygH5yLe3NIEcNLHGueS6bDatlhrPTXPE7SfytXWRvA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:37.2339417","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A37Z&sr=b&sp=r&sig=loSG2tlbSqWr8q9zWjemiK1x%2BAGM%2B%2B1R1S4cE7BctVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:37.2338552","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A37Z&sr=b&sp=r&sig=M6BqfKDVIMJduDGKpUMJ%2FkaFZ4ojEDA3IiYJrZvBUo8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:37.2339578","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-09T16:12:56.956Z","endDateTime":"2023-10-09T16:15:34.449Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:15:35.475Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3286'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:37 GMT
+      mise-correlation-id:
+      - 3b4085ee-9d45-4601-9665-d8e22029bb70
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1065,7 +1821,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:12:30.1446438Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:12:30.1446438Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:58.1750771Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:58.1750771Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1074,9 +1830,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:32 GMT
+      - Mon, 09 Oct 2023 16:15:37 GMT
       etag:
-      - '"1a0a09c2-0000-0100-0000-64af092f0000"'
+      - '"9201a5ad-0000-0100-0000-652426500000"'
       expires:
       - '-1'
       pragma:
@@ -1106,23 +1862,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"bdc1ebb5-0fab-424c-843b-910d78388102":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"ecee81e4-63ea-4b5f-859b-dcbc0554feb8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/52b8fa8f-631b-42a1-8533-ef94241933e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A34Z&sr=b&sp=r&sig=uGf4ffiw67KsDICqLoezLxzH3IQkZTIVJKb96NQW06M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:34.0693201","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A34Z&sr=b&sp=r&sig=AL8K4AUoxDJUTZKTOuPEl%2FOrgIpGCtEnYgct1GCCsmE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:34.0692348","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/499912f4-3c0f-42a6-92e1-a34cb52bd42f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A34Z&sr=b&sp=r&sig=0OH7urMq9qvt06gNeP5h%2Bhh%2BIgYG58ZgUWFqp%2FMafow%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:34.0693392","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/a591791c-864e-4853-9020-9e254ea5edcb_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A34Z&sr=b&sp=r&sig=88ELQHzVKeeIOfG%2Ba6%2FErOgPb%2BlsP2OG%2FI7Rt%2BFxq%2B4%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:34.0693569","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/a591791c-864e-4853-9020-9e254ea5edcb_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A34Z&sr=b&sp=r&sig=LOSeRhSVTNS8z4yT8kWdNq91OhOC%2BV5Cm7qtE6M1SfQ%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:34.0693755","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-07-12T20:13:29.812Z","endDateTime":"2023-07-12T20:14:24.534Z","executedDateTime":"2023-07-12T20:13:27.361Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-07-12T20:13:28.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:32.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A39Z&sr=b&sp=r&sig=6CamFr5aWrwXgyYZ1ekc1aIUJ7KltH9wqSlxVapauC0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:39.5695583","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A39Z&sr=b&sp=r&sig=IQfNzcZcWG3yeN4w3cHLxSTN6X54rdhCB%2Fzom5zIKSU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:39.569452","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A39Z&sr=b&sp=r&sig=FoIjDz6FB85TQlL7vw2OByYnj7Ic8sfUnmfxXqlpocU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:39.5695834","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-09T16:12:56.956Z","endDateTime":"2023-10-09T16:15:34.449Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:15:35.475Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4532'
+      - '3279'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:34 GMT
+      - Mon, 09 Oct 2023 16:15:39 GMT
       mise-correlation-id:
-      - f6291e8c-8b8c-45b4-81f2-cc1b150845ab
+      - 2ab76082-aa0c-46d6-8aea-87f307c2281e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1145,7 +1901,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:12:30.1446438Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:12:30.1446438Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:58.1750771Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:58.1750771Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1154,9 +1910,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:35 GMT
+      - Mon, 09 Oct 2023 16:15:40 GMT
       etag:
-      - '"1a0a09c2-0000-0100-0000-64af092f0000"'
+      - '"9201a5ad-0000-0100-0000-652426500000"'
       expires:
       - '-1'
       pragma:
@@ -1186,23 +1942,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fe641037-9de1-488d-a326-5c2429de2c59.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"12598af8-6425-4f9d-bfb0-3ea0fb75bd5c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"bdc1ebb5-0fab-424c-843b-910d78388102":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"ecee81e4-63ea-4b5f-859b-dcbc0554feb8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/52b8fa8f-631b-42a1-8533-ef94241933e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A37Z&sr=b&sp=r&sig=JiSEj2Q3dPaw4Unai69GgHisjZB6RGkOjQRJ8y%2FGb3o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:37.6641498","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/4458c537-1af1-4f6f-a47c-4eaa02dba8c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A37Z&sr=b&sp=r&sig=lvWDQGtgG9K%2F%2BbM9YROMS2cacjLG1NrZkWnhcfZEZoI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:37.6640542","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/499912f4-3c0f-42a6-92e1-a34cb52bd42f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A37Z&sr=b&sp=r&sig=TdpRfMR7wDJkpPugzJ2mOLNqQKp1AnOHisx4jshfKJU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:37.6641756","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/a591791c-864e-4853-9020-9e254ea5edcb_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A37Z&sr=b&sp=r&sig=u5x4AohpVrf2glbnO03B25hEf1m2pzkumnQRHntNiVs%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:37.664201","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/070c7e0f-914f-473e-b774-6689ab1803b8/a591791c-864e-4853-9020-9e254ea5edcb_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A37Z&sr=b&sp=r&sig=RIxWK7VqQf%2BI6ptlS2treMtwIzS5WPSj2l%2FHh42DqH0%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:37.6642273","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-07-12T20:13:29.812Z","endDateTime":"2023-07-12T20:14:24.534Z","executedDateTime":"2023-07-12T20:13:27.361Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-07-12T20:13:28.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:32.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A41Z&sr=b&sp=r&sig=HHuK4gB4U2jSikKe2GkPF%2BpWdgVczspWVfOePH%2B4Kew%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:41.9107357","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A41Z&sr=b&sp=r&sig=6ToUVOh9VLKtFWbVVnFtM8H8iOUJvB6xDEeN2kksbbc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:41.910643","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A41Z&sr=b&sp=r&sig=UHokNL211ZEWF56iXMq8H8OcMaUhdPTuC8fA97XP5o4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:41.9107619","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/94691505-9f32-4484-ad96-53795fcf3a83_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A41Z&sr=b&sp=r&sig=LV6sCxl3FNNHWDg6GoJ9YXEmlGlxDhco74qN8oC86Wo%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:41.9107872","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/94691505-9f32-4484-ad96-53795fcf3a83_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A41Z&sr=b&sp=r&sig=lebbza2n3hMXNGJYNbCMWWkDbLKLw90czxTvd4HWT%2FU%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:41.9108136","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-09T16:12:56.956Z","endDateTime":"2023-10-09T16:15:34.449Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:15:41.515Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4519'
+      - '4442'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:37 GMT
+      - Mon, 09 Oct 2023 16:15:41 GMT
       mise-correlation-id:
-      - adbf0116-117f-4d55-be06-faeecfb01e10
+      - c3894da5-9bfe-473a-9f15-b2dac02b2325
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_create.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_create.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:58.1750771Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:58.1750771Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:26.2350862Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:26.2350862Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:32 GMT
+      - Mon, 09 Oct 2023 19:19:00 GMT
       etag:
-      - '"9201a5ad-0000-0100-0000-652426500000"'
+      - '"5600b814-0000-0100-0000-652452040000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:12:33 GMT
+      - Mon, 09 Oct 2023 19:19:01 GMT
       mise-correlation-id:
-      - ef473bca-4a9d-4bb2-90f5-8cd0bc9fb10d
+      - 6701ea33-f621-4a70-9bc9-697888fbbfe0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"6fc89fb4-6bf3-4564-a707-4dd60502f3da": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "1b6bee86-72d8-405e-b03f-958dbd3cbd77":
+      {"passFailMetrics": {"7eafd8ff-0693-4dda-8561-41deeb0eeb7c": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "e58845ea-8f94-42a4-a2a9-c74a435b7bd4": {"aggregate": "avg", "clientMetric":
+      "50"}, "92ba572e-89da-4757-b0df-a6d5ddc50e43": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:33.634Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:33.634Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:01.836Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:01.836Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:33 GMT
+      - Mon, 09 Oct 2023 19:19:01 GMT
       location:
-      - https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+      - https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 5931128c-fa3b-4228-b3de-7bd8539fa810
+      - d6407df9-7e8a-499f-8b46-e69200dee37a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:33 GMT
+      - Mon, 09 Oct 2023 19:19:02 GMT
       mise-correlation-id:
-      - 292599a2-aa21-4594-a13f-7c7ab0c8447e
+      - f07cb74e-7cfa-4303-8e0b-6997ba36f2bf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A34Z&sr=b&sp=r&sig=%2Ff5NXM6EYfy6U6GJF2humuXun65QDoJg2aHTmfNQ90A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:34.5558875","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A03Z&sr=b&sp=r&sig=1DAhF3MZ8qurLC%2BVOieejnwRhzJXb2%2Bln35DLEomRwo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:03.2982942","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:34 GMT
+      - Mon, 09 Oct 2023 19:19:03 GMT
       location:
-      - https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - a1662b82-6195-4503-9df1-26270a51c59f
+      - 13491897-b45e-4e8c-8d26-4d7417321d34
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A34Z&sr=b&sp=r&sig=k1BZuaCwVjZwJkhpzlXor%2Fpcam0SA5Xj2uQNmVEHkv8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:34.8417345","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A03Z&sr=b&sp=r&sig=1DAhF3MZ8qurLC%2BVOieejnwRhzJXb2%2Bln35DLEomRwo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:03.6011739","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:19:03 GMT
+      mise-correlation-id:
+      - 8fc55b0d-1635-4a87-9b8d-4f124618cb39
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A08Z&sr=b&sp=r&sig=PWXkgJrhuHrfMjW3Y9yW%2Bg2bjmy8cQ6qeh47OLmF5Js%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:08.9220881","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:34 GMT
+      - Mon, 09 Oct 2023 19:19:08 GMT
       mise-correlation-id:
-      - bb750f23-fca2-4566-958d-5e92025b8f13
+      - 3b17b3a2-9955-4e0b-9461-a47b6a95c744
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A40Z&sr=b&sp=r&sig=zYnjPeheV%2BtA0PnanYwexZOKKAEJhNtw06PSbJmAwqs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:40.1253507","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A14Z&sr=b&sp=r&sig=UtDCHqOJeIjaHJ9DS0QF6CNoXdy6Jh7RzeS6GKZbmxM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:14.1934386","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:40 GMT
+      - Mon, 09 Oct 2023 19:19:14 GMT
       mise-correlation-id:
-      - 33bba84b-2f21-4096-95d8-6575f5c9687a
+      - a0cf8924-ae52-4f95-962a-2058179583bb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,46 +421,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A45Z&sr=b&sp=r&sig=xqvO5GggRe31pQFfeQ5hN36RfI49bzwLnXIOVO1QUzg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:45.397448","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '548'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:12:45 GMT
-      mise-correlation-id:
-      - d6c31ac7-9bbb-4773-a1a3-3308dbf33144
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A50Z&sr=b&sp=r&sig=otSjz1OC7BA185eull0FS45p8Ee2lrsLEIvDz6Gta3M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:50.6902824","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A19Z&sr=b&sp=r&sig=iF2LlzP2iJmMpwXIBdmZT7140wIN9Xnehiigpib01FE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:19.4817897","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:50 GMT
+      - Mon, 09 Oct 2023 19:19:19 GMT
       mise-correlation-id:
-      - 0b43ec69-8456-41d6-a878-f85f0f50e78c
+      - 8f148375-c557-4c21-bcec-5dd8141e791f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,11 +457,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A50Z&sr=b&sp=r&sig=tyWs3j15pmXyrzK7glkxA311FEBJJb6J22UYupOmfec%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:50.9482923","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:33.634Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:48.302Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A19Z&sr=b&sp=r&sig=JJ741TKYklUSWiwHCLlg8VCOWJmgznCPqYFamQDDFFA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:19.7826347","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:01.836Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:18.386Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,9 +472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:50 GMT
+      - Mon, 09 Oct 2023 19:19:19 GMT
       mise-correlation-id:
-      - eb371f93-9d96-455c-9ae9-f4d01297cf86
+      - 42f6a0b3-0a8b-499b-981a-9439909bb043
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:58.1750771Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:58.1750771Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:26.2350862Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:26.2350862Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:51 GMT
+      - Mon, 09 Oct 2023 19:19:21 GMT
       etag:
-      - '"9201a5ad-0000-0100-0000-652426500000"'
+      - '"5600b814-0000-0100-0000-652452040000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A52Z&sr=b&sp=r&sig=cUTDPBFiiBA87Ch3sTWcfD5flcDRvLKNGmjbJYtS0g8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:52.5080627","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:33.634Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:48.302Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A22Z&sr=b&sp=r&sig=nv5OpbiySoS67RD8AWTHDru6Ef%2FWg9flaR%2BGGVbnEU0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:22.2457858","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:01.836Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:18.386Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1589'
+      - '1593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:52 GMT
+      - Mon, 09 Oct 2023 19:19:22 GMT
       mise-correlation-id:
-      - 7864806c-5b44-43f8-94b8-69d0e30a8546
+      - 1782e304-9aec-4c55-8c08-2874d8d77c33
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:58.1750771Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:58.1750771Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:26.2350862Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:26.2350862Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:53 GMT
+      - Mon, 09 Oct 2023 19:19:23 GMT
       etag:
-      - '"9201a5ad-0000-0100-0000-652426500000"'
+      - '"5600b814-0000-0100-0000-652452040000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:12:54 GMT
+      - Mon, 09 Oct 2023 19:19:24 GMT
       mise-correlation-id:
-      - 95c315f0-e053-46fe-a068-d05eee1d52fe
+      - d7310c02-81aa-4604-a49a-978837783c65
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -664,10 +664,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A56Z&sr=b&sp=r&sig=Jfzsz%2BO2jP6Gh%2B9VnfKBlz32HB0Fcnabqw0W7lbQQaU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:12:56.1385709","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A56Z&sr=b&sp=r&sig=puenNnmPPdCD4ci%2F9Pou%2BEb5v8R7eICg%2BoSmgU%2FrjmE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:56.1384696","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A56Z&sr=b&sp=r&sig=QzwXRfiQxeLTWJV3LoutXRg02f6fwFehUwAyhAUBVhU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:12:56.1385914","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:56.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A25Z&sr=b&sp=r&sig=r9EF8%2FD6g%2BilfwWPnNIyrIiSp3xvEIR6yPQdLgz%2FHTY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:25.6614784","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A25Z&sr=b&sp=r&sig=BWYfFXfc5%2Fu6Dndd9u4f7NWfHG8MQJLFj5ycdaQkZRY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:25.6613491","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A25Z&sr=b&sp=r&sig=aoM9rbodpIyue%2F3Ey76Mru2FdeomIAd0ZLCI5p0JEgM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:25.6615387","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:25.589Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -678,11 +678,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:56 GMT
+      - Mon, 09 Oct 2023 19:19:25 GMT
       location:
-      - https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+      - https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - c2e4b8c7-b24f-4262-b25d-5421161d66a4
+      - fe7693da-b0d6-4076-8117-f8d6119c82de
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -702,23 +702,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A56Z&sr=b&sp=r&sig=Gc1ZO9qxga8Kzx9Sz3YSZcl6tiXWE4oqH0HmmNJ1hWQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:12:56.646986","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A56Z&sr=b&sp=r&sig=vWYbjwZNmIvKgg6kEWjEKltfD7TeBcuNhWM5%2F7msKss%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:56.6468801","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A56Z&sr=b&sp=r&sig=s5e1f1SiKMsrTqQNLUqMI%2F9Lg7xhCaJm7NMjPwTU18w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:12:56.6470103","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:56.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A26Z&sr=b&sp=r&sig=yHJITbnMldR5Cmj1yIxS405%2Br2pTtgIWcSBwd7vXl88%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:26.5688268","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A26Z&sr=b&sp=r&sig=D2eFGkW888ZVwtJ6dkEcSeab1VBOx3CxBrM6gKq8%2BnU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:26.5687568","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A26Z&sr=b&sp=r&sig=SiluhJIpZjuGGkRCii7LPG8qc4cjUnX78Y8WSsjD5Wg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:26.5688434","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:25.589Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3200'
+      - '3203'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:56 GMT
+      - Mon, 09 Oct 2023 19:19:26 GMT
       mise-correlation-id:
-      - 432dbba5-1677-4cc8-b73f-60714528dec0
+      - 06e2f8c5-f079-42fb-b03d-0b08cf060d88
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -738,658 +738,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A01Z&sr=b&sp=r&sig=CxKlovJpaQj1r9YD6mMB66XbIuVbUkPIyh0wI0WdniM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:01.9938911","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A01Z&sr=b&sp=r&sig=nSk7LdY7psXUJNY53eTFNLWg%2FjOjfyYrv5HeqYmnJSw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:01.993791","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A01Z&sr=b&sp=r&sig=pimboEHbCjoWXD6qVOiN6mqKoPK7rwMznQFf87TcKqw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:01.9939111","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:57.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3245'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:01 GMT
-      mise-correlation-id:
-      - 6328bd8f-b254-4d81-99aa-86778b6eac85
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A07Z&sr=b&sp=r&sig=sCbeXqtJs312XpAFRKrjgel0qmzpVdYpvr2LrCUWi0s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:07.2694345","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A07Z&sr=b&sp=r&sig=bmJV0t5PAq1I2Mf0USNY2qJZn%2BOIC2UnFrY5rPHDbPQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:07.2693298","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A07Z&sr=b&sp=r&sig=GmcibNZ%2Bp4GT1AgIYpRc9clTJCsMPJzkA%2BukePLwXME%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:07.2694601","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:57.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3250'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:07 GMT
-      mise-correlation-id:
-      - 57109860-3ef0-4637-8f3e-03ddd5536ff9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A12Z&sr=b&sp=r&sig=CALDRH64M4A7m0BZgJ8jOR6Wt%2F2NsuGr9zUQUBKn9IM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:12.5904772","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A12Z&sr=b&sp=r&sig=0H9QkRsLmVb9j1%2FqSAqa1pnZkz96ty7AUxSzEUMdmLY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:12.5903806","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A12Z&sr=b&sp=r&sig=p77MsFtzXk5vScQL32rbqpwOtbzmz7ialY%2F%2FbuFko5k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:12.590492","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:57.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3251'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:12 GMT
-      mise-correlation-id:
-      - 62aade8e-6de0-4d15-af50-51fdd829c4fe
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A17Z&sr=b&sp=r&sig=Jrgh2dFZB7A4iu36qlX8L0ooHVhG%2BbDUAiGKgFQBu9I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:17.8698317","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A17Z&sr=b&sp=r&sig=i8ZSmMPihz4IvQa64oE8vwtdiNF9mCAsD9eI3i1F%2FR8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:17.8697417","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A17Z&sr=b&sp=r&sig=3WGiK%2BrrTy4NfpXtaGfOp5rcylsGjJzlD0b1Nz1cOgw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:17.8698492","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:57.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3250'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:17 GMT
-      mise-correlation-id:
-      - fa59633a-b8b2-42e8-9cd3-771607a34a71
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A23Z&sr=b&sp=r&sig=k0WGI122%2BXXioelh0J%2FR%2B0u1WrVyjKBI2CZuoRhPNmk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:23.1681506","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A23Z&sr=b&sp=r&sig=UaYh2gYdsI%2F1ySI1Xn84oQbsl5RF6iB4OIAWualvbgE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:23.1680543","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A23Z&sr=b&sp=r&sig=LaswzNVcSePnONWnNX9ww4OPtPewWUb2W3hsNJs4t%2Fk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:23.1681733","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:57.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3254'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:23 GMT
-      mise-correlation-id:
-      - b8c187ad-0c45-4a55-ac53-eaadb5d126f0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A28Z&sr=b&sp=r&sig=gJnsHHiqm40%2BS2OTQfcjUKqIhNTCZxADZm8sPzn7B1Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:28.440104","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A28Z&sr=b&sp=r&sig=BHH0LsntJt9arhHHz%2BJq7kObyUWRrGcV%2BdqoJAFhJhM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:28.4400008","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A28Z&sr=b&sp=r&sig=FhgqXVv1IMdE%2FdSVSFR9uknAkG2qGmYaEYp9jKVipoE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:28.4401328","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:57.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3251'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:28 GMT
-      mise-correlation-id:
-      - ed73c38c-b7d4-47a5-afbe-80c034093121
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A33Z&sr=b&sp=r&sig=5ROm8Ihca3S54s69prDw4XcfRU3Vv8ImlrV8A2rZN8I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:33.7131811","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A33Z&sr=b&sp=r&sig=YpMaLWGIQBmgS%2BaYpgJsCvusL1nzwzxxIGKyiXqw3qQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:33.7131076","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A33Z&sr=b&sp=r&sig=a%2F6Dl%2Bl1WzgRYH9zIzQIwTwQ6Kyp9FfOC0QXIhosJgw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:33.7131979","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:57.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3250'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:33 GMT
-      mise-correlation-id:
-      - d8054ee3-9538-4a38-927d-e119998b2373
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A38Z&sr=b&sp=r&sig=V2mLTRNVSLUIMowXfgl%2FGxCr2E3xgsV2KXD%2BGXAh3Qs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:38.9892217","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A38Z&sr=b&sp=r&sig=fifJo47NYUc6gUiqJcD2fTGPlrtfq5p8a%2F2ItuaukDw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:38.9891343","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A38Z&sr=b&sp=r&sig=5ll7RgtWCS1vHEFTKx3D6UDG75VE72PHA507pML44Ro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:38.9892401","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:57.05Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3250'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:38 GMT
-      mise-correlation-id:
-      - 306a209f-f03c-4077-af33-f3dfbdecaa88
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A44Z&sr=b&sp=r&sig=PK1%2F5dbr%2FmI34ngnvXKJ2Lrg43H3n7NEp1TwlNnSc7U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:44.6572963","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A44Z&sr=b&sp=r&sig=U7ZMrvwthAvqXm%2FdukHDKIM5a8YXaOhSmIAYneFBASc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:44.6572009","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A44Z&sr=b&sp=r&sig=tvP5LbfPwjWizPx2oh85teXJl153uf83o1I01uVWky0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:44.6573201","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"CONFIGURING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:40.787Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3250'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:44 GMT
-      mise-correlation-id:
-      - 54761a0f-6c6c-4a44-a64a-845992e4d09c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A49Z&sr=b&sp=r&sig=lpat77um69dojaAVIG2yUtTLhcc2tHlU1KGlkDDDqF8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:49.9386201","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A49Z&sr=b&sp=r&sig=CrOMXXfL3KmxC1lvPsC2BlHluaxCsJNFSL%2BJPDFeEaA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:49.9385395","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A49Z&sr=b&sp=r&sig=a0JKzVgeoTQ3Vo3y4Wm64M%2FFI8qMVOrjfAoj2mqcUjk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:49.9386416","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3244'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:49 GMT
-      mise-correlation-id:
-      - 3e3d61a3-4bf9-420c-831c-1dd41eeb0f3d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A55Z&sr=b&sp=r&sig=%2FvNw3Y23Bi0IG2oFOCwlH4kRwa%2B4h3avmgg5xZYAwVQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:55.2226281","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A55Z&sr=b&sp=r&sig=gA0msrKV1M7vd5VfwXHPm43KrFV%2F5ziuCX8RAXBRtu4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:55.2225531","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A55Z&sr=b&sp=r&sig=%2BVcE%2F6yjI5zn%2B9XlzXx%2B1529z9%2FBH4Zv%2BeTP%2BgidbS8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:55.2226445","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3260'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:55 GMT
-      mise-correlation-id:
-      - e29ea4db-4874-4f8e-9eeb-6daab285d675
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A01Z&sr=b&sp=r&sig=yLWvSMYi0bsQH%2FnHDFoAd5%2FORnwo1CreNtPI33Tp44A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:01.172817","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A01Z&sr=b&sp=r&sig=nTUtNyZAj9jhPWyARt4MbuufRn7vFd7MtJXeq9HP9p8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:01.1727144","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A01Z&sr=b&sp=r&sig=yvjF08dgrXRF%2BlMHERq2IjLVOXzg9KGfPXaWMa%2FHC48%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:01.1728419","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3247'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:01 GMT
-      mise-correlation-id:
-      - a9b580af-c66f-4d3a-ab13-bd61d752f2b3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A06Z&sr=b&sp=r&sig=1GPjJJTiZi0uDQmjlJ5jMBz1sn0XnJ52GuNvKH6xz7A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:06.460126","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A06Z&sr=b&sp=r&sig=TOy9Y%2FL9o4fp0oV%2BzKRXRkOYBzN7acXzV0GQQoNpkdA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:06.4600594","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A06Z&sr=b&sp=r&sig=lc9CxLXhhhzeH3IVElj9e07ngPIOtS4oInnUrkE6wPA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:06.4601424","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3243'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:06 GMT
-      mise-correlation-id:
-      - 0232b963-43bd-4d1e-8f65-24fe0a47503d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A11Z&sr=b&sp=r&sig=kX9lyYWccJf5oIXmyIZltK6Q%2Bq9fDokqaKFzp1GMDME%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:11.737244","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A11Z&sr=b&sp=r&sig=pRl%2B4%2FPGwIPeMGaQ73wGvOnWG3ynTnmZJ5mmYVvZgek%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:11.7371579","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A11Z&sr=b&sp=r&sig=MMSdkXro9rX%2BvGzMgcnNi84OeCcio8ikpbpixji6Sig%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:11.7372657","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3247'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:11 GMT
-      mise-correlation-id:
-      - cf441c64-9309-43b4-933d-c14ca67e7322
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A17Z&sr=b&sp=r&sig=SxM4TEsWw8LXO%2FY4SgVG8Ya9X8FfNjToMfXHR3NVUDw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:17.0055986","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A17Z&sr=b&sp=r&sig=%2FQ8iPXwMF2cu1oBezFkvhNcUv730o0zdnCXJAsaKD0s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:17.0055284","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A17Z&sr=b&sp=r&sig=wic6NLbLcVfQUSXRslE6W4A97cKXfQlAbbgKRkShYiw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:17.0056124","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3244'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:17 GMT
-      mise-correlation-id:
-      - 7cdfd148-fb6e-4437-988b-14d94f10fb78
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A22Z&sr=b&sp=r&sig=LMq9uBhmJpDNoS1CRbVTZF2E71uISKo6mY%2BnD0apx0M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:22.2777558","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A22Z&sr=b&sp=r&sig=DLOHhJ1GjdKGFFLnVBRZX%2FE3mc9O4EK2p1qTFvwwCBM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:22.277661","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A22Z&sr=b&sp=r&sig=oo%2BSGJ5%2FqBdFb1o%2FrDeJqvxc05Dg2M9CP7mppPD8fko%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:22.2777719","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3249'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:22 GMT
-      mise-correlation-id:
-      - d4192ebe-bcaf-4157-a75a-653862b946b9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A27Z&sr=b&sp=r&sig=YlL9NnzZsC1fyLj7B%2FRrlc%2F5Nm2X%2BXuAB%2FuVQwUDnic%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:27.5553872","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A27Z&sr=b&sp=r&sig=732ry1LX8kD6sWuqJWpiICSkwr9jki7%2BNB%2BMgvSnDdI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:27.5552925","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A27Z&sr=b&sp=r&sig=4gF%2FtbUL0AXTA9Xzwhu2z4iLB8pTT2WVeWFbiuE05dM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:27.5554099","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3254'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:27 GMT
-      mise-correlation-id:
-      - d956ce17-74cc-45ee-9e63-37a5ec5f4018
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A32Z&sr=b&sp=r&sig=Qmo4MavlsaY8kIDqkeI7u0qHMNZqHGhI7pRSrMgNfu8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:32.8290379","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A32Z&sr=b&sp=r&sig=21H3ZUpZCfp1T1q%2BKJ7DfZTZhfgY3A2gOlk%2FJodsUBs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:32.8289715","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A32Z&sr=b&sp=r&sig=LpVxh8lpAvCQxhhVi7XQ7qmRT9mErv8nuqVFXT5FatY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:32.8290521","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3244'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:32 GMT
-      mise-correlation-id:
-      - dd61f02c-ab0c-4a06-8f15-25decd8f6037
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A38Z&sr=b&sp=r&sig=mlBWv%2Be0kzRclXnbfB0zcEQWhUCt9H4tpv0tzuRnhuo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:38.1248209","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A38Z&sr=b&sp=r&sig=vPxu2ypww8Ql0ZbI2lHFHSzcu%2BYlQs3%2Bq%2BYEdW6m220%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:38.1247529","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A38Z&sr=b&sp=r&sig=tzV4jIBXwEgGPM5Abw8PdoUK%2BitcJlP%2BZmF0NKfuE8o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:38.1248356","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A31Z&sr=b&sp=r&sig=zyY0tQwZ7AiyqFnUdCawAOJbatFAr3oyY1jHBe1FN5s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:31.8809159","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A31Z&sr=b&sp=r&sig=d2Ix6bY%2BMueypsh2KnWOa7b2%2FJtpgMI2wdFtt5SexXU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:31.8808444","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A31Z&sr=b&sp=r&sig=Mge0AVBxVUrKXXVNVGQOoga42z9WEFXRyRpsNk%2Fc8EU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:31.8809303","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:26.936Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1400,9 +752,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:14:38 GMT
+      - Mon, 09 Oct 2023 19:19:31 GMT
       mise-correlation-id:
-      - 0197265e-c77d-4d9a-a2ad-20115501d101
+      - 5f5d0636-04d1-4fa1-a51e-790dc86e61ce
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1422,23 +774,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A43Z&sr=b&sp=r&sig=BLHz8IKBnSpE53QFMKZUyCe7WS9v9ne1P%2Fk1%2FCZyPkM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:43.4010565","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A43Z&sr=b&sp=r&sig=moxPtoaMko2vjVn3%2FVIaxdOue3nr9VTy1tt4pLi5vdA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:43.4009659","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A43Z&sr=b&sp=r&sig=c8UKtkmfCHLcy%2FlTgSrRPkkcvLF8oFJ%2BDXm1zJ6wFWc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:43.4010777","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A37Z&sr=b&sp=r&sig=w%2BMGY6ov2VAsUBnx%2B6gE5UaugnSR5e1HtL%2BIK1UWz%2B0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:37.2507723","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A37Z&sr=b&sp=r&sig=u4HYcNGdES1hv2GWwjVDQ7vWKxuLO9tuEbB0MK%2FxxTc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:37.2506868","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A37Z&sr=b&sp=r&sig=Kd%2BVAfNstG7yxUq3Cglb4LwDHSTzDI2npR%2BZHSaT61A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:37.2507894","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:26.936Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3250'
+      - '3260'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:14:43 GMT
+      - Mon, 09 Oct 2023 19:19:37 GMT
       mise-correlation-id:
-      - 06e8b3f2-2f38-47bb-a104-d91a5c11584b
+      - 8538f03e-f72a-4f0e-b95a-e697af70daf6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1458,23 +810,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A48Z&sr=b&sp=r&sig=rwetN1ObckSCtxsU9JO5ofG3Lv5Yruo5IxDbuiS1894%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:48.6789935","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A48Z&sr=b&sp=r&sig=ZZDqp0jPRZK9UnQuOkjXj2vI91IXA8ONCjQRuP1aFSo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:48.6789128","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A48Z&sr=b&sp=r&sig=Ch0jC0wiRgBjgCxLyuKPa0wZ%2BIXFQmEzY7b3HsxWuYg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:48.6790133","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A42Z&sr=b&sp=r&sig=C3ByVuh%2BIjAeK%2Bv%2B2MImG36%2FcvOY5SSSGQaJxcsQrDY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:42.5194763","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A42Z&sr=b&sp=r&sig=PY5Z%2BBuslGl2xeMLsx%2BsSXBIDQj%2B8BDxgAUBQn7bteA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:42.5193804","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A42Z&sr=b&sp=r&sig=u29tY3qQG95ELhiA3Zxd7FLwP2oCUZT8Ru2WiXwy4Y4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:42.5195005","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:26.936Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3242'
+      - '3260'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:14:48 GMT
+      - Mon, 09 Oct 2023 19:19:42 GMT
       mise-correlation-id:
-      - 258c26db-6ca5-4a61-9f78-55e851fbfc1c
+      - d6942c5a-1b87-432f-9c0c-5bd1fd0efdac
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1494,23 +846,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A54Z&sr=b&sp=r&sig=fLsfSyqQUnURSjDQ7Ck0jU5nrAZvVTARZKuOgRS2MXw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:54.4761267","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A54Z&sr=b&sp=r&sig=aOhkpG6%2Fu4wVJQ2O%2FpAc%2BHJCdU2oJKSSNqE6ulwbKO0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:54.476031","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A54Z&sr=b&sp=r&sig=NtFnwKoAlfSQThoL9TsXqcYpyIn6l7QgJ1dBGnNaPUA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:54.4761511","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A47Z&sr=b&sp=r&sig=OGLG3%2BcA%2BYDZm%2BLXl6BqthmyuNWZ4ay6j6AtMhb9Zlg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:47.8117559","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A47Z&sr=b&sp=r&sig=UNxaWRAH6FsBxeOLRlTaA5GDzPw2ZM%2Fm9YBTB5KIcJU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:47.811542","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A47Z&sr=b&sp=r&sig=6iM320F26NnKTdu5KIzNhiqiL%2BHR93kCifVDT2hrwXo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:47.8117867","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:26.936Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3245'
+      - '3255'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:14:54 GMT
+      - Mon, 09 Oct 2023 19:19:47 GMT
       mise-correlation-id:
-      - 60e4f314-6b1f-4bb2-b9f0-128d6909e353
+      - 60e7a74b-2fd0-458c-a7d1-ac39d5f2463b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1530,226 +882,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A59Z&sr=b&sp=r&sig=QYxCCBpl7ZeXp3W%2B2eAPwpaV23%2F2o4jtx%2FWTzi1TCwI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:59.7413727","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A59Z&sr=b&sp=r&sig=dzffxArueyoSdOcwSjLJAC%2BbxRJEhypRQnJI9FolGQY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:59.7412805","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A59Z&sr=b&sp=r&sig=ygiFDBWv1CWA38sBqNJe0tIKV85g5Pxho8exW3rEE3s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:59.7413948","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3248'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:59 GMT
-      mise-correlation-id:
-      - 70ad66f4-5668-4eaa-a034-963a855cc6a2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A05Z&sr=b&sp=r&sig=pSiSN4m%2BFEo8olGt0XBIwqY720YQs8hRhqdDjqsH%2FxU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:05.0269895","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A05Z&sr=b&sp=r&sig=EeECyYY5477yzmmWpZjVPLjUqemU8CXiPX58O7mUQgc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:05.0269083","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A05Z&sr=b&sp=r&sig=%2FOdLhvGKRbQlQIEJysZbDZo22rzvnoJllBo9zT2JiqU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:05.0270097","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3246'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:05 GMT
-      mise-correlation-id:
-      - 6f0347be-046e-4828-a34d-e5d61496adba
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A10Z&sr=b&sp=r&sig=8BiXzcGwrrbanKmOoUmNvFTiQ1Fp0YsgrtowVqfUiMs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:10.8564747","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A10Z&sr=b&sp=r&sig=uwfq5W5n5h98P8KqXw6gzguWR24YR7u0I1P8tNTvUuI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:10.8564103","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A10Z&sr=b&sp=r&sig=afRMH5DdGal1ehs4CIExMXjP3hx%2Bt5YpmIA63YLgCkY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:10.8564887","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3242'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:10 GMT
-      mise-correlation-id:
-      - be7e57ae-e4c8-4905-907a-67dd6924a03b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A16Z&sr=b&sp=r&sig=Vth8SPHuIEynrcDcwAEMFhUO7%2BYpUFSEGYRv5HvmfpU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:16.1191143","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A16Z&sr=b&sp=r&sig=FA4uBhjrIyXWVtxUzMrnl9FzoMpJ%2BiyGHgye4qzX0N0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:16.1190476","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A16Z&sr=b&sp=r&sig=BGaZeMPRZ0ONUOYju1u3H0%2FQ5Ua73VmMxG5%2FKf9U%2BoU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:16.1191294","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3250'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:16 GMT
-      mise-correlation-id:
-      - e9d6de9e-caf4-4a38-a4a8-fefc51b1e99f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A21Z&sr=b&sp=r&sig=FPJftY5mE3vYdEaiNIEjlXqfeTAV%2BcepTsSMGeO0yek%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:21.4093533","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A21Z&sr=b&sp=r&sig=NShsyeR3RNCmdyI7%2F9aVgVpuiJBv8mKxHGG9z79DKL8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:21.4092435","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A21Z&sr=b&sp=r&sig=qiK%2FDtCjrKqqYz5NFxvgv0k2j78S9YJGTHkCLpIln68%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:21.4093716","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3246'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:21 GMT
-      mise-correlation-id:
-      - e101c3e6-8f01-4960-adc6-a30e6fe5fdb2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A26Z&sr=b&sp=r&sig=b3QTDdCWjdUDkl8htb8CTjcnkCOoc6QyYwuZfbYhQwA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:26.6822405","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A26Z&sr=b&sp=r&sig=8GbHotK0Ue2CV511dxb8Tl4evVVYgMFEOKLlv5v7jgw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:26.6821578","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A26Z&sr=b&sp=r&sig=BCSVxrBJITlA6mBORGXrcibsVS5gXqp9L6CPjvUpfsE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:26.6822619","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3240'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:26 GMT
-      mise-correlation-id:
-      - b6a806fa-7a1a-4836-9d34-1bddd7cfd0e9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A31Z&sr=b&sp=r&sig=nZI%2BcZvzCCIUM%2FEP360Id9YqojygW3hUhjxc4f2KmP8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:31.9552764","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A31Z&sr=b&sp=r&sig=U0vgWzTbnerkxv5KgAV%2BGtUXGiZrJpBYhu2Fvpv%2FRKM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:31.9552091","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A31Z&sr=b&sp=r&sig=uIdbux%2BXRnpLMB%2Birm%2BZfmHkf%2FCOdqq%2BfiZKyeraBAs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:31.9552903","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T16:12:56.956Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:44.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A53Z&sr=b&sp=r&sig=Qd5DrQIfZPp4%2FRoSg%2BkcqJcE%2FrtNlMxtlymuYyWE0sI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:53.1141173","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A53Z&sr=b&sp=r&sig=CqjkJTCP6N5kBiP91OviOygez%2BbBhRg5n7G8%2BkCdAyU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:53.1140142","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A53Z&sr=b&sp=r&sig=8Tsm%2FaAbguRLev8CMuQijtBvenMG1xQhrguspAsNl9I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:53.1141394","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:26.936Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1760,9 +896,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:31 GMT
+      - Mon, 09 Oct 2023 19:19:53 GMT
       mise-correlation-id:
-      - b4d0b64f-7289-484f-93bd-7cb9d38c8919
+      - ca6a83bc-1b2a-4f29-b4ea-de521b0f2233
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1782,23 +918,923 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A37Z&sr=b&sp=r&sig=tygH5yLe3NIEcNLHGueS6bDatlhrPTXPE7SfytXWRvA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:37.2339417","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A37Z&sr=b&sp=r&sig=loSG2tlbSqWr8q9zWjemiK1x%2BAGM%2B%2B1R1S4cE7BctVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:37.2338552","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A37Z&sr=b&sp=r&sig=M6BqfKDVIMJduDGKpUMJ%2FkaFZ4ojEDA3IiYJrZvBUo8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:37.2339578","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-09T16:12:56.956Z","endDateTime":"2023-10-09T16:15:34.449Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:15:35.475Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A58Z&sr=b&sp=r&sig=F86pVT2Jo8Jnn8D2l5621NQ6CAAnonJs0l4lT8v9WIY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:58.3943442","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A58Z&sr=b&sp=r&sig=uBycrD4gQg5JBgclH530E5qWXBQuwkKqvpHVpxqRMVk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:58.3942762","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A58Z&sr=b&sp=r&sig=rkKk6D8mQg9pMSks86cPnwlO0p9u%2Fa5Tu%2F978%2BvFq8k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:19:58.3943593","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:26.936Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3286'
+      - '3252'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:37 GMT
+      - Mon, 09 Oct 2023 19:19:58 GMT
       mise-correlation-id:
-      - 3b4085ee-9d45-4601-9665-d8e22029bb70
+      - 474bdf39-a78d-4529-8430-d5c7939ce733
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A03Z&sr=b&sp=r&sig=CZTLSAG9W51SIK23BuIR1Az7npE%2BPB8auWD1pAYHRX4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:03.7090459","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A03Z&sr=b&sp=r&sig=oTfdeRArJJsc7Xmd56NGsvKT%2FUYixSyQC6BIUQT3wzA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:03.708957","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A03Z&sr=b&sp=r&sig=QpMneEcJ2tmMpM3Tiy0REF9ZbO9HzoQ1IIXKj%2BxWvVE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:03.7090672","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:26.936Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3251'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:03 GMT
+      mise-correlation-id:
+      - 9a10da3b-d06c-4132-8fdf-cd5a054cfcc2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A09Z&sr=b&sp=r&sig=14kAKSxk0bLW9BZ40wxdS6cFADsvdU8yv5LJ62Oyp14%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:09.0841769","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A09Z&sr=b&sp=r&sig=io24fd8dVJJfMTtextZCqa9AMpY%2FCfNoNXEHJxFPy2Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:09.0840723","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A09Z&sr=b&sp=r&sig=wMNvUHxPz6TuaDP7oPQXFlZRNwD%2Bi0%2F4JIox4srGeoE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:09.0842036","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"CONFIGURING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:08.599Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3251'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:09 GMT
+      mise-correlation-id:
+      - 00a43e74-c335-4c67-8611-e320483775ed
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=nDx1Lv6H7BxsYWlW7dDowlzPFcX%2B0DIWu6udevGFHa0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:14.3825908","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=J78NPHaHFdDUVUVSd33ETrfMekq%2FCeSlc1ZWdLR%2F0U0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:14.38252","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=25r0XRQI5yDUNg6qWb2fc1MoASe%2FPfFDD1G04KGFtJE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:14.3826048","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3249'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:14 GMT
+      mise-correlation-id:
+      - 78c52154-07e2-49a2-a926-2f1869268b65
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A19Z&sr=b&sp=r&sig=wNVPVKnKO60Qe4Fn8jX%2FASOD6EtoN%2Bz8zLtoRutZV0E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:19.773071","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A19Z&sr=b&sp=r&sig=g%2BtmtyXkYQOrwH9xWsfr0BQbWzUPXt7V2Ht5vovcD20%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:19.7729876","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A19Z&sr=b&sp=r&sig=5sWYikJIvzt9kcudBsWx5lpM%2BMhESJOC8pwcxrrUNrg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:19.7730854","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3250'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:19 GMT
+      mise-correlation-id:
+      - b47b3da0-0415-4e2e-a040-fa50c0d14fff
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A25Z&sr=b&sp=r&sig=UZXh14D3bJ2RvRsP%2F8eeR6396nxmooxmF5AUnH6tfCI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:25.1164634","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A25Z&sr=b&sp=r&sig=JFOOWUKAIp68zZWIprMas7I3hjdnsUNmnnfK4vxn1Hw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:25.1163771","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A25Z&sr=b&sp=r&sig=99OVNGJafsJwbCVPezN6SHxMv2YMRjOK4Bc6KSoTWFo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:25.1164839","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3245'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:25 GMT
+      mise-correlation-id:
+      - 720abfee-0eb7-4079-b132-fc9b30db0e2b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A30Z&sr=b&sp=r&sig=UD24NmqbBZZCaoyy8if3kjCkJSXMQ%2BP7h1sQjvaI51E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:30.4011526","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A30Z&sr=b&sp=r&sig=Z9XpsMt5wPGaRXy6UNOR7MyIWHje5SRAd3Xh5RAMVqo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:30.4010729","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A30Z&sr=b&sp=r&sig=r2CJ2MhjjIf8sPaRUHftHizhjf6lvokQIePBRneBvuI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:30.4011691","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3245'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:30 GMT
+      mise-correlation-id:
+      - bfd551e9-841d-47bf-a6f9-a6339f6fd19f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A35Z&sr=b&sp=r&sig=Is6nGZr5uy3zVTNzVte6S4eCEvJQX3hqy3Av37b3xaU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:35.786187","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A35Z&sr=b&sp=r&sig=NpaWXPLLp6d0SBetHNiXLTiKUkqxDDGwLKj8%2BunT83Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:35.7861173","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A35Z&sr=b&sp=r&sig=czEK%2BjcF%2BnK8NXjdXSnri7w70%2BHYRRefaHhv81y%2Bmxs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:35.7862055","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3252'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:35 GMT
+      mise-correlation-id:
+      - 91d7bf17-2e52-433f-91d8-02fa8e0beeab
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A41Z&sr=b&sp=r&sig=BR3fBEt9YPTfDgYbcqZ7ZGWIChs3uI7N2MGjOlcBGUo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:41.0697667","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A41Z&sr=b&sp=r&sig=MvpYxpiz%2FK%2FbkFwhPb4HeeYFlc1GQ6doxgixNdNYZGI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:41.0696919","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A41Z&sr=b&sp=r&sig=lDeJAH4PQZ8Fihu9vl3hNNN%2BF2KbTngnGCOiz9aX9oE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:41.0697806","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3249'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:41 GMT
+      mise-correlation-id:
+      - 57ad51f7-3df0-4929-ab31-55a319ae8fca
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A46Z&sr=b&sp=r&sig=rjshGAjQoV4JSVtZ27%2BpHGquL95iCUKmg7WsHTMzt74%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:46.4412504","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A46Z&sr=b&sp=r&sig=gGuENa9Bh9klNX2jFg7IkDIH7%2BbQZeVSXueLMxYyMHE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:46.441175","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A46Z&sr=b&sp=r&sig=%2ByEwJWZsysiMqPO3LwwlmmC7BSyUxZHvfEeddpB7IGA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:46.4412676","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3248'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:46 GMT
+      mise-correlation-id:
+      - 4ab9f6db-bc44-4771-b831-1e74d9d43030
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A51Z&sr=b&sp=r&sig=ARO5a%2BldyZP1zSbeVZa2vcRNRU5a%2BoJp5iRKcoN6ep0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:51.7385109","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A51Z&sr=b&sp=r&sig=nSjOD1buYsEygAZLHN6qT858k94qQsaVhLeHowAYUJs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:51.738413","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A51Z&sr=b&sp=r&sig=QKcQiKrjKb2Ur0LRB1Z%2FKgw%2BfvCxgkidKw1ak%2BF6J3M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:51.7385501","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3252'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:51 GMT
+      mise-correlation-id:
+      - ae68892f-afe8-47c3-b38e-79e802ffdb6e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A57Z&sr=b&sp=r&sig=myGEesoRceTva0xk3O2zZdBD%2FZzvPecQd8pmsz2X%2Fbo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:57.139847","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A57Z&sr=b&sp=r&sig=gj6M60gxXSz0w1Rpkz3DtK2WD%2BThQ%2B8pC9VPftmBz90%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:57.138989","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A57Z&sr=b&sp=r&sig=0dRTNpfHfTEbq6tUuMjn1yJdR2eRA3G4oIAEsD20v5I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:57.139876","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3248'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:57 GMT
+      mise-correlation-id:
+      - 9f9c926b-bdc5-4249-a04e-2dccb3e56897
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A02Z&sr=b&sp=r&sig=%2BnH4rVjN2NH7r6R4MHyuE5lKJa3NuM%2BKzvIFFeRSvzs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:02.422162","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A02Z&sr=b&sp=r&sig=HBrQgpWGCMr6LwC%2BLeTGwNXrjttShUxFEcBpPm5FtzU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:02.4220716","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A02Z&sr=b&sp=r&sig=%2FqlzC%2Bl5uDnprY8NX72FCHQK3dMFsWdxuAPzD21aH%2BU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:02.4221847","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3254'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:02 GMT
+      mise-correlation-id:
+      - 9234daf0-0015-45f6-af55-b47561f3f308
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A07Z&sr=b&sp=r&sig=FzlSJe%2Bt7dYB1w41wXhw5f%2Fx2pyLfvMu%2BGXhCHPQqHQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:07.7216076","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A07Z&sr=b&sp=r&sig=2MYL2fsQAqUmuzFtZCqQGScLWqclGkU%2BYtoc9%2BLhBGo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:07.7215189","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A07Z&sr=b&sp=r&sig=jfxgbLFzDo8VH7Cj7nFhHv%2FCwef3D5l4EX84EemjJsA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:07.721628","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3254'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:07 GMT
+      mise-correlation-id:
+      - c9b792b5-4c1a-4728-bcb6-29b975edd5eb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A13Z&sr=b&sp=r&sig=wTenftXHj%2Fgkhv64t9HtD2zECBqjukPQVJQEo%2FhzgFE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:13.0501687","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A13Z&sr=b&sp=r&sig=hZBmHqSevlp4S2IwsRef9RWpdts0QPVnjJdUy5fCGcM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:13.0500832","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A13Z&sr=b&sp=r&sig=CR%2FdHDe2yOaIuXOQU%2FGF6OXJkzuCnmKRZ3sd193cEkU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:13.0501923","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3251'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:13 GMT
+      mise-correlation-id:
+      - 9ec28964-c880-4db7-b6d3-cd61e0e65848
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A18Z&sr=b&sp=r&sig=fXPJB4SolkdOYYBC%2BWBtsaBsaB5hpIBJWa4%2Fqw0HGSk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:18.4020508","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A18Z&sr=b&sp=r&sig=k3mLt4oNP%2FjFBb63Yffsz2OMi5yq7ES%2B5o7r3KvtLFc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:18.4019606","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A18Z&sr=b&sp=r&sig=%2BLhykluWHBlZaJUHuOHQEcQuYILVG2gBNKtzmde7TCI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:18.4020733","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3253'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:18 GMT
+      mise-correlation-id:
+      - f82d4ebb-ab36-4eac-aa2b-3409872a01bc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A23Z&sr=b&sp=r&sig=yEp3dmV3xiQaEoECQZLcX5UFMvBnm31Zbe0CQpTsMCs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:23.6757764","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A23Z&sr=b&sp=r&sig=WxawaM5Vwat0aGQdNXWsD50H23WbJCaJVpUA92VvKlI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:23.6756826","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A23Z&sr=b&sp=r&sig=REIszPnoUQmLifqdpegB8xr%2BK0YMrIfDGbCfWjr5zqk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:23.6757993","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3245'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:23 GMT
+      mise-correlation-id:
+      - a93725db-4930-4321-8c24-ddbf0e0d3007
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A28Z&sr=b&sp=r&sig=NLTLtfaI2qRPg6kdcFLiVjoel9iFvgevBs%2F6t7qgr0w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:28.9984533","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A28Z&sr=b&sp=r&sig=Ew7emDaJvAYM%2FbvWh8RC9ODJpnVOVFqWH88WVy59QXI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:28.9983936","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A28Z&sr=b&sp=r&sig=%2F6%2B0qUf9NPo%2B1ZSduLEFQyYcUJXo1xg18bxlIFCWrio%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:28.9984711","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3253'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:28 GMT
+      mise-correlation-id:
+      - 228c162b-72d7-4ec1-88fa-3e252bac6dd2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A34Z&sr=b&sp=r&sig=9n%2B7Dp4q%2FzE0q7%2Bk3zLyPRFo%2BkTaaSkpjnXiEy9SXv0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:34.2831179","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A34Z&sr=b&sp=r&sig=ICtUc2S0EiE2rBsbjpP57OON7P86%2FyNPLAiFxJZIF3g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:34.2830207","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A34Z&sr=b&sp=r&sig=RaFW%2Bfnf8HAR74XuZO0ctTAA%2BPM7mV%2B%2BAwBQ57uSJSc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:34.2831373","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3261'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:34 GMT
+      mise-correlation-id:
+      - 6cc3dc71-d26a-4d9d-b1f4-25b9ed1a375e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A39Z&sr=b&sp=r&sig=J7oZ7pLKuiETBleKzlhwzvzqTpxqNYd7kS5YAgB92D0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:39.5533645","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A39Z&sr=b&sp=r&sig=ehaQK1RcbU3ETdY1ksJ7J0c8nXtzaMs1GhTcF0VXv04%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:39.5532979","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A39Z&sr=b&sp=r&sig=YvvKXUmlK25DFT5EjfKKXaw1f1iZXqSXscHokwFA3XI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:39.5533801","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3243'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:39 GMT
+      mise-correlation-id:
+      - a0496518-f6b0-4313-83a3-8493d873891f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A44Z&sr=b&sp=r&sig=4GJr4dQvj%2BzUOEnDu0SRF2yI70EfWGvHQDuZcu%2Bpp%2FE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:44.8690285","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A44Z&sr=b&sp=r&sig=bQWSbetyGyk1yWQZEXXHZHQr%2BpeU1Ww3PUWAXhrnDlc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:44.8689629","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A44Z&sr=b&sp=r&sig=8EcAsM9A2h6Atjyci0mp66N7KvH7Ox9zRWNXswfpSzo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:44.869044","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3250'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:44 GMT
+      mise-correlation-id:
+      - 8cf5612a-56a0-4e7b-9568-81fd210be314
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A50Z&sr=b&sp=r&sig=8idhqPx%2BxNESAt8%2BJFx7O%2BOcAQHxj8ltU1mrsok6t5M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:50.1281631","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A50Z&sr=b&sp=r&sig=t3zRsfaqoGPqeLZDnoFPt9NhPLkeUlzJNeYG%2BAvEu1g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:50.1280676","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A50Z&sr=b&sp=r&sig=OXDOK%2FX0Rtvg53pgb2FqOcOocjjFA1VhBVwMdQYHdz0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:50.1281773","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3253'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:50 GMT
+      mise-correlation-id:
+      - 640f3bf8-b7bc-4fe8-b379-c1dbc94bc523
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A55Z&sr=b&sp=r&sig=EHnwECcjyhNfa5sCJlvVQIUNOfh%2BNcW3ipALCjLfVk4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:55.417523","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A55Z&sr=b&sp=r&sig=08v072bmdnpvPjyWzoZScpkSzWeQfhBFWczfbr9gRzg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:55.4174454","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A55Z&sr=b&sp=r&sig=27R73FyPwYc%2B7Bc3uuy%2BDR6V4%2BEMFwf1pehN5qTHNG4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:55.4175393","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3250'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:55 GMT
+      mise-correlation-id:
+      - d563e78b-937c-4390-955c-8205b9f63c81
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A00Z&sr=b&sp=r&sig=XQTxTwKa7cLIt9XEroclIgPC45G%2B5ZUSPw%2BWTWVK%2FaA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:00.6671996","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A00Z&sr=b&sp=r&sig=DIMuBao3gt%2FlxopAcgieh08PnRKbedmezdUrPupQSzg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:00.6671297","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A00Z&sr=b&sp=r&sig=WiI%2FIDqHqP1aGNdpLA9cPdzWPzQnOSomSMQggaagrJE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:00.6672158","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3253'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:00 GMT
+      mise-correlation-id:
+      - 95785046-51b3-4362-95a7-991a60ce6cc4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A05Z&sr=b&sp=r&sig=XXJZD1cq03R7s9Sf%2FzU82wCkNtDq%2F2op8T%2BFYiDZGm0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:05.9270334","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A05Z&sr=b&sp=r&sig=chDOBZzFnKY4PXZtJ96%2FYgSEpNZbtKXCKaVtDZoKSBg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:05.9269448","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A05Z&sr=b&sp=r&sig=Jz9S6B3F3miOPfEwJ4R6PySBuqFynDtDuF2L%2BqGVJIM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:05.9270517","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-09T19:19:26.768Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.134Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3253'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:05 GMT
+      mise-correlation-id:
+      - 2e154cc4-ac11-4125-8490-3baff9123081
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A11Z&sr=b&sp=r&sig=T1Wz9hxeOfygeO%2Fq%2BMxhFnblwcAB%2BzeCha4OuX1Fesw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:11.2026651","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A11Z&sr=b&sp=r&sig=M8Be%2BZOU6dvTHaUitsB12eGHZ9n6JZYgXLH7Nj7m0mw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:11.2025333","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A11Z&sr=b&sp=r&sig=yC430Xm8LGz1dn%2BG9TA%2BZ3ji9sj9hBW%2FrF0aaX9UI2I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:11.2026945","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-09T19:19:26.768Z","endDateTime":"2023-10-09T19:22:07.723Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:09.753Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3293'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:11 GMT
+      mise-correlation-id:
+      - 93396aee-6038-4b6c-8e51-0114b6dc9553
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1821,7 +1857,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:58.1750771Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:58.1750771Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:26.2350862Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:26.2350862Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1830,9 +1866,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:37 GMT
+      - Mon, 09 Oct 2023 19:22:12 GMT
       etag:
-      - '"9201a5ad-0000-0100-0000-652426500000"'
+      - '"5600b814-0000-0100-0000-652452040000"'
       expires:
       - '-1'
       pragma:
@@ -1862,23 +1898,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A39Z&sr=b&sp=r&sig=6CamFr5aWrwXgyYZ1ekc1aIUJ7KltH9wqSlxVapauC0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:39.5695583","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A39Z&sr=b&sp=r&sig=IQfNzcZcWG3yeN4w3cHLxSTN6X54rdhCB%2Fzom5zIKSU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:39.569452","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A39Z&sr=b&sp=r&sig=FoIjDz6FB85TQlL7vw2OByYnj7Ic8sfUnmfxXqlpocU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:39.5695834","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-09T16:12:56.956Z","endDateTime":"2023-10-09T16:15:34.449Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:15:35.475Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A13Z&sr=b&sp=r&sig=1FG6SrdCxbBaNimYWHNznAgl5rmfOSuren26hJ83odA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:13.4749725","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A13Z&sr=b&sp=r&sig=ye39ihzhjdYk8nppQCq6skPztjZRQEXZbFAdBpQm8g4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:13.4749043","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A13Z&sr=b&sp=r&sig=%2BoKhmP%2FL8jhTm90QgLQOElCWyl2gRRxbgs1bKeUAns0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:13.4749869","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-09T19:19:26.768Z","endDateTime":"2023-10-09T19:22:07.723Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:09.753Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3279'
+      - '3283'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:39 GMT
+      - Mon, 09 Oct 2023 19:22:13 GMT
       mise-correlation-id:
-      - 2ab76082-aa0c-46d6-8aea-87f307c2281e
+      - a967310e-34fb-4d54-b40a-21b92ac234c5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1901,7 +1937,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:58.1750771Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:58.1750771Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:18:26.2350862Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:18:26.2350862Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1910,9 +1946,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:40 GMT
+      - Mon, 09 Oct 2023 19:22:14 GMT
       etag:
-      - '"9201a5ad-0000-0100-0000-652426500000"'
+      - '"5600b814-0000-0100-0000-652452040000"'
       expires:
       - '-1'
       pragma:
@@ -1942,23 +1978,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2a40bdd0-9a15-4343-924d-50c61df623da.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://92950f4c-5ec9-406d-aa40-1c8afa785f01.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6fc89fb4-6bf3-4564-a707-4dd60502f3da":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1b6bee86-72d8-405e-b03f-958dbd3cbd77":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e58845ea-8f94-42a4-a2a9-c74a435b7bd4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/341cd8d0-7174-427e-b087-e811b2792315?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A41Z&sr=b&sp=r&sig=HHuK4gB4U2jSikKe2GkPF%2BpWdgVczspWVfOePH%2B4Kew%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:41.9107357","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/a61738dc-7577-4574-b0fb-d939990c5317?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A41Z&sr=b&sp=r&sig=6ToUVOh9VLKtFWbVVnFtM8H8iOUJvB6xDEeN2kksbbc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:41.910643","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/d1c6740b-cbea-455d-a4b1-8d5f4080b463?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A41Z&sr=b&sp=r&sig=UHokNL211ZEWF56iXMq8H8OcMaUhdPTuC8fA97XP5o4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:41.9107619","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/94691505-9f32-4484-ad96-53795fcf3a83_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A41Z&sr=b&sp=r&sig=LV6sCxl3FNNHWDg6GoJ9YXEmlGlxDhco74qN8oC86Wo%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:41.9107872","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d7c8a975-7de7-4ab1-8751-18feedc1862c/94691505-9f32-4484-ad96-53795fcf3a83_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A41Z&sr=b&sp=r&sig=lebbza2n3hMXNGJYNbCMWWkDbLKLw90czxTvd4HWT%2FU%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:41.9108136","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-09T16:12:56.956Z","endDateTime":"2023-10-09T16:15:34.449Z","executedDateTime":"2023-10-09T16:12:55.153Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T16:12:56.05Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:15:41.515Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"7eafd8ff-0693-4dda-8561-41deeb0eeb7c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6d8f7d27-5c2b-4bb4-b9c8-ef1836fa90d7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"92ba572e-89da-4757-b0df-a6d5ddc50e43":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/2d03018e-d128-4dee-8b81-9ecf31566b1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A15Z&sr=b&sp=r&sig=%2BXXrau8Zs%2FoYqnuhRfiyovsbz8eG2FQ%2BLo9s1fL9NmU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:15.7120699","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/5659ca73-0a7b-4ea7-8793-2909fc340242?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A15Z&sr=b&sp=r&sig=f9B0Vt%2B5EUOY%2B5YT0SyjOoGDJIA7VbyD9acWRaU5rMM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:15.7119739","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b5e2b32c-e2e2-4550-bf1b-7a601cbff438/a8fe983d-01a5-40d7-8fb0-017aa654e4ee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A15Z&sr=b&sp=r&sig=VxlE6o0TkJFp9b8tSg%2F3IUqGOat24jScCSSqU0AG5c8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:15.7120923","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-09T19:19:26.768Z","endDateTime":"2023-10-09T19:22:07.723Z","executedDateTime":"2023-10-09T19:19:24.958Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-09T19:19:25.589Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:09.753Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4442'
+      - '3291'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:41 GMT
+      - Mon, 09 Oct 2023 19:22:15 GMT
       mise-correlation-id:
-      - c3894da5-9bfe-473a-9f15-b2dac02b2325
+      - 62823244-4e8a-4cf8-99db-3affdf7e0065
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_create.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_create.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:11.2483666Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:11.2483666Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:44.1306584Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:44.1306584Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:45 GMT
+      - Sun, 29 Oct 2023 22:21:18 GMT
       etag:
-      - '"d300e23b-0000-0100-0000-6537b85d0000"'
+      - '"3c00ad27-0000-0100-0000-653edabe0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:28:46 GMT
+      - Sun, 29 Oct 2023 22:21:19 GMT
       mise-correlation-id:
-      - 6a0b93b3-621e-4261-9da1-b8c72d0578b8
+      - b1f3d013-1d9a-42a9-bce5-3636d4c5f7bf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"27c55f6c-f4e3-4744-b037-69ccbd54175c": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":
+      {"passFailMetrics": {"dda1905b-f02d-4f3b-85d8-b09f307a348f": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "f46ebd85-3b86-4296-b63e-f9bb751d380a":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "60818291-485b-469b-9ea4-310d3594f2cc": {"aggregate": "avg", "clientMetric":
+      "50"}, "3ed39a8e-2b5f-413f-b17e-437ddf203435": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:47.456Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:47.456Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:19.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:19.868Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:47 GMT
+      - Sun, 29 Oct 2023 22:21:19 GMT
       location:
-      - https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+      - https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 4e651766-a475-4b22-a45a-70984d8df109
+      - e4a582ea-557b-4b2d-9082-f5f515d95078
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:47 GMT
+      - Sun, 29 Oct 2023 22:21:20 GMT
       mise-correlation-id:
-      - 31d9594d-f08a-4288-ae24-ef2df25c9382
+      - 51f14d07-6eaa-4ebe-98a7-039bddf455dc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A48Z&sr=b&sp=r&sig=wWoBHmCEXHPTK4ceKP0FN5e4pt50KsT%2FpeKCdGUuDCA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:48.7667662","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A20Z&sr=b&sp=r&sig=v3gwEzYCTHMX%2FUQLxjzdo5t91EcD8lrXEqr3%2FVXQjPs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:20.7847772","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:48 GMT
+      - Sun, 29 Oct 2023 22:21:20 GMT
       location:
-      - https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 5b3dff14-3b83-44ae-93f1-797d55c42419
+      - 49e7b3d5-ee6e-4dee-9e11-f7cf8a289677
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A49Z&sr=b&sp=r&sig=QSgurHDccw38YNvhpLULUhnmp19j6ccqc1LGLHW1WrQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:49.0137122","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A21Z&sr=b&sp=r&sig=25WlEUr8gcQnFxQAFLEMqkzUuFLFTPGiF6m91mkTRaE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:21.0213365","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:49 GMT
+      - Sun, 29 Oct 2023 22:21:21 GMT
       mise-correlation-id:
-      - 10a770af-c500-418b-a2ee-04f4c9338f61
+      - 96fcde5c-f042-49e7-9056-fb8d35befc38
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,82 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A54Z&sr=b&sp=r&sig=A6y3e9dgzPiHks%2BuBS9GOPSgscirytgwUox4FVjf%2Frg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:54.2645366","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:28:54 GMT
-      mise-correlation-id:
-      - e0759d67-0a4a-434a-9d6b-0b37056eafef
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A59Z&sr=b&sp=r&sig=RfPwYsXIs7pbu1VImY4R%2FQxNRb6Gl%2Fl4pJDwxRT4k3g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:59.5348721","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:28:59 GMT
-      mise-correlation-id:
-      - 562c6a6d-3e7c-4f5a-a30d-2c4de3914dde
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A04Z&sr=b&sp=r&sig=hjd62qNJj31z88FiEUIrjw8svVegH%2BqpnGh2ZvRW4dY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:04.8095264","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A26Z&sr=b&sp=r&sig=EdUOOXqTORZ5etN40EyW8hYdFWC6rlFvMcEup18YJbM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:26.2687926","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:04 GMT
+      - Sun, 29 Oct 2023 22:21:26 GMT
       mise-correlation-id:
-      - ca348fd4-53d8-4ed7-8cee-2aa2025bb9d3
+      - e07cebf5-22a2-4791-95ef-1bff3bcadd22
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,11 +385,83 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A05Z&sr=b&sp=r&sig=jAS%2Ff4SIYCuXMR7Znk0vWQ8CtSluQ1s2BXYtzc6DkVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:05.0943153","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:47.456Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:01.909Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A31Z&sr=b&sp=r&sig=deC0zX%2FC4UjXbF7M%2FaZWCv1VCo9kPtSfef1ZLaz3jvU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:31.5238975","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:21:31 GMT
+      mise-correlation-id:
+      - bdeaa36f-1e3b-4184-8b2c-aaae168a8c90
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A36Z&sr=b&sp=r&sig=KqMJF9kLAudtanZFRAIBl7IeqV%2FrNFORtPJmKtBrODI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:36.7855727","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:21:36 GMT
+      mise-correlation-id:
+      - 59dacbbb-3c1a-42aa-91d8-7f3255244548
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests/create-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A37Z&sr=b&sp=r&sig=QoyQ2tk9KOCZKCEz0tegmQEmGeWkOtzW4tQtwMINT%2BQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:37.0378001","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:19.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:34.624Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,9 +472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:05 GMT
+      - Sun, 29 Oct 2023 22:21:37 GMT
       mise-correlation-id:
-      - c2fbbc01-5d30-49a9-a6a9-08fe87849e13
+      - 16476148-4f98-4560-98ab-820a889d3ed2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:11.2483666Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:11.2483666Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:44.1306584Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:44.1306584Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:05 GMT
+      - Sun, 29 Oct 2023 22:21:38 GMT
       etag:
-      - '"d300e23b-0000-0100-0000-6537b85d0000"'
+      - '"3c00ad27-0000-0100-0000-653edabe0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A07Z&sr=b&sp=r&sig=ho%2BbCX9g3FgkCfvvu5A3Fv7JXV4AYU0ghjys5uXZpqU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:07.5966382","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:47.456Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:01.909Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A39Z&sr=b&sp=r&sig=nykJ7T%2BIqOy172izmpIEox%2BKrUJV5NYav0%2F5IKtxJik%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:39.1772576","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"create-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:19.868Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:34.624Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1591'
+      - '1595'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:07 GMT
+      - Sun, 29 Oct 2023 22:21:39 GMT
       mise-correlation-id:
-      - 9d3ebd50-ede4-4a07-9a02-0bcedb9eee14
+      - 9971ce7b-fd41-4297-be6b-412f5618832e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:11.2483666Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:11.2483666Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:44.1306584Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:44.1306584Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:09 GMT
+      - Sun, 29 Oct 2023 22:21:39 GMT
       etag:
-      - '"d300e23b-0000-0100-0000-6537b85d0000"'
+      - '"3c00ad27-0000-0100-0000-653edabe0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:29:10 GMT
+      - Sun, 29 Oct 2023 22:21:41 GMT
       mise-correlation-id:
-      - 4e340de6-44e7-48b0-b921-a2b629cdea96
+      - fb7c4dcc-b8da-48b4-bad2-89508574bbba
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -664,25 +664,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A10Z&sr=b&sp=r&sig=KubJy0Gm%2B6yzgycUtsqelHE9cRis7VhHArRR6VYNEOc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:10.8663909","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A10Z&sr=b&sp=r&sig=KPM7znU6sKXMJOcLlh7JDFImIp9PdcN%2B8SK0UBFvMdY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:10.8662634","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A10Z&sr=b&sp=r&sig=2CLEgmKxSAQ1RKrhhiGVgCg6xooW%2FraTA4UsGQfOUlE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:10.8664356","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:10.772Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A43Z&sr=b&sp=r&sig=6%2B6RtrSAvp0s2Guj7Tjw1ZkjwTBM7AuzJPDMRCzfqnk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:21:43.2381699","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A43Z&sr=b&sp=r&sig=AGUdlE43kgM78Z7nENZj7R4cJkPvmgDQGOl23PWbOPg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:43.2380687","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A43Z&sr=b&sp=r&sig=wuVX7HNadfJKtSSxftPkkFHZ%2FAOg8wgON1%2B6AzM8ip0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:21:43.2382185","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:43.155Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3205'
+      - '3204'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:11 GMT
+      - Sun, 29 Oct 2023 22:21:43 GMT
       location:
-      - https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+      - https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - f8ae06f9-7836-4e73-9300-7ce77dfc4630
+      - 01515c03-9a10-4b3e-b537-a33b2faff68c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -702,23 +702,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A11Z&sr=b&sp=r&sig=AqwbuG1WtO4xilmbUBZxCFFzTb2yiA2pllcbRvyCp%2FA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:11.3398955","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A11Z&sr=b&sp=r&sig=1gQ6wmMN436fkWj%2FqMZSkGCRB0N3V7JVTz9b%2BavnSPE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:11.3398288","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A11Z&sr=b&sp=r&sig=ntj14H3hcWLuJst8Rgr6zhANx6Wx8WVUJjN7kd1fYOM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:11.3399108","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"ACCEPTED","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:10.772Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A44Z&sr=b&sp=r&sig=9%2BulmHqEc%2BhB82KzUYEl3M5H%2Bw8mrAq8jOkUjopfRyY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:21:44.5079973","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A44Z&sr=b&sp=r&sig=CN0dE2ZGBLTfDHQSqgA%2FsWsVGqwoWcLfwJT830ZE5ZE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:44.5079043","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A44Z&sr=b&sp=r&sig=srh94OkCxa87zvb%2BH59TWhVzQCpdztz5EEsWNqmuIrM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:21:44.5080183","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:43.933Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3205'
+      - '3255'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:11 GMT
+      - Sun, 29 Oct 2023 22:21:44 GMT
       mise-correlation-id:
-      - 96d93ccb-38d1-416d-bf63-61668e2f902d
+      - 4c7ef968-2227-4a52-b7bf-f6a3fb239a87
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -738,118 +738,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A16Z&sr=b&sp=r&sig=USOWviktUlZplpRVhAT6sPV0gdC0p5oF41IkLUmbuPM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:16.6130141","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A16Z&sr=b&sp=r&sig=X0HK9JFcf%2Bm4anJjP3E9WEr2kJyfa2DTO7vArX9oTHM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:16.6129461","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A16Z&sr=b&sp=r&sig=IxaFhp1LUwfo3%2FpGXO%2BjSvGklWu36okUuJKKpWzvDFA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:16.6130274","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:11.997Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3252'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:29:16 GMT
-      mise-correlation-id:
-      - a9ab5784-18eb-437e-908b-c945f044f26e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A21Z&sr=b&sp=r&sig=Y67MehXFCOXkIHPwT3BZtGYaRbT%2BokAXQrY3v7jaSiI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:21.8651162","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A21Z&sr=b&sp=r&sig=mKPyux%2FQkxaymtuaRGnuIOMBvHqBFbNsbnMD16izjm0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:21.8649612","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A21Z&sr=b&sp=r&sig=Qgx0TGoHVHEer%2F9GQsPj2BQC98vQfGYByNhImrX2cjs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:21.8651388","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:11.997Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3252'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:29:21 GMT
-      mise-correlation-id:
-      - 140a646b-d10d-4b68-bdc5-c68f8c86379b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A27Z&sr=b&sp=r&sig=dHSZCX1IOALfeheFywIszUvz%2FNYirm9wky14oddQaQ8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:27.199941","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A27Z&sr=b&sp=r&sig=UNB2k2en3O2Kbb7qHudrTuuDYA0mW%2FlWssKgbDmfvGQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:27.1998652","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A27Z&sr=b&sp=r&sig=BggihFtcFAXcMkTPX5z8FgJiTBv7OS53CnTaBxN7Gsc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:27.199955","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:11.997Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3248'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:29:27 GMT
-      mise-correlation-id:
-      - d0aa1c4f-d29d-4465-8367-ee0710146ca7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A32Z&sr=b&sp=r&sig=H0yV6T1Eq3okd9ECYgkud3sObDMpdTkmfK48bFLvaIk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:32.8793333","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A32Z&sr=b&sp=r&sig=IO4f7Ma%2FEhS2RS2aLglJVyCUsX19sAxIFvsEQ6RXuaM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:32.8792648","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A32Z&sr=b&sp=r&sig=Ct10WPdGyrCX1COG%2BayNYcC4NcD%2B8Y39DiX0fIAl%2BmA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:32.8793473","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:11.997Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A50Z&sr=b&sp=r&sig=05SCTPCpyqcZol%2F%2FSmvePnfdJ0rfdJEY4umFJQJaLUU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:21:50.1340556","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A50Z&sr=b&sp=r&sig=G1KcQ71%2BJ9pycpjW%2BaplhfdgiTJ6yYuDmJ265D9rQOE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:50.133967","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A50Z&sr=b&sp=r&sig=0eWFTN%2FL1D7G4lyS0gEHH5N5yGxBV5QODS9t4B9YRgo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:21:50.1340774","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:43.933Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -860,9 +752,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:32 GMT
+      - Sun, 29 Oct 2023 22:21:50 GMT
       mise-correlation-id:
-      - 1f6c62ab-6c6a-4446-8ba6-7e08d77a7141
+      - 9faa557d-80b7-4c0f-9149-a5adc13f5252
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -882,23 +774,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A38Z&sr=b&sp=r&sig=IT31i7MYFHdkNKAxa07ALQEh%2ByPrkFGse%2FIZYeoZlWk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:38.1335797","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A38Z&sr=b&sp=r&sig=twYmfifRqzjyxedR6JpS22aG9ckITEumw3Hiqmu4Qgo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:38.133509","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A38Z&sr=b&sp=r&sig=mjKZKlC8J10wqimRai6MGibBHD5BlaeX%2FLctXgPijkk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:38.133595","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:11.997Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A55Z&sr=b&sp=r&sig=BT8Rd5fbNU7PcM1Oa7oK1JzSGgQi01cusf9nsjI2EoU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:21:55.3946991","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A55Z&sr=b&sp=r&sig=gPp6%2BknZKat1v2b5XqALgXPSt9diQw0tG7fZpAfSzFM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:55.3946076","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A55Z&sr=b&sp=r&sig=%2FNSnYMz8MPYhe0VoJ7gBBK8hWfVOCAgiMkEWraOvJxs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:21:55.3947208","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:43.933Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3250'
+      - '3249'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:38 GMT
+      - Sun, 29 Oct 2023 22:21:55 GMT
       mise-correlation-id:
-      - e7bf6623-0e2e-40ba-a039-faf7c920277b
+      - d8b98193-c43e-465c-9ad4-9114d58f61d2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -918,23 +810,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A43Z&sr=b&sp=r&sig=cImVe3DfVvTfRduqTUJmSdM8RpHmvHHaD40kBFpcfxk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:43.4842552","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A43Z&sr=b&sp=r&sig=4ntOsqm0CkBrKC4J0g54df2TxNt5tpdS3b0SScDsyH4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:43.4841873","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A43Z&sr=b&sp=r&sig=LnfpSB%2FED1OQPhoch4GeBZaFZmOLwpnQLFUPbYpr4NE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:43.4842689","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:11.997Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A01Z&sr=b&sp=r&sig=qoHVO4QtvSH4m8ShVklJI4uiF9deDng93xSxKcgf4BM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:01.6940644","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A01Z&sr=b&sp=r&sig=l2XIYWYEILEL9gJwxcBeo%2BRkEuOY40bSCuimRr%2FTzz8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:01.6939937","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A01Z&sr=b&sp=r&sig=njrEasBNmsJ9dWhmROGVd8fBRE1JAzKRQqgi9yKFkKk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:01.6940788","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:43.933Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3248'
+      - '3249'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:43 GMT
+      - Sun, 29 Oct 2023 22:22:01 GMT
       mise-correlation-id:
-      - 04d20a5c-e35b-48e3-92f7-7484bb902653
+      - 9cf1bd33-3573-492b-af75-78f2a61fe58a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -954,190 +846,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A48Z&sr=b&sp=r&sig=JSnQtVJEM1pgq%2FGuq1Ke19dhzsvRssUTwDTpssN3gJE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:48.7708878","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A48Z&sr=b&sp=r&sig=t3pSYaJBiLVonlzNA03Hi5g%2Fv%2BRPL8oIHkRJz%2FeOGcI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:48.7708214","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A48Z&sr=b&sp=r&sig=nveMWlL6JGEABLIUuE2q5DSn%2BacrcB9dbYQBUMCrzbs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:48.7709023","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:11.997Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3256'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:29:48 GMT
-      mise-correlation-id:
-      - 88177697-4e47-43dc-a3f5-97e1fa5d6ea2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A54Z&sr=b&sp=r&sig=Nt95m1173v%2BpoFfvAwCOQgCZvHJitmWUQDBN%2FeBZTEE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:54.1390815","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A54Z&sr=b&sp=r&sig=%2B3kF3%2B75t7bbDkGwlmnRVUSVabIlXgbP2X7IMEfIoZA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:54.1390087","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A54Z&sr=b&sp=r&sig=Xx0FjqxggTEpIe0jj9unmxH1kzwcdO0HXiG%2FtHtgBqA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:54.1390963","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:11.997Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3256'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:29:54 GMT
-      mise-correlation-id:
-      - bc662ff6-78b2-45e5-9606-8ecf32291cbe
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A59Z&sr=b&sp=r&sig=UWeryib7NeH7v9L3mMlGQEyrspwrZfM1znkJq6FtTMo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:59.458533","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A59Z&sr=b&sp=r&sig=3x%2B19ScacxkDIA8mjY1phh60Rfl8lNADXyUn1YlONC8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:59.4584535","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A59Z&sr=b&sp=r&sig=qZ%2BI%2FQ25mEm886bT%2BhyO%2BY4%2BM8sJRegXqBQ6LbbqN7w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:59.4585469","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"CONFIGURING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.702Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3256'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:29:59 GMT
-      mise-correlation-id:
-      - 8a47a39a-9a2c-4fd8-94e1-bfb7abc4a427
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A05Z&sr=b&sp=r&sig=9chh2C3Dj1hQx6zndWCRcI%2BKp7oKoVui%2Fj4zntkLcUo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:05.1116794","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A05Z&sr=b&sp=r&sig=mcJrkhQjDroefTlbDN98cDuRfNb%2F3kuikz6f4izAUCw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:05.1115538","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A05Z&sr=b&sp=r&sig=MybXN1MIUSCg6DbhR7lq2V0bH5GyZGSUwCvA%2FkmHupQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:05.1117092","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3251'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:05 GMT
-      mise-correlation-id:
-      - 2a38c161-a56a-40a6-9d28-6b0ff7dc8612
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A10Z&sr=b&sp=r&sig=SX92kjEzyjRVBr0T4mDXawwZzSs0a8Knaje%2FIpNaHN8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:10.387646","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A10Z&sr=b&sp=r&sig=m6uIehj9gi%2B05MeGeiBpAOTUQiBU9KtzCb2EaWaURVY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:10.3875646","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A10Z&sr=b&sp=r&sig=hMqEehIMxXCLeKs27u56WNA9%2B15Xqg%2BX4gjGDFfsGlE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:10.3876628","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3250'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:10 GMT
-      mise-correlation-id:
-      - d650a8c6-6fd3-45ec-9f38-dc8ad9a2506a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A15Z&sr=b&sp=r&sig=bV0bTNBGNAgpYkKbsdf8wDb4nbAk0PgdwHMVDjE9vHE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:15.6794543","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A15Z&sr=b&sp=r&sig=44gtimqt6EpnsPcm%2B%2FK989mDh%2FbTSbjOYT%2FkgHj5j8E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:15.6793791","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A15Z&sr=b&sp=r&sig=%2FXZuwRjpgrI0ugup0pCMtfNuK3bLGtcEJeQRb%2FOIIkY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:15.679469","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A06Z&sr=b&sp=r&sig=BgKeDCOKvp%2F%2FGJH8jxRRfCS4l6SsfEBpROmxTkz1QPk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:06.9661149","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A06Z&sr=b&sp=r&sig=NOYPWArNk5utUiP0MPCT%2Bcr92p6%2BKsrmNOSWpFb7UvY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:06.966044","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A06Z&sr=b&sp=r&sig=UbdDU9tEC2KxWJvkz8kDrRvIUMI8xC%2Fm8eX86y83bLk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:06.9661293","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:43.933Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1148,9 +860,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:30:15 GMT
+      - Sun, 29 Oct 2023 22:22:06 GMT
       mise-correlation-id:
-      - f85942d2-789a-486b-b080-57a8025149cc
+      - 3edb172c-1150-45f8-b477-004390a6e87e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1170,46 +882,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A20Z&sr=b&sp=r&sig=zEKS1T0M8BQUDqnulHMVJmUmILE1hBjBOBLW0ZzlnWM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:20.9782188","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A20Z&sr=b&sp=r&sig=8w9qcW6zJHBOBGHnsvpWdxUgHh45lqJL3qxBAJvHCME%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:20.9781322","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A20Z&sr=b&sp=r&sig=apqD1GrJnt1ehN2ADweqX9KnSAKWnlslV6qQe%2BbhNX0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:20.9782401","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3245'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:20 GMT
-      mise-correlation-id:
-      - f62c7568-4b7c-4f40-afa6-4ba8504c786c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A26Z&sr=b&sp=r&sig=Rm8tTLvNk6QQIgfARdXxbxP7eKz5DQN0hbpYnIFFg7Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:26.3705813","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A26Z&sr=b&sp=r&sig=4HvkjB%2BxG9lScrg5Ul5yGZo93rzAcnDiITT%2BJ%2F9hi04%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:26.3704805","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A26Z&sr=b&sp=r&sig=HY%2BmBJ%2FNZqRLCL4vXqpFuVuBgl4EuUb9Buz53FbanYs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:26.3705997","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A12Z&sr=b&sp=r&sig=jsTB8Kpd5YQUNg0EzS0I2dAXCLyKAAYSX3vV1ytkJAI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:12.2637264","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A12Z&sr=b&sp=r&sig=RlhA75S%2BSokxLySFGWRZvxE6H7Ff5Dk%2BygfyGicgVQA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:12.2636565","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A12Z&sr=b&sp=r&sig=3Jmu4HU3O5gCbWTGbbmB8N%2BJbvXfmQDHoV8Jk2I%2FZFI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:12.2637411","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:43.933Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1220,9 +896,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:30:26 GMT
+      - Sun, 29 Oct 2023 22:22:12 GMT
       mise-correlation-id:
-      - b445bb79-6a96-427a-8897-47bf88aae2ee
+      - 364d7e52-11f0-4dcd-8a99-2030420f84e0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1242,23 +918,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A31Z&sr=b&sp=r&sig=oAf5K9Cmqt%2B21SnIyT%2F7sS93wo92oeiW52M63cNDP4g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:31.7216915","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A31Z&sr=b&sp=r&sig=vJx8p0%2F1cdeDZWSwRb513BFiH1KTE38m2eJD0KUgSFg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:31.7216231","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A31Z&sr=b&sp=r&sig=YqkcB3Nor9d20EHaDpW80Ua1j06QHCOPSKEI83nJzQE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:31.7217066","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A17Z&sr=b&sp=r&sig=%2FZv5yZLTt1%2FrZyVLJOBgCJTgPCNN259AGNGita8lEiw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:17.8632316","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A17Z&sr=b&sp=r&sig=VWn3QR9kMYjTl1Lh4r0s0UBy5dwxV%2BK9CyyC%2Bdzt%2FbI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:17.8631599","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A17Z&sr=b&sp=r&sig=A%2BzZ7aS0Exe23xOeIvqVIkvTUMn3F43UpbMp5VvyqDM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:17.863248","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:43.933Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3249'
+      - '3256'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:30:31 GMT
+      - Sun, 29 Oct 2023 22:22:17 GMT
       mise-correlation-id:
-      - 7ab9340c-8e35-4b73-81ea-3346b3bc2bfc
+      - 0a003070-ed60-4a5a-ae9e-62a32fb0df8d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1278,23 +954,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A36Z&sr=b&sp=r&sig=SnmPGE6Bg13W7NIO7ESwF7gSarJD5vuU%2F4POdwNhhUw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:36.9891763","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A36Z&sr=b&sp=r&sig=jO2fLEp3as55wrcDKaCypY2EuKJVLFgfjY0mOGpfF4k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:36.9891078","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A36Z&sr=b&sp=r&sig=o%2BV3VSddCzGl4kvEoC13SWZU6wdVsiqUv%2FT7e9iTt1w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:36.9891905","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A23Z&sr=b&sp=r&sig=ieBbyJ478RhZjhjH3zL%2Bl5%2FQCW%2Fl1I0tuTsmxC5nMFY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:23.1285562","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A23Z&sr=b&sp=r&sig=ZQGWz1%2BBo9hIXj1H0Lxfxug3SqG4jwe0XODwMvuOnVQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:23.1284671","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A23Z&sr=b&sp=r&sig=LcBZxp%2BWO5y7pDcMrNqTRT7JyvkfAqcK0eSCcOdRVsc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:23.1285774","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"PROVISIONING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:43.933Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3249'
+      - '3255'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:30:36 GMT
+      - Sun, 29 Oct 2023 22:22:23 GMT
       mise-correlation-id:
-      - 86529646-cc41-4beb-9f94-fe80e18846fd
+      - ca50860a-7f68-4575-8db9-f5dbd12d7cc3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1314,23 +990,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A42Z&sr=b&sp=r&sig=CORUI3AIotfPToC%2FQaEGgCwjDv%2FkRwhgTa7PROVNxKo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:42.2704661","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A42Z&sr=b&sp=r&sig=Yn7ful1oNmXso6GGki4nu%2FJb0iNMWvI3A5BSL7V2saU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:42.2703801","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A42Z&sr=b&sp=r&sig=FZ1Ssdg8klEuqmAjrLJkDa0MMLx9EQpzWLY94zG9zFQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:42.2704884","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A28Z&sr=b&sp=r&sig=hhWPRv8m4RSaOlN3W3Yu%2FA0yUB%2B6NgdtZRlXXjJ9h8k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:28.5062541","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A28Z&sr=b&sp=r&sig=V2nuHZPROqGDBCif%2B3yud4F%2FZgQIn4Gun1EeM4JY1Yc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:28.5061605","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A28Z&sr=b&sp=r&sig=QZKwFcH852AHCuKf3BniE4VrCUZWySJyvxnoJzS6V9s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:28.5062761","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"CONFIGURING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:25.266Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3249'
+      - '3252'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:30:42 GMT
+      - Sun, 29 Oct 2023 22:22:28 GMT
       mise-correlation-id:
-      - ac6a88d8-91d6-4ce8-a236-96e0963c962b
+      - 18a19be6-4b0a-483f-bf97-051d235a9a54
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1350,10 +1026,262 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A47Z&sr=b&sp=r&sig=LADzU3cHYK2KAKzr9gMj36iYvVmNXuZVyYUmW4F8%2FQM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:47.5642369","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A47Z&sr=b&sp=r&sig=xyCdeOuVeMEApgVEf4xf4%2BryNW3bvdP2sb2UCwlRojU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:47.5641688","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A47Z&sr=b&sp=r&sig=t9TfAHZcF4I4iMGdRqC5Wd6bPjPwFtv88O2InaqC2E0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:47.5642505","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A33Z&sr=b&sp=r&sig=sBHJ%2BsGpN%2Fnq8l1%2B4q9zANmBryAc%2B6nxBZXhL4LXr84%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:33.7640338","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A33Z&sr=b&sp=r&sig=reu4lKuJ%2FufgB5F6vjyHodGvcrU17u8B%2FNwfjayt9qE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:33.7639519","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A33Z&sr=b&sp=r&sig=pOyL0CsKcIRWOFBH1Bbpm3huhVRyxYJLdVeQ%2BKGwF9U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:33.7641725","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3256'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:22:33 GMT
+      mise-correlation-id:
+      - 13dc90b2-678c-4ab9-afed-892a070ebd30
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A39Z&sr=b&sp=r&sig=22s7vu5QltbgewDVfxRB5nCDnVT8immUyDxFwmp6Zyk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:39.0269624","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A39Z&sr=b&sp=r&sig=Vm5hA3ioO9Hb2rWn%2FBqP000TENhSGC%2F8J4WzDlhBH4g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:39.0268815","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A39Z&sr=b&sp=r&sig=0AeGf%2B1cxKB6BPQa2Py6HxXudqobYLla%2Bg02fAEPZGI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:39.0269764","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3250'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:22:39 GMT
+      mise-correlation-id:
+      - 5729d8e1-eab9-497c-b330-0992e6d1644d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A44Z&sr=b&sp=r&sig=On2Mk7ej4R2JgS5C%2FFJZ8%2BrcwN%2BRuk2y93ej%2FW44ICY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:44.3293162","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A44Z&sr=b&sp=r&sig=FqU0hyGh4xcsQwY%2FVyv6CmAhz0fngm0VST60d3klUxw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:44.3292477","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A44Z&sr=b&sp=r&sig=WkEp7ziUMbruqpM9XDKC%2BUpskZ7%2F13IRo%2BkJ7yKfYXI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:44.3293307","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3258'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:22:44 GMT
+      mise-correlation-id:
+      - 7cf8ecc5-ae5c-4b11-80eb-ba495bcc9df9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A49Z&sr=b&sp=r&sig=WayL9VYPQS65ZB0xgQEtx3GSFyQBt2oy4z34aS13%2BCw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:49.6944345","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A49Z&sr=b&sp=r&sig=h%2Fgt%2BQ4KOE00Zmyxv8meU7loudw56o9V9juEMZZ%2FkzA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:49.6943428","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A49Z&sr=b&sp=r&sig=hQwtf2qy20VPBIUAVBX7HHRU7M3b3FuQvamJuI6arhE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:49.6944574","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3250'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:22:49 GMT
+      mise-correlation-id:
+      - e3a80478-0250-4e8b-bbe2-1d5c9a6e711e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A55Z&sr=b&sp=r&sig=%2FT9IVyss3GSlGQYXR%2BCkWhRCjvAYp%2Bxo0aqRL3cQUEg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:55.061783","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A55Z&sr=b&sp=r&sig=8BudesILAu0m8RbHWP0bO5kZHUksN%2BfV%2FapOC543G2Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:55.0616981","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A55Z&sr=b&sp=r&sig=fCx5VDd9WHGXKGF6FT75s5a4GqvJ3Ce6HuRFKEaqYBc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:55.0617972","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3251'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:22:55 GMT
+      mise-correlation-id:
+      - 87158358-4cce-45aa-8795-7225e1839971
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A00Z&sr=b&sp=r&sig=i8rBQk%2BZIigc3tx0AsRHe%2FCkw7V9o8qxoCb7gPDVPiQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:00.3124417","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A00Z&sr=b&sp=r&sig=i3%2Ffjrg0wIG1Oi7y%2FTceMx0myriIwYSxKbmSeTQAfmc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:00.312373","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A00Z&sr=b&sp=r&sig=uUDWZl0GDs8rM3%2BlJ5UY9lRbbzNBJlJU1kyail8M5k4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:00.3124564","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3251'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:00 GMT
+      mise-correlation-id:
+      - f193777e-b1cf-42e0-bcc9-63355e89efcb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A05Z&sr=b&sp=r&sig=ievwjCx%2FVW%2FcUyVJCyCh7%2FwQ3gQc9CuOwKg0qcX6qKQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:05.5963881","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A05Z&sr=b&sp=r&sig=CIRFB8Y265HDE%2BsZiU57onsCnyB4TeRH4rX%2Fv5g9c5Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:05.5963152","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A05Z&sr=b&sp=r&sig=lTDITOmS6y%2BYHSDM3XGW2158l9opHmbidb25p9MHonc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:05.5964042","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3254'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:05 GMT
+      mise-correlation-id:
+      - 21d078fb-6474-47c1-8e18-3b78a1b1612a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A10Z&sr=b&sp=r&sig=TIkLT7dOOEng9iZqpZ0b9n%2F9Hf1Qx0Y1Gf%2FEuIr5SYM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:10.921073","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A10Z&sr=b&sp=r&sig=MlpejBJoD5iqc59ch49u%2Bg36HrFmUOKvSwtHeRkEd3w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:10.9209767","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A10Z&sr=b&sp=r&sig=qZippZ22hNdp7mtt5MQrpz5WkzXoSTdwbHkRUnpqyyE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:10.9210998","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1364,9 +1292,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:30:47 GMT
+      - Sun, 29 Oct 2023 22:23:10 GMT
       mise-correlation-id:
-      - ed589be6-624c-4533-bbf3-1c42340cb8b7
+      - 136dc81f-4c1a-4382-8e92-c6071e064616
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1386,10 +1314,154 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A52Z&sr=b&sp=r&sig=I12Ghl%2BS59JBtMtNRRTCFKZd68jxu7mVs2BcnExY4kc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:52.8265227","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A52Z&sr=b&sp=r&sig=OSnlEq6EDQXbB5jqplza4dI5qrOXVeDc%2BK%2BKxDa2LmA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:52.8264389","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A52Z&sr=b&sp=r&sig=lhGfRU0f2EkPCUR%2FwWEQnEqn4Q6O%2FacuWooAzDqjg8I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:52.8265381","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A16Z&sr=b&sp=r&sig=Niwpu%2B359y3zu0GgXC7VKSMUru%2BMTs4nqkZ3sHF%2FWWg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:16.2456123","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A16Z&sr=b&sp=r&sig=vojQfZyqA%2FRzYSTnUzERRYBo8zVYdxqaxqPKUzTwWuE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:16.245507","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A16Z&sr=b&sp=r&sig=GGHLUCk5nQGHt3WiJV8JT8jzJxFcVDHKs8LVypkeObg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:16.2456378","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3249'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:16 GMT
+      mise-correlation-id:
+      - f6616b8e-5f4d-4dea-acf3-6f33e8bf69d5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A21Z&sr=b&sp=r&sig=g%2BXiqz%2F7LBWpbXW7x75A2fi%2B85bSIyK7Kw%2B1eIKWghM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:21.5859668","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A21Z&sr=b&sp=r&sig=0DvqQefcgPmf%2Bt1a4soRoYjGtwMBhPqfKVu1WrPFXvo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:21.5858915","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A21Z&sr=b&sp=r&sig=eadynicSD8PLW%2FJg1VyHWC3F%2BctQUA%2B6wOgIqwAr7k8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:21.5859815","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3258'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:21 GMT
+      mise-correlation-id:
+      - 7d62e305-096d-417e-9e94-ed929c2145ae
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A26Z&sr=b&sp=r&sig=lOIgISu95DpzhxGtqgEo44H%2F6xpluhTFHfDxNAG9Dq8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:26.8405073","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A26Z&sr=b&sp=r&sig=dZQGcHgIbQyaeYiH1x3CoSvhrGcBp7iypVW%2FVickr6Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:26.8404167","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A26Z&sr=b&sp=r&sig=Kjl%2BvcNzuVU5mh%2BaMr3ywBBhB0VhGrWvdcqOHLxBTO4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:26.8405333","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3250'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:26 GMT
+      mise-correlation-id:
+      - 6f8cc4fd-6913-42d3-afa1-51df692a1dbf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A32Z&sr=b&sp=r&sig=16R%2F8bQjV2bTJF5I76ZgL4GKIB1tk5%2BnqXNv3p78l9g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:32.1237751","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A32Z&sr=b&sp=r&sig=OmxzDzDHm4%2BkdROKAdgs9SR5H0o25CQagW7zhTkJKBg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:32.1237054","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A32Z&sr=b&sp=r&sig=KQ16af0o2r6AIzzLrMJ0JUJpAd%2FnIeYP5L85RnjR5Q0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:32.1237891","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3250'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:32 GMT
+      mise-correlation-id:
+      - a04e9ee5-4780-491b-a186-9641a0c77526
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A37Z&sr=b&sp=r&sig=EkbV2ZOgxpOQ26BGBQx%2F4UuvRChrr%2FN31zLwD1Y4QPE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:37.373139","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A37Z&sr=b&sp=r&sig=aAQRupn50EQO%2B1b21m7bZk02x4aROUZs22dPDMT%2FNIE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:37.3730657","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A37Z&sr=b&sp=r&sig=%2BE6Fy2gd1TcQ%2B1sNLgJtXEUvbprqkz892MKFYg0CxwI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:37.3731532","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1400,9 +1472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:30:52 GMT
+      - Sun, 29 Oct 2023 22:23:37 GMT
       mise-correlation-id:
-      - 0d4b407c-3e65-4b3a-a25f-8eb444c170c8
+      - 3106a25e-3460-489f-9dd4-0a1b336b3b23
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1422,23 +1494,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A58Z&sr=b&sp=r&sig=%2BJxW2r03u%2Fmqj2HyoVo3mfRJu3ubDzZP%2BNb4kut16cQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:58.4962713","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A58Z&sr=b&sp=r&sig=%2FfuQQUNNrX3WB8epW4WGsSYJw0ZJ3QryA9xDGHBZQhg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:58.4961833","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A58Z&sr=b&sp=r&sig=e138rjpSj47%2BeM%2F4hiOJSy%2BUo0JMu7vl8p6OtzCsz9o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:58.4962924","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A42Z&sr=b&sp=r&sig=ig8cqi8Nt%2FBP4YibfEhr%2BWAhW55vYPUr7Jr4i%2FDIPis%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:42.6718794","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A42Z&sr=b&sp=r&sig=0x%2BoGn7L7F9HW5Ert355euyPbjqRhefx3R3T4vXGjko%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:42.6718073","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A42Z&sr=b&sp=r&sig=KEzxH0GTOSj9FDXivyFdKtu3fiya4mt%2B0miJTVYJAMg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:42.6718937","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3257'
+      - '3252'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:30:58 GMT
+      - Sun, 29 Oct 2023 22:23:42 GMT
       mise-correlation-id:
-      - 834e70f7-a966-4a5c-b546-23c9490652dc
+      - a552077e-3042-4c89-841d-884873fd213a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1458,23 +1530,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A03Z&sr=b&sp=r&sig=Hky45OGyoGiTMYjWaVtvfHE5msExF%2Bsu1Z%2Fp%2F%2BED8dk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:03.7794522","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A03Z&sr=b&sp=r&sig=BQVuPIsPO5DDKNdLT58ZCa%2BekuudFrNquy6eZTpPXao%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:03.7793812","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A03Z&sr=b&sp=r&sig=YjllfmIz%2FzMSYTt9lQwzlaG%2FmWVfEVyFvH3TEpBh0gg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:03.7794664","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A48Z&sr=b&sp=r&sig=VBhLysxFbJDEu0GHbjPoQ1M%2Fd%2B5oujcsLFKquSGy66c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:48.0066777","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A48Z&sr=b&sp=r&sig=9jUNTy9ck0eAeWNUOET9LjJkwhj%2Fc0CkVgVjVsEYyb4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:48.0066081","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A48Z&sr=b&sp=r&sig=zoZI%2BPk4yxSVJn97n%2FeAWfLBm0oNNhIaqThM0DnrFXY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:48.0066918","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3257'
+      - '3252'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:03 GMT
+      - Sun, 29 Oct 2023 22:23:48 GMT
       mise-correlation-id:
-      - 350aa062-93ea-4115-8e81-d0703229ef9e
+      - 277e4ce3-d269-4f2d-9530-0b6fbbbedbd2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1494,23 +1566,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A09Z&sr=b&sp=r&sig=CPCA7EvJ1VxJVsMii6N0UESTR%2Bo3JKZDGWGhExg6Y%2Bo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:09.0521707","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A09Z&sr=b&sp=r&sig=WWBo0TIntvHECX5f2BfHip5SrAnNgp7N6CB7yu%2FETWM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:09.0520768","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A09Z&sr=b&sp=r&sig=tWiJR%2FLBfQS9YpGotF0gKx51vaQd6BK3z3e4SYx2KZk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:09.052194","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A53Z&sr=b&sp=r&sig=UNYGNllPxqabZEY4z7GG4w%2BF%2Fw10vCvX8IMZrDGFfqY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:53.6115406","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A53Z&sr=b&sp=r&sig=qZVh5GWDyOLUx3ua99%2Bd6ySgug08%2FsqgC6poem2MEAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:53.6114718","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A53Z&sr=b&sp=r&sig=P1UiAUzmZny%2FtD1oMAclOljGcxM7%2Bo9q0TDQnE1UAmM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:53.6115551","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3250'
+      - '3254'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:09 GMT
+      - Sun, 29 Oct 2023 22:23:53 GMT
       mise-correlation-id:
-      - a737cb27-24a7-48d2-8842-5b3f72c66287
+      - 0607c3ce-4f1e-4b62-b953-93dce17a0cef
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1530,23 +1602,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A14Z&sr=b&sp=r&sig=k5QvgPyYf5HFvw6qrR98LB%2F9dae7JB68VvCrurUtDo0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:14.354957","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A14Z&sr=b&sp=r&sig=Nf8qaeDeIqQdarf70TcY5yLXMT8zH2LXai98UnThs4I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:14.3548808","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A14Z&sr=b&sp=r&sig=nKJkcM0K%2BaE3FDsknZgjAzkaGb56G%2FbOL4Vr8%2FjybGY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:14.3549739","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A59Z&sr=b&sp=r&sig=eduLrW6%2BD1Bl2BHFZrrNFPKdSn4jludt6ijDlFI33sY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:59.2233695","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A59Z&sr=b&sp=r&sig=F74jK671xa3refvd4ov63Sf%2FdgqS1dYlgrkGVY4nWkk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:59.2232957","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A59Z&sr=b&sp=r&sig=G1S0LNvkpgksW2PPcX7ozL74JMp2CIKv1a4c4LoIH%2Fg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:59.2233826","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3250'
+      - '3248'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:14 GMT
+      - Sun, 29 Oct 2023 22:23:59 GMT
       mise-correlation-id:
-      - 63c48e85-0f5c-4e11-9682-0e05f72d5192
+      - 1c78abd3-d533-4935-80f4-6e9d3b7ca492
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1566,46 +1638,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A19Z&sr=b&sp=r&sig=3mloBzZEr6B99QjwT4qpGuQJF4pihHtjTbFZ8KmptsU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:19.6410117","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A19Z&sr=b&sp=r&sig=FhO7iG4uTDn29m9jh4VFkZrsliS%2FxMigDP8bOubkMUU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:19.6409249","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A19Z&sr=b&sp=r&sig=ijMi4UxMJ5d0JGcC1GgfwoW54eRwMIEfmc%2BTL0p6rb0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:19.6410343","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3247'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:19 GMT
-      mise-correlation-id:
-      - 5485c8bf-e92d-4d4e-89e1-5eda88c3db31
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A25Z&sr=b&sp=r&sig=IlsVlhWYZ6NM9upN55tc6TUuKkl2JloCfx%2FV4ChBuco%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:25.8905345","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A25Z&sr=b&sp=r&sig=7aUmKm1NYKEU9lGpjBoEucLMfblTyXnO%2BWPSnlpolTc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:25.8904577","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A25Z&sr=b&sp=r&sig=ofWiQ0Mync09bdcEK%2BcpjfdrETPVDwtPMtfF1NGwKYc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:25.8905492","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A04Z&sr=b&sp=r&sig=G4oUl977WGf9jjVJeo7xa%2F%2F9I9KaaMBrvjW3naWBBPw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:04.4764349","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A04Z&sr=b&sp=r&sig=nEvAn60vtGgFBrzAJxLfwwfjlGF%2FWHSZBpb8S532ti4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:04.4763544","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A04Z&sr=b&sp=r&sig=fguC40YVxiVMSHwl9lX0z%2BIYmeQ5C5IkzsRIHnDmKow%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:04.476449","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1616,9 +1652,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:25 GMT
+      - Sun, 29 Oct 2023 22:24:04 GMT
       mise-correlation-id:
-      - daf8d9f5-0d32-4ff2-b10b-54c2f5b6a6cd
+      - bea971e6-5425-4f69-885a-27a2d7fadd81
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1638,23 +1674,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A31Z&sr=b&sp=r&sig=W97Wxu3w9UT6cQvg8SnUOsfX970Yk95bSHxTwpp5fYU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:31.2161344","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A31Z&sr=b&sp=r&sig=IVtvdMHnSXP2748R181rLhFh8TEP0ffG%2FssgF0xtvRg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:31.21602","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A31Z&sr=b&sp=r&sig=%2FPifLT4kkBk%2B9JNNgfwKj02LfIZ2Jhvg%2Fz3h8%2BbOmjA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:31.2161605","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A09Z&sr=b&sp=r&sig=Cwfl640CPLXZzpmEMnmLit17f1BFwdtvqyijOBuDF6o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:09.7315354","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A09Z&sr=b&sp=r&sig=UDbVAPTBoQEL8jU2WYyXpYVJO63ych1axruc9abJdGQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:09.7314316","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A09Z&sr=b&sp=r&sig=yMftaMtx1qL%2BXAeH6s0B3Giz6tOUg8h0m8ZHuD0W7us%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:09.7315598","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3251'
+      - '3244'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:31 GMT
+      - Sun, 29 Oct 2023 22:24:09 GMT
       mise-correlation-id:
-      - 8a49a645-148b-4864-b2b5-c2192c38fc66
+      - 75ea6081-bb66-45ea-bf9b-00cab51b9465
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1674,23 +1710,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A36Z&sr=b&sp=r&sig=NMsqPjXT9OD3LhZKH8ZtYg1NZq4m0JC94GnHaEnMA%2F4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:36.5271456","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A36Z&sr=b&sp=r&sig=sj%2F88hXocnPU9zKYjEyscjGW2CE9kjnWWgdKCJkV%2B54%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:36.5270752","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A36Z&sr=b&sp=r&sig=UjSYbxAHFas%2FKb9WbTd7ZshqY5CiVyOADEo4OJ5XLWU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:36.5271602","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A14Z&sr=b&sp=r&sig=dsU67kpdM%2FblI56%2BTZYVl82xxk1lUMg513RB620n6J8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:14.9857899","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A14Z&sr=b&sp=r&sig=ohnXUmxa7vC8A0pI0%2F2aB5NVUJuaCYptHpSU1AjVFfU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:14.9857023","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A14Z&sr=b&sp=r&sig=Ux%2BLdQ%2F1TYfDFpZTBB98u2%2BXU4lB139ZXi4LqSpgO%2BM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:14.9858109","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3251'
+      - '3256'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:36 GMT
+      - Sun, 29 Oct 2023 22:24:14 GMT
       mise-correlation-id:
-      - 6a7abdbb-e38b-4a5e-bdc8-6a43f23ca650
+      - 3a20a10f-523e-40c2-b9a2-bec790749125
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1710,23 +1746,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A41Z&sr=b&sp=r&sig=K7a1FAQ5EmGoatg3eCg77FScXZ%2BxdWyo4NCmcrtolUw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:41.8594374","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A41Z&sr=b&sp=r&sig=pukQbMPzuUC9ouEOuYFVmoJqolgP9jPxdd74zyqzZYE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:41.8593526","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A41Z&sr=b&sp=r&sig=CCcQgRYbQbD6E2ENkdHSsvisb9jYT618NDZGryqgsgM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:41.8594597","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A20Z&sr=b&sp=r&sig=FmSC6uZyVkVd6nRusBSgLAteWsoTBT48%2FSSqci8dba8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:20.2567671","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A20Z&sr=b&sp=r&sig=uk7J%2F2ntHPCN5H6qgDCgyLjH7TQdnTMF9L76AW1Cffg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:20.2566739","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A20Z&sr=b&sp=r&sig=wo7dJz5BscFuO%2F0rAqU92M8axdyRwIWnAtISXrofeKE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:20.2567907","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-29T22:21:43.696Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:29.164Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3245'
+      - '3248'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:41 GMT
+      - Sun, 29 Oct 2023 22:24:20 GMT
       mise-correlation-id:
-      - 200160bd-347a-476d-9a79-109d3d6c4284
+      - 8754665f-e4ee-4bcb-90b5-3a5a667c6087
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1746,95 +1782,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A47Z&sr=b&sp=r&sig=R4MVUWopIUFgI3fW5KPtBpdEb97pIdvOE9c9Vz945S0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:47.1161768","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A47Z&sr=b&sp=r&sig=59Lb6BauUJsgiLANCIi943On1M85APGuvbUjZCQ2ilw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:47.1161022","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A47Z&sr=b&sp=r&sig=OFWZdg186kDtPk7gK0tqqKU%2B0Mqc1aWvSitzi6XIyVA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:47.1161924","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A25Z&sr=b&sp=r&sig=szsCs88E1AXYe1Dk3uIRW5SC%2Byk6vs%2Bh8z743KfTBGw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:25.513665","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A25Z&sr=b&sp=r&sig=wYslShif4MPMnp%2FwJFHLhCJ3cTteDXm8WAHAKTG1r8Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:25.5135568","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A25Z&sr=b&sp=r&sig=Y2oIhestfJDJwf8Qgi456engpiKjqeDug8jia2oW64M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:25.5136804","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-29T22:21:43.696Z","endDateTime":"2023-10-29T22:24:21.171Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:24:22.53Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3245'
+      - '3282'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:47 GMT
+      - Sun, 29 Oct 2023 22:24:25 GMT
       mise-correlation-id:
-      - b86f673f-1927-4fb4-b6d9-af498c74506c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A52Z&sr=b&sp=r&sig=4R0%2Be640J%2F7uNRTnlu71hFSvHP0dzJFD98cz%2BnRQWH8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:52.4241345","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A52Z&sr=b&sp=r&sig=JLyIkKhwHBD48p5p3FJCKzkAlEYhAtSWokeSPojul%2Fg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:52.4240488","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A52Z&sr=b&sp=r&sig=NeYUs5oKpbuyzyOKXHdS3GsJemAd87wtpu921hPurQI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:52.4241497","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"EXECUTING","startDateTime":"2023-10-24T12:29:11.794Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:01.542Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3251'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:52 GMT
-      mise-correlation-id:
-      - 1680ca35-b487-46ec-b926-6216dc2a4f71
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A57Z&sr=b&sp=r&sig=5AHC3zs1hVuW6noN55%2BK0aBcMDGLR8lJ2Yg5c9kn1uk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:57.8369763","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A57Z&sr=b&sp=r&sig=bxC%2B3pN5gtWbOmeQHZSkpqTa%2BcO%2B31UEEchmYMp6E8A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:57.8369095","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A57Z&sr=b&sp=r&sig=jMuf%2BHvTKgM1MvepYn8i058chQz0nvmaRm5%2Fo52OjAA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:57.8369905","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-24T12:29:11.794Z","endDateTime":"2023-10-24T12:31:55.06Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:31:56.807Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3290'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:57 GMT
-      mise-correlation-id:
-      - 9054c6f1-2959-4bb4-bc9b-abf6d66111e5
+      - 9ffdc97f-c893-4b9e-afce-c5bde5c29038
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1857,18 +1821,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:11.2483666Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:11.2483666Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:44.1306584Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:44.1306584Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:59 GMT
+      - Sun, 29 Oct 2023 22:24:26 GMT
       etag:
-      - '"d300e23b-0000-0100-0000-6537b85d0000"'
+      - '"3c00ad27-0000-0100-0000-653edabe0000"'
       expires:
       - '-1'
       pragma:
@@ -1898,23 +1862,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A00Z&sr=b&sp=r&sig=WLXJ5MMr86dJ2noulzrDp3sOHYAj%2BvFLIMjAuB9o9GQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:00.2865177","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A00Z&sr=b&sp=r&sig=6s6dKwHN9HZWQGyhPVsmJHap%2FpzaSXQY3hG0jWxrFf4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:00.2864154","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A00Z&sr=b&sp=r&sig=4a0tAKJSX1%2BO%2B0mW8crlYUBQ2O0VJzzc6m6QCdawmHw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:00.2865402","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-24T12:29:11.794Z","endDateTime":"2023-10-24T12:31:55.06Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:31:56.807Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A27Z&sr=b&sp=r&sig=xuBmZ8Sj4X%2B5yL3qWIl5tdMA1ERxT2kdLre6RGgVe%2F0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:27.6292608","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A27Z&sr=b&sp=r&sig=ornLl7GmxsvuRErBsVkEet4Zjh6n2kAuV3FiyLZM3iA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:27.6291584","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A27Z&sr=b&sp=r&sig=newLcsMTfWOY6T4ZHLELFzFXF9Xi%2BQg%2FirU8ZoKMnlk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:27.6292759","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-29T22:21:43.696Z","endDateTime":"2023-10-29T22:24:21.171Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:24:22.53Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3286'
+      - '3285'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:00 GMT
+      - Sun, 29 Oct 2023 22:24:27 GMT
       mise-correlation-id:
-      - 965d2f07-1b29-444c-b586-50ba260bed7d
+      - ac25d5a9-a07b-484e-b2c3-e39f57aa2502
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1937,18 +1901,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:11.2483666Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:11.2483666Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:44.1306584Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:44.1306584Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:01 GMT
+      - Sun, 29 Oct 2023 22:24:28 GMT
       etag:
-      - '"d300e23b-0000-0100-0000-6537b85d0000"'
+      - '"3c00ad27-0000-0100-0000-653edabe0000"'
       expires:
       - '-1'
       pragma:
@@ -1978,23 +1942,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://364502cb-65c6-4d0c-98f1-caee92afa836.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
+    uri: https://1ea5d644-cd13-421a-a78c-0473fdb9d0c0.eastus.cnt-prod.loadtesting.azure.com/test-runs/create-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"27c55f6c-f4e3-4744-b037-69ccbd54175c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"cfe528e6-6b15-4f2c-bd89-78e6db8ee0c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"60818291-485b-469b-9ea4-310d3594f2cc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/db2d1cab-6d27-41ec-ab4c-8db036662891?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A02Z&sr=b&sp=r&sig=Jn3ZzcnEWK82rS4QQeisqwmxZ5LRxfxkZywXe6iR5qU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:02.9352502","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/43d994c4-7c6d-4b48-b148-4310b6ec36cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A02Z&sr=b&sp=r&sig=zxyGZDSziHORkCHSb7z%2FCWGm7tGf35uQhBV8vTl7V2g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:02.9351757","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bfcecc99-b7c7-4537-a6d0-31b94d9f4d95/36308d2d-7a53-4904-89f3-4c02141a4f8a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A02Z&sr=b&sp=r&sig=w7cTj1%2Bm5gVfhxhhS9yyrUJc9UNSR4I%2BQ4ErDWdBKek%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:02.935264","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-24T12:29:11.794Z","endDateTime":"2023-10-24T12:31:55.06Z","executedDateTime":"2023-10-24T12:29:10.531Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-24T12:29:10.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:31:56.807Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dda1905b-f02d-4f3b-85d8-b09f307a348f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f46ebd85-3b86-4296-b63e-f9bb751d380a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3ed39a8e-2b5f-413f-b17e-437ddf203435":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"11","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/d3ce5fb7-9ca0-4357-ab23-e855d0a52800?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A29Z&sr=b&sp=r&sig=DIHzMb1UUpm%2Bxd5cZipPAuqf1blxwizSc3demzI6vnc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:29.7855984","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/6173e0e6-ebaf-41de-a467-fa309684c5d0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A29Z&sr=b&sp=r&sig=IaaZeXUL43TinUVT8LkZ2Rd5yIcZLStM4Do0%2FQxLX5o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:29.7855297","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/c3528375-4964-4969-a7e9-3ef7175b398f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A29Z&sr=b&sp=r&sig=aEogQ%2F0%2FoXSkCj7bihFy0E5uMFVzU%2FYbGWFf%2BQvBtdA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:29.7856148","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/8623bf12-7f28-431d-bfb1-1057dbfd5615_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A29Z&sr=b&sp=r&sig=H0tXFEbxuChu4rAUJ7ZBvvH5THfeH8aL3vpqGfHXls0%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:29.7856303","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ec92371d-cb8a-4a09-9c2b-efbba90a7e5a/8623bf12-7f28-431d-bfb1-1057dbfd5615_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A29Z&sr=b&sp=r&sig=SNJP7WPhgznCx1j9GXrBAD9jf%2FXZi3Sgp0DhMdgGero%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:29.7856468","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"create-test-run-case","displayName":"Sample_testrun_display_name","testId":"create-test-case","description":"Sample_testrun_description","status":"DONE","startDateTime":"2023-10-29T22:21:43.696Z","endDateTime":"2023-10-29T22:24:21.171Z","executedDateTime":"2023-10-29T22:21:41.94Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/create-test-case/testRunId/create-test-run-case","createdDateTime":"2023-10-29T22:21:43.155Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:24:28.815Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3283'
+      - '4451'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:02 GMT
+      - Sun, 29 Oct 2023 22:24:29 GMT
       mise-correlation-id:
-      - b58e4272-3717-4cf2-abfe-c9eb0f2a68cd
+      - e8141acf-4964-49a6-b3a6-a0b09e3f71b2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_delete.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_delete.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:36.7813407Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:36.7813407Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:54.2589267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:54.2589267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:10 GMT
+      - Tue, 24 Oct 2023 12:29:26 GMT
       etag:
-      - '"7500314e-0000-0100-0000-6530455a0000"'
+      - '"d300a43d-0000-0100-0000-6537b8870000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:52:10 GMT
+      - Tue, 24 Oct 2023 12:29:27 GMT
       mise-correlation-id:
-      - 35a85318-d7f2-48e2-85ca-a03cddb465f8
+      - eeaff721-5b91-4b2c-a6a0-5fe47db16d5d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"506415db-e616-41bc-bd5e-ee08c40caea7": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "86fd3a31-c089-4092-a5f7-fa63fd157566":
+      {"passFailMetrics": {"762b94d9-7054-4c80-a066-90da8932b523": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "fd473a70-3e78-4a18-bd11-234a91ae5024":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "bef1de58-a689-479f-802d-ffe758da1dd1": {"aggregate": "avg", "clientMetric":
+      "50"}, "03c9f4a7-edd4-4584-a436-a4d050ff2742": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:52:11.327Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:11.327Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:29:28.343Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:28.343Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:11 GMT
+      - Tue, 24 Oct 2023 12:29:28 GMT
       location:
-      - https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+      - https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - caf86f6d-a791-4d74-a6fc-8633cce63630
+      - 36bba253-2701-4498-b521-93cb8b19a240
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:11 GMT
+      - Tue, 24 Oct 2023 12:29:28 GMT
       mise-correlation-id:
-      - e1347f97-d51b-4c36-a498-f69d54e09a1a
+      - 15495cbf-a2db-4efe-9259-5077310eb9e2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A12Z&sr=b&sp=r&sig=AFFvgbHZ3NTbPNfDb%2BrOnb9jvtmbPbGyzuzKzH2R9So%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:12.1559152","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A30Z&sr=b&sp=r&sig=oEijXBADOS%2BBetlgz7rLx%2FWjYlkd5M93m8PCfKVm0O0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:30.0326766","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:12 GMT
+      - Tue, 24 Oct 2023 12:29:30 GMT
       location:
-      - https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - aa57d4b8-6f2e-4582-a656-4bfebee32b08
+      - aa7cb081-7606-493f-b213-b3e99e94e909
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A12Z&sr=b&sp=r&sig=r%2Fotf%2FJm4kMMN5%2BbZvYoojh0583fKk%2FOKn2BAJPK2dk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:12.4940714","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A30Z&sr=b&sp=r&sig=sjQsFMSlhPN1BeyNCiHjCmL2pF33UNJLGyOnBy6PKdk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:30.3833039","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '557'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:12 GMT
+      - Tue, 24 Oct 2023 12:29:30 GMT
       mise-correlation-id:
-      - 4658e98a-7394-4b23-b6db-80b0c0b6b0f0
+      - 960eaf2f-8374-45ed-a382-5ed5be9fb28f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,10 +349,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A17Z&sr=b&sp=r&sig=PIa7NV%2BLAUilk7u6SQXCBHo1ULxSY9UthGOj9Y0U6Zo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:17.7677886","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A36Z&sr=b&sp=r&sig=5hAkvV2P0q42KsJuccx3r9iCO5NkQ%2FHaLaaVYqhtlWw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:36.054114","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '550'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:29:36 GMT
+      mise-correlation-id:
+      - aa0c504a-1fa1-46fe-b68e-652ae69f8dbc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A41Z&sr=b&sp=r&sig=KLvtBe0dCeKG%2BIxwb2hF9w8bP4JHTk9wD3atclq4BU8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:41.3235205","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:17 GMT
+      - Tue, 24 Oct 2023 12:29:41 GMT
       mise-correlation-id:
-      - 65933222-5221-4e2d-9bfc-01aacd077afc
+      - 7c1f4720-df8d-40ae-b5de-a1cbbd15cd6e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A23Z&sr=b&sp=r&sig=kxEth%2BdutQ4L4bid5BQSqbMAyWr8ASE8TLg7itNKIsY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:23.0266492","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A47Z&sr=b&sp=r&sig=q%2BYl%2B09%2FCzm1nTuQMSm4Gl8NTOJI3iOrEsmXe4fliZg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:47.0174882","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:23 GMT
+      - Tue, 24 Oct 2023 12:29:47 GMT
       mise-correlation-id:
-      - bfe11f45-5d15-4eab-94b3-a0d18649fb4c
+      - bee46778-ca4f-462c-acdd-88525abbd7d5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,60 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A28Z&sr=b&sp=r&sig=ra5oTBwlQ4X0yoY83iKw%2FVzrjlX%2FCBCjoh9C3EYcWaY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:28.2899638","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A47Z&sr=b&sp=r&sig=VBHk1SpABVGnlYgUd4Yz1tCKQjJ614QyTFio6xCABtA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:47.2857954","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:29:28.343Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:42.887Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '1577'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:28 GMT
+      - Tue, 24 Oct 2023 12:29:47 GMT
       mise-correlation-id:
-      - 50239093-e5f7-4126-b443-38df7499ac60
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A28Z&sr=b&sp=r&sig=iFUDUjaNd36JkzbVZL%2B4GoOrPV3cLc2dcSK07%2BlZogM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:28.5394255","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:52:11.327Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:26.126Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1581'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:52:28 GMT
-      mise-correlation-id:
-      - 92d5aba2-6e98-44d8-ae54-5738782f8cbf
+      - 9b867eb1-f101-4c28-8cae-065a9ec2288f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:36.7813407Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:36.7813407Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:54.2589267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:54.2589267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:29 GMT
+      - Tue, 24 Oct 2023 12:29:49 GMT
       etag:
-      - '"7500314e-0000-0100-0000-6530455a0000"'
+      - '"d300a43d-0000-0100-0000-6537b8870000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A30Z&sr=b&sp=r&sig=TKvOFURuZWlM1HqgEPlIyrD0Ot0OYFwNESSuakCH6h0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:30.8126589","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:52:11.327Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:26.126Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A50Z&sr=b&sp=r&sig=Wcotj2b4AxATbANWsQqCtJcCc%2BL4qG%2BouXA9TgXrbGE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:50.0375588","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:29:28.343Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:42.887Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1589'
+      - '1593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:30 GMT
+      - Tue, 24 Oct 2023 12:29:50 GMT
       mise-correlation-id:
-      - c8a81ed7-64e2-4bc0-8c4a-0c17fc51f68c
+      - 78643d53-55bc-4ce6-b272-9ab649ade8aa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:36.7813407Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:36.7813407Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:54.2589267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:54.2589267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:31 GMT
+      - Tue, 24 Oct 2023 12:29:50 GMT
       etag:
-      - '"7500314e-0000-0100-0000-6530455a0000"'
+      - '"d300a43d-0000-0100-0000-6537b8870000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:52:33 GMT
+      - Tue, 24 Oct 2023 12:29:51 GMT
       mise-correlation-id:
-      - cffeda7f-3787-4131-969b-43e935f47c69
+      - 8ff5bec5-096e-4c34-9963-a6c79fef1445
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A34Z&sr=b&sp=r&sig=grRYvKveUfHESqiNbuOFyYJpssEsJz6fB%2Fk%2BtNaSqhA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:34.553071","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A34Z&sr=b&sp=r&sig=2Gq2s0kfazfkA%2FMvBTjgYMqMMOZcf5C3Vwdk9fx4UhY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:34.5529284","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A34Z&sr=b&sp=r&sig=o1V9vMhLJPSS53lJyKLrZEfYeQtV%2FGPJUcxxSEhVu1c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:34.5530949","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:34.479Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A54Z&sr=b&sp=r&sig=KSyldyJiMJaesXuFBaPpKPokPR%2B8Zt%2BDa7p%2FDdNu6mk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:54.3606334","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A54Z&sr=b&sp=r&sig=rz3RswYuEVoUor3OVD2hud8DKAC%2FZlsFEw3TnviZC9s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:54.3605202","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A54Z&sr=b&sp=r&sig=0FDBRkRDNt7YtC86BDsDH9UWqokvY9FHJ4%2BWjp9z8Tw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:54.3606621","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:54.28Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3155'
+      - '3156'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:34 GMT
+      - Tue, 24 Oct 2023 12:29:54 GMT
       location:
-      - https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+      - https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - d16db58c-2c5d-43d4-926b-bd5eb2a3c80e
+      - 00c7886e-2a3c-494a-bd09-dfe73c397aeb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A35Z&sr=b&sp=r&sig=NZayFMtPYweBKKnErgmQCj%2FF3NvgtTEocUuyF7zv6eU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:35.4521213","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A35Z&sr=b&sp=r&sig=ixN6TVJfmCqWcoW1Z0qeIdtdaRoMVtGkK3CEZzUd%2BAo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:35.4520334","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A35Z&sr=b&sp=r&sig=OJCfGplYwNCxCgJAZoNZfL5mfbnxrielYqD4MK4xL54%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:35.4521351","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:34.479Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A54Z&sr=b&sp=r&sig=KSyldyJiMJaesXuFBaPpKPokPR%2B8Zt%2BDa7p%2FDdNu6mk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:54.8279702","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A54Z&sr=b&sp=r&sig=rz3RswYuEVoUor3OVD2hud8DKAC%2FZlsFEw3TnviZC9s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:54.8279041","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A54Z&sr=b&sp=r&sig=0FDBRkRDNt7YtC86BDsDH9UWqokvY9FHJ4%2BWjp9z8Tw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:54.8279846","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"NOTSTARTED","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:54.723Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3152'
+      - '3202'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:35 GMT
+      - Tue, 24 Oct 2023 12:29:54 GMT
       mise-correlation-id:
-      - 44831bdc-b9f4-497a-9c12-16ae98386e98
+      - ca6f2532-4da7-4c61-ab63-daf825c98287
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,118 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A40Z&sr=b&sp=r&sig=X3L6FeSaHSG%2B2%2FYaHxBeu2moq0Cy5LdbtRb4AllejFk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:40.7472704","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A40Z&sr=b&sp=r&sig=n7rJqHMJt0%2FJJUopN1BJjOpOn2CM3Af354PaK81C6ko%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:40.7471917","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A40Z&sr=b&sp=r&sig=8IaV1UDHxTfwn22EXStkaylGzxPf%2BiPOwPlK8xty6tc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:40.747284","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:35.86Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:52:40 GMT
-      mise-correlation-id:
-      - c3eebc1a-14e1-49ff-ac90-183300aea219
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A46Z&sr=b&sp=r&sig=88rM5binPzoJcnf8fVuzVAGGQC%2FU%2BnGVZg%2Fo%2FpNrv8M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:46.0790454","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A46Z&sr=b&sp=r&sig=hoiEqbiADPqXx7%2FXkiJ1Ga9Xh9Oh2p50SZKiMoqoBY4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:46.0789693","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A46Z&sr=b&sp=r&sig=3os5NrFhb1D2yIyIrC%2BoisweVcQOuonj%2FB%2FyWs%2BWKRg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:46.0790603","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:35.86Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3212'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:52:46 GMT
-      mise-correlation-id:
-      - 657caa44-e0e9-4e00-aef3-fa765bcdfeff
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A51Z&sr=b&sp=r&sig=gh2CfJKaRTlFZFIum9oNf6xSxSuTdY%2Bj%2F2No6mDZv8k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:51.3605426","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A51Z&sr=b&sp=r&sig=rmCrR%2FEi5nXwVDuYYGjnF6XnmJ9v%2F1L2BySdgY62YRw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:51.3604633","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A51Z&sr=b&sp=r&sig=tur5yVp67TEbKPqA6WhK5yJXUT6sngPQsNHcfeRHxJo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:51.360557","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:35.86Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:52:51 GMT
-      mise-correlation-id:
-      - 2d9df636-1968-4958-85c3-b09df9a93d20
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A56Z&sr=b&sp=r&sig=7l2Y%2BPCr9GFdUh7VFQQVkYcSK4JjiOrS1m2Yn69DeAU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:56.6409037","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A56Z&sr=b&sp=r&sig=pqH%2F2psJjBvZ%2FutwljcFR8qtn50dZFl2v8pBCtGvcFo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:56.6408331","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A56Z&sr=b&sp=r&sig=svwWyXzS8UX%2BXJMgn6ZJjWB9%2BuztICAv2ZzkhE57Srw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:56.6409176","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:35.86Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A00Z&sr=b&sp=r&sig=BSrFsGCLbipAVw5yPrbQzEpoi8E7uwH%2FT2bRRIE1l7s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:00.1012143","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A00Z&sr=b&sp=r&sig=sADcuwv1wiKTvVwTU2WzuaHRe4J1m2Txki2uVouyyZg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:00.1008721","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A00Z&sr=b&sp=r&sig=kczGCr%2B%2BLM8JvLOVA0hJaS0is%2FQwUctJfIC%2BvpVAuPY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:00.1012385","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:54.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -858,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:56 GMT
+      - Tue, 24 Oct 2023 12:30:00 GMT
       mise-correlation-id:
-      - 0f5b97a7-3770-4e7b-bda4-59d90503f48e
+      - 86cae9bf-392c-45be-849b-a3f30e5f663b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -880,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A01Z&sr=b&sp=r&sig=7zJSvYFEPpsoacjZ7XIz%2FSoXXdbkfRTMxr9q9RwMFJM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:01.9441255","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A01Z&sr=b&sp=r&sig=Sk5YUHkUv24OODOeT8e%2B2xwkpG8gpLVx49k4NRkxL1U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:01.9439721","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A01Z&sr=b&sp=r&sig=Zo5I96nyIp69Gea%2BEa5nVI8r7imQ1wMjPH5Sy0sE3zQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:01.944148","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:35.86Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A06Z&sr=b&sp=r&sig=o%2F0h%2F2QZHV0mVND8R1SEP8HZu3cyaD18GBi03cPqcT8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:06.0655278","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A06Z&sr=b&sp=r&sig=%2B7eysEHi%2FP430oTPPZ9%2Fhx9NibmchIk3h2%2FITW%2Bbpcg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:06.0654285","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A06Z&sr=b&sp=r&sig=xVTvg7jH0KIGlTjmxUeeO8B14bZxz86XubHpBb3zdXo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:06.0655517","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:54.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3199'
+      - '3208'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:01 GMT
+      - Tue, 24 Oct 2023 12:30:06 GMT
       mise-correlation-id:
-      - b2096c47-202f-4c65-a817-bb82a4db5888
+      - 80a5b818-1a7d-4c1c-9c44-6836a06dc9ae
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -916,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A07Z&sr=b&sp=r&sig=ljiXmHXCjpT%2Bbieo61T09ANmqt6Fhyo3844tENRWDrI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:07.2112844","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A07Z&sr=b&sp=r&sig=2b989ihk9ieKiXnTQT1r1FAG9B7sv5RsnXGx%2BeR6UR8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:07.2107083","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A07Z&sr=b&sp=r&sig=0XkPR%2FcK%2Bw47p2srGUz5TqWWf2QUHLA5J8WQDTYy10w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:07.2113152","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:35.86Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A11Z&sr=b&sp=r&sig=LQFJ48C7m4t%2FLdKJqn3%2Fnw%2BaD4pDsNl2Ehk3Q39K%2BTI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:11.4501887","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A11Z&sr=b&sp=r&sig=k%2Fl2EHVQg%2Bj2vrsAxjlClRnoguQ5ldVNZvTTIVyzhuQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:11.4500891","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A11Z&sr=b&sp=r&sig=2S2y%2Bo6W5ZXsa%2BpLABgttUnRTLp4SyT003MjZZtzlZs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:11.4502135","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:54.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3202'
+      - '3210'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:07 GMT
+      - Tue, 24 Oct 2023 12:30:11 GMT
       mise-correlation-id:
-      - 13ea9fc1-8c6b-4db1-bd91-cef2fc3289b1
+      - c72d8873-5394-438f-957a-eec0f06e42fd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -952,226 +844,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A13Z&sr=b&sp=r&sig=791f%2F%2F2cwpdYrte5xH2DBZ4amq9DaLQTTTFxfzqhQiU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:13.2354604","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A13Z&sr=b&sp=r&sig=xfK9CU6FTotdp9f7tYuWXaI2GyOk7A0s6hnraJHZLWo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:13.2353836","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A13Z&sr=b&sp=r&sig=M2YTQIGwRixa7eEaw9UwBbnH%2BaDH%2BEYfvJPBzrjM3tI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:13.2354747","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:35.86Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:13 GMT
-      mise-correlation-id:
-      - 387dc77c-d8e9-4066-b9e9-0ce82072595d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A18Z&sr=b&sp=r&sig=LBzfPah4GPEWSGlGt5X28OOd30lW1Hx3bJmhv9%2Ba4Cc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:18.5213979","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A18Z&sr=b&sp=r&sig=FlX4k96eV%2BgjlJC4QjQ6VvCNgd3sowrAacA9N7yYeA0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:18.5213244","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A18Z&sr=b&sp=r&sig=bPWcoqXZreZ4%2BxaBoibf%2Bdyf3627PRsq0n0vbQfpQRY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:18.5214119","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:35.86Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:18 GMT
-      mise-correlation-id:
-      - 023f233e-48a9-4810-a8f0-dc0971c56728
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A23Z&sr=b&sp=r&sig=gydxOFhfzXgqc3ToQ0PuHIKzAFnHNmUgKDRYhwgDf%2Bw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:23.8350651","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A23Z&sr=b&sp=r&sig=%2FvEyP7jmJ8G4hmnD%2BR3a2vFsP0Ue1sQEax5HO%2BRs6JA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:23.83498","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A23Z&sr=b&sp=r&sig=v2KiBwLbHV8KE%2FuknU3ua59%2FgfJFdaN1tmpj0apxpow%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:23.8350864","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:23 GMT
-      mise-correlation-id:
-      - 7435de6b-525b-465e-a51f-93df63ce97d6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A29Z&sr=b&sp=r&sig=1mJ0%2FMqt1PbX92QgLq9jE2tKSrngZt8YhbtEesvG6OY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:29.1104038","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A29Z&sr=b&sp=r&sig=WGPl%2BMaIC%2BvJa14%2B6ovxCUboaYigHa31Eq3VqGL5EQM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:29.1102936","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A29Z&sr=b&sp=r&sig=UgURt4uLFoYai3v8AaEcSI%2Fwk%2FKixD%2BygLbt1CSEQoI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:29.1104264","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:29 GMT
-      mise-correlation-id:
-      - 3ab69808-baf4-4fdd-ad3d-efa97b57f458
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A34Z&sr=b&sp=r&sig=%2Fd8OehjMykgyNVmWlWVx9yTJYlCT7gYCj%2B1ONx4M7M8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:34.3784181","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A34Z&sr=b&sp=r&sig=X6vIIjw0RNxkc8ViI1YG%2BWviMiN9FjojE2Mi67G%2BWC8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:34.3783635","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A34Z&sr=b&sp=r&sig=E8Y5VmwMgvzV0EUApats0koYXKk32QxkaLUhZRd6H%2F4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:34.3784325","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:34 GMT
-      mise-correlation-id:
-      - ec71149d-27b1-4541-bef5-3a9c7750cda3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A39Z&sr=b&sp=r&sig=YmIHwU1efwJ5YeXJqrZpJz%2BFFq7WCm6nQo%2BvAMX%2B8Jo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:39.8417273","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A39Z&sr=b&sp=r&sig=ao0n6RzeH2EgWsKhwDKkf6GzCGKN%2B7m6hMZPbnnTCxU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:39.8416597","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A39Z&sr=b&sp=r&sig=%2BmzEeMGaOsL8sWQ63mqKzi4G7snODoCJWZLLJUmNueg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:39.841742","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:39 GMT
-      mise-correlation-id:
-      - f1bef388-42d5-4ba3-9684-006cc443eee7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A45Z&sr=b&sp=r&sig=VvPYHMvJguxzwSlfhGco1hRugLkH4g7evbk1Iwn1d6M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:45.1570356","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A45Z&sr=b&sp=r&sig=OY9pg89pTSeByiCcp9j%2FTwtIazJU4%2Fx10DMi%2F8ORfnU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:45.1569403","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A45Z&sr=b&sp=r&sig=7rj5F3B4C1qPlu05SrbkOFALd37oAI2VH0fq6ISqPuA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:45.1570564","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A16Z&sr=b&sp=r&sig=wMYC7GxyAAGvzUusdO4FIDFZdtTmz3IzB8BO6djRsdA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:16.7568198","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A16Z&sr=b&sp=r&sig=QggVIecfdmUzKScz010ckUSuzARBChe2HGx55oniQYA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:16.7567511","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A16Z&sr=b&sp=r&sig=WXoOHs3vSdvTuLHQ6wxgMgZv%2FhTlTchm%2FchXmibDSp0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:16.7568334","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:54.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1182,9 +858,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:45 GMT
+      - Tue, 24 Oct 2023 12:30:16 GMT
       mise-correlation-id:
-      - 17d41ba6-1a70-4f20-af9b-0c74ce37a369
+      - 8d8e6f7d-a802-48e2-95e8-b3a4d1d1d613
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1204,46 +880,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A50Z&sr=b&sp=r&sig=lloue1TcD%2BTHAaCRAFxVPLTwQxMJ1x9zNLnAhq7HHzA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:50.4435018","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A50Z&sr=b&sp=r&sig=QPYotbg6HhaoXKwQOgZ9LrISRL3syfhFvC623t3AmHc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:50.4434227","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A50Z&sr=b&sp=r&sig=%2BRJgKFz5VyfgOI1g4CQFzRa6HGGGmW%2FxIOi7jLr2UOs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:50.4435162","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:50 GMT
-      mise-correlation-id:
-      - 6ab43e6b-3759-4df5-a85c-2ea225c2539e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A55Z&sr=b&sp=r&sig=1R6Msl2DckEsm8dSoiv1yKAPAnW3fccaBSIQVNgpRhY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:55.7369414","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A55Z&sr=b&sp=r&sig=FemlS2vq0PXKU2TlWHzPY8Vr%2F4yrzguJuAMs2XP00NY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:55.7368526","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A55Z&sr=b&sp=r&sig=lb38fIehELX5MTje9CaS1ddnS1szB8OK2wBGfdqtwKE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:55.7369625","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A22Z&sr=b&sp=r&sig=IbrBCQw81Iz6fRdNSy0FK6JT303LXsbQHKyQY82FGO4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:22.0358442","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A22Z&sr=b&sp=r&sig=MWgjHdgEVadFCaaVorTnapdCUl2qmdcwx6GE9BJpGcE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:22.0357761","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A22Z&sr=b&sp=r&sig=90u1juppSWkpCYhJfZobqc7HYQGCfdddV3iPUgkvOu4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:22.0358589","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:54.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1254,9 +894,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:55 GMT
+      - Tue, 24 Oct 2023 12:30:22 GMT
       mise-correlation-id:
-      - 64ffd117-92af-4723-830d-20019803b20b
+      - 3deca25d-853d-400b-ac66-c7943d22fd11
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1276,23 +916,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A01Z&sr=b&sp=r&sig=Lq06Bj2eKYVLND83qmbhgn0OZfF0wWaq4imEuKqNSD4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:01.042995","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A01Z&sr=b&sp=r&sig=TaHRhj%2B4l8RYWpMCI2oQh7FlO2AvaDpZsuNhtaJWYIE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:01.0429096","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A01Z&sr=b&sp=r&sig=vVJpGURNyGden%2BYObcpfhpZ4ecoQ9sRv0irD27y9HH0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:01.0430174","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A27Z&sr=b&sp=r&sig=HPe47vzR8mxdp2EtxS9PuXRnPVgiLmKiEKNrVvJtnfY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:27.3606466","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A27Z&sr=b&sp=r&sig=CBPnZ6lnsemQ%2Fkmxr%2FUWiYff0TEDGeOZ9gvvuaAtIr8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:27.3605651","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A27Z&sr=b&sp=r&sig=0TUw19OglNyQjMsh6ayFKWezMukJn1FvsESC3Laulss%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:27.3606611","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:54.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3195'
+      - '3198'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:01 GMT
+      - Tue, 24 Oct 2023 12:30:27 GMT
       mise-correlation-id:
-      - 1f90bc7f-a312-4f5f-92eb-2f6b927d2326
+      - f9500dd3-18ce-46e5-8c79-5f68da780d4a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1312,23 +952,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A06Z&sr=b&sp=r&sig=nptPT8YkD6wCBTmw74%2FpXrfeZA3LNq658vHbLWk6TbY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:06.3578829","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A06Z&sr=b&sp=r&sig=3awNdghMmg%2BCPuoI%2BZeECNbblQJ6QncNPQyc4y6XPIU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:06.3578102","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A06Z&sr=b&sp=r&sig=4OF9q%2FGLBuLu%2F5f2lZHB89Oj3ShYmAXBkb3Oslsggpg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:06.3579007","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A32Z&sr=b&sp=r&sig=SSlA8SP7DS3Lc3QBTXMuexqj%2BRH6z9VtALpm7%2B3SKTo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:32.6430327","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A32Z&sr=b&sp=r&sig=W13Ab90e7NU5IIIGdXjJ7BnrfdpT0XIVkLF9v4SGxi8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:32.6429622","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A32Z&sr=b&sp=r&sig=YFyFcYLdOMjNI5EH%2BHZslGYpaDGVan1mN8pKeEcgRlM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:32.6430471","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:54.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3202'
+      - '3200'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:06 GMT
+      - Tue, 24 Oct 2023 12:30:32 GMT
       mise-correlation-id:
-      - 46b2e25f-9e7c-46d3-aa7f-1cdfae9252b6
+      - 7bbf9998-8e0f-42e2-97cc-e7e109e42bcb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1348,10 +988,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A11Z&sr=b&sp=r&sig=aqpKsbt1zDdpSJCFCQYy7QR5QJ3%2BMEpe0GTDIIdwcpA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:11.6920507","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A11Z&sr=b&sp=r&sig=DwpOXDT5o7Pd%2BKGu42HSlF2Fq08%2F%2BPYMgKi6VYx9tGU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:11.6919821","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A11Z&sr=b&sp=r&sig=i3SF%2FD5054XF0%2BF2BKjgQizKujh9dkxWJXZt1HvtmH4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:11.6920659","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A37Z&sr=b&sp=r&sig=SyfjmUUC%2B14kHrs2xwq8mj9YKx9k0Zr872lHroCiwso%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:37.9659114","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A37Z&sr=b&sp=r&sig=Pz%2BZJM9jeae%2BGybrPSdEjLYz4g1OurfJvBspUgNMBCY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:37.9658421","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A37Z&sr=b&sp=r&sig=Q%2BHWQ8w3EsXrYfamqsCRX92VpPu37pW3qSOuu%2F6%2BEJI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:37.9659259","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"CONFIGURING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:35.595Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:37 GMT
+      mise-correlation-id:
+      - 5d4c2579-ab44-409e-8444-bb748876571b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A43Z&sr=b&sp=r&sig=XKGLlqF2%2Fym%2FZ7fAepPnl%2F0f9OpQjjYkpcOJN%2BTWSgk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:43.2901791","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A43Z&sr=b&sp=r&sig=4n0pHD%2B1sVUN0MQUcihJ8YTQwcl2sS25r2Rt3y%2BVprs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:43.290111","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A43Z&sr=b&sp=r&sig=hhH%2FWn1GHdLJluwl2gkUyZlnoAGSUUJKIzKlbHcbUHU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:43.2901934","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1362,9 +1038,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:11 GMT
+      - Tue, 24 Oct 2023 12:30:43 GMT
       mise-correlation-id:
-      - 7552c721-83b7-41fa-92e2-f41240d1e33c
+      - efe85f64-5fc3-447f-b5dd-581d10e7c8ae
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1384,10 +1060,298 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A17Z&sr=b&sp=r&sig=PLUUxg065H5KTYHpRGXKJLxDlCBT3a9ztR9RfjqQzQg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:17.0148673","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A17Z&sr=b&sp=r&sig=oVjJn6gIMBWKCGCWmbqAVhao6RO78i5YCNBKOsewOfE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:17.0147911","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A17Z&sr=b&sp=r&sig=U87WYSZ8emJ8UcYSQuITZHGn%2B4GgoavUfOdaE36j%2B2A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:17.0148825","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A48Z&sr=b&sp=r&sig=Dr%2BcySZxIkdBDUW2Fozl13VEgTk%2B9FypMAEisoIANns%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:48.6065181","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A48Z&sr=b&sp=r&sig=rfHR9bPmy0LvxBWUb%2BgzMgSkIAAJKThcdnuMC3bRl9o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:48.6064473","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A48Z&sr=b&sp=r&sig=gMjocM5pEsSGuG%2FsaYzRpXsuS8v53up8%2F8lv7jezqgk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:48.6065324","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:48 GMT
+      mise-correlation-id:
+      - ed96abfe-6df4-447e-b9b9-1e37d34e0073
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A53Z&sr=b&sp=r&sig=WQnjwMHR5wVKSErDIvn8I6mbQyFHP2CcTGWXLMVcMGY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:53.9383748","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A53Z&sr=b&sp=r&sig=ri9UU2MZuHwBBt5%2BdBZTAKu5iPQV7EYZwLHIvbSXt%2FA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:53.9382993","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A53Z&sr=b&sp=r&sig=m0Y7by9q7Yj3%2B0WT2GlrfzhvkSxyCSanIwDgzydqwrA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:53.9383895","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:53 GMT
+      mise-correlation-id:
+      - 34db3efb-5d86-4283-adbd-86de1ec2b5db
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A59Z&sr=b&sp=r&sig=wIr%2F2wArWJvXWN11w3ogrCUr4fbA7CxkfaL7SvHwo74%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:59.4267373","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A59Z&sr=b&sp=r&sig=hJFUg9G96i%2FDVbXSR1xUJj1ZC7JW0HgEBRsXgJ4UqZs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:59.4266131","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A59Z&sr=b&sp=r&sig=N6NfW8kcTatoOaPs3HiFHKSVJRO6HfG0%2BBIy1ctuIn4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:59.4267659","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:59 GMT
+      mise-correlation-id:
+      - 61f1448d-0fcf-4c5a-a7a5-01e818404e87
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A05Z&sr=b&sp=r&sig=ysOYVlZqKBIoyVo8lO%2F96SJWKL%2Fddz5uHzEuySGTANc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:05.0750281","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A05Z&sr=b&sp=r&sig=iGir4Ane8hsZyBiRi1hoNrOjabYtUnVifESBCiLpuaE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:05.0749442","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A05Z&sr=b&sp=r&sig=oZnjK4TiWgLXpXAws7ldJoOKb0UmgWljzt%2BFRV03v7c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:05.07505","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:05 GMT
+      mise-correlation-id:
+      - 4ee7d74e-4484-43b5-938a-87efd85feac9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A10Z&sr=b&sp=r&sig=5BYWefmSxmCg4SfWz35hinvCrPjcjPqtJlmu141TF9I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:10.351031","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A10Z&sr=b&sp=r&sig=r8%2B3MwtoG%2Ft0uABI%2FWMXF%2FbPFzehR1DfTYdOe1Ouc%2BA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:10.3509599","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A10Z&sr=b&sp=r&sig=yrRuXMaFNB4nS%2BBbHhxpmr0Modg6rqutKBEGuD9PUj0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:10.351045","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:10 GMT
+      mise-correlation-id:
+      - 8c4a8dd1-18b9-4ee9-808a-db0c63017891
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A15Z&sr=b&sp=r&sig=aL17KL9DqA%2Bnjs54rTP%2FgELfRD%2BEKcA8yrtNK91h6EI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:15.6530872","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A15Z&sr=b&sp=r&sig=v9tWS5QwlWpHEoCUbClIq59slTDwXCW8Hnwphrvte0k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:15.653018","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A15Z&sr=b&sp=r&sig=P99ZGvAvNNH8177Umlm%2B4bGrGTYV0TlCxpI%2BdzMv0Z8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:15.6531018","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:15 GMT
+      mise-correlation-id:
+      - 71f9283d-c681-4c46-9d6d-94f8c35067b2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A21Z&sr=b&sp=r&sig=KymMkw4YfzhGZtMirwxr5omTq%2FYsYKwtkFZpHmbIlgo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:21.3505262","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A21Z&sr=b&sp=r&sig=bdTHj2Ew3EXRVsbyaEQnQV5z0VYUqaLxL3RPgrd1Leo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:21.350436","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A21Z&sr=b&sp=r&sig=mFPSRbqIUp%2B2dB6tsPqKRoMNKFbFSnZ6MDqox123MQw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:21.3505484","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:21 GMT
+      mise-correlation-id:
+      - f1cb8bf8-1de0-47a4-ad0e-3e7f4c6f57db
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A26Z&sr=b&sp=r&sig=1dBRy3lC4zUlt5FaMFrmllTEySt8AxF9PxAA4dPvNuw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:26.6949839","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A26Z&sr=b&sp=r&sig=of4Mqtigpi9fkVIeNOHrWVNemTJ0NEl9NMKtqGFAajk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:26.6949143","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A26Z&sr=b&sp=r&sig=WuT4kAvSGD9bL%2BimOZNDxBxied4zpiSykMEkZqarX1E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:26.6949981","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:26 GMT
+      mise-correlation-id:
+      - 38ed80d5-3ec2-44f5-9584-d7dbf050b545
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A32Z&sr=b&sp=r&sig=nlZo5QkQfJAdaPEYvhPYWn33CYw98rKwnH72yUpPbgg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:32.0436505","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A32Z&sr=b&sp=r&sig=WHmU4jLZkYXK9qvfT6QhQH0nqt3%2FJ9hCcEBHR%2BBOc6w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:32.043582","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A32Z&sr=b&sp=r&sig=G059UKEQDr6pSNFnzXzTq%2FNYjQcs6AS80M6k9nsB8a4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:32.0436651","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1398,9 +1362,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:17 GMT
+      - Tue, 24 Oct 2023 12:31:32 GMT
       mise-correlation-id:
-      - 52ac1922-f122-4ad9-acce-8c40118dcc2e
+      - 91f429c7-debf-486f-890b-fe20916926a0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1420,82 +1384,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A22Z&sr=b&sp=r&sig=49PK1o8ep2tOVyRU%2BTyVPX77yDMKMYl7YMXrlt0ojp4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:22.3442087","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A22Z&sr=b&sp=r&sig=Iqon3CF3GAHnJk%2FSLMRTDzm8geX3ACANp7en8KcNnRY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:22.3441367","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A22Z&sr=b&sp=r&sig=%2FaICVSXTLbO2u0UFN9jKPEpanvkeB28XBI%2Ffz9yvdK8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:22.3442233","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:22 GMT
-      mise-correlation-id:
-      - 57f171e8-a43e-4e8d-b396-22e7d7b8cf33
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A27Z&sr=b&sp=r&sig=uy1bcvpelASUeAez17G0%2BDQvy7XFJyAtEo6E2jvTdc4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:27.6606405","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A27Z&sr=b&sp=r&sig=692yR7EPyfjCz3Da2YFLHZIXSbhNnGGb7ooGixj6xeA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:27.6605734","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A27Z&sr=b&sp=r&sig=AbZWwnxOMMY3WkD%2BDIECJHwc74fL47izv%2BzJMuRwPCA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:27.6606556","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:27 GMT
-      mise-correlation-id:
-      - 6596f6d7-67e9-44e2-ad4c-336c5451850b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A32Z&sr=b&sp=r&sig=viQKyFgx7c%2BeQTFcvV1hjlpwKy5nAbtz%2FK2c5pn%2Bv7Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:32.9855842","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A32Z&sr=b&sp=r&sig=l9HvxdFRxXXV%2B2tXEEaGESkC8UpNmIaMBVKBZ0jOdj4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:32.985517","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A32Z&sr=b&sp=r&sig=y1KrxOtvS6Nc6rg%2BtYne5O0htok1%2F48PflGdx1lBD8A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:32.9855989","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A37Z&sr=b&sp=r&sig=%2FyKKZNlwrLGaHhCTBV%2F5koM0OjRE845o8AlzfA6dHyg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:37.3691561","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A37Z&sr=b&sp=r&sig=XHY0ttymHkwjZKx0brgYEfvnvPpHgt%2B4VfbcQlaqtN0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:37.3690863","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A37Z&sr=b&sp=r&sig=BMe14AFJSM2BQxaFPFpAl%2FvW9ET4%2FlKs%2BLwcseIuNAE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:37.3691709","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1506,9 +1398,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:32 GMT
+      - Tue, 24 Oct 2023 12:31:37 GMT
       mise-correlation-id:
-      - 9bf14687-8927-43a2-ab33-8b8ac055fa41
+      - 30fc68fd-fb85-4121-bd16-8dd8660cd846
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1528,23 +1420,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A38Z&sr=b&sp=r&sig=mCR2Sdqt31ihWEd%2BI%2BC3ATAIuUzf2XGGYeGhfs4IWe8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:38.3052533","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A38Z&sr=b&sp=r&sig=yq%2B3Cp4MCndz9OM%2BSrVPVRRNWwc9%2FcmhS4qQ85g8%2BJ0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:38.3051748","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A38Z&sr=b&sp=r&sig=APdhFGGWsKZVfEPBt27ACCvEyqAsO7KcQueG86ot%2Fyg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:38.3052671","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A42Z&sr=b&sp=r&sig=x8B5zr4Zul%2BpprTv2LShd7htXiD13ZtR28Xe8AC4lVg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:42.6631614","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A42Z&sr=b&sp=r&sig=pOcoRYwlFdTi4RzMi6VYzI9Kjq4ouZ73rtjyzdWg6yk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:42.6630869","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A42Z&sr=b&sp=r&sig=ZKrThpbqo65Qr2rIEEctpQTp1bxMi9rbsQo7fTXbgQQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:42.6631768","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3206'
+      - '3193'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:38 GMT
+      - Tue, 24 Oct 2023 12:31:42 GMT
       mise-correlation-id:
-      - d5e8ae45-6524-4b18-aaa9-d27bb5d9b1f2
+      - a6d560b2-1947-4ad9-848a-33ce844e945f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,23 +1456,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A43Z&sr=b&sp=r&sig=p4sa4GyKP0u29AwNCxP5RS8RVKcOGuVv3aUYbmdl6ow%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:43.643384","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A43Z&sr=b&sp=r&sig=5DSpwKI5xMn%2F3AIiGac9E58PWWFV3x0FMWoz6wNa9qs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:43.6432935","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A43Z&sr=b&sp=r&sig=nzcY1ukbnYsYIyC%2B3976WKZUZaGP1ij6I4L5fO0zyAg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:43.6434075","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A47Z&sr=b&sp=r&sig=k8sILWs4lUuf3Yh6VZ93kh0ZyV2nN8k5c7SKByenZxQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:47.9557949","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A47Z&sr=b&sp=r&sig=OJ14ShDczNz1RoE%2BRNdhj2zOVpdms4ZLohGec6%2Fcgr8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:47.9557199","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A47Z&sr=b&sp=r&sig=wv9SqsAClkgu5OetBEBrh7hc%2F4LwxETRTC6ZF7wOa30%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:47.9558088","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3195'
+      - '3197'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:43 GMT
+      - Tue, 24 Oct 2023 12:31:47 GMT
       mise-correlation-id:
-      - db8c6747-6a71-4277-a711-e9e21ea7cac9
+      - d85e79bc-8fbd-4fb3-ab32-04e28764b1a3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,23 +1492,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A48Z&sr=b&sp=r&sig=mvkxTpm9ApJk6Dn7hSkmBsHrv%2BclMojeoPr1zNNgJek%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:48.9645851","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A48Z&sr=b&sp=r&sig=ulixQ0AR%2BQS7Xoop61KWBWQgYctpPbw0O6oGJUt4Bbk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:48.9644785","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A48Z&sr=b&sp=r&sig=k5RplXl%2BSOMMcMKqlmGl%2F4WXNWHcoAI0kKHK6Zz0Oi0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:48.9645994","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A53Z&sr=b&sp=r&sig=G%2BvZiLAdYh9R47QZfADuvV%2FdarZ%2FVmVaqJxaHXuWxBg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:53.3056699","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A53Z&sr=b&sp=r&sig=3FKJvzLBxEVK11EFkJCwYgwVT5VJO1sI0QR1UccN2l0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:53.3055874","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A53Z&sr=b&sp=r&sig=%2Bg8%2BFwKYkFayyyFdDAnA2YeOT77JK%2BwO2HbaUSLOBGs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:53.3056857","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3200'
+      - '3203'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:48 GMT
+      - Tue, 24 Oct 2023 12:31:53 GMT
       mise-correlation-id:
-      - 1adf9a72-54d7-4a59-a344-ea20c64b1b4e
+      - 129ae57b-c999-4495-805e-11741764130c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,23 +1528,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A54Z&sr=b&sp=r&sig=MiLnwVsTkQGrmWYx5dkSlzETxTpNpZGUEfWgMdVMKrI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:54.2515527","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A54Z&sr=b&sp=r&sig=gMy9Zp7KLKyeLk26CKfhzwjgQzp1q6WAgfbASqeDj5o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:54.2514817","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A54Z&sr=b&sp=r&sig=3ml5cbCD7cIP7Xhwo7EXoXYdexa4XNWcd6p99RmiJ2Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:54.2515682","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A59Z&sr=b&sp=r&sig=BJlk4GDn%2F6qZNd5JlZes9t0KDuPCBK23p2n3%2ByL4dLA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:59.0069443","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A59Z&sr=b&sp=r&sig=i%2Fze5ujvj8sEQk4RA%2FUD5nkyeswpdNhmaQ0KCuM3MRU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:59.0068368","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A59Z&sr=b&sp=r&sig=gcoio1W3o5liYWazAXNnQ4ZFYZ3fR1Q0jOIikrkkDEc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:59.0069731","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3192'
+      - '3199'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:54 GMT
+      - Tue, 24 Oct 2023 12:31:59 GMT
       mise-correlation-id:
-      - 5e57edb1-4f7f-4f3e-94cc-ebd3314c919e
+      - db640b76-1df4-4240-8cac-10708d75de8a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,23 +1564,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A59Z&sr=b&sp=r&sig=14iw0W61wREPQ30iegA2Iiqh%2BicQUlZCbfLQQAhaQrw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:59.6281343","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A59Z&sr=b&sp=r&sig=URR5Xz%2BhRvlhCAs%2FgOPXiEXfFSAOoNmMT4leCZXV4Gs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:59.6280555","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A59Z&sr=b&sp=r&sig=JxNZiTiRdoVhk3K1tBDbim92z5%2FZcCyV4cKZKSxNkzM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:59.6281503","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A04Z&sr=b&sp=r&sig=CdJj6pX%2Bwo%2BKOQ5dfpcMLzTj0nTWJrK%2F7vwazFdd1Ms%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:04.3416785","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A04Z&sr=b&sp=r&sig=yLDicFoUef1OTyDHVYciXl8sJkCEswBNBi3vNGPJ%2BcI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:04.3415935","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A04Z&sr=b&sp=r&sig=tjAOB13GXOkcJWH8H6hQ9Z5e0dfWGFI3vMG0hqpEs%2FA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:04.3416928","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3200'
+      - '3201'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:59 GMT
+      - Tue, 24 Oct 2023 12:32:04 GMT
       mise-correlation-id:
-      - 00f6e234-a403-4be1-b80a-120c3d41153a
+      - 894e4608-44c3-4ffe-acac-19a7cd76c3aa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,23 +1600,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A05Z&sr=b&sp=r&sig=6OijgGPtg0nSVdNjSprlrBjtoCp6gEmetVCpQULg55c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:05.5245153","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A05Z&sr=b&sp=r&sig=5J6knmFYvemXbvQc3%2B0QqNbAuQ1UqbzzhTriPvo5snc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:05.524449","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A05Z&sr=b&sp=r&sig=adUF4qsG6kJY2b87fcVjvDyz0j%2BbJLZOP5826cwY1i0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:05.5245299","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A09Z&sr=b&sp=r&sig=SSXVYbtJlPuI2A2Fct12lLjDZ4oRdHu2QuJ1KmAm%2FME%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:09.6139571","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A09Z&sr=b&sp=r&sig=cpAxo7Ke6FODvmv%2B1mBDFblKkceJ%2F%2F9ZELwaTcGX1yc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:09.6138864","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A09Z&sr=b&sp=r&sig=x21pRi5sIjmpHubAf3XLPgrRAFQr9amwP3DI4%2Fq3sVs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:09.6139714","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3195'
+      - '3201'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:05 GMT
+      - Tue, 24 Oct 2023 12:32:09 GMT
       mise-correlation-id:
-      - f35c9d93-d64e-4c74-97ad-69f16bb115fb
+      - f03e212b-1ce4-433c-b403-06ebd5d147bf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,23 +1636,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A10Z&sr=b&sp=r&sig=gVUkTERESCkuVqTtCnHaIlUQCQRsA5JrSDrpvqUGifM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:10.7896056","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A10Z&sr=b&sp=r&sig=FuLYXDAsRZaroB9RGA%2F9FamCJsT9Hg3rWkdm4mVX1uk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:10.7895111","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A10Z&sr=b&sp=r&sig=IY44uM5K6ZOwPVcmSYLmYYvPP5Vi46QgQhYdFJJOAL8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:10.7896277","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A14Z&sr=b&sp=r&sig=tYVZpA9F%2BknEAM8pIKK9t2mRbQ2jAUxaO3aKdGFoGtI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:14.9291989","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A14Z&sr=b&sp=r&sig=WUBlitougDuTCcUTLbI%2BYjK%2BsPfk6Q2BGEao6eGA0aQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:14.9290974","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A14Z&sr=b&sp=r&sig=5TqZCpK5EYrLJcxOS34ABOoFnIEFX01oNU4EGre3xJM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:14.9292233","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3194'
+      - '3197'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:10 GMT
+      - Tue, 24 Oct 2023 12:32:14 GMT
       mise-correlation-id:
-      - badbc13d-4fb8-4c1d-995a-e2db2ee14241
+      - 6567b80a-cdc7-4039-9d30-8f81c733e359
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,24 +1672,132 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A16Z&sr=b&sp=r&sig=iqlmWXfYbiowFOk5QBWzsWCqfC6%2Bu%2Bf6jJ0z96UihK4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:16.0823837","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A16Z&sr=b&sp=r&sig=ZqeWpzSG5DDZSXpH7qFF0szZ%2FLwGgP5NwnpbNesY4To%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:16.0823093","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A16Z&sr=b&sp=r&sig=2HSoJs4F4kknrXpDImx6PEjqKjrF650MPGgbKMVWTxg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:16.0823996","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-18T20:52:35.651Z","endDateTime":"2023-10-18T20:55:11.771Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:11.847Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A20Z&sr=b&sp=r&sig=N7sLC36kNZNZJ9alhWalNr0ThVjJRPc91RWMuW%2BOhO8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:20.8162945","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A20Z&sr=b&sp=r&sig=iL3FLdksMWTj1gEEbAS1TqEGl%2F7qzk7Dis%2Fb1%2Fw3OQg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:20.8162272","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A20Z&sr=b&sp=r&sig=BcsewyQUdipQ%2FhsUgn7hyK%2BFNKuu9sqrF9xkOusWEI4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:20.8163101","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3333'
+      - '3203'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:16 GMT
+      - Tue, 24 Oct 2023 12:32:20 GMT
       mise-correlation-id:
-      - 608e7ed6-0fbe-4e50-b29c-f8b471af33cb
+      - a4a29bfa-3f0e-4fea-b6dd-cc373e504c7b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A26Z&sr=b&sp=r&sig=O%2FCsxxPlM1SD7DsJOgCFdDysACmZRTtjS0T%2FllKBilA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:26.089868","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A26Z&sr=b&sp=r&sig=yRCeU7A6LPaszh638PVdiS10J3Hj5DrQSKGeqhzG2JQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:26.0897929","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A26Z&sr=b&sp=r&sig=iy6jsWwmSEczm8HT1t8zdYrHneYZwQ%2F2HHLaUySRzFs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:26.0898842","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:32:26 GMT
+      mise-correlation-id:
+      - c4b18d14-c858-4ff3-836b-83d04557150d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A31Z&sr=b&sp=r&sig=Wi0O8krQSIE%2BAT3yKeEGCUEG5snJQ6gRdCp%2FRDxsbLA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:31.416712","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A31Z&sr=b&sp=r&sig=Wqsm%2Bw0Tr8np2%2FYpSdCgJ9riFEWeQ%2FGc7ydPZwOAmXo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:31.4166207","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A31Z&sr=b&sp=r&sig=jJf8f4M6E8xOvjLgxGcCCDtGaDMuc7y37ei2b8eN%2F7I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:31.4167282","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:32:31 GMT
+      mise-correlation-id:
+      - 2e1bbc00-90e2-4bb8-b72b-35a0248dbedb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A36Z&sr=b&sp=r&sig=hO%2BhE2dbCVZ1i8%2Fj88C%2B7GgotOR2vOIfoxuUMcZTAL0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:36.6789605","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A36Z&sr=b&sp=r&sig=09rNT4JiWeckjDwXXEYzwc8qsPfVP4hgdE6Wup5Vtnk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:36.6788786","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A36Z&sr=b&sp=r&sig=NCu2RiaRAt%2Fz1UhMBltfg3PkgshYZjxT%2BtBLKmXtdKw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:36.6789759","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-24T12:29:54.723Z","endDateTime":"2023-10-24T12:32:32.726Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:35.478Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3336'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:32:36 GMT
+      mise-correlation-id:
+      - 589f48f9-7663-4455-ba69-9f4bb6573fe1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,7 +1820,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:36.7813407Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:36.7813407Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:54.2589267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:54.2589267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1829,9 +1829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:17 GMT
+      - Tue, 24 Oct 2023 12:32:38 GMT
       etag:
-      - '"7500314e-0000-0100-0000-6530455a0000"'
+      - '"d300a43d-0000-0100-0000-6537b8870000"'
       expires:
       - '-1'
       pragma:
@@ -1861,24 +1861,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A18Z&sr=b&sp=r&sig=PtvmxgtZG2%2BdwB1CoaxLdhkKwaGpCXyUyq4m%2BIQXHS4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:18.34434","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A18Z&sr=b&sp=r&sig=nOwH8Wq9qc8NOILvCYKhRhUH2y%2BavRlAxC078r%2BAp%2F8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:18.3442599","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A18Z&sr=b&sp=r&sig=wfz66BRjK4U%2FNebDS6FW1X5ZWU0WGKEFFdiem%2FGmDjQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:18.3443545","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-18T20:52:35.651Z","endDateTime":"2023-10-18T20:55:11.771Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:17.152Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A39Z&sr=b&sp=r&sig=zL6%2B24pIgl9J9sBqKLjb98MYPGjPbrLTySnaziDLkJg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:39.1024045","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A39Z&sr=b&sp=r&sig=TQUa0yPfL%2F7Rg7ZiGC7E7%2BH6qr%2F0NitYEhJnCldd7RI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:39.1023333","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A39Z&sr=b&sp=r&sig=3qFfR2tqhaKHsSXjCrfoRIlv3ib%2Bh6YOG7LmDavpKR4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:39.1024186","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-24T12:29:54.723Z","endDateTime":"2023-10-24T12:32:32.726Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:35.478Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3351'
+      - '3348'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:18 GMT
+      - Tue, 24 Oct 2023 12:32:39 GMT
       mise-correlation-id:
-      - e049fcdb-860e-4b9c-ac1c-67290acf4f0c
+      - be5fbbcd-d11f-4166-bb14-fd66112ddd2c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1901,7 +1901,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:36.7813407Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:36.7813407Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:54.2589267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:54.2589267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1910,9 +1910,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:18 GMT
+      - Tue, 24 Oct 2023 12:32:39 GMT
       etag:
-      - '"7500314e-0000-0100-0000-6530455a0000"'
+      - '"d300a43d-0000-0100-0000-6537b8870000"'
       expires:
       - '-1'
       pragma:
@@ -1944,7 +1944,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -1954,9 +1954,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Wed, 18 Oct 2023 20:55:20 GMT
+      - Tue, 24 Oct 2023 12:32:41 GMT
       mise-correlation-id:
-      - 065f957d-742b-477f-9446-7026defbc8c6
+      - d28564e8-85ac-4274-a482-afb24ebdec9a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1979,7 +1979,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:36.7813407Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:36.7813407Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:54.2589267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:54.2589267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1988,9 +1988,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:21 GMT
+      - Tue, 24 Oct 2023 12:32:42 GMT
       etag:
-      - '"7500314e-0000-0100-0000-6530455a0000"'
+      - '"d300a43d-0000-0100-0000-6537b8870000"'
       expires:
       - '-1'
       pragma:
@@ -2020,7 +2020,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
+    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -2034,9 +2034,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:22 GMT
+      - Tue, 24 Oct 2023 12:32:43 GMT
       mise-correlation-id:
-      - 5d9d5df5-b5c6-4d79-b4be-13e24e936cb9
+      - 6bbe74fd-89af-4896-a7f5-870cec2f942d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_delete.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_delete.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:07.1706004Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:07.1706004Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:36.7813407Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:36.7813407Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:40 GMT
+      - Wed, 18 Oct 2023 20:52:10 GMT
       etag:
-      - '"d8013df6-0000-0100-0000-65294b890000"'
+      - '"7500314e-0000-0100-0000-6530455a0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:52:41 GMT
+      - Wed, 18 Oct 2023 20:52:10 GMT
       mise-correlation-id:
-      - a5d568a6-8820-451e-b0e5-6b2acb0e6640
+      - 35a85318-d7f2-48e2-85ca-a03cddb465f8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"95c9282c-2e6c-405d-ab78-c35409476a2c": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "aaedaf4c-b014-4f57-b057-4c148fa7de03":
+      {"passFailMetrics": {"506415db-e616-41bc-bd5e-ee08c40caea7": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "86fd3a31-c089-4092-a5f7-fa63fd157566":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "ab5435b0-bf22-4d68-b3d8-b1b953694252": {"aggregate": "avg", "clientMetric":
+      "50"}, "bef1de58-a689-479f-802d-ffe758da1dd1": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,26 +106,26 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:42.36Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:42.36Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:52:11.327Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:11.327Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1006'
+      - '1008'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:42 GMT
+      - Wed, 18 Oct 2023 20:52:11 GMT
       location:
-      - https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+      - https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 080c2025-8fa6-471a-81c7-824805b14c76
+      - caf86f6d-a791-4d74-a6fc-8633cce63630
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:42 GMT
+      - Wed, 18 Oct 2023 20:52:11 GMT
       mise-correlation-id:
-      - db65f034-5c88-4040-9f33-c480f34147ed
+      - e1347f97-d51b-4c36-a498-f69d54e09a1a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,10 +275,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A43Z&sr=b&sp=r&sig=tf721DJdEZpzcaRk9dC1L4Zla95gCBxsjSICx%2BTRvHQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:43.7622613","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A12Z&sr=b&sp=r&sig=AFFvgbHZ3NTbPNfDb%2BrOnb9jvtmbPbGyzuzKzH2R9So%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:12.1559152","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -289,11 +289,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:43 GMT
+      - Wed, 18 Oct 2023 20:52:12 GMT
       location:
-      - https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 6f592d6b-8536-4c94-bf6b-109b156bef7f
+      - aa57d4b8-6f2e-4582-a656-4bfebee32b08
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A44Z&sr=b&sp=r&sig=2eZbXAvce6UAI5UWIv17k%2Byxabnvz9adeRoXJCQMxVQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:44.043973","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A12Z&sr=b&sp=r&sig=r%2Fotf%2FJm4kMMN5%2BbZvYoojh0583fKk%2FOKn2BAJPK2dk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:12.4940714","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '557'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:44 GMT
+      - Wed, 18 Oct 2023 20:52:12 GMT
       mise-correlation-id:
-      - fd9ac0c2-237f-4d91-8ba2-d809aceceb8e
+      - 4658e98a-7394-4b23-b6db-80b0c0b6b0f0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A49Z&sr=b&sp=r&sig=FHrwov8hwpauZh7zIvtd4kh4CIZkUT3cW9vOgD2Pw04%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:49.3410338","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A17Z&sr=b&sp=r&sig=PIa7NV%2BLAUilk7u6SQXCBHo1ULxSY9UthGOj9Y0U6Zo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:17.7677886","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:49 GMT
+      - Wed, 18 Oct 2023 20:52:17 GMT
       mise-correlation-id:
-      - 48f4073a-2895-4f3e-8b46-7c3b73d17468
+      - 65933222-5221-4e2d-9bfc-01aacd077afc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A54Z&sr=b&sp=r&sig=1HovGCE7K1yEJoFswxrA0n6XoJMgD9zmIor80F44yao%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:54.6104403","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A23Z&sr=b&sp=r&sig=kxEth%2BdutQ4L4bid5BQSqbMAyWr8ASE8TLg7itNKIsY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:23.0266492","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:54 GMT
+      - Wed, 18 Oct 2023 20:52:23 GMT
       mise-correlation-id:
-      - 6ee7dd47-ce5d-4fef-ba12-eaf5943b90e5
+      - bfe11f45-5d15-4eab-94b3-a0d18649fb4c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A59Z&sr=b&sp=r&sig=P2VzZ4%2F19OE3l4WvIIiZJ%2F0QUdRX1wUAC4M%2FuY1XlEk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:59.9035943","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A28Z&sr=b&sp=r&sig=ra5oTBwlQ4X0yoY83iKw%2FVzrjlX%2FCBCjoh9C3EYcWaY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:28.2899638","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:59 GMT
+      - Wed, 18 Oct 2023 20:52:28 GMT
       mise-correlation-id:
-      - 3f9ff3e5-5c7e-4c2b-ae85-bee752b29deb
+      - 50239093-e5f7-4126-b443-38df7499ac60
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A00Z&sr=b&sp=r&sig=QGL3oYKMicj5vZPb%2B6Wru3jyEocZtfsV7EfRa1iwVSM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:00.2370098","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:42.36Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:56.374Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A28Z&sr=b&sp=r&sig=iFUDUjaNd36JkzbVZL%2B4GoOrPV3cLc2dcSK07%2BlZogM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:28.5394255","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:52:11.327Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:26.126Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1578'
+      - '1581'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:00 GMT
+      - Wed, 18 Oct 2023 20:52:28 GMT
       mise-correlation-id:
-      - 7e3d7c49-4b91-4d5a-86c2-5c719ff2a6ed
+      - 92d5aba2-6e98-44d8-ae54-5738782f8cbf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:07.1706004Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:07.1706004Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:36.7813407Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:36.7813407Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:01 GMT
+      - Wed, 18 Oct 2023 20:52:29 GMT
       etag:
-      - '"d8013df6-0000-0100-0000-65294b890000"'
+      - '"7500314e-0000-0100-0000-6530455a0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A03Z&sr=b&sp=r&sig=F%2Ff7lwFoem9QgFMJ1gmEi9xdnFY%2BJXLrpT%2BkhAqGzRY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:03.5254237","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:42.36Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:56.374Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A30Z&sr=b&sp=r&sig=TKvOFURuZWlM1HqgEPlIyrD0Ot0OYFwNESSuakCH6h0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:30.8126589","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:52:11.327Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:26.126Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1594'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:03 GMT
+      - Wed, 18 Oct 2023 20:52:30 GMT
       mise-correlation-id:
-      - c954bece-571a-4bfd-84fc-024ac537e3e1
+      - c8a81ed7-64e2-4bc0-8c4a-0c17fc51f68c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:07.1706004Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:07.1706004Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:36.7813407Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:36.7813407Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:05 GMT
+      - Wed, 18 Oct 2023 20:52:31 GMT
       etag:
-      - '"d8013df6-0000-0100-0000-65294b890000"'
+      - '"7500314e-0000-0100-0000-6530455a0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:53:06 GMT
+      - Wed, 18 Oct 2023 20:52:33 GMT
       mise-correlation-id:
-      - adb2156d-386d-4a26-bf16-ee3704c64148
+      - cffeda7f-3787-4131-969b-43e935f47c69
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A08Z&sr=b&sp=r&sig=fcymRtAofHFw62aLq5AeDPoq18FkxC3s1sVLGlXhLeU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:08.8857542","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A08Z&sr=b&sp=r&sig=aUGHuAOD8KWT2UH%2Fmlwj324Ecz5X60%2BFOg5xd2D3L%2BU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:08.8856492","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A08Z&sr=b&sp=r&sig=bVXaKDbxes7WIRpk4fYZwL%2FB9mZzUnkCaJZ%2BS8ddwb4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:08.8857775","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:08.822Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A34Z&sr=b&sp=r&sig=grRYvKveUfHESqiNbuOFyYJpssEsJz6fB%2Fk%2BtNaSqhA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:34.553071","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A34Z&sr=b&sp=r&sig=2Gq2s0kfazfkA%2FMvBTjgYMqMMOZcf5C3Vwdk9fx4UhY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:34.5529284","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A34Z&sr=b&sp=r&sig=o1V9vMhLJPSS53lJyKLrZEfYeQtV%2FGPJUcxxSEhVu1c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:34.5530949","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:34.479Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3158'
+      - '3155'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:09 GMT
+      - Wed, 18 Oct 2023 20:52:34 GMT
       location:
-      - https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+      - https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 9253b638-e67d-4493-837e-c70cbfa30396
+      - d16db58c-2c5d-43d4-926b-bd5eb2a3c80e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A09Z&sr=b&sp=r&sig=KZDLFuekZfKReu8KAGF95o1Kl6D%2FMBgI%2FUVvdBcd61I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:09.3132234","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A09Z&sr=b&sp=r&sig=LCfPYGRHaHQyQf6FRHn541fvkjP5R8coxYkQuhMM5L4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:09.3131553","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A09Z&sr=b&sp=r&sig=8YiOQiqIS%2FjkPVv1XAK%2BPWScXTlM36XKPe5Vv6ujHGI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:09.3132384","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:08.822Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A35Z&sr=b&sp=r&sig=NZayFMtPYweBKKnErgmQCj%2FF3NvgtTEocUuyF7zv6eU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:35.4521213","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A35Z&sr=b&sp=r&sig=ixN6TVJfmCqWcoW1Z0qeIdtdaRoMVtGkK3CEZzUd%2BAo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:35.4520334","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A35Z&sr=b&sp=r&sig=OJCfGplYwNCxCgJAZoNZfL5mfbnxrielYqD4MK4xL54%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:35.4521351","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:34.479Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3156'
+      - '3152'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:09 GMT
+      - Wed, 18 Oct 2023 20:52:35 GMT
       mise-correlation-id:
-      - 808dd3b2-39d3-4c74-b061-67c6e85a498e
+      - 44831bdc-b9f4-497a-9c12-16ae98386e98
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A14Z&sr=b&sp=r&sig=i64Vx6%2FFNrlywABFLKuy0tIi5QK2IJSCCejvMpdOlp8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:14.6431859","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A14Z&sr=b&sp=r&sig=HN0M9Imj3IGy1O%2Bu2Vdf5a94TCOY3MrOrk3bwTJjjYc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:14.6431004","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A14Z&sr=b&sp=r&sig=MhoToJWEuUaBMTGve8VJ8Vlxaw9ShX4nsL4eB0SbFSQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:14.643207","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:10.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A40Z&sr=b&sp=r&sig=X3L6FeSaHSG%2B2%2FYaHxBeu2moq0Cy5LdbtRb4AllejFk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:40.7472704","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A40Z&sr=b&sp=r&sig=n7rJqHMJt0%2FJJUopN1BJjOpOn2CM3Af354PaK81C6ko%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:40.7471917","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A40Z&sr=b&sp=r&sig=8IaV1UDHxTfwn22EXStkaylGzxPf%2BiPOwPlK8xty6tc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:40.747284","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:35.86Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3197'
+      - '3201'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:14 GMT
+      - Wed, 18 Oct 2023 20:52:40 GMT
       mise-correlation-id:
-      - ae003bbe-f363-4699-9c4c-0b86ba89878b
+      - c3eebc1a-14e1-49ff-ac90-183300aea219
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,226 +772,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A19Z&sr=b&sp=r&sig=LcBMbdDirGKFCKgKuIQ4bPUqYXNbAbAMIvxSCALw1AI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:19.8909617","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A19Z&sr=b&sp=r&sig=xpkq9%2Fr%2BGYDJXytDUnAsDahDhwaWkeJvSoPuNA%2F3hpg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:19.8908637","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A19Z&sr=b&sp=r&sig=g%2Fmsjs188ZAyFNFgybey%2BQov6VRe0v2%2Fo2eIzyi%2Ftys%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:19.8909844","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:10.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3208'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:19 GMT
-      mise-correlation-id:
-      - beb5511c-ec34-41da-84bd-b308235b096e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A25Z&sr=b&sp=r&sig=yq78tNr%2BmPvNNQvCQzG0Bb7PpnWa6na6Q5wJYUOsJgc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:25.1380397","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A25Z&sr=b&sp=r&sig=7RPWg2HKtpF6P9i7lQ1Kx3ktXlNpkIdsgitYEAOTnIA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:25.1379734","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A25Z&sr=b&sp=r&sig=%2FRSH2VjMFoi76z3ZE54XKgo%2Bsv%2Bp4pdAUNYwNRNmzz8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:25.1380554","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:10.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:25 GMT
-      mise-correlation-id:
-      - 96fa9a4a-8586-46a4-8a5f-844d53bdc41a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A30Z&sr=b&sp=r&sig=rDkpJ4HclVsn0I6r16QCqV3S4Vm%2FwfNySATHZfKdgXg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:30.4379821","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A30Z&sr=b&sp=r&sig=JPG9YVUEdTWyRjQMfPhhOMmjMMmzIltmwzt3IfHwezc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:30.437915","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A30Z&sr=b&sp=r&sig=WfBpmRcKh0%2Bc5cbdDSiOmHVMQsTjtJXKfiKmJWt%2FilI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:30.4379961","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:10.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:30 GMT
-      mise-correlation-id:
-      - 800460df-9ac5-4754-9651-d2bdf25faa9e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A35Z&sr=b&sp=r&sig=ONJFtD7k0WI%2FKgECQ%2FTxolM9hcK6Q04JY9EhJZtZWwU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:35.7189925","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A35Z&sr=b&sp=r&sig=%2BDzEtK9UGxQvH4V85LaWPwOwFYHj%2BS%2BNeOysn%2FimuzQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:35.7188879","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A35Z&sr=b&sp=r&sig=G5YDXA2i9BXUPPiQCjWlbM%2FBR%2Ftx0kaipImIaegACQE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:35.7190089","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:10.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3210'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:35 GMT
-      mise-correlation-id:
-      - 3060a087-1659-4b20-89e0-284a1fa51dc9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A40Z&sr=b&sp=r&sig=Mst4Z%2BshrzuusGXr9JAn1c9%2F45FM9M1%2FduLNVhIzUus%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:40.9994657","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A40Z&sr=b&sp=r&sig=%2FpHzd5Lb7hz%2B%2Fzpt1o0TKdeJVTOFHEUJ9ERRMUyqO7k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:40.9993834","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A40Z&sr=b&sp=r&sig=suZF28IkEneUqAgkzE7OiE437Ozujsazc5woidsexLg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:40.9994868","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:10.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:41 GMT
-      mise-correlation-id:
-      - 919abbd6-e39e-4971-ac50-4cce17449b47
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A46Z&sr=b&sp=r&sig=nsg7FeGodneTcDuf8JlOElWhEJmVpq22BWk7NT1pNXI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:46.2887305","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A46Z&sr=b&sp=r&sig=uS%2BqD4D6MHb8%2F3jQNEuzQfJ9x03MYwqkF5sS6TYRarY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:46.2886618","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A46Z&sr=b&sp=r&sig=z3VLkUnceaf0SjyEKDR0ENO%2BgJv%2BQM9NE442SGECUy0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:46.2887443","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:10.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:46 GMT
-      mise-correlation-id:
-      - 897ddfd5-1622-468e-b7f4-09bb32807824
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A51Z&sr=b&sp=r&sig=%2BfehDe2XAyR88ufgEDrCXwGqSOmZvBXs6%2FN%2BTWBra2w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:51.6237885","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A51Z&sr=b&sp=r&sig=J156SEt%2Bl3SApfFtjB9HsLyrrcrGK5fiRni0V4wxOPQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:51.6236966","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A51Z&sr=b&sp=r&sig=ijW2K4j6qzEwvj%2F7%2FecfzJqgfv%2F1bTzU%2Br3%2BihW6cY8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:51.6238061","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:10.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A46Z&sr=b&sp=r&sig=88rM5binPzoJcnf8fVuzVAGGQC%2FU%2BnGVZg%2Fo%2FpNrv8M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:46.0790454","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A46Z&sr=b&sp=r&sig=hoiEqbiADPqXx7%2FXkiJ1Ga9Xh9Oh2p50SZKiMoqoBY4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:46.0789693","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A46Z&sr=b&sp=r&sig=3os5NrFhb1D2yIyIrC%2BoisweVcQOuonj%2FB%2FyWs%2BWKRg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:46.0790603","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:35.86Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1002,9 +786,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:51 GMT
+      - Wed, 18 Oct 2023 20:52:46 GMT
       mise-correlation-id:
-      - 25dbcc1a-e0d4-4116-adb7-6579b318978f
+      - 657caa44-e0e9-4e00-aef3-fa765bcdfeff
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1024,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A56Z&sr=b&sp=r&sig=q%2FAMiqAXCjcFEFx9Wtt5gNe2A%2Byk%2BymNfg6XBG13H74%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:56.873604","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A56Z&sr=b&sp=r&sig=DljKVAnWOc3FGpcaRjM3RPwdu8LGvoi2AR58UPWG8NA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:56.8735371","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A56Z&sr=b&sp=r&sig=8L4oJBvFbZ46uy4VRpq3QGTgWJlpZSAnLX6g4lsXNCA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:56.8736191","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A51Z&sr=b&sp=r&sig=gh2CfJKaRTlFZFIum9oNf6xSxSuTdY%2Bj%2F2No6mDZv8k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:51.3605426","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A51Z&sr=b&sp=r&sig=rmCrR%2FEi5nXwVDuYYGjnF6XnmJ9v%2F1L2BySdgY62YRw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:51.3604633","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A51Z&sr=b&sp=r&sig=tur5yVp67TEbKPqA6WhK5yJXUT6sngPQsNHcfeRHxJo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:51.360557","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:35.86Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3196'
+      - '3201'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:56 GMT
+      - Wed, 18 Oct 2023 20:52:51 GMT
       mise-correlation-id:
-      - 4452e1cb-f0c7-4143-b8ab-d3b80861b0d2
+      - 2d9df636-1968-4958-85c3-b09df9a93d20
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,694 +844,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A02Z&sr=b&sp=r&sig=vWoT1I%2BvufH5ULxvKziR4dvkJnSwTsC%2Frnq1eHG0878%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:02.1525601","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A02Z&sr=b&sp=r&sig=JhFeZhyTI6SGLR72gtSsf3%2BetCbgzQFwzxHkxn0RHGQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:02.1524609","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A02Z&sr=b&sp=r&sig=IBGGx29wvtgCNwOASEe9TaJMJ795ng%2BMeELjPZ8Nvwg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:02.1525825","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:02 GMT
-      mise-correlation-id:
-      - eef8029a-574f-4625-997b-5ebfbc190c83
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A07Z&sr=b&sp=r&sig=Bsq0wef483sg8dRTg43VPXOUMogHGJju9for1X%2BG7l8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:07.4796234","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A07Z&sr=b&sp=r&sig=Qs0Hs%2B5U%2BpUHvDopuYQZ0X5PNzZCYpEWw5HyebZRTCc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:07.4795164","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A07Z&sr=b&sp=r&sig=Ac6Nk%2BJqrUF80Aol5fple5IQyLTvPIHzzq9okuaAyEA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:07.4796475","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:07 GMT
-      mise-correlation-id:
-      - c22edeba-6fe6-427a-a632-a5c57d2af9cb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A12Z&sr=b&sp=r&sig=4vhHu4Cx25jJ0eaewQQ1gu%2BSEJZ8UHLn4sENf28Z8Yo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:12.8792363","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A12Z&sr=b&sp=r&sig=uQY%2FbY1B6zWjKo1y9YNGekaOKQgQySgizxuxl5EH%2FWs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:12.8791538","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A12Z&sr=b&sp=r&sig=cqokINVsMYWElNsu%2BghKGbLbObc8CH5ynYaxeXh6Jj8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:12.8792573","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:12 GMT
-      mise-correlation-id:
-      - c456e31f-273a-49ad-9f0a-85f22babc468
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A18Z&sr=b&sp=r&sig=TrqVE8S2tS5G1G%2Bk5CegX%2Bers3l1e9JONOSsbS%2BiCsQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:18.1587793","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A18Z&sr=b&sp=r&sig=EbxrOoMH5ucuQfif9Ui7%2FX2OZWAXiAgXRTzeBuwCmxY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:18.1586857","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A18Z&sr=b&sp=r&sig=MyQJFVsK3%2FeNL%2FxWQdX38d1rtxmyK0NnBGqbloItv70%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:18.1588038","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:18 GMT
-      mise-correlation-id:
-      - fd15e1f6-69bd-448f-9913-e5014c45cd35
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A23Z&sr=b&sp=r&sig=F54DbKRAZasW4r2VcPr5xB4J42ZB7x2qyCUohbijUDU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:23.4163738","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A23Z&sr=b&sp=r&sig=mRYLmoj09eUxnypDqif38Kzzqcr9Vy%2BQ1ZTWYZEsfLM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:23.4162822","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A23Z&sr=b&sp=r&sig=JrkL95h5fuFPF7R1f1OtrLDpEaTBFRwv2jFf2YSU5jk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:23.4163912","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:23 GMT
-      mise-correlation-id:
-      - 8e90f779-9209-427e-8b47-a7ce12fbf263
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A28Z&sr=b&sp=r&sig=PcgYCFXzg8KbTMksBwexxXYjI9YVkzmwb8nsEQtwTI0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:28.6762834","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A28Z&sr=b&sp=r&sig=cNWmhW3VbXO4PJF3NeJD4Gua9dAMtWEKxvzwC44kIDI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:28.6762173","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A28Z&sr=b&sp=r&sig=gfzTYBN%2Bzsv30wUEwLvfJxczCWh4cGfwf0uluPDRaw4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:28.6762982","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:28 GMT
-      mise-correlation-id:
-      - 8e44c31a-ade0-4568-95e3-b4e666d3c953
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A34Z&sr=b&sp=r&sig=jY2elTvRGRZR1B12ZTRlt%2B2x9uUj%2FIGeks30elXWhUM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:34.0191704","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A34Z&sr=b&sp=r&sig=CcKWNMdJLpWlj7eAFxoFzLEIG8uhs8pelcKJ%2Fc9r738%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:34.0190731","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A34Z&sr=b&sp=r&sig=XH43UEGjdXI8mvaOB4M3ivxfQxVidAg9wecyMbMtpe4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:34.0191989","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:34 GMT
-      mise-correlation-id:
-      - b97c3f94-0cae-40d7-ba5d-bd1b0b246f73
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A39Z&sr=b&sp=r&sig=p2pk7y7gF%2FETW7r01mi%2BJ7V5ZZp%2BoKr2B8SWZwWoJkw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:39.551309","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A39Z&sr=b&sp=r&sig=%2F%2FDLcmZnlWU45913A0qnmfRA8BX%2Fl8rRol94z%2B1bY%2Bw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:39.5512395","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A39Z&sr=b&sp=r&sig=nnwNqN0ISmjWkCLkOmN46oO8YxgNWZ4%2F7pmw9ytDgKE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:39.55133","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:39 GMT
-      mise-correlation-id:
-      - 3dab2b37-3dab-4506-8709-ce21aecfcefc
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A44Z&sr=b&sp=r&sig=yUnfpfO6UcV6mkJ%2FWNa9HBcsmFYI5qnNHXljImAr4Do%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:44.7877639","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A44Z&sr=b&sp=r&sig=RPTaPeDcjH0th5ti%2FVgu0pAo6J3yk32r8rg3bTYezyE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:44.787667","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A44Z&sr=b&sp=r&sig=LB11H%2FItMnPgh8jq368MW7uYgXZk6VwBkNTkRnl99IY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:44.7877844","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:44 GMT
-      mise-correlation-id:
-      - ccf69ddd-e413-4997-8542-8f65fc6b2f82
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A50Z&sr=b&sp=r&sig=i4OSFSkM%2BEwFH%2FBHCBs1LYnZPAG6wFZm3ExqfNGke0k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:50.0563626","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A50Z&sr=b&sp=r&sig=v1JwfdXeWhAEakbUe%2BEanWzK6OC4dh99%2Fbuo7LDCAS8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:50.0562376","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A50Z&sr=b&sp=r&sig=ozgaGfVlcw7vXseEWkYwMcAnhOc3ZaEuTW7KnmAJPS8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:50.0563855","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:50 GMT
-      mise-correlation-id:
-      - 5eb63a41-7012-48a0-8b29-848e51961a0a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A55Z&sr=b&sp=r&sig=TxNJFibV2ErQNaLK%2B1WSGbbuA0a26Gt7tizvR1%2Fz7dA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:55.2995517","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A55Z&sr=b&sp=r&sig=V1ldF24R4So%2BF7V5PDmG4vHfr57T4tZLJKUECA4vL18%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:55.2994215","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A55Z&sr=b&sp=r&sig=x%2BKFhcUT6Z8DD2YqUdr%2BfVUoxVqEeHxA9Mhgqijke%2Bs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:55.2995765","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:55 GMT
-      mise-correlation-id:
-      - b8ec394e-69e8-4726-9b82-24c0414e2241
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A00Z&sr=b&sp=r&sig=wqFhlo%2FBhuYAY6TZ1fzz%2BLC7p1okC5NguAwdLaRYFlE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:00.5336781","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A00Z&sr=b&sp=r&sig=aj2cz%2F2ZrwNhQRYzhC%2BcbZ6X1v3wjThwFBO7X7zdbBo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:00.5333654","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A00Z&sr=b&sp=r&sig=%2Bu%2B2Nwo%2FZOrQICMfwU3NvRK6xJnMcjb5AvPT6tGCxQo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:00.5336994","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:55:00 GMT
-      mise-correlation-id:
-      - 6d1aa7aa-6477-40ff-b497-d2b29d1658f9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A05Z&sr=b&sp=r&sig=3I1FOCFnukV5gZmSrX1vt%2FrGlBk4WfdrZxOxlHrZAq0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:05.8204684","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A05Z&sr=b&sp=r&sig=2wnKmXnMKrHkfpn6kJi5jWegtDPZhu2X72Jdd9dh0Tc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:05.8203951","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A05Z&sr=b&sp=r&sig=BRF%2BUpa4ag5hEQlGGun%2FRrEes6oRFO1HMWzPeGblZ4o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:05.8204825","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:55:05 GMT
-      mise-correlation-id:
-      - 6e5e0a5d-ae03-4e06-8d2f-24b3055adad6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A11Z&sr=b&sp=r&sig=4iVe1vODwL8slJknQXX9SSNsafOY7YlX5RJauk6dywo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:11.0977611","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A11Z&sr=b&sp=r&sig=B8xMt1qQ4ASWW%2F8sX1SXp0zvE01vopo3W6j5Mfiq778%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:11.0976538","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A11Z&sr=b&sp=r&sig=42Q2DzHsrd7c2%2FAGmlSPlktv7a9XHwnGY%2F2ZgqyOriE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:11.0977821","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:55:11 GMT
-      mise-correlation-id:
-      - 3d23ece9-f8fe-4fba-9507-7377de65dd4a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A16Z&sr=b&sp=r&sig=IgbemwFhc5krvkLtxBbmx5mPLPLfmY301gMHdnBZyyE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:16.3976902","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A16Z&sr=b&sp=r&sig=zb8U9JZn5LgXzRZeS5SZcsV32jbMh4Z%2FG96URuQDwno%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:16.3976233","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A16Z&sr=b&sp=r&sig=1ahSC3V7rLSxWxhTq95XOf5heaxi4NSi6RL7IFpHRqs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:16.3977052","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:55:16 GMT
-      mise-correlation-id:
-      - d240e945-c5b7-47ed-bccb-bd46ce1313b9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A21Z&sr=b&sp=r&sig=GQ9PqTtOJU5vGVH6APAlOIfnq2sQmytJED%2FqwrOdN3U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:21.8148772","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A21Z&sr=b&sp=r&sig=26qiTsRMHbB4iiMLjJg9z0oceE4SJpuqeYRkzjp3EFk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:21.8147794","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A21Z&sr=b&sp=r&sig=WrO1cn1kn%2BN%2FrT9Gn0AxUbGKY3R2rrx80Ub9ee6%2BEwk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:21.8149027","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:55:21 GMT
-      mise-correlation-id:
-      - 541ed6f1-6395-465c-8a91-07040d400699
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A27Z&sr=b&sp=r&sig=z5cBw4MC79H20dLT5S%2B9gSlozSwJGEzIRKkqcYPiJSw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:27.0900716","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A27Z&sr=b&sp=r&sig=mYM2OXqw0yecpkTkvlyagJWtruUyB3PPifnbSUacsVs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:27.0899815","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A27Z&sr=b&sp=r&sig=Dj0y7xhWUHQAikhpHorsdTyorsR9ywYDd4KfRf8AQok%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:27.0900872","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:55:27 GMT
-      mise-correlation-id:
-      - 4f14761e-d6be-4273-bcca-44a9490e49aa
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A32Z&sr=b&sp=r&sig=LfAJX45iFbT0irtpZb4iMSDr%2FNQAtYOUtcRq0BZ8bl8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:32.3782507","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A32Z&sr=b&sp=r&sig=64yuMexILCxLCW7iwPf%2FcAcwRVQ0wD9bQhEuf0yfzQg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:32.3781494","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A32Z&sr=b&sp=r&sig=TwtTjFQ5Qty2uvJavoO%2BSS34cFoCt7juxVJevEVoD%2FI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:32.3782721","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:55:32 GMT
-      mise-correlation-id:
-      - baac2673-854c-4657-a439-91e71210d610
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A37Z&sr=b&sp=r&sig=iaLgaMsnLrG383QIxrKVa%2BGaHPeg%2FLZv6SFeTKLh5zk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:37.6284842","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A37Z&sr=b&sp=r&sig=jUvUWdazm8KMzor8mCXHWw0ihXDABteOMwa40UFBNdQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:37.6284139","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A37Z&sr=b&sp=r&sig=AC6b9ckgXixz0c3aHGVpijacIa%2BqHeX9YT4nnCLSgP8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:37.6284987","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:55:37 GMT
-      mise-correlation-id:
-      - a4230c6e-f78c-4eca-af12-be8b1e186369
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A42Z&sr=b&sp=r&sig=VzcmCD9wjxffg2JOtZMPpGP%2FIjJniPAkIIp%2BRcPTiKg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:42.8965045","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A42Z&sr=b&sp=r&sig=itiOs1YgNiY%2F2FAvGwuOs%2B7dKzl0esR9BJAdxPfEvXM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:42.896421","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A42Z&sr=b&sp=r&sig=UAnBiup11l3OkD%2FWnl2HYHQ%2B742S3%2B74fNOpJ7uCRWI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:42.8965207","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A56Z&sr=b&sp=r&sig=7l2Y%2BPCr9GFdUh7VFQQVkYcSK4JjiOrS1m2Yn69DeAU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:56.6409037","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A56Z&sr=b&sp=r&sig=pqH%2F2psJjBvZ%2FutwljcFR8qtn50dZFl2v8pBCtGvcFo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:56.6408331","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A56Z&sr=b&sp=r&sig=svwWyXzS8UX%2BXJMgn6ZJjWB9%2BuztICAv2ZzkhE57Srw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:52:56.6409176","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:35.86Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +858,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:42 GMT
+      - Wed, 18 Oct 2023 20:52:56 GMT
       mise-correlation-id:
-      - c0a00be3-6695-4d42-b101-2a9c7183e165
+      - 0f5b97a7-3770-4e7b-bda4-59d90503f48e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,10 +880,406 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A48Z&sr=b&sp=r&sig=zy7yVXH0WrmEmafTNTc41KqyblN9GjXXvOG91naXPMs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:48.8006312","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A48Z&sr=b&sp=r&sig=UgufX7gJjhQ9Ru8FsPPPrjzKPyU%2BTvOHQQ6cxDI5ueU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:48.8005532","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A48Z&sr=b&sp=r&sig=cfRwZhdoQ%2FcaivljrbNHrPADYVMieiJfWNwKmqXfwYI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:48.8006448","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A01Z&sr=b&sp=r&sig=7zJSvYFEPpsoacjZ7XIz%2FSoXXdbkfRTMxr9q9RwMFJM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:01.9441255","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A01Z&sr=b&sp=r&sig=Sk5YUHkUv24OODOeT8e%2B2xwkpG8gpLVx49k4NRkxL1U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:01.9439721","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A01Z&sr=b&sp=r&sig=Zo5I96nyIp69Gea%2BEa5nVI8r7imQ1wMjPH5Sy0sE3zQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:01.944148","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:35.86Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:01 GMT
+      mise-correlation-id:
+      - b2096c47-202f-4c65-a817-bb82a4db5888
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A07Z&sr=b&sp=r&sig=ljiXmHXCjpT%2Bbieo61T09ANmqt6Fhyo3844tENRWDrI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:07.2112844","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A07Z&sr=b&sp=r&sig=2b989ihk9ieKiXnTQT1r1FAG9B7sv5RsnXGx%2BeR6UR8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:07.2107083","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A07Z&sr=b&sp=r&sig=0XkPR%2FcK%2Bw47p2srGUz5TqWWf2QUHLA5J8WQDTYy10w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:07.2113152","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:35.86Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:07 GMT
+      mise-correlation-id:
+      - 13ea9fc1-8c6b-4db1-bd91-cef2fc3289b1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A13Z&sr=b&sp=r&sig=791f%2F%2F2cwpdYrte5xH2DBZ4amq9DaLQTTTFxfzqhQiU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:13.2354604","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A13Z&sr=b&sp=r&sig=xfK9CU6FTotdp9f7tYuWXaI2GyOk7A0s6hnraJHZLWo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:13.2353836","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A13Z&sr=b&sp=r&sig=M2YTQIGwRixa7eEaw9UwBbnH%2BaDH%2BEYfvJPBzrjM3tI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:13.2354747","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:35.86Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:13 GMT
+      mise-correlation-id:
+      - 387dc77c-d8e9-4066-b9e9-0ce82072595d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A18Z&sr=b&sp=r&sig=LBzfPah4GPEWSGlGt5X28OOd30lW1Hx3bJmhv9%2Ba4Cc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:18.5213979","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A18Z&sr=b&sp=r&sig=FlX4k96eV%2BgjlJC4QjQ6VvCNgd3sowrAacA9N7yYeA0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:18.5213244","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A18Z&sr=b&sp=r&sig=bPWcoqXZreZ4%2BxaBoibf%2Bdyf3627PRsq0n0vbQfpQRY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:18.5214119","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:35.86Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:18 GMT
+      mise-correlation-id:
+      - 023f233e-48a9-4810-a8f0-dc0971c56728
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A23Z&sr=b&sp=r&sig=gydxOFhfzXgqc3ToQ0PuHIKzAFnHNmUgKDRYhwgDf%2Bw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:23.8350651","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A23Z&sr=b&sp=r&sig=%2FvEyP7jmJ8G4hmnD%2BR3a2vFsP0Ue1sQEax5HO%2BRs6JA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:23.83498","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A23Z&sr=b&sp=r&sig=v2KiBwLbHV8KE%2FuknU3ua59%2FgfJFdaN1tmpj0apxpow%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:23.8350864","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:23 GMT
+      mise-correlation-id:
+      - 7435de6b-525b-465e-a51f-93df63ce97d6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A29Z&sr=b&sp=r&sig=1mJ0%2FMqt1PbX92QgLq9jE2tKSrngZt8YhbtEesvG6OY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:29.1104038","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A29Z&sr=b&sp=r&sig=WGPl%2BMaIC%2BvJa14%2B6ovxCUboaYigHa31Eq3VqGL5EQM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:29.1102936","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A29Z&sr=b&sp=r&sig=UgURt4uLFoYai3v8AaEcSI%2Fwk%2FKixD%2BygLbt1CSEQoI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:29.1104264","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:29 GMT
+      mise-correlation-id:
+      - 3ab69808-baf4-4fdd-ad3d-efa97b57f458
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A34Z&sr=b&sp=r&sig=%2Fd8OehjMykgyNVmWlWVx9yTJYlCT7gYCj%2B1ONx4M7M8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:34.3784181","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A34Z&sr=b&sp=r&sig=X6vIIjw0RNxkc8ViI1YG%2BWviMiN9FjojE2Mi67G%2BWC8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:34.3783635","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A34Z&sr=b&sp=r&sig=E8Y5VmwMgvzV0EUApats0koYXKk32QxkaLUhZRd6H%2F4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:34.3784325","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:34 GMT
+      mise-correlation-id:
+      - ec71149d-27b1-4541-bef5-3a9c7750cda3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A39Z&sr=b&sp=r&sig=YmIHwU1efwJ5YeXJqrZpJz%2BFFq7WCm6nQo%2BvAMX%2B8Jo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:39.8417273","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A39Z&sr=b&sp=r&sig=ao0n6RzeH2EgWsKhwDKkf6GzCGKN%2B7m6hMZPbnnTCxU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:39.8416597","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A39Z&sr=b&sp=r&sig=%2BmzEeMGaOsL8sWQ63mqKzi4G7snODoCJWZLLJUmNueg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:39.841742","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:39 GMT
+      mise-correlation-id:
+      - f1bef388-42d5-4ba3-9684-006cc443eee7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A45Z&sr=b&sp=r&sig=VvPYHMvJguxzwSlfhGco1hRugLkH4g7evbk1Iwn1d6M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:45.1570356","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A45Z&sr=b&sp=r&sig=OY9pg89pTSeByiCcp9j%2FTwtIazJU4%2Fx10DMi%2F8ORfnU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:45.1569403","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A45Z&sr=b&sp=r&sig=7rj5F3B4C1qPlu05SrbkOFALd37oAI2VH0fq6ISqPuA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:45.1570564","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:45 GMT
+      mise-correlation-id:
+      - 17d41ba6-1a70-4f20-af9b-0c74ce37a369
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A50Z&sr=b&sp=r&sig=lloue1TcD%2BTHAaCRAFxVPLTwQxMJ1x9zNLnAhq7HHzA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:50.4435018","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A50Z&sr=b&sp=r&sig=QPYotbg6HhaoXKwQOgZ9LrISRL3syfhFvC623t3AmHc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:50.4434227","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A50Z&sr=b&sp=r&sig=%2BRJgKFz5VyfgOI1g4CQFzRa6HGGGmW%2FxIOi7jLr2UOs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:50.4435162","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:50 GMT
+      mise-correlation-id:
+      - 6ab43e6b-3759-4df5-a85c-2ea225c2539e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A55Z&sr=b&sp=r&sig=1R6Msl2DckEsm8dSoiv1yKAPAnW3fccaBSIQVNgpRhY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:55.7369414","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A55Z&sr=b&sp=r&sig=FemlS2vq0PXKU2TlWHzPY8Vr%2F4yrzguJuAMs2XP00NY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:55.7368526","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A55Z&sr=b&sp=r&sig=lb38fIehELX5MTje9CaS1ddnS1szB8OK2wBGfdqtwKE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:55.7369625","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:55 GMT
+      mise-correlation-id:
+      - 64ffd117-92af-4723-830d-20019803b20b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A01Z&sr=b&sp=r&sig=Lq06Bj2eKYVLND83qmbhgn0OZfF0wWaq4imEuKqNSD4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:01.042995","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A01Z&sr=b&sp=r&sig=TaHRhj%2B4l8RYWpMCI2oQh7FlO2AvaDpZsuNhtaJWYIE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:01.0429096","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A01Z&sr=b&sp=r&sig=vVJpGURNyGden%2BYObcpfhpZ4ecoQ9sRv0irD27y9HH0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:01.0430174","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1794,9 +1290,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:48 GMT
+      - Wed, 18 Oct 2023 20:54:01 GMT
       mise-correlation-id:
-      - 21342c5b-5b33-44bd-8784-2f748a9f8e68
+      - 1f90bc7f-a312-4f5f-92eb-2f6b927d2326
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1816,24 +1312,492 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A54Z&sr=b&sp=r&sig=7fNJyAWX2MzFMS5qvcQi0gUqYJA0lp1cgNwxCYqLblA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:54.0478913","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A54Z&sr=b&sp=r&sig=cXif2B0Ywt%2F7vYjyl2ZF%2Fa1Aw%2FJ8edj%2BmvOBE0jBLOg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:54.0477901","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A54Z&sr=b&sp=r&sig=nZRhGdK3kGuZ5XwT11Hzfg7cC9rW54XxdgsSZS81eSk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:54.0479123","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-13T13:53:10.05Z","endDateTime":"2023-10-13T13:55:49.449Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:52.173Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A06Z&sr=b&sp=r&sig=nptPT8YkD6wCBTmw74%2FpXrfeZA3LNq658vHbLWk6TbY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:06.3578829","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A06Z&sr=b&sp=r&sig=3awNdghMmg%2BCPuoI%2BZeECNbblQJ6QncNPQyc4y6XPIU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:06.3578102","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A06Z&sr=b&sp=r&sig=4OF9q%2FGLBuLu%2F5f2lZHB89Oj3ShYmAXBkb3Oslsggpg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:06.3579007","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3334'
+      - '3202'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:54 GMT
+      - Wed, 18 Oct 2023 20:54:06 GMT
       mise-correlation-id:
-      - a8b919d4-5fe7-4927-a594-984f1d870370
+      - 46b2e25f-9e7c-46d3-aa7f-1cdfae9252b6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A11Z&sr=b&sp=r&sig=aqpKsbt1zDdpSJCFCQYy7QR5QJ3%2BMEpe0GTDIIdwcpA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:11.6920507","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A11Z&sr=b&sp=r&sig=DwpOXDT5o7Pd%2BKGu42HSlF2Fq08%2F%2BPYMgKi6VYx9tGU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:11.6919821","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A11Z&sr=b&sp=r&sig=i3SF%2FD5054XF0%2BF2BKjgQizKujh9dkxWJXZt1HvtmH4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:11.6920659","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:11 GMT
+      mise-correlation-id:
+      - 7552c721-83b7-41fa-92e2-f41240d1e33c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A17Z&sr=b&sp=r&sig=PLUUxg065H5KTYHpRGXKJLxDlCBT3a9ztR9RfjqQzQg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:17.0148673","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A17Z&sr=b&sp=r&sig=oVjJn6gIMBWKCGCWmbqAVhao6RO78i5YCNBKOsewOfE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:17.0147911","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A17Z&sr=b&sp=r&sig=U87WYSZ8emJ8UcYSQuITZHGn%2B4GgoavUfOdaE36j%2B2A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:17.0148825","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:17 GMT
+      mise-correlation-id:
+      - 52ac1922-f122-4ad9-acce-8c40118dcc2e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A22Z&sr=b&sp=r&sig=49PK1o8ep2tOVyRU%2BTyVPX77yDMKMYl7YMXrlt0ojp4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:22.3442087","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A22Z&sr=b&sp=r&sig=Iqon3CF3GAHnJk%2FSLMRTDzm8geX3ACANp7en8KcNnRY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:22.3441367","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A22Z&sr=b&sp=r&sig=%2FaICVSXTLbO2u0UFN9jKPEpanvkeB28XBI%2Ffz9yvdK8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:22.3442233","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:22 GMT
+      mise-correlation-id:
+      - 57f171e8-a43e-4e8d-b396-22e7d7b8cf33
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A27Z&sr=b&sp=r&sig=uy1bcvpelASUeAez17G0%2BDQvy7XFJyAtEo6E2jvTdc4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:27.6606405","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A27Z&sr=b&sp=r&sig=692yR7EPyfjCz3Da2YFLHZIXSbhNnGGb7ooGixj6xeA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:27.6605734","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A27Z&sr=b&sp=r&sig=AbZWwnxOMMY3WkD%2BDIECJHwc74fL47izv%2BzJMuRwPCA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:27.6606556","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:27 GMT
+      mise-correlation-id:
+      - 6596f6d7-67e9-44e2-ad4c-336c5451850b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A32Z&sr=b&sp=r&sig=viQKyFgx7c%2BeQTFcvV1hjlpwKy5nAbtz%2FK2c5pn%2Bv7Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:32.9855842","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A32Z&sr=b&sp=r&sig=l9HvxdFRxXXV%2B2tXEEaGESkC8UpNmIaMBVKBZ0jOdj4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:32.985517","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A32Z&sr=b&sp=r&sig=y1KrxOtvS6Nc6rg%2BtYne5O0htok1%2F48PflGdx1lBD8A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:32.9855989","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:32 GMT
+      mise-correlation-id:
+      - 9bf14687-8927-43a2-ab33-8b8ac055fa41
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A38Z&sr=b&sp=r&sig=mCR2Sdqt31ihWEd%2BI%2BC3ATAIuUzf2XGGYeGhfs4IWe8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:38.3052533","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A38Z&sr=b&sp=r&sig=yq%2B3Cp4MCndz9OM%2BSrVPVRRNWwc9%2FcmhS4qQ85g8%2BJ0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:38.3051748","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A38Z&sr=b&sp=r&sig=APdhFGGWsKZVfEPBt27ACCvEyqAsO7KcQueG86ot%2Fyg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:38.3052671","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:38 GMT
+      mise-correlation-id:
+      - d5e8ae45-6524-4b18-aaa9-d27bb5d9b1f2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A43Z&sr=b&sp=r&sig=p4sa4GyKP0u29AwNCxP5RS8RVKcOGuVv3aUYbmdl6ow%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:43.643384","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A43Z&sr=b&sp=r&sig=5DSpwKI5xMn%2F3AIiGac9E58PWWFV3x0FMWoz6wNa9qs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:43.6432935","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A43Z&sr=b&sp=r&sig=nzcY1ukbnYsYIyC%2B3976WKZUZaGP1ij6I4L5fO0zyAg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:43.6434075","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:43 GMT
+      mise-correlation-id:
+      - db8c6747-6a71-4277-a711-e9e21ea7cac9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A48Z&sr=b&sp=r&sig=mvkxTpm9ApJk6Dn7hSkmBsHrv%2BclMojeoPr1zNNgJek%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:48.9645851","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A48Z&sr=b&sp=r&sig=ulixQ0AR%2BQS7Xoop61KWBWQgYctpPbw0O6oGJUt4Bbk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:48.9644785","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A48Z&sr=b&sp=r&sig=k5RplXl%2BSOMMcMKqlmGl%2F4WXNWHcoAI0kKHK6Zz0Oi0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:48.9645994","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:48 GMT
+      mise-correlation-id:
+      - 1adf9a72-54d7-4a59-a344-ea20c64b1b4e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A54Z&sr=b&sp=r&sig=MiLnwVsTkQGrmWYx5dkSlzETxTpNpZGUEfWgMdVMKrI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:54.2515527","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A54Z&sr=b&sp=r&sig=gMy9Zp7KLKyeLk26CKfhzwjgQzp1q6WAgfbASqeDj5o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:54.2514817","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A54Z&sr=b&sp=r&sig=3ml5cbCD7cIP7Xhwo7EXoXYdexa4XNWcd6p99RmiJ2Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:54.2515682","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:54 GMT
+      mise-correlation-id:
+      - 5e57edb1-4f7f-4f3e-94cc-ebd3314c919e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A59Z&sr=b&sp=r&sig=14iw0W61wREPQ30iegA2Iiqh%2BicQUlZCbfLQQAhaQrw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:59.6281343","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A59Z&sr=b&sp=r&sig=URR5Xz%2BhRvlhCAs%2FgOPXiEXfFSAOoNmMT4leCZXV4Gs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:59.6280555","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A59Z&sr=b&sp=r&sig=JxNZiTiRdoVhk3K1tBDbim92z5%2FZcCyV4cKZKSxNkzM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:59.6281503","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:59 GMT
+      mise-correlation-id:
+      - 00f6e234-a403-4be1-b80a-120c3d41153a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A05Z&sr=b&sp=r&sig=6OijgGPtg0nSVdNjSprlrBjtoCp6gEmetVCpQULg55c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:05.5245153","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A05Z&sr=b&sp=r&sig=5J6knmFYvemXbvQc3%2B0QqNbAuQ1UqbzzhTriPvo5snc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:05.524449","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A05Z&sr=b&sp=r&sig=adUF4qsG6kJY2b87fcVjvDyz0j%2BbJLZOP5826cwY1i0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:05.5245299","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:05 GMT
+      mise-correlation-id:
+      - f35c9d93-d64e-4c74-97ad-69f16bb115fb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A10Z&sr=b&sp=r&sig=gVUkTERESCkuVqTtCnHaIlUQCQRsA5JrSDrpvqUGifM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:10.7896056","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A10Z&sr=b&sp=r&sig=FuLYXDAsRZaroB9RGA%2F9FamCJsT9Hg3rWkdm4mVX1uk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:10.7895111","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A10Z&sr=b&sp=r&sig=IY44uM5K6ZOwPVcmSYLmYYvPP5Vi46QgQhYdFJJOAL8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:10.7896277","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:52:35.651Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:22.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:10 GMT
+      mise-correlation-id:
+      - badbc13d-4fb8-4c1d-995a-e2db2ee14241
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A16Z&sr=b&sp=r&sig=iqlmWXfYbiowFOk5QBWzsWCqfC6%2Bu%2Bf6jJ0z96UihK4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:16.0823837","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A16Z&sr=b&sp=r&sig=ZqeWpzSG5DDZSXpH7qFF0szZ%2FLwGgP5NwnpbNesY4To%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:16.0823093","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A16Z&sr=b&sp=r&sig=2HSoJs4F4kknrXpDImx6PEjqKjrF650MPGgbKMVWTxg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:16.0823996","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-18T20:52:35.651Z","endDateTime":"2023-10-18T20:55:11.771Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:11.847Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3333'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:16 GMT
+      mise-correlation-id:
+      - 608e7ed6-0fbe-4e50-b29c-f8b471af33cb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1856,7 +1820,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:07.1706004Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:07.1706004Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:36.7813407Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:36.7813407Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1865,9 +1829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:55 GMT
+      - Wed, 18 Oct 2023 20:55:17 GMT
       etag:
-      - '"d8013df6-0000-0100-0000-65294b890000"'
+      - '"7500314e-0000-0100-0000-6530455a0000"'
       expires:
       - '-1'
       pragma:
@@ -1897,24 +1861,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A56Z&sr=b&sp=r&sig=ApXn%2F9fx3MkZlmSxbNwrLEbzSf9Y5Wbn6q97W4W%2FGwQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:56.8303033","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A56Z&sr=b&sp=r&sig=5hy8yOGNdSQs0MjfBJmNLI96kkj%2FfMQpcRzz8BZ832E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:56.8302193","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A56Z&sr=b&sp=r&sig=yA6q1NY1nJ%2F099lV8rygAaLcWHnI1RoUcYHbQ6icEk0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:56.8303248","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-13T13:53:10.05Z","endDateTime":"2023-10-13T13:55:49.449Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:52.173Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"506415db-e616-41bc-bd5e-ee08c40caea7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"86fd3a31-c089-4092-a5f7-fa63fd157566":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"bef1de58-a689-479f-802d-ffe758da1dd1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/d6cb4356-5503-41d9-b1fb-fa02660105fa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A18Z&sr=b&sp=r&sig=PtvmxgtZG2%2BdwB1CoaxLdhkKwaGpCXyUyq4m%2BIQXHS4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:18.34434","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/06878a86-2947-4608-9be9-ee9111aa057f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A18Z&sr=b&sp=r&sig=nOwH8Wq9qc8NOILvCYKhRhUH2y%2BavRlAxC078r%2BAp%2F8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:18.3442599","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7a92d465-92b3-423b-92e2-253e872e6b57/1f116a0e-e457-43cc-ab2c-78749df3c067?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A18Z&sr=b&sp=r&sig=wfz66BRjK4U%2FNebDS6FW1X5ZWU0WGKEFFdiem%2FGmDjQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:18.3443545","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-18T20:52:35.651Z","endDateTime":"2023-10-18T20:55:11.771Z","executedDateTime":"2023-10-18T20:52:33.514Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-18T20:52:34.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:55:17.152Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3346'
+      - '3351'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:56 GMT
+      - Wed, 18 Oct 2023 20:55:18 GMT
       mise-correlation-id:
-      - c561b56b-4b69-4061-a022-e5fe68baeedc
+      - e049fcdb-860e-4b9c-ac1c-67290acf4f0c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1937,7 +1901,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:07.1706004Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:07.1706004Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:36.7813407Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:36.7813407Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1946,9 +1910,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:57 GMT
+      - Wed, 18 Oct 2023 20:55:18 GMT
       etag:
-      - '"d8013df6-0000-0100-0000-65294b890000"'
+      - '"7500314e-0000-0100-0000-6530455a0000"'
       expires:
       - '-1'
       pragma:
@@ -1980,7 +1944,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -1990,9 +1954,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Fri, 13 Oct 2023 13:55:59 GMT
+      - Wed, 18 Oct 2023 20:55:20 GMT
       mise-correlation-id:
-      - 1f492117-f729-466a-a274-75e110de205a
+      - 065f957d-742b-477f-9446-7026defbc8c6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2015,7 +1979,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:07.1706004Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:07.1706004Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:36.7813407Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:36.7813407Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2024,9 +1988,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:59 GMT
+      - Wed, 18 Oct 2023 20:55:21 GMT
       etag:
-      - '"d8013df6-0000-0100-0000-65294b890000"'
+      - '"7500314e-0000-0100-0000-6530455a0000"'
       expires:
       - '-1'
       pragma:
@@ -2056,7 +2020,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
+    uri: https://5edda366-4a52-4492-82dc-7a82ecc09a98.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -2070,9 +2034,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:01 GMT
+      - Wed, 18 Oct 2023 20:55:22 GMT
       mise-correlation-id:
-      - d025dd30-1ee4-4cdf-b6ba-2a343d2cf76b
+      - 5d9d5df5-b5c6-4d79-b4be-13e24e936cb9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_delete.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_delete.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:49.9979583Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:49.9979583Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:15.8114883Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:15.8114883Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:22 GMT
+      - Mon, 09 Oct 2023 19:19:49 GMT
       etag:
-      - '"9201fcb4-0000-0100-0000-652426830000"'
+      - '"5600d22d-0000-0100-0000-652452350000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:13:23 GMT
+      - Mon, 09 Oct 2023 19:19:50 GMT
       mise-correlation-id:
-      - 080c79a2-f0f4-4864-82f6-f92886d7df28
+      - 792dcbab-4f9d-46b5-a76a-6912b988d6f6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"922adde6-d529-4eae-a7e7-83b251a05045": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "941e5a0e-25ff-446b-826d-9b6622947495":
+      {"passFailMetrics": {"6986a558-25a2-4e7a-b03c-f83307a4a419": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "26934601-08fd-4fba-a8d0-fd388aefba0c":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "f2709412-7090-4297-94c4-b061847f9a6d": {"aggregate": "avg", "clientMetric":
+      "50"}, "c735a1eb-253b-4872-8cdb-d0ed4aa5db2a": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:13:24.492Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:24.492Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:51.266Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:51.266Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:24 GMT
+      - Mon, 09 Oct 2023 19:19:51 GMT
       location:
-      - https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+      - https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - df960bd3-50ab-4a46-919b-c680ad3ba390
+      - fe8252b8-fd29-4b9b-9076-acb95224c406
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:24 GMT
+      - Mon, 09 Oct 2023 19:19:51 GMT
       mise-correlation-id:
-      - d0f132e1-afb0-4568-9f73-533c702404e9
+      - 87c51601-2e12-4fd7-ae6b-34c44aaadb0a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A25Z&sr=b&sp=r&sig=XAMWpOUHgX%2BYaj%2By4m%2Bui9g7JOrXX%2BxnZ2Q6XKwcz4I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:25.2923711","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A52Z&sr=b&sp=r&sig=OiCrn1XnVnTsXIhIxFeZ6FhBRbq4WBeV4AGsc%2FDTBBM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:52.2818272","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '557'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:25 GMT
+      - Mon, 09 Oct 2023 19:19:52 GMT
       location:
-      - https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - a095359b-3a99-4f9a-9a18-69adfcfac6b3
+      - 76bd135e-81ce-4d8f-9255-1a25f40406b5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A25Z&sr=b&sp=r&sig=mBVdvBtbet9O69kVGrK1DmAMrowBL5eS57jq4YQtgRw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:25.573014","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A52Z&sr=b&sp=r&sig=FdvKw9XW8Aw2TiMx1nIzO9hW0z9Fg9otWyvGza8MlY4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:52.5739782","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '548'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:25 GMT
+      - Mon, 09 Oct 2023 19:19:52 GMT
       mise-correlation-id:
-      - 8d0ee836-ed74-4ad0-acbb-1045a1530959
+      - 1b6ff010-df0a-4233-b4cb-0023da6c5d23
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A30Z&sr=b&sp=r&sig=L5v%2B0HzpEzlJ7%2Bu%2BwRFLQ2aF48rdl1r8%2BBan4svzkzI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:30.8464948","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A57Z&sr=b&sp=r&sig=cmBvxw88PbA0vQvyrEhwZ%2BgvTX9L%2F6HIvveXIaDmEvQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:57.8906945","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '557'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:30 GMT
+      - Mon, 09 Oct 2023 19:19:57 GMT
       mise-correlation-id:
-      - 2edf02c6-a198-42f3-82f4-bd31b6465169
+      - 20f63330-a2d6-4797-825b-8f0e2b8e56a0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A36Z&sr=b&sp=r&sig=Dr7IiOuVyqZpSyyOoYMlzi8vehDz7R0Xi%2FSEOBScW48%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:36.1304883","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A30%3A03Z&sr=b&sp=r&sig=%2FDB06nya0j%2FYbDtr3cNzmGM0eIL9rkHDm1qxDP1NIh8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:30:03.2167643","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:36 GMT
+      - Mon, 09 Oct 2023 19:20:03 GMT
       mise-correlation-id:
-      - ecf6af1d-d74f-4641-8151-9b00dc8ca092
+      - 80e461b7-5ed6-4411-8e3d-ae2d7c8206dd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A41Z&sr=b&sp=r&sig=E8UwO8l3knJA5n5Tqt1GlOial3RNfpptDZysEwfnrfE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:41.41201","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A30%3A08Z&sr=b&sp=r&sig=fM%2Fpr30k6NX7x3ZmBDK6tJnKenkE0DN4sgPVewbbANQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:30:08.4999575","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '545'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:41 GMT
+      - Mon, 09 Oct 2023 19:20:08 GMT
       mise-correlation-id:
-      - f7b1ad7b-5f8b-45bb-bc43-e4563aa12fee
+      - 8c28e51f-6326-4bbf-ae10-b74015d2b9a1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A41Z&sr=b&sp=r&sig=%2BnOPAyshPmP7XA2lpX0q7bnOtDUHzxj%2FrAi7hxjMIgM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:41.6827014","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:13:24.492Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:38.715Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A08Z&sr=b&sp=r&sig=PT0RSIhwCjsiwNgBdY13A2aS4y33cWmB0gK8ftQ8yus%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:08.8817564","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:51.266Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:07.78Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1581'
+      - '1576'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:41 GMT
+      - Mon, 09 Oct 2023 19:20:08 GMT
       mise-correlation-id:
-      - 389f0d2a-b558-474a-bbc8-1b2a0a3677f5
+      - e7219e58-b90b-40af-981c-00a266c4b20a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:49.9979583Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:49.9979583Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:15.8114883Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:15.8114883Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:42 GMT
+      - Mon, 09 Oct 2023 19:20:10 GMT
       etag:
-      - '"9201fcb4-0000-0100-0000-652426830000"'
+      - '"5600d22d-0000-0100-0000-652452350000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A43Z&sr=b&sp=r&sig=Yd0nQGQW04nq3y1ohMN9bJTOUgXXt%2BWhfrGu%2BPVNr20%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:43.9672361","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:13:24.492Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:38.715Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A11Z&sr=b&sp=r&sig=BoXd6hphN9FaEKS6kkGIUEyLThwIQ4O%2FpLCxLMY5kjk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:11.3861213","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:51.266Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:07.78Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1593'
+      - '1590'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:43 GMT
+      - Mon, 09 Oct 2023 19:20:11 GMT
       mise-correlation-id:
-      - 06d4d261-aeef-49dd-96b5-f96321e7029e
+      - 38e1347f-d8f0-476a-9508-8c3e61f521fa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:49.9979583Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:49.9979583Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:15.8114883Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:15.8114883Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:44 GMT
+      - Mon, 09 Oct 2023 19:20:12 GMT
       etag:
-      - '"9201fcb4-0000-0100-0000-652426830000"'
+      - '"5600d22d-0000-0100-0000-652452350000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:13:46 GMT
+      - Mon, 09 Oct 2023 19:20:13 GMT
       mise-correlation-id:
-      - 603e046e-f79f-4409-be2d-652ab38a57be
+      - 9aac3fa1-78dd-4b23-8303-0342fe67f9eb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A47Z&sr=b&sp=r&sig=51dWVaXu%2FtS48B0OVfmOmGTvJseHQCgijVtMvx43%2BBw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:47.0844048","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A47Z&sr=b&sp=r&sig=K4Im7rXkpcJytIDugRgL2M7ybq7LER%2BzJeUNXZeHuVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:47.0842529","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A47Z&sr=b&sp=r&sig=Nw3yyPG3wXr0b1i55m6u6uxXlHQCIYFviuE9L%2FfGQEg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:47.0844285","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:46.996Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=XrU5EYhHNjdoafpBp0gMNm%2Ba1FtPBUvavP%2FSM0M6ZLo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:14.7390604","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=XqiVJjPbpIp8BPKb6UYRjDCHeXmYCDsq0XHVoDx4SAE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:14.7389632","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=i7jDd0SWXunoocJdgW7aRCaIzUwwA0xzw9bAKUeV5zQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:14.7390815","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.672Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3156'
+      - '3152'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:47 GMT
+      - Mon, 09 Oct 2023 19:20:14 GMT
       location:
-      - https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+      - https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 78c39a13-a87c-49c5-9ec8-8fec53dd41e3
+      - 448ad50e-4ffb-4b87-a0b7-2f9a9029d73e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,982 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A47Z&sr=b&sp=r&sig=twXuxF%2BroLgRLYteda9yyocIKMvli9IoL985xGs04mo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:47.5344788","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A47Z&sr=b&sp=r&sig=T1kbernuQyQkg7bRk41A3IJA9mg2piOS0TExdywn8KE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:47.534391","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A47Z&sr=b&sp=r&sig=9GMuOufzXIWfEvdZ1uoU8rlBgedIYVlVMZpsBKZUH8s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:47.5345045","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:47.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:47 GMT
-      mise-correlation-id:
-      - ec768601-2091-499a-8a50-097528ace9ad
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A52Z&sr=b&sp=r&sig=4U3xN5fVGDbRpHBoW%2BRO1NOpFGfPom2uQT3JbEz3WYA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:52.8450172","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A52Z&sr=b&sp=r&sig=t53j5aNQdWOBbySkZXwcM2h3Igb8eRMbFpBbwYC5oXA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:52.8449224","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A52Z&sr=b&sp=r&sig=zLFUHj6Rbe6qHTaerZ34owFSmSuqMH6tTrvIZSOXC1c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:52.8450385","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:47.601Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:52 GMT
-      mise-correlation-id:
-      - a1ece2fb-90e4-4ac0-b685-1d7414d4ef77
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A58Z&sr=b&sp=r&sig=ZyGliS041tI8yecibsSqpu%2FDzSfpt762GSjhs9kh9co%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:58.1469445","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A58Z&sr=b&sp=r&sig=uRYlYDbWhj3Ms30jBcuhgo2%2Fu%2BhJXfDWRK8BCK6KbeE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:58.1468364","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A58Z&sr=b&sp=r&sig=T62SqqJ50kaMUywuIj%2FApAKoN4554UuL%2Foq%2BEmApmsE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:58.1469708","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:47.601Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3207'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:58 GMT
-      mise-correlation-id:
-      - f9585f18-857a-4e20-a589-51073fb195fb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A03Z&sr=b&sp=r&sig=aMWWLDhYmS0XvypDwhvlo%2FWIjv4M3a4Q5oaADny8%2B%2Fc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:03.4322775","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A03Z&sr=b&sp=r&sig=h7wOlRqHsEzlO2CAwEkneXnK4VwfSiD0L3mfJKJxtCA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:03.4321848","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A03Z&sr=b&sp=r&sig=g8peeZxv78ThWgMYbP6xKvGV3SeQQDdkZjfgsiGgNag%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:03.4322987","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:47.601Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:03 GMT
-      mise-correlation-id:
-      - a7ac0877-3832-47c2-803c-86955c5cdd77
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A08Z&sr=b&sp=r&sig=cJYmMVs%2Bl%2FhZBJjMEU7VQqVknztx18Mr6e62JtJdoHc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:08.7099803","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A08Z&sr=b&sp=r&sig=X1Hqi8iKDPwZrcNClhHRP4nuZiJBrPVvQ6QDUc9%2FkcM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:08.7099081","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A08Z&sr=b&sp=r&sig=DgvLLahCYVz5SSbB%2B1eoiE3G%2FqT6GQ%2FUs9cP3vk92G0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:08.709994","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:47.601Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:08 GMT
-      mise-correlation-id:
-      - 0c07fc8d-b0be-4ce7-829f-74b7065710e4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A14Z&sr=b&sp=r&sig=AwcUH3my07gc73GmH8Y7VuSvG2xn2%2BxWkTOUApSC4kw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:14.3263628","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A14Z&sr=b&sp=r&sig=qHrn5bTzlhzdIdbLNiDfjM7EFosyTUmCjhMJqq%2FD6qA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:14.3262859","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A14Z&sr=b&sp=r&sig=EQkF1jtyh%2BdVDRQDr8zdexqJrG6RVLovLIaVQG5GuNw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:14.3263921","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:47.601Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:14 GMT
-      mise-correlation-id:
-      - 031bc97b-47eb-4011-8fd3-81d3d654f60c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A19Z&sr=b&sp=r&sig=hjjvCFpTz5pCCNF0j7SJ0CXP%2BZ38%2F7YZ2XKqHfCwbpU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:19.6214184","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A19Z&sr=b&sp=r&sig=oawAE2bKSKY11lQl%2BQUNTWkEf%2FVS%2FcxQYWUUlEFPGnE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:19.6213217","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A19Z&sr=b&sp=r&sig=jEmZEm5QIH8aIHQqQMf8oewbA%2F5cyqjz4JdPhXJqWdw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:19.6214395","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:47.601Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3207'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:19 GMT
-      mise-correlation-id:
-      - 77e20adc-0d8f-415e-8f61-8b620ac13ca8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A25Z&sr=b&sp=r&sig=np6%2BR9Dghbmzp1QQo10%2FPFC9U3yhLQVbSCnLN5lpyew%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:25.003221","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A25Z&sr=b&sp=r&sig=ECQyChfWS%2FZBfoUOCTieOAOIzKOkl5EOaf1P1Th3LWA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:25.0031156","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A25Z&sr=b&sp=r&sig=tOP%2FPN%2B15BbotJgbnup1%2BIFaZRK7BAcafP5%2BNgz3lqY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:25.0032441","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:47.601Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3208'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:25 GMT
-      mise-correlation-id:
-      - e143cfb8-719b-4979-86ea-8a50b005225d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A30Z&sr=b&sp=r&sig=sjtCmo1gDd%2FpwzmPiVtzqIVxQrj%2FNwkqf8Q0fF2%2BaWc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:30.2843163","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A30Z&sr=b&sp=r&sig=mG2o21jJGCnx0IIImovis1Vx%2BGiuzo1KUDYGKgPp4h8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:30.2842121","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A30Z&sr=b&sp=r&sig=PWSJqj%2FINVtn%2BfMqatrgj4pDyYSLYwPjFMTfY8jSenQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:30.284331","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONED","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:30.225Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:30 GMT
-      mise-correlation-id:
-      - e5b494f3-8d3d-4e63-bcea-402b021c3843
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A35Z&sr=b&sp=r&sig=YBYwhLRCCWBr0HClgMLTCtQhzRN9qmSl8Tg5PhK0zx4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:35.5612035","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A35Z&sr=b&sp=r&sig=W5Z5q53QAuBuDg0tWEMaqMEOTTxGABF0xQ2MQDNUXQY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:35.5611113","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A35Z&sr=b&sp=r&sig=0txgpDo7sPwme4SIlbcJ%2BACmQh77yHtjE6hoWe2opQM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:35.5612197","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:35 GMT
-      mise-correlation-id:
-      - 26afd526-ed8d-4bc8-9613-324639030043
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A40Z&sr=b&sp=r&sig=XH%2Fc6DnkOmTKuJsrqZjOGwO5sZU8wwYthY%2Boi0q0NM4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:40.8294694","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A40Z&sr=b&sp=r&sig=tS1QaNfzwuJFGIAtmQ3T1TVGQTQqyzJ1s1ZZ1jDeZO8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:40.8293998","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A40Z&sr=b&sp=r&sig=lLLqHTrlZKZcj4GEpm7C7sliAV90QER%2FPDC8B6%2F4OiE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:40.829484","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:40 GMT
-      mise-correlation-id:
-      - c01eaab0-abe4-4d21-9e71-3a57974b840c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A46Z&sr=b&sp=r&sig=O4scBzbFtYnspzZvP2xnf0uxeBkRj0zONyGbAKy%2BB7o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:46.1435692","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A46Z&sr=b&sp=r&sig=JSWH%2FMSliq%2FMo%2FpdiI39tIMRJFM96OBam%2FHXupIVGTY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:46.1434784","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A46Z&sr=b&sp=r&sig=ezq5DMuC0dKDLVd5wYWF9W9glqXdF3sLxVQGQ%2FrSqrc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:46.1435901","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:46 GMT
-      mise-correlation-id:
-      - 9839fca3-e06c-4cb0-8ee0-83568d0a339a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A51Z&sr=b&sp=r&sig=CF545PSvlZFmXUa3s2rW0UychkLecU%2FDVTZz%2BH%2Bfc9w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:51.4131897","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A51Z&sr=b&sp=r&sig=xh8PMIjYRqApNRa9d1mz1%2BTxp3EjIY4ONtZ6fGGEEto%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:51.4130965","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A51Z&sr=b&sp=r&sig=k%2FZJxDWoQ1ZNvAgtvM6TUgyS4A%2FFDrN34Wd0Neyetd4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:51.4132121","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:51 GMT
-      mise-correlation-id:
-      - 118325b7-fc29-42b9-834a-82322ae4efe9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A56Z&sr=b&sp=r&sig=IuOJKOML6Wpns3kpj59GWnnsHRelv23GhltqkSq9sMk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:56.6799024","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A56Z&sr=b&sp=r&sig=ZxXK%2B%2BzFFckjOG6RfDFb22p2mgUk0xVW1kNAxMeCtTQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:56.6797642","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A56Z&sr=b&sp=r&sig=UgdtcMGhP2sAtP2JMzjs%2BQI%2BsRkyGl5Xd9uzjWZfAik%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:56.67993","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:56 GMT
-      mise-correlation-id:
-      - 8723b23e-eb4d-490e-865f-30a0665b3065
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A01Z&sr=b&sp=r&sig=GYOlZAfbRec8kIgYWL%2BprJNhnN65GM0zMUKKozGUz1M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:01.9547032","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A01Z&sr=b&sp=r&sig=x1Y5K08D3r9RbkkCcdAsEeagKjSXl1bINXGd%2BH%2B6Hl0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:01.954602","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A01Z&sr=b&sp=r&sig=XlppS43mYDK%2FW3ScG4sH9uaDwTM0iTwrSVF2la1LSfQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:01.9547267","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:01 GMT
-      mise-correlation-id:
-      - ba8964b2-2e63-4fe6-99d0-9752a8b1e8ac
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A07Z&sr=b&sp=r&sig=9vNc7PZx%2BUj8LVTmZkctYevGiHRkA8qwyByW%2BSoZ7iQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:07.236345","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A07Z&sr=b&sp=r&sig=EOuH%2BMptL2f364DgWYVORyADK7riUHG3qr81yHzaWig%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:07.2362759","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A07Z&sr=b&sp=r&sig=eQmgXrn3GjKXDYHx4haVFGb3UnkVQeLxm6W8ywD5cdE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:07.2363602","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:07 GMT
-      mise-correlation-id:
-      - 5906b5c2-2171-4d05-9e71-9b76d3457ade
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A12Z&sr=b&sp=r&sig=o%2FYgAECiceUyFeU9EetXmJVAMakRoXWF8LkjqEShods%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:12.5131532","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A12Z&sr=b&sp=r&sig=UFm2qK90vYSukRItaNEaYcpguTqe5o6LdVM4Z4iuI0g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:12.5130635","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A12Z&sr=b&sp=r&sig=pzKH2ucCm3aRG66jOmnSTcx7IQtGseCOK7dzhAyP%2BQE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:12.5131762","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:12 GMT
-      mise-correlation-id:
-      - 7c73192e-33a8-467c-bde4-e4a9ffdb51a1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A17Z&sr=b&sp=r&sig=mZrwhO0SAkDZJTygSsUwUZtVkHS%2FUTPcpkk%2B47NolAM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:17.7823616","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A17Z&sr=b&sp=r&sig=OHNmxYIN41oNLpwNpzk1cGmBYnDLsrqp%2BOA%2BZ4Xe324%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:17.782298","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A17Z&sr=b&sp=r&sig=hKwolnN%2FUeoMGb8bCFkeuGa3fpmF4i2fyhPMQwDP2Zw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:17.7823768","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:17 GMT
-      mise-correlation-id:
-      - 47adb3c4-7efa-48fe-a3aa-f35a3d83dbfc
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A23Z&sr=b&sp=r&sig=wkPlnc7J0PKnyiVB3Ks3dvr57j4qyMhmAcWshlP8nMM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:23.0613654","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A23Z&sr=b&sp=r&sig=Q%2B6Gw%2B7Id4YeWrgoeVnlEeRE3NVTc0Ij3ZQ8FoxPZAA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:23.061272","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A23Z&sr=b&sp=r&sig=Vy93NgvGYX9ILZI2TUCzeEYurb%2Bt66BkNbjHM01J6rc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:23.0613879","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:23 GMT
-      mise-correlation-id:
-      - 5703851c-07ed-47fd-9438-3cd3e1feef65
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A28Z&sr=b&sp=r&sig=HRUKaaJ42aWTLwa2GW9TjlX68kqPo%2Bq38ZWmewokz70%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:28.3578265","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A28Z&sr=b&sp=r&sig=sN7raQJJ%2FYduvZacFG4IzmCUX029IVNByzWD5M%2F561E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:28.3577316","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A28Z&sr=b&sp=r&sig=pcWIGqnqYHRwNIgXp8Q4GOvqvWRS6SXzP4MY41u7%2BTE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:28.3578479","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:28 GMT
-      mise-correlation-id:
-      - 3a573ee3-4be6-4a2d-b30b-25ce6df3aa5e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A33Z&sr=b&sp=r&sig=%2FgQfA8uhXoqPxvb1pD8FnDmZedM074CNfUltXsTk%2F%2Bc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:33.6221114","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A33Z&sr=b&sp=r&sig=vWdwD4pa54xZOkl%2FnriqlgihiTZZtKd8Hg2wKSfDn%2FA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:33.6220229","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A33Z&sr=b&sp=r&sig=%2BwA9ZAFVdAtWWDPrxR5lSgdi%2BDD%2FaJ8H6XsJaPzmo8M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:33.6221332","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3208'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:33 GMT
-      mise-correlation-id:
-      - f83a031d-1526-423d-940a-2a7688a35557
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A38Z&sr=b&sp=r&sig=4qDeAQDyBHN96h0vJn4aBa71FX26nourxYXbSO0J%2BNY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:38.90553","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A38Z&sr=b&sp=r&sig=CbbXLEpqF%2Bz%2BKNV7Umh8aYTSzDmKUWJN1IMnvDnzY3w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:38.9054586","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A38Z&sr=b&sp=r&sig=UKKph8QY%2FcwC7ns0nKdxJ9QjkC3Y4GM%2FYzBwjOjzi2I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:38.9055454","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:38 GMT
-      mise-correlation-id:
-      - 3bc1412a-651f-4b38-a1d5-eeb7618f43bb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A44Z&sr=b&sp=r&sig=w2Ld0ld2Kq2ykLlH44yNK5KcueXmDVrOeKMOv6OHi2U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:44.1698112","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A44Z&sr=b&sp=r&sig=R9ftj5t73WvC9iCYJZpNuGENEADULEilA3zUY6Vt%2BWI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:44.1697408","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A44Z&sr=b&sp=r&sig=MZ3e6FOMJDVqRGzHOb6gARTu3bILcMgqga7TzwZwgLw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:44.169827","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:44 GMT
-      mise-correlation-id:
-      - bdb388e8-84c6-4348-9cd7-a0731d87cc72
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A49Z&sr=b&sp=r&sig=7p5tHG3d0QblN55ILTWmQvSObjCZ0%2FI5RCXaI1mu9eg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:49.4508562","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A49Z&sr=b&sp=r&sig=ph2fjijzhGjs2Gl45DHn5TjbpggPiwqThJIj%2FtnRwg4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:49.4507615","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A49Z&sr=b&sp=r&sig=lMNfrfPwFh4qr3mnXlEvOSfKafNQKQ4C0s6t7tXXK6w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:49.4508821","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:49 GMT
-      mise-correlation-id:
-      - a254a394-2dc7-475f-8e15-25dcdda176b3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A54Z&sr=b&sp=r&sig=FIX7UsYfO3yPyH2VGDlgiWj%2BD1yPMjg%2BvmeEzeSQJ0Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:54.7178795","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A54Z&sr=b&sp=r&sig=yP1dQoh9zfFQW8s9b0aj%2Fy%2Ff6u%2B25SCZv8f%2BzKBfNRs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:54.7177895","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A54Z&sr=b&sp=r&sig=Q4MjgNHxDLChr5MlG07E%2BOcfwptWf9ISOieHM8i2XkQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:54.7179012","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:54 GMT
-      mise-correlation-id:
-      - a10b5c63-5728-4dbd-98f7-ca9b23da1589
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A59Z&sr=b&sp=r&sig=mWEPbC4KY2o17b%2F63bgMvRxtDuQPpKyBMrxBfSfRkQg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:59.9925728","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A59Z&sr=b&sp=r&sig=zs9Eq85FqZEo2n2Nw%2FHx%2F6Sfh2r%2FHp0anaoQ%2FV3b5PU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:59.9924914","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A59Z&sr=b&sp=r&sig=yABXAoL%2BUCb1zvum8bzMDjQSCC%2F0r6NBEacGSWNLlY0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:59.9925912","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:59 GMT
-      mise-correlation-id:
-      - cd61d4a4-66b7-418b-a20e-3b09184b40af
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A05Z&sr=b&sp=r&sig=9ipsY47rgJjG316gcoAdmommu1bYipxnTqlUME%2FvyP8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:05.2700463","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A05Z&sr=b&sp=r&sig=xx8kPzZqqBoyoAefpAZxiZw1AL%2BKc4zhYd1uaRyNMuY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:05.2699743","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A05Z&sr=b&sp=r&sig=dAMVBXTQbsLwHCBOE%2BGMer%2FB0qmJEuh%2FLgoR6oBsDn8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:05.2700625","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:16:05 GMT
-      mise-correlation-id:
-      - 45d22cb1-0e40-4091-9186-755452316d8f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A10Z&sr=b&sp=r&sig=2YBoh5XmT1dv%2BssAyg5XFClNK80j%2FLQHaxn0LYwMATg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:10.5565946","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A10Z&sr=b&sp=r&sig=k9auxSq2nB9zB268AX0Onk8aDcM7BljRqO4DONU9rfw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:10.556514","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A10Z&sr=b&sp=r&sig=cl98mkNxtJl20fkSfhoTJlj3oprgjIlLohfwR0uWk2o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:10.5566098","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A15Z&sr=b&sp=r&sig=XMQ4SHVPdNmnlF06wSXcvlJrSDqWf5x8G0FzGJKV9CI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:15.2061351","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A15Z&sr=b&sp=r&sig=8z5xoRVi431EWWmIP3FX39h4EnF2jGEbydZIZj8e0gU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:15.2060318","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A15Z&sr=b&sp=r&sig=rI8v6iW8IG2MxGV%2BrAvfRKrLZ6yc7pld9xEIgcmRzrs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:15.2061589","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:15.119Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1686,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:10 GMT
+      - Mon, 09 Oct 2023 19:20:15 GMT
       mise-correlation-id:
-      - 3b5bdbf0-af77-4779-a21f-270d0690e567
+      - 4e382f0a-91f9-4342-92d0-1e6683eb01a2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A15Z&sr=b&sp=r&sig=%2Bi8O6pOoDFqI3h6p85WYuCdF6oqf8e88DO5CoMJRzDo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:15.8287872","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A15Z&sr=b&sp=r&sig=azM%2Bt6%2FkQ6apJ2eY%2BY3YrSqm%2BptU%2F13mvxO705vWcKI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:15.8287174","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A15Z&sr=b&sp=r&sig=a6ZxIw152qT8%2B90JsFI1H%2FG8dp6cCiVZxPzt87%2F6yFY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:15.8288032","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A20Z&sr=b&sp=r&sig=M5TPQj%2BXPlccaFBVVg4bf5Br5xroFmo3xLMm5T2xe5s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:20.506849","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A20Z&sr=b&sp=r&sig=Pj3JrHN00yMLWd%2FHIG9YeWak%2B5irtiFghP3on%2BMvRtc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:20.506764","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A20Z&sr=b&sp=r&sig=k9jj%2BHgkcZyfbrVAaFCqFeWWcWyaj9RIBzBc%2BwFuosY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:20.5068698","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:15.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3210'
+      - '3205'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:15 GMT
+      - Mon, 09 Oct 2023 19:20:20 GMT
       mise-correlation-id:
-      - 12ee4730-dd1f-43f5-a286-b7393d628212
+      - b3df3d3f-bd3e-4a4c-bd18-6f9d881f3e5e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,10 +772,190 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A21Z&sr=b&sp=r&sig=pRJK6VGHbndwQAfdG5t%2FT5fuXr2%2BG%2FYkRP26CIRfDG4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:21.101953","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A21Z&sr=b&sp=r&sig=KPKeCEfY%2BgV7ja9i80Mm%2BxB%2BxPNuf9TEc5gqHYKAZ6E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:21.1018868","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A21Z&sr=b&sp=r&sig=kmqmmDdIfBbvHDAxaGoq6mu8CfefQWTHzHWTuIW9Zec%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:21.1019665","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A25Z&sr=b&sp=r&sig=UjaZOnber8ft3mjLk2pE%2BrZ8R52m8HQAaPmE0NIXCKc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:25.8451971","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A25Z&sr=b&sp=r&sig=IOuWwOUZ42yWLyOm7RIg1x0DoFRQJDt1TFwNhdzjoJw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:25.8451234","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A25Z&sr=b&sp=r&sig=XUYxNsmQchVpgkuvAegyW%2FKwLk68r2BzDZfgk6HNapM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:25.8452117","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:15.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:25 GMT
+      mise-correlation-id:
+      - 099d3d2d-1718-4d44-9bd1-b3300f390451
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A31Z&sr=b&sp=r&sig=CSsLvFD6XobKeP1J5VSjL%2Bf1KEeY%2BWaZuqYiwxbbnZ0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:31.1553767","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A31Z&sr=b&sp=r&sig=Jah7171TRD54c8yoAwRnqT7d6kTCiM4sW1YKWEtzwnw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:31.1553057","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A31Z&sr=b&sp=r&sig=GE1rQtFrWARWNfcmfb16Xt0DPIcn%2BAAi1Lh1V7Vxvug%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:31.1553908","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:15.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:31 GMT
+      mise-correlation-id:
+      - a2915c36-26e3-4839-8c6e-23455171c8d7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A36Z&sr=b&sp=r&sig=8NyKZgqxg%2FlCaUPLMvVCMxLs2dMOS1eZkOXsdUnkMVI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:36.4290998","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A36Z&sr=b&sp=r&sig=Jgzu7rL8IWXe5NR9iKMeFgfnN63alui9MDn06TwgmM8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:36.4290118","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A36Z&sr=b&sp=r&sig=Mky4fGDrFuwRw77Bpis4iEP6X5UfBv0360ASIAgwHNg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:36.4291217","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:15.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:36 GMT
+      mise-correlation-id:
+      - 726ffcbe-8d3f-4eff-bf5e-6f737b5f96c2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A41Z&sr=b&sp=r&sig=4ODqVYs%2FEFBArYq6E%2Fc6pdRCTbFgZmOY0R%2FhODF1P1w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:41.7242037","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A41Z&sr=b&sp=r&sig=xIAK%2BmXUKZjc80P9hdKiqEy094%2FBYFImpUKWH3N%2FaYI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:41.7241189","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A41Z&sr=b&sp=r&sig=Bch642fv3jMfJ5cI0DHuhEmIVQvTCAvCLrHptMTqa4o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:41.7242242","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:15.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3207'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:41 GMT
+      mise-correlation-id:
+      - 2801b672-14b6-4310-a9e2-f741b3a34110
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A47Z&sr=b&sp=r&sig=JHSG%2BTptBJ%2BzNjJpsZPYdh92atjDctn2VXccaRu8Hpk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:47.0384877","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A47Z&sr=b&sp=r&sig=vHc%2BBzu2lXQrUzYXIJPW9nRy89Okl5lKmf8%2Fb54aqf4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:47.0384036","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A47Z&sr=b&sp=r&sig=r4D9BHEB63FvpqiVTKy31yMWQUswE55teYa5qrZ%2FoEo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:47.0385096","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:15.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:47 GMT
+      mise-correlation-id:
+      - 0242dc18-eb13-43c4-816c-438f2dd304c7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A52Z&sr=b&sp=r&sig=r4YA69%2FG50tQHoqsuLQSrI1eeqjxmX0%2BA4bZL4o%2B2Uo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:52.3592926","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A52Z&sr=b&sp=r&sig=BHMfmeCllquUN9w%2BJoSjXfz0CO4yjtRxu5cJsNswEgk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:52.3591975","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A52Z&sr=b&sp=r&sig=81RsK9U8hHqoiMq7fiQQRfh6l67Wu99jv29nbbjFKCg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:52.3593171","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:15.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +966,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:21 GMT
+      - Mon, 09 Oct 2023 19:20:52 GMT
       mise-correlation-id:
-      - 4ec72f43-b379-4ef4-8313-35ceaa2649bf
+      - dccd3e07-be66-41ef-9159-2b9773be7392
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,10 +988,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A26Z&sr=b&sp=r&sig=2GPDQh%2Bx0e%2FQtFi3gNZvozc3iWBIVYlqN85hZDDZiVM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:26.3783775","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A26Z&sr=b&sp=r&sig=GKyMkTvlxuFLOkC%2B%2BmJv27ghik6BqwajmjjqMqIjRvI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:26.3782956","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A26Z&sr=b&sp=r&sig=Yh2QXat0UtRkjrjnHcWbhnRdMokbmMtlNmS00ToH%2BAs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:26.3783961","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A57Z&sr=b&sp=r&sig=ZS6seRIzNdt%2FNM65FXCY7R58oyWD3%2BoNo4orYlIPV2s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:57.6454314","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A57Z&sr=b&sp=r&sig=dAUNELNVYR1huOEujGU%2FYIi8sT6hmhHIuxaeg5mvu1c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:57.6453547","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A57Z&sr=b&sp=r&sig=IJx6NAHnyHd5y5Fcf52tl8GWtLjhoUaSqLeMiozTN1A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:57.6454459","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:15.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:57 GMT
+      mise-correlation-id:
+      - 34327e09-e22a-4046-acd8-9623211ecdc8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A03Z&sr=b&sp=r&sig=PPgplDFJypgQBxfaiJr36%2Flmbri51LzAqss1iZRwEAI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:03.0324726","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A03Z&sr=b&sp=r&sig=KZfcAwK2MY%2Fq%2Bv7Z1Cqiw3hXv9cC7zHlNLTfpVS85G0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:03.0323663","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A03Z&sr=b&sp=r&sig=jSL2SzmXYyOMB%2Bx%2FQRzwAK9UibrCs0wELXbsxWi3HLc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:03.0325014","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:59.124Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:03 GMT
+      mise-correlation-id:
+      - 1bfe52ee-6c1f-4467-9b7c-a73aefc59022
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A08Z&sr=b&sp=r&sig=BY8M5IdzgLTfdqk%2BMrDMx01XtmlMth7Ortqlxeo73Tc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:08.3433911","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A08Z&sr=b&sp=r&sig=%2Fv6aYts%2FurvtSSGv3pMaBf5Pkhg6L9FexroaN0JFPWM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:08.3433174","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A08Z&sr=b&sp=r&sig=D8B3U0Dae1KJXK6EChyD5IPk6fAZi1m5ax%2BD%2FdrEZ6k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:08.3434062","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1794,9 +1074,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:26 GMT
+      - Mon, 09 Oct 2023 19:21:08 GMT
       mise-correlation-id:
-      - 3d0df511-5d7b-4f13-9d89-9bd7275a3a1d
+      - 274f9832-783d-45e4-84b7-7d4ceccbac77
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1816,24 +1096,708 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A31Z&sr=b&sp=r&sig=QMKYDEU0YEms8JrpAt%2BLJe8b6Pm5hedbq%2BZ4k%2B3jnwo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:31.6657331","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A31Z&sr=b&sp=r&sig=bmO6ni7qAG1qnHuMfFLO8EyDy44JFZyo%2FbnvGmXyW%2BQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:31.6656329","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A31Z&sr=b&sp=r&sig=Dve%2BwQTuZADozTiQK05VDfMuquhPhf8lzmcMraAJWLU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:31.6657551","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-09T16:13:47.398Z","endDateTime":"2023-10-09T16:16:28.805Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:28.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A13Z&sr=b&sp=r&sig=W70mWOmqWB%2FJjkr1jQmkcNmAtx93OO1nsm6hAEJGIRQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:13.6938847","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A13Z&sr=b&sp=r&sig=eqQjotvDZcEi7jkA9TrC%2F%2BEAchtS%2BWwlAnOkLaB%2FyGc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:13.693782","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A13Z&sr=b&sp=r&sig=pH%2BBVXxGTFknAg1hAqx9u11%2FCHWaBlAvLsDFOACwKjk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:13.6939086","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3339'
+      - '3205'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:31 GMT
+      - Mon, 09 Oct 2023 19:21:13 GMT
       mise-correlation-id:
-      - fa858c7a-220f-443d-9c01-7a6c0ea54383
+      - 107e7866-2943-4f81-9ef9-34904b84cfd0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A18Z&sr=b&sp=r&sig=1ZTEiKRP73Wc7xn1D0ondr60narJl06XWjA0Padh2vs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:18.9981807","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A18Z&sr=b&sp=r&sig=ox5OvPprcoGJwrYoVSe2zjY9Am7yUhBAtO9sMhuh9Yo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:18.998109","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A18Z&sr=b&sp=r&sig=VjtQK11Fq2EwVL0oXYDvBUMF4pLdBFrlrK4AUbQSDhE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:18.9981977","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:19 GMT
+      mise-correlation-id:
+      - 886f609d-dfcf-4f0b-a01e-c71ff79903dd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A24Z&sr=b&sp=r&sig=QJ2B7ebasp9gvz6dLYOGFZAKc30QCXw5UKsU9jXtPi4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:24.3140422","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A24Z&sr=b&sp=r&sig=Bae5xtONiVzbqneRv0fa9%2BdSgVguoZ9g4nQMcsDDFcU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:24.3139733","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A24Z&sr=b&sp=r&sig=5ilbwuzPxt9isjKJ90kKe59cE83e2hrWq9kYRrxG24A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:24.3140592","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:24 GMT
+      mise-correlation-id:
+      - a12e94fa-236c-49d9-8e08-2a934e03c590
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A29Z&sr=b&sp=r&sig=OJH9ROtZGwTBjIeVxABmGE04rvV%2F%2B2%2FTfXFiELzoors%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:29.5839533","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A29Z&sr=b&sp=r&sig=Non443BoRf48%2BgGrz5luMi8GG6RJ6GC8LrU09PyeDjs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:29.5838779","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A29Z&sr=b&sp=r&sig=pBtzrE8fidL1oPdmnAc3GBzHprme88MHORRVERMvrN0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:29.5839699","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:29 GMT
+      mise-correlation-id:
+      - 4cd8f2c7-c793-4293-a0c9-e5ca52e26a98
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A34Z&sr=b&sp=r&sig=zKEQR%2BObINkOdqOMkrRZ7ftQTKIV9Rma2NDf6rnUFVY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:34.8436851","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A34Z&sr=b&sp=r&sig=u%2FMMArQ2sPEcrBPgI8z1JhATtWVVmF7rwsVU0%2BiVqfQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:34.8436185","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A34Z&sr=b&sp=r&sig=wx6Pb6IWOsey1girrtpQKQ1JVGyuCpnwd3yAg0YUu3U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:34.8437008","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:34 GMT
+      mise-correlation-id:
+      - 9f58d08d-d530-412c-8343-ecc791de7ab0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A40Z&sr=b&sp=r&sig=Nq6a8igmau6eTOHBFtDtfnRT4qkGcCoqmP%2BZKg0iB%2BQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:40.2916345","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A40Z&sr=b&sp=r&sig=D%2BA%2FGPCtbdnsVCbDPA9E%2BERD4YIhb7JWTMmo4ugsgm0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:40.291559","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A40Z&sr=b&sp=r&sig=cc9Wgv5TEpLILhWSwOtLCjGnOugUvcsobaaXmGCIq7Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:40.2916523","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:40 GMT
+      mise-correlation-id:
+      - ccf063a8-724a-4bc3-92f4-a65038b52abc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A45Z&sr=b&sp=r&sig=FtnCnfwpVQlDHFKttamM5mHVsAebjouekuXxCBaKEFk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:45.5482501","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A45Z&sr=b&sp=r&sig=swaE440XwuCeOIxTkXb12laMqW11XBetkKTUckdv8ug%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:45.5481575","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A45Z&sr=b&sp=r&sig=2nYhWVRmNv189OD7dJStuRjnTS3SDVNHwhMbCxrhHOI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:45.5482709","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:45 GMT
+      mise-correlation-id:
+      - ad5fd52e-e7e9-442c-a9ed-a51a7ed38e73
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A50Z&sr=b&sp=r&sig=uXeQYIM0PmbqVqdZxCnlAKaUUQ1DCTg6bZ9xirQhxzo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:50.8189273","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A50Z&sr=b&sp=r&sig=DV9OMIWrE8Msokl9e6cv44PBVPP3S03tqWSnnhekA0E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:50.8188548","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A50Z&sr=b&sp=r&sig=%2FXFa%2Bjzub7kRxGCoqV3YPecIogo4oXzYQKwphRIqLQw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:50.8189439","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:50 GMT
+      mise-correlation-id:
+      - 6ead2c0a-a8e7-4e12-b211-4a9a67fe3ced
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A56Z&sr=b&sp=r&sig=YNGaG9gXsMsWfcu2q4mzW2wxcSwjYQ0umSKthpBpV08%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:56.1666904","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A56Z&sr=b&sp=r&sig=ct7uZ64zA9Mo0qcDHmQ41V7GiqRYRKHxTr030y0JhDU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:56.1665957","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A56Z&sr=b&sp=r&sig=nRGQWcflSXKcpBfp99TOtRStI6T1iQ8be7reI36n9uM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:56.1667133","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:56 GMT
+      mise-correlation-id:
+      - f82601d6-c752-49f3-bbda-83c40af6605c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A01Z&sr=b&sp=r&sig=khS1wqE%2B4dj7D87MUhkBx%2FFJbDB79KgovImDSH75w4c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:01.440486","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A01Z&sr=b&sp=r&sig=i7R8EZ9W8aQ%2BIj8VPJZ1nmetJkR3%2FJ6qcRRJa5b%2FQEw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:01.4403976","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A01Z&sr=b&sp=r&sig=Ffq4s6bsKyBKUQ2BUWKwnvBukqxn%2B8jgtTC%2FR6TjHwg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:01.4405076","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:01 GMT
+      mise-correlation-id:
+      - 3f3ce8d7-98d8-41ca-9f7c-46e4e4e10d97
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A06Z&sr=b&sp=r&sig=gStCDxmcqAs5xBw4xSOq6wnNiYyMmXSAoEZfD1kCAd8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:06.6954012","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A06Z&sr=b&sp=r&sig=wK7iBoXrCUdxRHPvMaBD0uhB%2FvIyBMPEvMKKWJxcXMQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:06.69532","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A06Z&sr=b&sp=r&sig=fy7zbZ%2FdhULgJeG678Sl74Hbz411xMAWZCN51aGxxew%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:06.6954219","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:06 GMT
+      mise-correlation-id:
+      - ac37c1d7-68f7-4572-b539-9ea62e675e4d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A11Z&sr=b&sp=r&sig=hL%2Bn84ftWRDLY5TYUXrzVl2fj73ESvZmWz87QMoU5j8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:11.9636158","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A11Z&sr=b&sp=r&sig=mo%2BxCjbnRypu5VSAcYcIIkkEsRJxP%2Bxw1DEV235aLJA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:11.9635407","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A11Z&sr=b&sp=r&sig=c8pa9PKmMHYsZjA%2B3SLoivPhOW1XK7mx4009UbADMxk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:11.9636303","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:11 GMT
+      mise-correlation-id:
+      - 3cf05923-0471-4693-8535-d75554e6ee9d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A17Z&sr=b&sp=r&sig=52mXsGFTtOSlvQfs79A4S4FglEgAAEkm2bREERK9WWo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:17.2211012","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A17Z&sr=b&sp=r&sig=s%2FMYxhcLuqPy2oHEdOL8iYcPMlH%2B7JgfwDy6YSA6buo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:17.2210204","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A17Z&sr=b&sp=r&sig=%2BNasrjjKUO%2FC%2FqG0BU4B0zlHIRd1wUzi4fLhn0raHpk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:17.2211152","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:17 GMT
+      mise-correlation-id:
+      - a8914906-8135-4b1d-8a9c-845afca8a767
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A22Z&sr=b&sp=r&sig=LxGldI67BzO9jK8Hqw47zFs3Tfk%2BYuar8aQmcm6gnjo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:22.4912025","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A22Z&sr=b&sp=r&sig=posnQgGdHC4yuWXy8xu2t3do4z9bHQDFqMbTY0ZBZAs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:22.4911276","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A22Z&sr=b&sp=r&sig=68GPTRZtiRoA25KHJCe5MS2KWdFR8zT2dquO7z%2FZxsQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:22.4912173","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:22 GMT
+      mise-correlation-id:
+      - d1aaa8ad-c59a-4fe9-b853-f688b8087846
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A27Z&sr=b&sp=r&sig=oGvmUy4rC8fPQgtnf%2B4%2F7AdhMo7xYfhH3fRoPYdA5f8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:27.7883079","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A27Z&sr=b&sp=r&sig=lzhoQ9juc3LZ1x4xCpIJyKDnffuMouBLHTzbjsdO0F4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:27.7882385","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A27Z&sr=b&sp=r&sig=8AZ%2BDxfxMMVbV2ibj7DzPdSeIC4iE0ZYQkng2mukiss%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:27.7883228","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:27 GMT
+      mise-correlation-id:
+      - 0144d3ea-4f44-413b-abb0-cd28ae64a66f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A33Z&sr=b&sp=r&sig=yAwkLEGehuXaTGo3Rqi0Mm%2BegO4yyT%2FDMA%2FPG4Apt7U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:33.1065867","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A33Z&sr=b&sp=r&sig=G6LfnS975BHKGcr2iCXpqeZHswTlet9wEO2XQjTLJBA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:33.1065173","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A33Z&sr=b&sp=r&sig=UMK4dsBJWs4X5MJJbuyiZv8C4XG%2BX1QxZ7tMfs4QD4c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:33.1066021","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:33 GMT
+      mise-correlation-id:
+      - 70e848f9-536a-4c06-be52-699b677071d9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A38Z&sr=b&sp=r&sig=K%2Fgq7hfhioGCr2sXOfdqGmkJG5D9I8038t9lsJh3%2FLU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:38.4372313","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A38Z&sr=b&sp=r&sig=Op5U8712YgLs3b5ywndseCLhXgsKWH5ZbC8ilOV%2Fm4U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:38.4371469","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A38Z&sr=b&sp=r&sig=CLJ4hB5x%2Bt2t1tWZi3vrbiUeeAx1mTQTT4rWYi0Xkag%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:38.4372582","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:38 GMT
+      mise-correlation-id:
+      - 60f23734-998d-4b54-9856-f72788e7be91
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A43Z&sr=b&sp=r&sig=EB%2B03ZPP8iXJ0SCIYbTa%2Feaw1aw1Z2DIQY7jxajxypE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:43.7699822","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A43Z&sr=b&sp=r&sig=QiTbuhYW1FS2qwGp61Ejpt%2B1bwuNl0NZmKGlTxkkiIc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:43.7698807","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A43Z&sr=b&sp=r&sig=yfDSyRSaW%2Byx6dxtNLOGvxYgSRNQ9%2FnhlL5l2oP2Rx8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:43.7700059","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:43 GMT
+      mise-correlation-id:
+      - ca630ac8-4969-4ae5-b57a-afa6cab906e8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A49Z&sr=b&sp=r&sig=aO75DWTc3fgcvBFD%2BYMzTfBZj0AMR0Ry2YIDtYKPqrg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:49.0504127","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A49Z&sr=b&sp=r&sig=b9gNoLHvovfLurE7iF14oIXPdrAlONBnvQloMlTMzPs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:49.0503312","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A49Z&sr=b&sp=r&sig=KvL3GYl1HIuwMBIVgpR8kTMNpGIvEI9bhj%2BEQjfJSPo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:49.050429","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:49 GMT
+      mise-correlation-id:
+      - 095c550e-e3e8-42ba-9b17-c1454991bd02
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A54Z&sr=b&sp=r&sig=86NQTDCFAzF5rmWD2NfLQmvVM6HVHVEyrOqk3ryUxQo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:54.3167215","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A54Z&sr=b&sp=r&sig=gAjxMX6QYzyBUhOVxzDq44kXsgV%2BEMgYBOnk2Ceqg2g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:54.3166362","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A54Z&sr=b&sp=r&sig=0qDcb%2FsA1v%2BS79%2BuaGNk3T%2FhSxaniJj4EHjdJriHqRM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:54.3167416","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-09T19:20:15.119Z","endDateTime":"2023-10-09T19:22:52.684Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:52.93Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3336'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:54 GMT
+      mise-correlation-id:
+      - c9b5ca26-4258-4ac8-9c93-f0b60310f4e4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1856,7 +1820,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:49.9979583Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:49.9979583Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:15.8114883Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:15.8114883Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1865,9 +1829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:32 GMT
+      - Mon, 09 Oct 2023 19:22:55 GMT
       etag:
-      - '"9201fcb4-0000-0100-0000-652426830000"'
+      - '"5600d22d-0000-0100-0000-652452350000"'
       expires:
       - '-1'
       pragma:
@@ -1897,24 +1861,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A34Z&sr=b&sp=r&sig=lKzJMCZgSuaLyOfMhKPwIKW2ZXNMIi13O%2FyPPb0tpjk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:34.0848839","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A34Z&sr=b&sp=r&sig=ZEDef3uq%2BSbBbF3KMJvacFt4cgFIyCLB98B5EZwkuxk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:34.0847914","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A34Z&sr=b&sp=r&sig=oh%2FVACXCkeW3oXVV9nWLhJk9qG8aEJBKKxCsI2WrUls%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:34.0849094","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-09T16:13:47.398Z","endDateTime":"2023-10-09T16:16:28.805Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:28.894Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A56Z&sr=b&sp=r&sig=RaDPzaNTGAkm1ZEX37tf1VPH8aRJlQOAUFC0jLn9q6Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:56.6807791","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A56Z&sr=b&sp=r&sig=zAfzeCVT4Ntuw%2FlCiVJdmj1lBWiKlDSOWYs2pwfO2Wk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:56.6807099","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A56Z&sr=b&sp=r&sig=l5f57iuUFQ6IQj4V5mHmqMMynNEIZv7bYWXVXMmvML0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:56.680795","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-09T19:20:15.119Z","endDateTime":"2023-10-09T19:22:52.684Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:52.93Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3345'
+      - '3339'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:34 GMT
+      - Mon, 09 Oct 2023 19:22:56 GMT
       mise-correlation-id:
-      - 8d8b93f7-a9b0-4834-aa99-24cf2be3593b
+      - 69a03065-fa42-4e85-95f1-4ab6bc6f5604
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1937,7 +1901,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:49.9979583Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:49.9979583Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:15.8114883Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:15.8114883Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1946,9 +1910,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:34 GMT
+      - Mon, 09 Oct 2023 19:22:58 GMT
       etag:
-      - '"9201fcb4-0000-0100-0000-652426830000"'
+      - '"5600d22d-0000-0100-0000-652452350000"'
       expires:
       - '-1'
       pragma:
@@ -1980,7 +1944,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -1990,9 +1954,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Mon, 09 Oct 2023 16:16:36 GMT
+      - Mon, 09 Oct 2023 19:22:59 GMT
       mise-correlation-id:
-      - c446b35e-3448-40a4-8dd3-3d91982c39cf
+      - 8c8c428c-49f9-447e-b2ca-781b3112f01b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2015,7 +1979,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:49.9979583Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:49.9979583Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:15.8114883Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:15.8114883Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2024,9 +1988,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:37 GMT
+      - Mon, 09 Oct 2023 19:23:00 GMT
       etag:
-      - '"9201fcb4-0000-0100-0000-652426830000"'
+      - '"5600d22d-0000-0100-0000-652452350000"'
       expires:
       - '-1'
       pragma:
@@ -2056,7 +2020,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
+    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -2070,9 +2034,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:38 GMT
+      - Mon, 09 Oct 2023 19:23:01 GMT
       mise-correlation-id:
-      - b2e3cf7e-5ddc-4564-a5b5-cf6bb99d5988
+      - b3251e9c-06ac-4798-884f-5cf9173ab421
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_delete.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_delete.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:12:19.411425Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:12:19.411425Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:49.9979583Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:49.9979583Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:54 GMT
+      - Mon, 09 Oct 2023 16:13:22 GMT
       etag:
-      - '"1a0a5ac0-0000-0100-0000-64af09250000"'
+      - '"9201fcb4-0000-0100-0000-652426830000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:12:55 GMT
+      - Mon, 09 Oct 2023 16:13:23 GMT
       mise-correlation-id:
-      - 992806a1-0f88-4062-9aeb-a8c961e21861
+      - 080c79a2-f0f4-4864-82f6-f92886d7df28
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -85,12 +85,12 @@ interactions:
 - request:
     body: '{"displayName": "CLI-Test", "description": "Test created from az load test
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
-      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "loadTestConfiguration":
+      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"11dddcfb-68e7-41c0-ac1c-debd805549a0": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "c863aaae-f00e-40bb-94b7-437fcf5ddff3":
+      {"passFailMetrics": {"922adde6-d529-4eae-a7e7-83b251a05045": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "941e5a0e-25ff-446b-826d-9b6622947495":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "2ee24c9a-cb00-4fc3-a690-e754d00b19c0": {"aggregate": "avg", "clientMetric":
+      "50"}, "f2709412-7090-4297-94c4-b061847f9a6d": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -100,32 +100,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '768'
+      - '789'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"11dddcfb-68e7-41c0-ac1c-debd805549a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"c863aaae-f00e-40bb-94b7-437fcf5ddff3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"2ee24c9a-cb00-4fc3-a690-e754d00b19c0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:12:56.163Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:12:56.163Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:13:24.492Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:24.492Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1062'
+      - '1008'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:56 GMT
+      - Mon, 09 Oct 2023 16:13:24 GMT
       location:
-      - https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+      - https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 542dae19-8977-4d17-914c-22b1a38b489e
+      - df960bd3-50ab-4a46-919b-c680ad3ba390
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:56 GMT
+      - Mon, 09 Oct 2023 16:13:24 GMT
       mise-correlation-id:
-      - 25ebd598-44a6-42f7-8744-bd7040f63442
+      - d0f132e1-afb0-4568-9f73-533c702404e9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A22%3A57Z&sr=b&sp=r&sig=Zk4NCdVYDw59afLjlfaGlxLL3j5MeCVLTvbMe3VqZGQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:22:57.1664817","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A25Z&sr=b&sp=r&sig=XAMWpOUHgX%2BYaj%2By4m%2Bui9g7JOrXX%2BxnZ2Q6XKwcz4I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:25.2923711","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '557'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:57 GMT
+      - Mon, 09 Oct 2023 16:13:25 GMT
       location:
-      - https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 156f20f9-cff8-45eb-ba9a-19cda2f79ca9
+      - a095359b-3a99-4f9a-9a18-69adfcfac6b3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A22%3A57Z&sr=b&sp=r&sig=A2CL1uMC1goptut4VdaQ38lgAxfqjlsR8Z3LsQNusCE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:22:57.4330347","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A25Z&sr=b&sp=r&sig=mBVdvBtbet9O69kVGrK1DmAMrowBL5eS57jq4YQtgRw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:25.573014","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '548'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:57 GMT
+      - Mon, 09 Oct 2023 16:13:25 GMT
       mise-correlation-id:
-      - bd4cde77-72e2-4448-8689-c5a3a24621ba
+      - 8d0ee836-ed74-4ad0-acbb-1045a1530959
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A23%3A03Z&sr=b&sp=r&sig=nSYf8kofLdarbl5A9A5H4LOl%2B4bNU60%2B7TfAzM3j2U0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:23:03.7308575","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A30Z&sr=b&sp=r&sig=L5v%2B0HzpEzlJ7%2Bu%2BwRFLQ2aF48rdl1r8%2BBan4svzkzI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:30.8464948","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '557'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:03 GMT
+      - Mon, 09 Oct 2023 16:13:30 GMT
       mise-correlation-id:
-      - 67250821-80ef-41b0-898b-f57ad1cb8524
+      - 2edf02c6-a198-42f3-82f4-bd31b6465169
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A23%3A09Z&sr=b&sp=r&sig=3Uas0hG7vPa%2BSZ8RROP%2FOTV2Jhryvq2mFx4Wk%2BLluKw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:23:09.0503397","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A36Z&sr=b&sp=r&sig=Dr7IiOuVyqZpSyyOoYMlzi8vehDz7R0Xi%2FSEOBScW48%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:36.1304883","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:09 GMT
+      - Mon, 09 Oct 2023 16:13:36 GMT
       mise-correlation-id:
-      - a747da57-f590-40ff-9ae6-8c4f88ba1653
+      - ecf6af1d-d74f-4641-8151-9b00dc8ca092
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A23%3A18Z&sr=b&sp=r&sig=hXckXwwbfF2fJ98bc28UYgOaRtwsgh6VfYwRD09TI3U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:23:18.5954447","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A41Z&sr=b&sp=r&sig=E8UwO8l3knJA5n5Tqt1GlOial3RNfpptDZysEwfnrfE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:41.41201","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '545'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:18 GMT
+      - Mon, 09 Oct 2023 16:13:41 GMT
       mise-correlation-id:
-      - 3bdb71e5-815e-4bd6-a372-ee2a3c3192f2
+      - f7b1ad7b-5f8b-45bb-bc43-e4563aa12fee
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"11dddcfb-68e7-41c0-ac1c-debd805549a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"c863aaae-f00e-40bb-94b7-437fcf5ddff3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"2ee24c9a-cb00-4fc3-a690-e754d00b19c0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A19Z&sr=b&sp=r&sig=mFbLYsLjeBkE69Szx%2FXg8qhkB5SDs0%2BbwOkwDIdoiTc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:19.2298776","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:12:56.163Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:10.428Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A41Z&sr=b&sp=r&sig=%2BnOPAyshPmP7XA2lpX0q7bnOtDUHzxj%2FrAi7hxjMIgM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:41.6827014","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:13:24.492Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:38.715Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1635'
+      - '1581'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:19 GMT
+      - Mon, 09 Oct 2023 16:13:41 GMT
       mise-correlation-id:
-      - 85e2a261-31e2-4cee-b435-fb4118784dc0
+      - 389f0d2a-b558-474a-bbc8-1b2a0a3677f5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:12:19.411425Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:12:19.411425Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:49.9979583Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:49.9979583Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:20 GMT
+      - Mon, 09 Oct 2023 16:13:42 GMT
       etag:
-      - '"1a0a5ac0-0000-0100-0000-64af09250000"'
+      - '"9201fcb4-0000-0100-0000-652426830000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"11dddcfb-68e7-41c0-ac1c-debd805549a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"c863aaae-f00e-40bb-94b7-437fcf5ddff3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"2ee24c9a-cb00-4fc3-a690-e754d00b19c0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A24Z&sr=b&sp=r&sig=dISuulfUkbfXsocC6Me%2BU09JzkozTd6QINrBuOXDI5U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:24.347174","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:12:56.163Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:10.428Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A43Z&sr=b&sp=r&sig=Yd0nQGQW04nq3y1ohMN9bJTOUgXXt%2BWhfrGu%2BPVNr20%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:43.9672361","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:13:24.492Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:38.715Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1644'
+      - '1593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:24 GMT
+      - Mon, 09 Oct 2023 16:13:43 GMT
       mise-correlation-id:
-      - eefea105-2d54-4481-a94b-78a5cf50abee
+      - 06d4d261-aeef-49dd-96b5-f96321e7029e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:12:19.411425Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:12:19.411425Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:49.9979583Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:49.9979583Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:26 GMT
+      - Mon, 09 Oct 2023 16:13:44 GMT
       etag:
-      - '"1a0a5ac0-0000-0100-0000-64af09250000"'
+      - '"9201fcb4-0000-0100-0000-652426830000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:13:27 GMT
+      - Mon, 09 Oct 2023 16:13:46 GMT
       mise-correlation-id:
-      - 083988be-8a0b-4e14-a927-a6dd7dce8aaa
+      - 603e046e-f79f-4409-be2d-652ab38a57be
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"11dddcfb-68e7-41c0-ac1c-debd805549a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"c863aaae-f00e-40bb-94b7-437fcf5ddff3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"2ee24c9a-cb00-4fc3-a690-e754d00b19c0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/3b837208-03a5-44d0-9cee-43e610b00364?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A28Z&sr=b&sp=r&sig=4Z%2BVk0zL%2FoUYRURaXsZ9av0tbMtFK5mCZ35dauM8aO4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:28.6497071","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A28Z&sr=b&sp=r&sig=xK2PCJ%2BQv9Vd%2FBemhdhFhBKNdisZO%2BFjQUx3CE1XwIQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:28.6496341","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/ad14f197-35b1-4adb-ae55-fea081030678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A28Z&sr=b&sp=r&sig=Wi6ScAzdBxc0jjJKrc8bCPuiHcE7IMtHC3sSsr%2BPlOU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:28.64973","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-07-12T20:13:27.625Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-07-12T20:13:29.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:29.108Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A47Z&sr=b&sp=r&sig=51dWVaXu%2FtS48B0OVfmOmGTvJseHQCgijVtMvx43%2BBw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:47.0844048","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A47Z&sr=b&sp=r&sig=K4Im7rXkpcJytIDugRgL2M7ybq7LER%2BzJeUNXZeHuVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:47.0842529","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A47Z&sr=b&sp=r&sig=Nw3yyPG3wXr0b1i55m6u6uxXlHQCIYFviuE9L%2FfGQEg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:47.0844285","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:46.996Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3193'
+      - '3156'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:29 GMT
+      - Mon, 09 Oct 2023 16:13:47 GMT
       location:
-      - https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+      - https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 9a4e257a-2285-496a-a87a-62ddebdde465
+      - 78c39a13-a87c-49c5-9ec8-8fec53dd41e3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"11dddcfb-68e7-41c0-ac1c-debd805549a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"c863aaae-f00e-40bb-94b7-437fcf5ddff3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"2ee24c9a-cb00-4fc3-a690-e754d00b19c0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/3b837208-03a5-44d0-9cee-43e610b00364?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A29Z&sr=b&sp=r&sig=lV2UBdahkpTRKskl7Fpfj92Rs4efi05Up2XDPqk0WC0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:29.396401","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A29Z&sr=b&sp=r&sig=imtCFB95k6k6ZwILdaUSWjgrhIQnzdbtSCJBmRSTCTI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:29.3963302","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/ad14f197-35b1-4adb-ae55-fea081030678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A29Z&sr=b&sp=r&sig=jxaP%2FvH1do%2BZHHs38a%2BhYP0FmHSeXTl9c5mO3%2FSHxv0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:29.3964155","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-07-12T20:13:27.625Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-07-12T20:13:29.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:29.108Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A47Z&sr=b&sp=r&sig=twXuxF%2BroLgRLYteda9yyocIKMvli9IoL985xGs04mo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:47.5344788","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A47Z&sr=b&sp=r&sig=T1kbernuQyQkg7bRk41A3IJA9mg2piOS0TExdywn8KE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:47.534391","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A47Z&sr=b&sp=r&sig=9GMuOufzXIWfEvdZ1uoU8rlBgedIYVlVMZpsBKZUH8s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:47.5345045","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:47.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3190'
+      - '3194'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:29 GMT
+      - Mon, 09 Oct 2023 16:13:47 GMT
       mise-correlation-id:
-      - ef4c0d8d-3042-4f27-a649-54e766685593
+      - ec768601-2091-499a-8a50-097528ace9ad
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"11dddcfb-68e7-41c0-ac1c-debd805549a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"c863aaae-f00e-40bb-94b7-437fcf5ddff3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"2ee24c9a-cb00-4fc3-a690-e754d00b19c0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/3b837208-03a5-44d0-9cee-43e610b00364?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A34Z&sr=b&sp=r&sig=SyxjQujOf1TmqfZ4jU06K9y0l3jpdgn6shQW8QzQE%2Fo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:34.6742077","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A34Z&sr=b&sp=r&sig=aumHe1j1hJV7Gw3kzRel7geAqUfuWx1DYd1%2BqEdlUAI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:34.6741281","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/ad14f197-35b1-4adb-ae55-fea081030678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A34Z&sr=b&sp=r&sig=NQtN3MHgQ%2FDYtopS6HXx%2Fyw7sX3oreINe0G%2FmEBaMh8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:34.6742221","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:30.328Z","executedDateTime":"2023-07-12T20:13:27.625Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-07-12T20:13:29.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:30.474Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A52Z&sr=b&sp=r&sig=4U3xN5fVGDbRpHBoW%2BRO1NOpFGfPom2uQT3JbEz3WYA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:52.8450172","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A52Z&sr=b&sp=r&sig=t53j5aNQdWOBbySkZXwcM2h3Igb8eRMbFpBbwYC5oXA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:52.8449224","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A52Z&sr=b&sp=r&sig=zLFUHj6Rbe6qHTaerZ34owFSmSuqMH6tTrvIZSOXC1c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:52.8450385","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:47.601Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3240'
+      - '3197'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:34 GMT
+      - Mon, 09 Oct 2023 16:13:52 GMT
       mise-correlation-id:
-      - 36d44743-cd32-43d3-8be9-c556d875be94
+      - a1ece2fb-90e4-4ac0-b685-1d7414d4ef77
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"11dddcfb-68e7-41c0-ac1c-debd805549a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"c863aaae-f00e-40bb-94b7-437fcf5ddff3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"2ee24c9a-cb00-4fc3-a690-e754d00b19c0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/3b837208-03a5-44d0-9cee-43e610b00364?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A40Z&sr=b&sp=r&sig=098a%2BOL%2BPg1haULmrSJ62UESCjXE0XsPU5LQ2Hy2nAg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:40.0011026","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A40Z&sr=b&sp=r&sig=yu%2FdItsHL2GRz5DyN76J8%2FQVNpvJZhYmxRZRCrk6cos%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:40.0010081","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/ad14f197-35b1-4adb-ae55-fea081030678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A40Z&sr=b&sp=r&sig=PEDMmdCVq0n6OTvneE53bAPb5v%2F4OjVxjmgN0KMpnOA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:40.0011177","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:30.328Z","executedDateTime":"2023-07-12T20:13:27.625Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-07-12T20:13:29.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:30.474Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A58Z&sr=b&sp=r&sig=ZyGliS041tI8yecibsSqpu%2FDzSfpt762GSjhs9kh9co%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:58.1469445","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A58Z&sr=b&sp=r&sig=uRYlYDbWhj3Ms30jBcuhgo2%2Fu%2BhJXfDWRK8BCK6KbeE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:58.1468364","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A58Z&sr=b&sp=r&sig=T62SqqJ50kaMUywuIj%2FApAKoN4554UuL%2Foq%2BEmApmsE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:58.1469708","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:47.601Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3240'
+      - '3207'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:39 GMT
+      - Mon, 09 Oct 2023 16:13:58 GMT
       mise-correlation-id:
-      - ed7b5c77-35a1-4d15-b097-8ef66e8a21f5
+      - f9585f18-857a-4e20-a589-51073fb195fb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"11dddcfb-68e7-41c0-ac1c-debd805549a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"c863aaae-f00e-40bb-94b7-437fcf5ddff3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"2ee24c9a-cb00-4fc3-a690-e754d00b19c0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/3b837208-03a5-44d0-9cee-43e610b00364?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A45Z&sr=b&sp=r&sig=ypYOColi6Oq6JecP1vBtVy3hEhBHiKlaApgkDTu%2BVlM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:45.3481226","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A45Z&sr=b&sp=r&sig=QIRRsJQblDdRSm5UPykIK6mLfMSTA4sFi3NzMULiZhg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:45.3480358","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/ad14f197-35b1-4adb-ae55-fea081030678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A45Z&sr=b&sp=r&sig=0S0U0PtZDv8sTk0W7oTT%2F49ulLZFh9S33GZpjnuLRSY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:45.3481403","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:30.328Z","executedDateTime":"2023-07-12T20:13:27.625Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-07-12T20:13:29.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:30.474Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A03Z&sr=b&sp=r&sig=aMWWLDhYmS0XvypDwhvlo%2FWIjv4M3a4Q5oaADny8%2B%2Fc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:03.4322775","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A03Z&sr=b&sp=r&sig=h7wOlRqHsEzlO2CAwEkneXnK4VwfSiD0L3mfJKJxtCA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:03.4321848","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A03Z&sr=b&sp=r&sig=g8peeZxv78ThWgMYbP6xKvGV3SeQQDdkZjfgsiGgNag%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:03.4322987","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:47.601Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3234'
+      - '3201'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:46 GMT
+      - Mon, 09 Oct 2023 16:14:03 GMT
       mise-correlation-id:
-      - 1ce12fef-2b8e-4cf6-8938-82644816432c
+      - a7ac0877-3832-47c2-803c-86955c5cdd77
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"11dddcfb-68e7-41c0-ac1c-debd805549a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"c863aaae-f00e-40bb-94b7-437fcf5ddff3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"2ee24c9a-cb00-4fc3-a690-e754d00b19c0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/3b837208-03a5-44d0-9cee-43e610b00364?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A51Z&sr=b&sp=r&sig=p%2B%2BsibPhKgPqNXg%2BBFWpvnegqqoPqQSWmfV69pF9%2FAE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:51.9199181","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A51Z&sr=b&sp=r&sig=Kk4VR7t0kJJ%2FlDtUG9dduFqM8R%2B3NSOZinUcGBNYubk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:51.9198439","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/ad14f197-35b1-4adb-ae55-fea081030678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A51Z&sr=b&sp=r&sig=RXJmxvRzNFumfa%2FwGnLk7prIsUEIMeLmXDjZZVU6ZUo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:51.9199324","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:30.328Z","executedDateTime":"2023-07-12T20:13:27.625Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-07-12T20:13:29.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:30.474Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A08Z&sr=b&sp=r&sig=cJYmMVs%2Bl%2FhZBJjMEU7VQqVknztx18Mr6e62JtJdoHc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:08.7099803","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A08Z&sr=b&sp=r&sig=X1Hqi8iKDPwZrcNClhHRP4nuZiJBrPVvQ6QDUc9%2FkcM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:08.7099081","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A08Z&sr=b&sp=r&sig=DgvLLahCYVz5SSbB%2B1eoiE3G%2FqT6GQ%2FUs9cP3vk92G0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:08.709994","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:47.601Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3244'
+      - '3206'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:51 GMT
+      - Mon, 09 Oct 2023 16:14:08 GMT
       mise-correlation-id:
-      - cbdfb63c-6b36-45fa-a462-90571e7e76e0
+      - 0c07fc8d-b0be-4ce7-829f-74b7065710e4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -880,23 +880,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"11dddcfb-68e7-41c0-ac1c-debd805549a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"c863aaae-f00e-40bb-94b7-437fcf5ddff3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"2ee24c9a-cb00-4fc3-a690-e754d00b19c0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/3b837208-03a5-44d0-9cee-43e610b00364?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A57Z&sr=b&sp=r&sig=0ho2mYMsIcoo%2Ffxr7cCywoFeo09%2FZceqfuHLu9N9a%2Fg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:57.2129938","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A57Z&sr=b&sp=r&sig=kB8lFR%2BW9HPteoomXNQMb9FaUHhEGD%2BLWPi3Gpv%2BRis%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:57.212927","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/ad14f197-35b1-4adb-ae55-fea081030678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A57Z&sr=b&sp=r&sig=Lzyl6HCRJv3c%2B6Poi%2Fsjh%2F7Uapr6BFdjwy7Bzjv2uls%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:57.2130079","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:30.328Z","executedDateTime":"2023-07-12T20:13:27.625Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-07-12T20:13:29.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:30.474Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A14Z&sr=b&sp=r&sig=AwcUH3my07gc73GmH8Y7VuSvG2xn2%2BxWkTOUApSC4kw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:14.3263628","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A14Z&sr=b&sp=r&sig=qHrn5bTzlhzdIdbLNiDfjM7EFosyTUmCjhMJqq%2FD6qA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:14.3262859","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A14Z&sr=b&sp=r&sig=EQkF1jtyh%2BdVDRQDr8zdexqJrG6RVLovLIaVQG5GuNw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:14.3263921","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:47.601Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3247'
+      - '3201'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:57 GMT
+      - Mon, 09 Oct 2023 16:14:14 GMT
       mise-correlation-id:
-      - 81eef054-4806-464d-8f6e-19ed91a1a1ea
+      - 031bc97b-47eb-4011-8fd3-81d3d654f60c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -916,23 +916,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"11dddcfb-68e7-41c0-ac1c-debd805549a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"c863aaae-f00e-40bb-94b7-437fcf5ddff3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"2ee24c9a-cb00-4fc3-a690-e754d00b19c0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/3b837208-03a5-44d0-9cee-43e610b00364?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A03Z&sr=b&sp=r&sig=RCXyW17%2B%2FF%2BV7viun7INTkcLSkvcnb6BJWDATKlpmdQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:03.2711407","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A03Z&sr=b&sp=r&sig=%2FUPwxYdvKr696SFylCDLh2xor7pM2p%2FsrWQJqUT0oVE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:03.27108","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/ad14f197-35b1-4adb-ae55-fea081030678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A03Z&sr=b&sp=r&sig=YKsegLP248w%2Fvy9bjtVIDyVVpr%2F7jjALs4Ljx2Drqps%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:03.2711545","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:30.328Z","executedDateTime":"2023-07-12T20:13:27.625Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-07-12T20:13:29.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:30.474Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A19Z&sr=b&sp=r&sig=hjjvCFpTz5pCCNF0j7SJ0CXP%2BZ38%2F7YZ2XKqHfCwbpU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:19.6214184","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A19Z&sr=b&sp=r&sig=oawAE2bKSKY11lQl%2BQUNTWkEf%2FVS%2FcxQYWUUlEFPGnE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:19.6213217","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A19Z&sr=b&sp=r&sig=jEmZEm5QIH8aIHQqQMf8oewbA%2F5cyqjz4JdPhXJqWdw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:19.6214395","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:47.601Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3242'
+      - '3207'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:03 GMT
+      - Mon, 09 Oct 2023 16:14:19 GMT
       mise-correlation-id:
-      - 7fe8d12b-e928-4388-bee6-dd12e7db1bd8
+      - 77e20adc-0d8f-415e-8f61-8b620ac13ca8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -952,23 +952,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"11dddcfb-68e7-41c0-ac1c-debd805549a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"c863aaae-f00e-40bb-94b7-437fcf5ddff3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"2ee24c9a-cb00-4fc3-a690-e754d00b19c0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/3b837208-03a5-44d0-9cee-43e610b00364?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A08Z&sr=b&sp=r&sig=G8koEiwkdljnFveoVGavZ6XHOkj9WRhqBteniam935I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:08.8674735","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A08Z&sr=b&sp=r&sig=rrVZNJWRgb0xUgYHKlupewn8jYy5awRGdyWoADdYWR0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:08.8674096","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/ad14f197-35b1-4adb-ae55-fea081030678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A08Z&sr=b&sp=r&sig=jlgD24MasUH1hGc3igE%2BIOK%2FG2lpjuLPrgZ9bnRKNX8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:08.8674877","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:30.328Z","executedDateTime":"2023-07-12T20:13:27.625Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-07-12T20:13:29.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:30.474Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A25Z&sr=b&sp=r&sig=np6%2BR9Dghbmzp1QQo10%2FPFC9U3yhLQVbSCnLN5lpyew%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:25.003221","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A25Z&sr=b&sp=r&sig=ECQyChfWS%2FZBfoUOCTieOAOIzKOkl5EOaf1P1Th3LWA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:25.0031156","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A25Z&sr=b&sp=r&sig=tOP%2FPN%2B15BbotJgbnup1%2BIFaZRK7BAcafP5%2BNgz3lqY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:25.0032441","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:47.601Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3234'
+      - '3208'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:08 GMT
+      - Mon, 09 Oct 2023 16:14:25 GMT
       mise-correlation-id:
-      - 1220de20-1a33-4074-bdfa-a789b1a64228
+      - e143cfb8-719b-4979-86ea-8a50b005225d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -988,23 +988,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"11dddcfb-68e7-41c0-ac1c-debd805549a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"c863aaae-f00e-40bb-94b7-437fcf5ddff3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"2ee24c9a-cb00-4fc3-a690-e754d00b19c0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/3b837208-03a5-44d0-9cee-43e610b00364?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A14Z&sr=b&sp=r&sig=81aG2kaBc6oycPx63bI8Xwzml5H%2BnsL2a1z23jSKNTA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:14.1871704","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A14Z&sr=b&sp=r&sig=NyOhW0D5ELsVvRVKup%2FQVLuJQ%2BWDw4nA%2FYU2XmM7iks%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:14.1871034","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/ad14f197-35b1-4adb-ae55-fea081030678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A14Z&sr=b&sp=r&sig=1Jv4bFiADORjDinIMw7XP9MI0uG9NXSyGTWxM17gyU8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:14.1871846","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","testId":"delete-test-case","status":"CONFIGURING","startDateTime":"2023-07-12T20:13:30.328Z","executedDateTime":"2023-07-12T20:13:27.625Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-07-12T20:13:29.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:13.138Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A30Z&sr=b&sp=r&sig=sjtCmo1gDd%2FpwzmPiVtzqIVxQrj%2FNwkqf8Q0fF2%2BaWc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:30.2843163","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A30Z&sr=b&sp=r&sig=mG2o21jJGCnx0IIImovis1Vx%2BGiuzo1KUDYGKgPp4h8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:30.2842121","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A30Z&sr=b&sp=r&sig=PWSJqj%2FINVtn%2BfMqatrgj4pDyYSLYwPjFMTfY8jSenQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:30.284331","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONED","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:30.225Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3237'
+      - '3205'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:14 GMT
+      - Mon, 09 Oct 2023 16:14:30 GMT
       mise-correlation-id:
-      - 5eb7b328-f1e5-4b92-9144-985fa12e002d
+      - e5b494f3-8d3d-4e63-bcea-402b021c3843
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1024,23 +1024,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"11dddcfb-68e7-41c0-ac1c-debd805549a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"c863aaae-f00e-40bb-94b7-437fcf5ddff3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"2ee24c9a-cb00-4fc3-a690-e754d00b19c0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/3b837208-03a5-44d0-9cee-43e610b00364?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A19Z&sr=b&sp=r&sig=HK5rwcO9Jh1FhM2t83mgeYiMYE495%2FO9%2FExpLIw78oM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:19.4680638","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A19Z&sr=b&sp=r&sig=IE8LnjOBnY22rMqFKDhRkg%2Bv5dubtT19DM4APuKOsV0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:19.4679953","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/ad14f197-35b1-4adb-ae55-fea081030678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A19Z&sr=b&sp=r&sig=PE1DeO7eRdmKBLe9Mnz7JQCqAETDbke2VTEUCj8Ps2Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:19.4680781","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:13:30.328Z","executedDateTime":"2023-07-12T20:13:27.625Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-07-12T20:13:29.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:16.841Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A35Z&sr=b&sp=r&sig=YBYwhLRCCWBr0HClgMLTCtQhzRN9qmSl8Tg5PhK0zx4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:35.5612035","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A35Z&sr=b&sp=r&sig=W5Z5q53QAuBuDg0tWEMaqMEOTTxGABF0xQ2MQDNUXQY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:35.5611113","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A35Z&sr=b&sp=r&sig=0txgpDo7sPwme4SIlbcJ%2BACmQh77yHtjE6hoWe2opQM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:35.5612197","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3233'
+      - '3194'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:19 GMT
+      - Mon, 09 Oct 2023 16:14:35 GMT
       mise-correlation-id:
-      - d5a81d0b-7984-470a-b215-daee7ea298d7
+      - 26afd526-ed8d-4bc8-9613-324639030043
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,23 +1060,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"11dddcfb-68e7-41c0-ac1c-debd805549a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"c863aaae-f00e-40bb-94b7-437fcf5ddff3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"2ee24c9a-cb00-4fc3-a690-e754d00b19c0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/3b837208-03a5-44d0-9cee-43e610b00364?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A24Z&sr=b&sp=r&sig=CqVowcswfnfgyZJUQx%2FO%2FdRkvZ96K0EYI4J2bUVmFIk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:24.7380782","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A24Z&sr=b&sp=r&sig=fg4SebsKaCNmUOub9K4nl4kXEXFdapXf1TYH2YmgQSU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:24.7379964","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/ad14f197-35b1-4adb-ae55-fea081030678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A24Z&sr=b&sp=r&sig=wAmp62hyQCerOpVWuZ%2FR7kQlJbD3aHWj%2FKTeSWU7m4I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:24.7380978","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:13:30.328Z","executedDateTime":"2023-07-12T20:13:27.625Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-07-12T20:13:29.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:16.841Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A40Z&sr=b&sp=r&sig=XH%2Fc6DnkOmTKuJsrqZjOGwO5sZU8wwYthY%2Boi0q0NM4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:40.8294694","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A40Z&sr=b&sp=r&sig=tS1QaNfzwuJFGIAtmQ3T1TVGQTQqyzJ1s1ZZ1jDeZO8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:40.8293998","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A40Z&sr=b&sp=r&sig=lLLqHTrlZKZcj4GEpm7C7sliAV90QER%2FPDC8B6%2F4OiE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:40.829484","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3235'
+      - '3199'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:24 GMT
+      - Mon, 09 Oct 2023 16:14:40 GMT
       mise-correlation-id:
-      - 42592a20-116e-45be-b201-7ecf7217aa1f
+      - c01eaab0-abe4-4d21-9e71-3a57974b840c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1096,24 +1096,744 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"11dddcfb-68e7-41c0-ac1c-debd805549a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"c863aaae-f00e-40bb-94b7-437fcf5ddff3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"2ee24c9a-cb00-4fc3-a690-e754d00b19c0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/3b837208-03a5-44d0-9cee-43e610b00364?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A30Z&sr=b&sp=r&sig=vGYz6GrXkRzegWk1PernI9FJk8kdbvmMT%2B%2FJvSLTMl8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:30.0139312","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A30Z&sr=b&sp=r&sig=eB4lT62os0trZJeeShpv5fLtNVWHY2w4HjHJSPJY0T8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:30.0138596","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/ad14f197-35b1-4adb-ae55-fea081030678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A30Z&sr=b&sp=r&sig=dPv4mdMuc5VQ3RUgbsYFKEjIcemTb3jB5xq8E47a9gc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:30.0139461","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-07-12T20:13:30.328Z","endDateTime":"2023-07-12T20:14:27.291Z","executedDateTime":"2023-07-12T20:13:27.625Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-07-12T20:13:29.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:27.365Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A46Z&sr=b&sp=r&sig=O4scBzbFtYnspzZvP2xnf0uxeBkRj0zONyGbAKy%2BB7o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:46.1435692","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A46Z&sr=b&sp=r&sig=JSWH%2FMSliq%2FMo%2FpdiI39tIMRJFM96OBam%2FHXupIVGTY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:46.1434784","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A46Z&sr=b&sp=r&sig=ezq5DMuC0dKDLVd5wYWF9W9glqXdF3sLxVQGQ%2FrSqrc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:46.1435901","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3366'
+      - '3204'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:30 GMT
+      - Mon, 09 Oct 2023 16:14:46 GMT
       mise-correlation-id:
-      - a39ad90f-6840-41ff-aa1e-b098bcaeecb1
+      - 9839fca3-e06c-4cb0-8ee0-83568d0a339a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A51Z&sr=b&sp=r&sig=CF545PSvlZFmXUa3s2rW0UychkLecU%2FDVTZz%2BH%2Bfc9w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:51.4131897","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A51Z&sr=b&sp=r&sig=xh8PMIjYRqApNRa9d1mz1%2BTxp3EjIY4ONtZ6fGGEEto%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:51.4130965","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A51Z&sr=b&sp=r&sig=k%2FZJxDWoQ1ZNvAgtvM6TUgyS4A%2FFDrN34Wd0Neyetd4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:51.4132121","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:51 GMT
+      mise-correlation-id:
+      - 118325b7-fc29-42b9-834a-82322ae4efe9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A56Z&sr=b&sp=r&sig=IuOJKOML6Wpns3kpj59GWnnsHRelv23GhltqkSq9sMk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:56.6799024","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A56Z&sr=b&sp=r&sig=ZxXK%2B%2BzFFckjOG6RfDFb22p2mgUk0xVW1kNAxMeCtTQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:56.6797642","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A56Z&sr=b&sp=r&sig=UgdtcMGhP2sAtP2JMzjs%2BQI%2BsRkyGl5Xd9uzjWZfAik%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:56.67993","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:56 GMT
+      mise-correlation-id:
+      - 8723b23e-eb4d-490e-865f-30a0665b3065
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A01Z&sr=b&sp=r&sig=GYOlZAfbRec8kIgYWL%2BprJNhnN65GM0zMUKKozGUz1M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:01.9547032","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A01Z&sr=b&sp=r&sig=x1Y5K08D3r9RbkkCcdAsEeagKjSXl1bINXGd%2BH%2B6Hl0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:01.954602","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A01Z&sr=b&sp=r&sig=XlppS43mYDK%2FW3ScG4sH9uaDwTM0iTwrSVF2la1LSfQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:01.9547267","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:01 GMT
+      mise-correlation-id:
+      - ba8964b2-2e63-4fe6-99d0-9752a8b1e8ac
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A07Z&sr=b&sp=r&sig=9vNc7PZx%2BUj8LVTmZkctYevGiHRkA8qwyByW%2BSoZ7iQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:07.236345","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A07Z&sr=b&sp=r&sig=EOuH%2BMptL2f364DgWYVORyADK7riUHG3qr81yHzaWig%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:07.2362759","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A07Z&sr=b&sp=r&sig=eQmgXrn3GjKXDYHx4haVFGb3UnkVQeLxm6W8ywD5cdE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:07.2363602","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:07 GMT
+      mise-correlation-id:
+      - 5906b5c2-2171-4d05-9e71-9b76d3457ade
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A12Z&sr=b&sp=r&sig=o%2FYgAECiceUyFeU9EetXmJVAMakRoXWF8LkjqEShods%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:12.5131532","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A12Z&sr=b&sp=r&sig=UFm2qK90vYSukRItaNEaYcpguTqe5o6LdVM4Z4iuI0g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:12.5130635","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A12Z&sr=b&sp=r&sig=pzKH2ucCm3aRG66jOmnSTcx7IQtGseCOK7dzhAyP%2BQE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:12.5131762","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:12 GMT
+      mise-correlation-id:
+      - 7c73192e-33a8-467c-bde4-e4a9ffdb51a1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A17Z&sr=b&sp=r&sig=mZrwhO0SAkDZJTygSsUwUZtVkHS%2FUTPcpkk%2B47NolAM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:17.7823616","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A17Z&sr=b&sp=r&sig=OHNmxYIN41oNLpwNpzk1cGmBYnDLsrqp%2BOA%2BZ4Xe324%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:17.782298","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A17Z&sr=b&sp=r&sig=hKwolnN%2FUeoMGb8bCFkeuGa3fpmF4i2fyhPMQwDP2Zw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:17.7823768","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:17 GMT
+      mise-correlation-id:
+      - 47adb3c4-7efa-48fe-a3aa-f35a3d83dbfc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A23Z&sr=b&sp=r&sig=wkPlnc7J0PKnyiVB3Ks3dvr57j4qyMhmAcWshlP8nMM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:23.0613654","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A23Z&sr=b&sp=r&sig=Q%2B6Gw%2B7Id4YeWrgoeVnlEeRE3NVTc0Ij3ZQ8FoxPZAA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:23.061272","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A23Z&sr=b&sp=r&sig=Vy93NgvGYX9ILZI2TUCzeEYurb%2Bt66BkNbjHM01J6rc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:23.0613879","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:23 GMT
+      mise-correlation-id:
+      - 5703851c-07ed-47fd-9438-3cd3e1feef65
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A28Z&sr=b&sp=r&sig=HRUKaaJ42aWTLwa2GW9TjlX68kqPo%2Bq38ZWmewokz70%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:28.3578265","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A28Z&sr=b&sp=r&sig=sN7raQJJ%2FYduvZacFG4IzmCUX029IVNByzWD5M%2F561E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:28.3577316","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A28Z&sr=b&sp=r&sig=pcWIGqnqYHRwNIgXp8Q4GOvqvWRS6SXzP4MY41u7%2BTE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:28.3578479","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:28 GMT
+      mise-correlation-id:
+      - 3a573ee3-4be6-4a2d-b30b-25ce6df3aa5e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A33Z&sr=b&sp=r&sig=%2FgQfA8uhXoqPxvb1pD8FnDmZedM074CNfUltXsTk%2F%2Bc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:33.6221114","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A33Z&sr=b&sp=r&sig=vWdwD4pa54xZOkl%2FnriqlgihiTZZtKd8Hg2wKSfDn%2FA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:33.6220229","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A33Z&sr=b&sp=r&sig=%2BwA9ZAFVdAtWWDPrxR5lSgdi%2BDD%2FaJ8H6XsJaPzmo8M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:33.6221332","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:33 GMT
+      mise-correlation-id:
+      - f83a031d-1526-423d-940a-2a7688a35557
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A38Z&sr=b&sp=r&sig=4qDeAQDyBHN96h0vJn4aBa71FX26nourxYXbSO0J%2BNY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:38.90553","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A38Z&sr=b&sp=r&sig=CbbXLEpqF%2Bz%2BKNV7Umh8aYTSzDmKUWJN1IMnvDnzY3w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:38.9054586","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A38Z&sr=b&sp=r&sig=UKKph8QY%2FcwC7ns0nKdxJ9QjkC3Y4GM%2FYzBwjOjzi2I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:38.9055454","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:38 GMT
+      mise-correlation-id:
+      - 3bc1412a-651f-4b38-a1d5-eeb7618f43bb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A44Z&sr=b&sp=r&sig=w2Ld0ld2Kq2ykLlH44yNK5KcueXmDVrOeKMOv6OHi2U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:44.1698112","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A44Z&sr=b&sp=r&sig=R9ftj5t73WvC9iCYJZpNuGENEADULEilA3zUY6Vt%2BWI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:44.1697408","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A44Z&sr=b&sp=r&sig=MZ3e6FOMJDVqRGzHOb6gARTu3bILcMgqga7TzwZwgLw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:44.169827","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:44 GMT
+      mise-correlation-id:
+      - bdb388e8-84c6-4348-9cd7-a0731d87cc72
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A49Z&sr=b&sp=r&sig=7p5tHG3d0QblN55ILTWmQvSObjCZ0%2FI5RCXaI1mu9eg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:49.4508562","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A49Z&sr=b&sp=r&sig=ph2fjijzhGjs2Gl45DHn5TjbpggPiwqThJIj%2FtnRwg4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:49.4507615","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A49Z&sr=b&sp=r&sig=lMNfrfPwFh4qr3mnXlEvOSfKafNQKQ4C0s6t7tXXK6w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:49.4508821","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:49 GMT
+      mise-correlation-id:
+      - a254a394-2dc7-475f-8e15-25dcdda176b3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A54Z&sr=b&sp=r&sig=FIX7UsYfO3yPyH2VGDlgiWj%2BD1yPMjg%2BvmeEzeSQJ0Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:54.7178795","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A54Z&sr=b&sp=r&sig=yP1dQoh9zfFQW8s9b0aj%2Fy%2Ff6u%2B25SCZv8f%2BzKBfNRs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:54.7177895","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A54Z&sr=b&sp=r&sig=Q4MjgNHxDLChr5MlG07E%2BOcfwptWf9ISOieHM8i2XkQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:54.7179012","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:54 GMT
+      mise-correlation-id:
+      - a10b5c63-5728-4dbd-98f7-ca9b23da1589
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A59Z&sr=b&sp=r&sig=mWEPbC4KY2o17b%2F63bgMvRxtDuQPpKyBMrxBfSfRkQg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:59.9925728","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A59Z&sr=b&sp=r&sig=zs9Eq85FqZEo2n2Nw%2FHx%2F6Sfh2r%2FHp0anaoQ%2FV3b5PU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:59.9924914","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A59Z&sr=b&sp=r&sig=yABXAoL%2BUCb1zvum8bzMDjQSCC%2F0r6NBEacGSWNLlY0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:59.9925912","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:59 GMT
+      mise-correlation-id:
+      - cd61d4a4-66b7-418b-a20e-3b09184b40af
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A05Z&sr=b&sp=r&sig=9ipsY47rgJjG316gcoAdmommu1bYipxnTqlUME%2FvyP8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:05.2700463","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A05Z&sr=b&sp=r&sig=xx8kPzZqqBoyoAefpAZxiZw1AL%2BKc4zhYd1uaRyNMuY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:05.2699743","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A05Z&sr=b&sp=r&sig=dAMVBXTQbsLwHCBOE%2BGMer%2FB0qmJEuh%2FLgoR6oBsDn8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:05.2700625","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:16:05 GMT
+      mise-correlation-id:
+      - 45d22cb1-0e40-4091-9186-755452316d8f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A10Z&sr=b&sp=r&sig=2YBoh5XmT1dv%2BssAyg5XFClNK80j%2FLQHaxn0LYwMATg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:10.5565946","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A10Z&sr=b&sp=r&sig=k9auxSq2nB9zB268AX0Onk8aDcM7BljRqO4DONU9rfw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:10.556514","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A10Z&sr=b&sp=r&sig=cl98mkNxtJl20fkSfhoTJlj3oprgjIlLohfwR0uWk2o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:10.5566098","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:16:10 GMT
+      mise-correlation-id:
+      - 3b5bdbf0-af77-4779-a21f-270d0690e567
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A15Z&sr=b&sp=r&sig=%2Bi8O6pOoDFqI3h6p85WYuCdF6oqf8e88DO5CoMJRzDo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:15.8287872","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A15Z&sr=b&sp=r&sig=azM%2Bt6%2FkQ6apJ2eY%2BY3YrSqm%2BptU%2F13mvxO705vWcKI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:15.8287174","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A15Z&sr=b&sp=r&sig=a6ZxIw152qT8%2B90JsFI1H%2FG8dp6cCiVZxPzt87%2F6yFY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:15.8288032","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:16:15 GMT
+      mise-correlation-id:
+      - 12ee4730-dd1f-43f5-a286-b7393d628212
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A21Z&sr=b&sp=r&sig=pRJK6VGHbndwQAfdG5t%2FT5fuXr2%2BG%2FYkRP26CIRfDG4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:21.101953","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A21Z&sr=b&sp=r&sig=KPKeCEfY%2BgV7ja9i80Mm%2BxB%2BxPNuf9TEc5gqHYKAZ6E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:21.1018868","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A21Z&sr=b&sp=r&sig=kmqmmDdIfBbvHDAxaGoq6mu8CfefQWTHzHWTuIW9Zec%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:21.1019665","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:16:21 GMT
+      mise-correlation-id:
+      - 4ec72f43-b379-4ef4-8313-35ceaa2649bf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A26Z&sr=b&sp=r&sig=2GPDQh%2Bx0e%2FQtFi3gNZvozc3iWBIVYlqN85hZDDZiVM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:26.3783775","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A26Z&sr=b&sp=r&sig=GKyMkTvlxuFLOkC%2B%2BmJv27ghik6BqwajmjjqMqIjRvI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:26.3782956","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A26Z&sr=b&sp=r&sig=Yh2QXat0UtRkjrjnHcWbhnRdMokbmMtlNmS00ToH%2BAs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:26.3783961","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:47.398Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:34.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:16:26 GMT
+      mise-correlation-id:
+      - 3d0df511-5d7b-4f13-9d89-9bd7275a3a1d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A31Z&sr=b&sp=r&sig=QMKYDEU0YEms8JrpAt%2BLJe8b6Pm5hedbq%2BZ4k%2B3jnwo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:31.6657331","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A31Z&sr=b&sp=r&sig=bmO6ni7qAG1qnHuMfFLO8EyDy44JFZyo%2FbnvGmXyW%2BQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:31.6656329","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A31Z&sr=b&sp=r&sig=Dve%2BwQTuZADozTiQK05VDfMuquhPhf8lzmcMraAJWLU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:31.6657551","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-09T16:13:47.398Z","endDateTime":"2023-10-09T16:16:28.805Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:28.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3339'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:16:31 GMT
+      mise-correlation-id:
+      - fa858c7a-220f-443d-9c01-7a6c0ea54383
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1136,18 +1856,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:12:19.411425Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:12:19.411425Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:49.9979583Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:49.9979583Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:31 GMT
+      - Mon, 09 Oct 2023 16:16:32 GMT
       etag:
-      - '"1a0a5ac0-0000-0100-0000-64af09250000"'
+      - '"9201fcb4-0000-0100-0000-652426830000"'
       expires:
       - '-1'
       pragma:
@@ -1177,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"11dddcfb-68e7-41c0-ac1c-debd805549a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"c863aaae-f00e-40bb-94b7-437fcf5ddff3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"2ee24c9a-cb00-4fc3-a690-e754d00b19c0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/3b837208-03a5-44d0-9cee-43e610b00364?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A32Z&sr=b&sp=r&sig=DbeeTsVuJytqoJSb4KvHfP8FcPPT1xGxfM85Mb38YLk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:32.408362","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/083a0805-5b4d-4d2e-8ea2-ebd5a7a4d722?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A32Z&sr=b&sp=r&sig=DN%2BBetcwZnQea%2FnJ6gklAj%2Bvio3Q9TpPOVjwkJNsF0c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:32.4082919","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3b18eb9a-3c76-4abf-a17d-3449479a3e67/ad14f197-35b1-4adb-ae55-fea081030678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A32Z&sr=b&sp=r&sig=pjTNxmeyvnpn0XYCGXxW5jZI3PcbkTpUexmdwtzUPOE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:32.4083763","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-07-12T20:13:30.328Z","endDateTime":"2023-07-12T20:14:27.291Z","executedDateTime":"2023-07-12T20:13:27.625Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-07-12T20:13:29.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:30.884Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"922adde6-d529-4eae-a7e7-83b251a05045":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"941e5a0e-25ff-446b-826d-9b6622947495":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f2709412-7090-4297-94c4-b061847f9a6d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/124b055f-4386-4a3b-aa12-1864c41d538d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A34Z&sr=b&sp=r&sig=lKzJMCZgSuaLyOfMhKPwIKW2ZXNMIi13O%2FyPPb0tpjk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:34.0848839","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/e9ca4705-6841-4092-a342-0afc3b307465?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A34Z&sr=b&sp=r&sig=ZEDef3uq%2BSbBbF3KMJvacFt4cgFIyCLB98B5EZwkuxk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:34.0847914","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/78f31dcf-c762-45f5-9626-1af4907d6a65/9130b28a-14de-4f63-b935-40c69fe60d49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A34Z&sr=b&sp=r&sig=oh%2FVACXCkeW3oXVV9nWLhJk9qG8aEJBKKxCsI2WrUls%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:34.0849094","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-09T16:13:47.398Z","endDateTime":"2023-10-09T16:16:28.805Z","executedDateTime":"2023-10-09T16:13:46.768Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T16:13:46.996Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:28.894Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3379'
+      - '3345'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:32 GMT
+      - Mon, 09 Oct 2023 16:16:34 GMT
       mise-correlation-id:
-      - 97b46149-5b24-41b2-ba60-2944ba85023e
+      - 8d8b93f7-a9b0-4834-aa99-24cf2be3593b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1217,18 +1937,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:12:19.411425Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:12:19.411425Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:49.9979583Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:49.9979583Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:34 GMT
+      - Mon, 09 Oct 2023 16:16:34 GMT
       etag:
-      - '"1a0a5ac0-0000-0100-0000-64af09250000"'
+      - '"9201fcb4-0000-0100-0000-652426830000"'
       expires:
       - '-1'
       pragma:
@@ -1260,7 +1980,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -1270,9 +1990,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Wed, 12 Jul 2023 20:14:41 GMT
+      - Mon, 09 Oct 2023 16:16:36 GMT
       mise-correlation-id:
-      - 65e76164-9a34-46fa-ad36-e24a39319db9
+      - c446b35e-3448-40a4-8dd3-3d91982c39cf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1295,18 +2015,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:12:19.411425Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:12:19.411425Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:49.9979583Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:49.9979583Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:42 GMT
+      - Mon, 09 Oct 2023 16:16:37 GMT
       etag:
-      - '"1a0a5ac0-0000-0100-0000-64af09250000"'
+      - '"9201fcb4-0000-0100-0000-652426830000"'
       expires:
       - '-1'
       pragma:
@@ -1336,7 +2056,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bde36a73-149e-4a6f-b871-a5a86a10438f.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
+    uri: https://44e411e8-38ec-4fc7-9592-b6927aa7efeb.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -1350,9 +2070,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:44 GMT
+      - Mon, 09 Oct 2023 16:16:38 GMT
       mise-correlation-id:
-      - 3b2c93eb-70c6-4777-8767-a0616b83ac03
+      - b2e3cf7e-5ddc-4564-a5b5-cf6bb99d5988
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_delete.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_delete.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:15.8114883Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:15.8114883Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:07.1706004Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:07.1706004Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:49 GMT
+      - Fri, 13 Oct 2023 13:52:40 GMT
       etag:
-      - '"5600d22d-0000-0100-0000-652452350000"'
+      - '"d8013df6-0000-0100-0000-65294b890000"'
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:19:50 GMT
+      - Fri, 13 Oct 2023 13:52:41 GMT
       mise-correlation-id:
-      - 792dcbab-4f9d-46b5-a76a-6912b988d6f6
+      - a5d568a6-8820-451e-b0e5-6b2acb0e6640
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"6986a558-25a2-4e7a-b03c-f83307a4a419": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "26934601-08fd-4fba-a8d0-fd388aefba0c":
+      {"passFailMetrics": {"95c9282c-2e6c-405d-ab78-c35409476a2c": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "aaedaf4c-b014-4f57-b057-4c148fa7de03":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "c735a1eb-253b-4872-8cdb-d0ed4aa5db2a": {"aggregate": "avg", "clientMetric":
+      "50"}, "ab5435b0-bf22-4d68-b3d8-b1b953694252": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -104,28 +104,28 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:51.266Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:51.266Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:42.36Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:42.36Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1008'
+      - '1006'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:51 GMT
+      - Fri, 13 Oct 2023 13:52:42 GMT
       location:
-      - https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+      - https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - fe8252b8-fd29-4b9b-9076-acb95224c406
+      - 080c2025-8fa6-471a-81c7-824805b14c76
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -143,9 +143,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:51 GMT
+      - Fri, 13 Oct 2023 13:52:42 GMT
       mise-correlation-id:
-      - 87c51601-2e12-4fd7-ae6b-34c44aaadb0a
+      - db65f034-5c88-4040-9f33-c480f34147ed
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -273,12 +273,12 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A52Z&sr=b&sp=r&sig=OiCrn1XnVnTsXIhIxFeZ6FhBRbq4WBeV4AGsc%2FDTBBM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:52.2818272","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A43Z&sr=b&sp=r&sig=tf721DJdEZpzcaRk9dC1L4Zla95gCBxsjSICx%2BTRvHQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:43.7622613","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -289,11 +289,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:52 GMT
+      - Fri, 13 Oct 2023 13:52:43 GMT
       location:
-      - https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 76bd135e-81ce-4d8f-9255-1a25f40406b5
+      - 6f592d6b-8536-4c94-bf6b-109b156bef7f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -311,12 +311,48 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A52Z&sr=b&sp=r&sig=FdvKw9XW8Aw2TiMx1nIzO9hW0z9Fg9otWyvGza8MlY4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:52.5739782","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A44Z&sr=b&sp=r&sig=2eZbXAvce6UAI5UWIv17k%2Byxabnvz9adeRoXJCQMxVQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:44.043973","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '550'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:52:44 GMT
+      mise-correlation-id:
+      - fd9ac0c2-237f-4d91-8ba2-d809aceceb8e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A49Z&sr=b&sp=r&sig=FHrwov8hwpauZh7zIvtd4kh4CIZkUT3cW9vOgD2Pw04%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:49.3410338","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:52 GMT
+      - Fri, 13 Oct 2023 13:52:49 GMT
       mise-correlation-id:
-      - 1b6ff010-df0a-4233-b4cb-0023da6c5d23
+      - 48f4073a-2895-4f3e-8b46-7c3b73d17468
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -347,84 +383,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A57Z&sr=b&sp=r&sig=cmBvxw88PbA0vQvyrEhwZ%2BgvTX9L%2F6HIvveXIaDmEvQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:57.8906945","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:19:57 GMT
-      mise-correlation-id:
-      - 20f63330-a2d6-4797-825b-8f0e2b8e56a0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A30%3A03Z&sr=b&sp=r&sig=%2FDB06nya0j%2FYbDtr3cNzmGM0eIL9rkHDm1qxDP1NIh8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:30:03.2167643","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:03 GMT
-      mise-correlation-id:
-      - 80e461b7-5ed6-4411-8e3d-ae2d7c8206dd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A30%3A08Z&sr=b&sp=r&sig=fM%2Fpr30k6NX7x3ZmBDK6tJnKenkE0DN4sgPVewbbANQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:30:08.4999575","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A54Z&sr=b&sp=r&sig=1HovGCE7K1yEJoFswxrA0n6XoJMgD9zmIor80F44yao%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:54.6104403","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:08 GMT
+      - Fri, 13 Oct 2023 13:52:54 GMT
       mise-correlation-id:
-      - 8c28e51f-6326-4bbf-ae10-b74015d2b9a1
+      - 6ee7dd47-ce5d-4fef-ba12-eaf5943b90e5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -455,26 +419,62 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A08Z&sr=b&sp=r&sig=PT0RSIhwCjsiwNgBdY13A2aS4y33cWmB0gK8ftQ8yus%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:08.8817564","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:51.266Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:07.78Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A59Z&sr=b&sp=r&sig=P2VzZ4%2F19OE3l4WvIIiZJ%2F0QUdRX1wUAC4M%2FuY1XlEk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:59.9035943","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1576'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:08 GMT
+      - Fri, 13 Oct 2023 13:52:59 GMT
       mise-correlation-id:
-      - e7219e58-b90b-40af-981c-00a266c4b20a
+      - 3f9ff3e5-5c7e-4c2b-ae85-bee752b29deb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A00Z&sr=b&sp=r&sig=QGL3oYKMicj5vZPb%2B6Wru3jyEocZtfsV7EfRa1iwVSM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:00.2370098","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:42.36Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:56.374Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1578'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:00 GMT
+      mise-correlation-id:
+      - 7e3d7c49-4b91-4d5a-86c2-5c719ff2a6ed
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:15.8114883Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:15.8114883Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:07.1706004Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:07.1706004Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:10 GMT
+      - Fri, 13 Oct 2023 13:53:01 GMT
       etag:
-      - '"5600d22d-0000-0100-0000-652452350000"'
+      - '"d8013df6-0000-0100-0000-65294b890000"'
       expires:
       - '-1'
       pragma:
@@ -536,26 +536,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A11Z&sr=b&sp=r&sig=BoXd6hphN9FaEKS6kkGIUEyLThwIQ4O%2FpLCxLMY5kjk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:11.3861213","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:51.266Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:07.78Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A03Z&sr=b&sp=r&sig=F%2Ff7lwFoem9QgFMJ1gmEi9xdnFY%2BJXLrpT%2BkhAqGzRY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:03.5254237","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:42.36Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:56.374Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1590'
+      - '1594'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:11 GMT
+      - Fri, 13 Oct 2023 13:53:03 GMT
       mise-correlation-id:
-      - 38e1347f-d8f0-476a-9508-8c3e61f521fa
+      - c954bece-571a-4bfd-84fc-024ac537e3e1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:15.8114883Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:15.8114883Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:07.1706004Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:07.1706004Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:12 GMT
+      - Fri, 13 Oct 2023 13:53:05 GMT
       etag:
-      - '"5600d22d-0000-0100-0000-652452350000"'
+      - '"d8013df6-0000-0100-0000-65294b890000"'
       expires:
       - '-1'
       pragma:
@@ -617,9 +617,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:20:13 GMT
+      - Fri, 13 Oct 2023 13:53:06 GMT
       mise-correlation-id:
-      - 9aac3fa1-78dd-4b23-8303-0342fe67f9eb
+      - adb2156d-386d-4a26-bf16-ee3704c64148
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -660,27 +660,27 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=XrU5EYhHNjdoafpBp0gMNm%2Ba1FtPBUvavP%2FSM0M6ZLo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:14.7390604","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=XqiVJjPbpIp8BPKb6UYRjDCHeXmYCDsq0XHVoDx4SAE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:14.7389632","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=i7jDd0SWXunoocJdgW7aRCaIzUwwA0xzw9bAKUeV5zQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:14.7390815","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.672Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A08Z&sr=b&sp=r&sig=fcymRtAofHFw62aLq5AeDPoq18FkxC3s1sVLGlXhLeU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:08.8857542","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A08Z&sr=b&sp=r&sig=aUGHuAOD8KWT2UH%2Fmlwj324Ecz5X60%2BFOg5xd2D3L%2BU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:08.8856492","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A08Z&sr=b&sp=r&sig=bVXaKDbxes7WIRpk4fYZwL%2FB9mZzUnkCaJZ%2BS8ddwb4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:08.8857775","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:08.822Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3152'
+      - '3158'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:14 GMT
+      - Fri, 13 Oct 2023 13:53:09 GMT
       location:
-      - https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+      - https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 448ad50e-4ffb-4b87-a0b7-2f9a9029d73e
+      - 9253b638-e67d-4493-837e-c70cbfa30396
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -698,25 +698,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A15Z&sr=b&sp=r&sig=XMQ4SHVPdNmnlF06wSXcvlJrSDqWf5x8G0FzGJKV9CI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:15.2061351","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A15Z&sr=b&sp=r&sig=8z5xoRVi431EWWmIP3FX39h4EnF2jGEbydZIZj8e0gU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:15.2060318","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A15Z&sr=b&sp=r&sig=rI8v6iW8IG2MxGV%2BrAvfRKrLZ6yc7pld9xEIgcmRzrs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:15.2061589","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:15.119Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A09Z&sr=b&sp=r&sig=KZDLFuekZfKReu8KAGF95o1Kl6D%2FMBgI%2FUVvdBcd61I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:09.3132234","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A09Z&sr=b&sp=r&sig=LCfPYGRHaHQyQf6FRHn541fvkjP5R8coxYkQuhMM5L4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:09.3131553","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A09Z&sr=b&sp=r&sig=8YiOQiqIS%2FjkPVv1XAK%2BPWScXTlM36XKPe5Vv6ujHGI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:09.3132384","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:08.822Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3195'
+      - '3156'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:15 GMT
+      - Fri, 13 Oct 2023 13:53:09 GMT
       mise-correlation-id:
-      - 4e382f0a-91f9-4342-92d0-1e6683eb01a2
+      - 808dd3b2-39d3-4c74-b061-67c6e85a498e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -734,120 +734,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A20Z&sr=b&sp=r&sig=M5TPQj%2BXPlccaFBVVg4bf5Br5xroFmo3xLMm5T2xe5s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:20.506849","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A20Z&sr=b&sp=r&sig=Pj3JrHN00yMLWd%2FHIG9YeWak%2B5irtiFghP3on%2BMvRtc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:20.506764","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A20Z&sr=b&sp=r&sig=k9jj%2BHgkcZyfbrVAaFCqFeWWcWyaj9RIBzBc%2BwFuosY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:20.5068698","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:15.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:20 GMT
-      mise-correlation-id:
-      - b3df3d3f-bd3e-4a4c-bd18-6f9d881f3e5e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A25Z&sr=b&sp=r&sig=UjaZOnber8ft3mjLk2pE%2BrZ8R52m8HQAaPmE0NIXCKc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:25.8451971","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A25Z&sr=b&sp=r&sig=IOuWwOUZ42yWLyOm7RIg1x0DoFRQJDt1TFwNhdzjoJw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:25.8451234","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A25Z&sr=b&sp=r&sig=XUYxNsmQchVpgkuvAegyW%2FKwLk68r2BzDZfgk6HNapM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:25.8452117","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:15.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:25 GMT
-      mise-correlation-id:
-      - 099d3d2d-1718-4d44-9bd1-b3300f390451
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A31Z&sr=b&sp=r&sig=CSsLvFD6XobKeP1J5VSjL%2Bf1KEeY%2BWaZuqYiwxbbnZ0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:31.1553767","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A31Z&sr=b&sp=r&sig=Jah7171TRD54c8yoAwRnqT7d6kTCiM4sW1YKWEtzwnw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:31.1553057","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A31Z&sr=b&sp=r&sig=GE1rQtFrWARWNfcmfb16Xt0DPIcn%2BAAi1Lh1V7Vxvug%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:31.1553908","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:15.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:31 GMT
-      mise-correlation-id:
-      - a2915c36-26e3-4839-8c6e-23455171c8d7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A36Z&sr=b&sp=r&sig=8NyKZgqxg%2FlCaUPLMvVCMxLs2dMOS1eZkOXsdUnkMVI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:36.4290998","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A36Z&sr=b&sp=r&sig=Jgzu7rL8IWXe5NR9iKMeFgfnN63alui9MDn06TwgmM8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:36.4290118","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A36Z&sr=b&sp=r&sig=Mky4fGDrFuwRw77Bpis4iEP6X5UfBv0360ASIAgwHNg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:36.4291217","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:15.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A14Z&sr=b&sp=r&sig=i64Vx6%2FFNrlywABFLKuy0tIi5QK2IJSCCejvMpdOlp8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:14.6431859","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A14Z&sr=b&sp=r&sig=HN0M9Imj3IGy1O%2Bu2Vdf5a94TCOY3MrOrk3bwTJjjYc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:14.6431004","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A14Z&sr=b&sp=r&sig=MhoToJWEuUaBMTGve8VJ8Vlxaw9ShX4nsL4eB0SbFSQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:14.643207","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:10.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -858,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:36 GMT
+      - Fri, 13 Oct 2023 13:53:14 GMT
       mise-correlation-id:
-      - 726ffcbe-8d3f-4eff-bf5e-6f737b5f96c2
+      - ae003bbe-f363-4699-9c4c-0b86ba89878b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -878,25 +770,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A41Z&sr=b&sp=r&sig=4ODqVYs%2FEFBArYq6E%2Fc6pdRCTbFgZmOY0R%2FhODF1P1w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:41.7242037","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A41Z&sr=b&sp=r&sig=xIAK%2BmXUKZjc80P9hdKiqEy094%2FBYFImpUKWH3N%2FaYI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:41.7241189","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A41Z&sr=b&sp=r&sig=Bch642fv3jMfJ5cI0DHuhEmIVQvTCAvCLrHptMTqa4o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:41.7242242","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:15.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A19Z&sr=b&sp=r&sig=LcBMbdDirGKFCKgKuIQ4bPUqYXNbAbAMIvxSCALw1AI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:19.8909617","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A19Z&sr=b&sp=r&sig=xpkq9%2Fr%2BGYDJXytDUnAsDahDhwaWkeJvSoPuNA%2F3hpg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:19.8908637","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A19Z&sr=b&sp=r&sig=g%2Fmsjs188ZAyFNFgybey%2BQov6VRe0v2%2Fo2eIzyi%2Ftys%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:19.8909844","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:10.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3207'
+      - '3208'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:41 GMT
+      - Fri, 13 Oct 2023 13:53:19 GMT
       mise-correlation-id:
-      - 2801b672-14b6-4310-a9e2-f741b3a34110
+      - beb5511c-ec34-41da-84bd-b308235b096e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -914,25 +806,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A47Z&sr=b&sp=r&sig=JHSG%2BTptBJ%2BzNjJpsZPYdh92atjDctn2VXccaRu8Hpk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:47.0384877","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A47Z&sr=b&sp=r&sig=vHc%2BBzu2lXQrUzYXIJPW9nRy89Okl5lKmf8%2Fb54aqf4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:47.0384036","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A47Z&sr=b&sp=r&sig=r4D9BHEB63FvpqiVTKy31yMWQUswE55teYa5qrZ%2FoEo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:47.0385096","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:15.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A25Z&sr=b&sp=r&sig=yq78tNr%2BmPvNNQvCQzG0Bb7PpnWa6na6Q5wJYUOsJgc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:25.1380397","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A25Z&sr=b&sp=r&sig=7RPWg2HKtpF6P9i7lQ1Kx3ktXlNpkIdsgitYEAOTnIA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:25.1379734","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A25Z&sr=b&sp=r&sig=%2FRSH2VjMFoi76z3ZE54XKgo%2Bsv%2Bp4pdAUNYwNRNmzz8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:25.1380554","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:10.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3205'
+      - '3202'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:47 GMT
+      - Fri, 13 Oct 2023 13:53:25 GMT
       mise-correlation-id:
-      - 0242dc18-eb13-43c4-816c-438f2dd304c7
+      - 96fa9a4a-8586-46a4-8a5f-844d53bdc41a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -950,12 +842,336 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A52Z&sr=b&sp=r&sig=r4YA69%2FG50tQHoqsuLQSrI1eeqjxmX0%2BA4bZL4o%2B2Uo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:52.3592926","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A52Z&sr=b&sp=r&sig=BHMfmeCllquUN9w%2BJoSjXfz0CO4yjtRxu5cJsNswEgk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:52.3591975","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A52Z&sr=b&sp=r&sig=81RsK9U8hHqoiMq7fiQQRfh6l67Wu99jv29nbbjFKCg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:52.3593171","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:15.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A30Z&sr=b&sp=r&sig=rDkpJ4HclVsn0I6r16QCqV3S4Vm%2FwfNySATHZfKdgXg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:30.4379821","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A30Z&sr=b&sp=r&sig=JPG9YVUEdTWyRjQMfPhhOMmjMMmzIltmwzt3IfHwezc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:30.437915","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A30Z&sr=b&sp=r&sig=WfBpmRcKh0%2Bc5cbdDSiOmHVMQsTjtJXKfiKmJWt%2FilI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:30.4379961","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:10.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:30 GMT
+      mise-correlation-id:
+      - 800460df-9ac5-4754-9651-d2bdf25faa9e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A35Z&sr=b&sp=r&sig=ONJFtD7k0WI%2FKgECQ%2FTxolM9hcK6Q04JY9EhJZtZWwU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:35.7189925","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A35Z&sr=b&sp=r&sig=%2BDzEtK9UGxQvH4V85LaWPwOwFYHj%2BS%2BNeOysn%2FimuzQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:35.7188879","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A35Z&sr=b&sp=r&sig=G5YDXA2i9BXUPPiQCjWlbM%2FBR%2Ftx0kaipImIaegACQE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:35.7190089","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:10.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:35 GMT
+      mise-correlation-id:
+      - 3060a087-1659-4b20-89e0-284a1fa51dc9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A40Z&sr=b&sp=r&sig=Mst4Z%2BshrzuusGXr9JAn1c9%2F45FM9M1%2FduLNVhIzUus%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:40.9994657","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A40Z&sr=b&sp=r&sig=%2FpHzd5Lb7hz%2B%2Fzpt1o0TKdeJVTOFHEUJ9ERRMUyqO7k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:40.9993834","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A40Z&sr=b&sp=r&sig=suZF28IkEneUqAgkzE7OiE437Ozujsazc5woidsexLg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:40.9994868","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:10.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:41 GMT
+      mise-correlation-id:
+      - 919abbd6-e39e-4971-ac50-4cce17449b47
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A46Z&sr=b&sp=r&sig=nsg7FeGodneTcDuf8JlOElWhEJmVpq22BWk7NT1pNXI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:46.2887305","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A46Z&sr=b&sp=r&sig=uS%2BqD4D6MHb8%2F3jQNEuzQfJ9x03MYwqkF5sS6TYRarY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:46.2886618","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A46Z&sr=b&sp=r&sig=z3VLkUnceaf0SjyEKDR0ENO%2BgJv%2BQM9NE442SGECUy0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:46.2887443","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:10.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:46 GMT
+      mise-correlation-id:
+      - 897ddfd5-1622-468e-b7f4-09bb32807824
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A51Z&sr=b&sp=r&sig=%2BfehDe2XAyR88ufgEDrCXwGqSOmZvBXs6%2FN%2BTWBra2w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:51.6237885","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A51Z&sr=b&sp=r&sig=J156SEt%2Bl3SApfFtjB9HsLyrrcrGK5fiRni0V4wxOPQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:51.6236966","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A51Z&sr=b&sp=r&sig=ijW2K4j6qzEwvj%2F7%2FecfzJqgfv%2F1bTzU%2Br3%2BihW6cY8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:51.6238061","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:10.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3212'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:51 GMT
+      mise-correlation-id:
+      - 25dbcc1a-e0d4-4116-adb7-6579b318978f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A56Z&sr=b&sp=r&sig=q%2FAMiqAXCjcFEFx9Wtt5gNe2A%2Byk%2BymNfg6XBG13H74%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:56.873604","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A56Z&sr=b&sp=r&sig=DljKVAnWOc3FGpcaRjM3RPwdu8LGvoi2AR58UPWG8NA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:56.8735371","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A56Z&sr=b&sp=r&sig=8L4oJBvFbZ46uy4VRpq3QGTgWJlpZSAnLX6g4lsXNCA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:56.8736191","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:56 GMT
+      mise-correlation-id:
+      - 4452e1cb-f0c7-4143-b8ab-d3b80861b0d2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A02Z&sr=b&sp=r&sig=vWoT1I%2BvufH5ULxvKziR4dvkJnSwTsC%2Frnq1eHG0878%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:02.1525601","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A02Z&sr=b&sp=r&sig=JhFeZhyTI6SGLR72gtSsf3%2BetCbgzQFwzxHkxn0RHGQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:02.1524609","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A02Z&sr=b&sp=r&sig=IBGGx29wvtgCNwOASEe9TaJMJ795ng%2BMeELjPZ8Nvwg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:02.1525825","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:02 GMT
+      mise-correlation-id:
+      - eef8029a-574f-4625-997b-5ebfbc190c83
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A07Z&sr=b&sp=r&sig=Bsq0wef483sg8dRTg43VPXOUMogHGJju9for1X%2BG7l8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:07.4796234","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A07Z&sr=b&sp=r&sig=Qs0Hs%2B5U%2BpUHvDopuYQZ0X5PNzZCYpEWw5HyebZRTCc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:07.4795164","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A07Z&sr=b&sp=r&sig=Ac6Nk%2BJqrUF80Aol5fple5IQyLTvPIHzzq9okuaAyEA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:07.4796475","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:07 GMT
+      mise-correlation-id:
+      - c22edeba-6fe6-427a-a632-a5c57d2af9cb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A12Z&sr=b&sp=r&sig=4vhHu4Cx25jJ0eaewQQ1gu%2BSEJZ8UHLn4sENf28Z8Yo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:12.8792363","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A12Z&sr=b&sp=r&sig=uQY%2FbY1B6zWjKo1y9YNGekaOKQgQySgizxuxl5EH%2FWs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:12.8791538","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A12Z&sr=b&sp=r&sig=cqokINVsMYWElNsu%2BghKGbLbObc8CH5ynYaxeXh6Jj8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:12.8792573","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:12 GMT
+      mise-correlation-id:
+      - c456e31f-273a-49ad-9f0a-85f22babc468
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A18Z&sr=b&sp=r&sig=TrqVE8S2tS5G1G%2Bk5CegX%2Bers3l1e9JONOSsbS%2BiCsQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:18.1587793","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A18Z&sr=b&sp=r&sig=EbxrOoMH5ucuQfif9Ui7%2FX2OZWAXiAgXRTzeBuwCmxY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:18.1586857","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A18Z&sr=b&sp=r&sig=MyQJFVsK3%2FeNL%2FxWQdX38d1rtxmyK0NnBGqbloItv70%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:18.1588038","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -966,9 +1182,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:52 GMT
+      - Fri, 13 Oct 2023 13:54:18 GMT
       mise-correlation-id:
-      - dccd3e07-be66-41ef-9159-2b9773be7392
+      - fd15e1f6-69bd-448f-9913-e5014c45cd35
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -986,25 +1202,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A57Z&sr=b&sp=r&sig=ZS6seRIzNdt%2FNM65FXCY7R58oyWD3%2BoNo4orYlIPV2s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:57.6454314","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A57Z&sr=b&sp=r&sig=dAUNELNVYR1huOEujGU%2FYIi8sT6hmhHIuxaeg5mvu1c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:57.6453547","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A57Z&sr=b&sp=r&sig=IJx6NAHnyHd5y5Fcf52tl8GWtLjhoUaSqLeMiozTN1A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:57.6454459","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:15.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A23Z&sr=b&sp=r&sig=F54DbKRAZasW4r2VcPr5xB4J42ZB7x2qyCUohbijUDU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:23.4163738","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A23Z&sr=b&sp=r&sig=mRYLmoj09eUxnypDqif38Kzzqcr9Vy%2BQ1ZTWYZEsfLM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:23.4162822","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A23Z&sr=b&sp=r&sig=JrkL95h5fuFPF7R1f1OtrLDpEaTBFRwv2jFf2YSU5jk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:23.4163912","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3201'
+      - '3193'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:57 GMT
+      - Fri, 13 Oct 2023 13:54:23 GMT
       mise-correlation-id:
-      - 34327e09-e22a-4046-acd8-9623211ecdc8
+      - 8e90f779-9209-427e-8b47-a7ce12fbf263
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1022,12 +1238,516 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A03Z&sr=b&sp=r&sig=PPgplDFJypgQBxfaiJr36%2Flmbri51LzAqss1iZRwEAI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:03.0324726","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A03Z&sr=b&sp=r&sig=KZfcAwK2MY%2Fq%2Bv7Z1Cqiw3hXv9cC7zHlNLTfpVS85G0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:03.0323663","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A03Z&sr=b&sp=r&sig=jSL2SzmXYyOMB%2Bx%2FQRzwAK9UibrCs0wELXbsxWi3HLc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:03.0325014","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:59.124Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A28Z&sr=b&sp=r&sig=PcgYCFXzg8KbTMksBwexxXYjI9YVkzmwb8nsEQtwTI0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:28.6762834","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A28Z&sr=b&sp=r&sig=cNWmhW3VbXO4PJF3NeJD4Gua9dAMtWEKxvzwC44kIDI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:28.6762173","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A28Z&sr=b&sp=r&sig=gfzTYBN%2Bzsv30wUEwLvfJxczCWh4cGfwf0uluPDRaw4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:28.6762982","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:28 GMT
+      mise-correlation-id:
+      - 8e44c31a-ade0-4568-95e3-b4e666d3c953
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A34Z&sr=b&sp=r&sig=jY2elTvRGRZR1B12ZTRlt%2B2x9uUj%2FIGeks30elXWhUM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:34.0191704","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A34Z&sr=b&sp=r&sig=CcKWNMdJLpWlj7eAFxoFzLEIG8uhs8pelcKJ%2Fc9r738%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:34.0190731","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A34Z&sr=b&sp=r&sig=XH43UEGjdXI8mvaOB4M3ivxfQxVidAg9wecyMbMtpe4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:34.0191989","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:34 GMT
+      mise-correlation-id:
+      - b97c3f94-0cae-40d7-ba5d-bd1b0b246f73
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A39Z&sr=b&sp=r&sig=p2pk7y7gF%2FETW7r01mi%2BJ7V5ZZp%2BoKr2B8SWZwWoJkw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:39.551309","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A39Z&sr=b&sp=r&sig=%2F%2FDLcmZnlWU45913A0qnmfRA8BX%2Fl8rRol94z%2B1bY%2Bw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:39.5512395","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A39Z&sr=b&sp=r&sig=nnwNqN0ISmjWkCLkOmN46oO8YxgNWZ4%2F7pmw9ytDgKE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:39.55133","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:39 GMT
+      mise-correlation-id:
+      - 3dab2b37-3dab-4506-8709-ce21aecfcefc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A44Z&sr=b&sp=r&sig=yUnfpfO6UcV6mkJ%2FWNa9HBcsmFYI5qnNHXljImAr4Do%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:44.7877639","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A44Z&sr=b&sp=r&sig=RPTaPeDcjH0th5ti%2FVgu0pAo6J3yk32r8rg3bTYezyE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:44.787667","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A44Z&sr=b&sp=r&sig=LB11H%2FItMnPgh8jq368MW7uYgXZk6VwBkNTkRnl99IY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:44.7877844","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:44 GMT
+      mise-correlation-id:
+      - ccf69ddd-e413-4997-8542-8f65fc6b2f82
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A50Z&sr=b&sp=r&sig=i4OSFSkM%2BEwFH%2FBHCBs1LYnZPAG6wFZm3ExqfNGke0k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:50.0563626","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A50Z&sr=b&sp=r&sig=v1JwfdXeWhAEakbUe%2BEanWzK6OC4dh99%2Fbuo7LDCAS8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:50.0562376","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A50Z&sr=b&sp=r&sig=ozgaGfVlcw7vXseEWkYwMcAnhOc3ZaEuTW7KnmAJPS8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:50.0563855","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:50 GMT
+      mise-correlation-id:
+      - 5eb63a41-7012-48a0-8b29-848e51961a0a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A55Z&sr=b&sp=r&sig=TxNJFibV2ErQNaLK%2B1WSGbbuA0a26Gt7tizvR1%2Fz7dA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:55.2995517","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A55Z&sr=b&sp=r&sig=V1ldF24R4So%2BF7V5PDmG4vHfr57T4tZLJKUECA4vL18%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:55.2994215","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A55Z&sr=b&sp=r&sig=x%2BKFhcUT6Z8DD2YqUdr%2BfVUoxVqEeHxA9Mhgqijke%2Bs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:55.2995765","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:54:55 GMT
+      mise-correlation-id:
+      - b8ec394e-69e8-4726-9b82-24c0414e2241
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A00Z&sr=b&sp=r&sig=wqFhlo%2FBhuYAY6TZ1fzz%2BLC7p1okC5NguAwdLaRYFlE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:00.5336781","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A00Z&sr=b&sp=r&sig=aj2cz%2F2ZrwNhQRYzhC%2BcbZ6X1v3wjThwFBO7X7zdbBo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:00.5333654","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A00Z&sr=b&sp=r&sig=%2Bu%2B2Nwo%2FZOrQICMfwU3NvRK6xJnMcjb5AvPT6tGCxQo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:00.5336994","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:00 GMT
+      mise-correlation-id:
+      - 6d1aa7aa-6477-40ff-b497-d2b29d1658f9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A05Z&sr=b&sp=r&sig=3I1FOCFnukV5gZmSrX1vt%2FrGlBk4WfdrZxOxlHrZAq0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:05.8204684","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A05Z&sr=b&sp=r&sig=2wnKmXnMKrHkfpn6kJi5jWegtDPZhu2X72Jdd9dh0Tc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:05.8203951","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A05Z&sr=b&sp=r&sig=BRF%2BUpa4ag5hEQlGGun%2FRrEes6oRFO1HMWzPeGblZ4o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:05.8204825","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:05 GMT
+      mise-correlation-id:
+      - 6e5e0a5d-ae03-4e06-8d2f-24b3055adad6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A11Z&sr=b&sp=r&sig=4iVe1vODwL8slJknQXX9SSNsafOY7YlX5RJauk6dywo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:11.0977611","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A11Z&sr=b&sp=r&sig=B8xMt1qQ4ASWW%2F8sX1SXp0zvE01vopo3W6j5Mfiq778%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:11.0976538","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A11Z&sr=b&sp=r&sig=42Q2DzHsrd7c2%2FAGmlSPlktv7a9XHwnGY%2F2ZgqyOriE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:11.0977821","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:11 GMT
+      mise-correlation-id:
+      - 3d23ece9-f8fe-4fba-9507-7377de65dd4a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A16Z&sr=b&sp=r&sig=IgbemwFhc5krvkLtxBbmx5mPLPLfmY301gMHdnBZyyE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:16.3976902","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A16Z&sr=b&sp=r&sig=zb8U9JZn5LgXzRZeS5SZcsV32jbMh4Z%2FG96URuQDwno%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:16.3976233","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A16Z&sr=b&sp=r&sig=1ahSC3V7rLSxWxhTq95XOf5heaxi4NSi6RL7IFpHRqs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:16.3977052","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:16 GMT
+      mise-correlation-id:
+      - d240e945-c5b7-47ed-bccb-bd46ce1313b9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A21Z&sr=b&sp=r&sig=GQ9PqTtOJU5vGVH6APAlOIfnq2sQmytJED%2FqwrOdN3U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:21.8148772","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A21Z&sr=b&sp=r&sig=26qiTsRMHbB4iiMLjJg9z0oceE4SJpuqeYRkzjp3EFk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:21.8147794","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A21Z&sr=b&sp=r&sig=WrO1cn1kn%2BN%2FrT9Gn0AxUbGKY3R2rrx80Ub9ee6%2BEwk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:21.8149027","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:21 GMT
+      mise-correlation-id:
+      - 541ed6f1-6395-465c-8a91-07040d400699
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A27Z&sr=b&sp=r&sig=z5cBw4MC79H20dLT5S%2B9gSlozSwJGEzIRKkqcYPiJSw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:27.0900716","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A27Z&sr=b&sp=r&sig=mYM2OXqw0yecpkTkvlyagJWtruUyB3PPifnbSUacsVs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:27.0899815","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A27Z&sr=b&sp=r&sig=Dj0y7xhWUHQAikhpHorsdTyorsR9ywYDd4KfRf8AQok%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:27.0900872","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:27 GMT
+      mise-correlation-id:
+      - 4f14761e-d6be-4273-bcca-44a9490e49aa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A32Z&sr=b&sp=r&sig=LfAJX45iFbT0irtpZb4iMSDr%2FNQAtYOUtcRq0BZ8bl8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:32.3782507","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A32Z&sr=b&sp=r&sig=64yuMexILCxLCW7iwPf%2FcAcwRVQ0wD9bQhEuf0yfzQg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:32.3781494","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A32Z&sr=b&sp=r&sig=TwtTjFQ5Qty2uvJavoO%2BSS34cFoCt7juxVJevEVoD%2FI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:32.3782721","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:32 GMT
+      mise-correlation-id:
+      - baac2673-854c-4657-a439-91e71210d610
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A37Z&sr=b&sp=r&sig=iaLgaMsnLrG383QIxrKVa%2BGaHPeg%2FLZv6SFeTKLh5zk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:37.6284842","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A37Z&sr=b&sp=r&sig=jUvUWdazm8KMzor8mCXHWw0ihXDABteOMwa40UFBNdQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:37.6284139","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A37Z&sr=b&sp=r&sig=AC6b9ckgXixz0c3aHGVpijacIa%2BqHeX9YT4nnCLSgP8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:37.6284987","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:37 GMT
+      mise-correlation-id:
+      - a4230c6e-f78c-4eca-af12-be8b1e186369
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A42Z&sr=b&sp=r&sig=VzcmCD9wjxffg2JOtZMPpGP%2FIjJniPAkIIp%2BRcPTiKg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:42.8965045","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A42Z&sr=b&sp=r&sig=itiOs1YgNiY%2F2FAvGwuOs%2B7dKzl0esR9BJAdxPfEvXM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:42.896421","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A42Z&sr=b&sp=r&sig=UAnBiup11l3OkD%2FWnl2HYHQ%2B742S3%2B74fNOpJ7uCRWI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:42.8965207","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1038,9 +1758,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:21:03 GMT
+      - Fri, 13 Oct 2023 13:55:42 GMT
       mise-correlation-id:
-      - 1bfe52ee-6c1f-4467-9b7c-a73aefc59022
+      - c0a00be3-6695-4d42-b101-2a9c7183e165
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1058,696 +1778,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A08Z&sr=b&sp=r&sig=BY8M5IdzgLTfdqk%2BMrDMx01XtmlMth7Ortqlxeo73Tc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:08.3433911","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A08Z&sr=b&sp=r&sig=%2Fv6aYts%2FurvtSSGv3pMaBf5Pkhg6L9FexroaN0JFPWM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:08.3433174","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A08Z&sr=b&sp=r&sig=D8B3U0Dae1KJXK6EChyD5IPk6fAZi1m5ax%2BD%2FdrEZ6k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:08.3434062","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:08 GMT
-      mise-correlation-id:
-      - 274f9832-783d-45e4-84b7-7d4ceccbac77
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A13Z&sr=b&sp=r&sig=W70mWOmqWB%2FJjkr1jQmkcNmAtx93OO1nsm6hAEJGIRQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:13.6938847","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A13Z&sr=b&sp=r&sig=eqQjotvDZcEi7jkA9TrC%2F%2BEAchtS%2BWwlAnOkLaB%2FyGc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:13.693782","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A13Z&sr=b&sp=r&sig=pH%2BBVXxGTFknAg1hAqx9u11%2FCHWaBlAvLsDFOACwKjk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:13.6939086","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:13 GMT
-      mise-correlation-id:
-      - 107e7866-2943-4f81-9ef9-34904b84cfd0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A18Z&sr=b&sp=r&sig=1ZTEiKRP73Wc7xn1D0ondr60narJl06XWjA0Padh2vs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:18.9981807","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A18Z&sr=b&sp=r&sig=ox5OvPprcoGJwrYoVSe2zjY9Am7yUhBAtO9sMhuh9Yo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:18.998109","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A18Z&sr=b&sp=r&sig=VjtQK11Fq2EwVL0oXYDvBUMF4pLdBFrlrK4AUbQSDhE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:18.9981977","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:19 GMT
-      mise-correlation-id:
-      - 886f609d-dfcf-4f0b-a01e-c71ff79903dd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A24Z&sr=b&sp=r&sig=QJ2B7ebasp9gvz6dLYOGFZAKc30QCXw5UKsU9jXtPi4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:24.3140422","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A24Z&sr=b&sp=r&sig=Bae5xtONiVzbqneRv0fa9%2BdSgVguoZ9g4nQMcsDDFcU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:24.3139733","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A24Z&sr=b&sp=r&sig=5ilbwuzPxt9isjKJ90kKe59cE83e2hrWq9kYRrxG24A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:24.3140592","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:24 GMT
-      mise-correlation-id:
-      - a12e94fa-236c-49d9-8e08-2a934e03c590
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A29Z&sr=b&sp=r&sig=OJH9ROtZGwTBjIeVxABmGE04rvV%2F%2B2%2FTfXFiELzoors%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:29.5839533","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A29Z&sr=b&sp=r&sig=Non443BoRf48%2BgGrz5luMi8GG6RJ6GC8LrU09PyeDjs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:29.5838779","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A29Z&sr=b&sp=r&sig=pBtzrE8fidL1oPdmnAc3GBzHprme88MHORRVERMvrN0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:29.5839699","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:29 GMT
-      mise-correlation-id:
-      - 4cd8f2c7-c793-4293-a0c9-e5ca52e26a98
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A34Z&sr=b&sp=r&sig=zKEQR%2BObINkOdqOMkrRZ7ftQTKIV9Rma2NDf6rnUFVY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:34.8436851","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A34Z&sr=b&sp=r&sig=u%2FMMArQ2sPEcrBPgI8z1JhATtWVVmF7rwsVU0%2BiVqfQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:34.8436185","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A34Z&sr=b&sp=r&sig=wx6Pb6IWOsey1girrtpQKQ1JVGyuCpnwd3yAg0YUu3U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:34.8437008","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:34 GMT
-      mise-correlation-id:
-      - 9f58d08d-d530-412c-8343-ecc791de7ab0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A40Z&sr=b&sp=r&sig=Nq6a8igmau6eTOHBFtDtfnRT4qkGcCoqmP%2BZKg0iB%2BQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:40.2916345","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A40Z&sr=b&sp=r&sig=D%2BA%2FGPCtbdnsVCbDPA9E%2BERD4YIhb7JWTMmo4ugsgm0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:40.291559","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A40Z&sr=b&sp=r&sig=cc9Wgv5TEpLILhWSwOtLCjGnOugUvcsobaaXmGCIq7Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:40.2916523","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:40 GMT
-      mise-correlation-id:
-      - ccf063a8-724a-4bc3-92f4-a65038b52abc
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A45Z&sr=b&sp=r&sig=FtnCnfwpVQlDHFKttamM5mHVsAebjouekuXxCBaKEFk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:45.5482501","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A45Z&sr=b&sp=r&sig=swaE440XwuCeOIxTkXb12laMqW11XBetkKTUckdv8ug%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:45.5481575","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A45Z&sr=b&sp=r&sig=2nYhWVRmNv189OD7dJStuRjnTS3SDVNHwhMbCxrhHOI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:45.5482709","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:45 GMT
-      mise-correlation-id:
-      - ad5fd52e-e7e9-442c-a9ed-a51a7ed38e73
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A50Z&sr=b&sp=r&sig=uXeQYIM0PmbqVqdZxCnlAKaUUQ1DCTg6bZ9xirQhxzo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:50.8189273","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A50Z&sr=b&sp=r&sig=DV9OMIWrE8Msokl9e6cv44PBVPP3S03tqWSnnhekA0E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:50.8188548","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A50Z&sr=b&sp=r&sig=%2FXFa%2Bjzub7kRxGCoqV3YPecIogo4oXzYQKwphRIqLQw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:50.8189439","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:50 GMT
-      mise-correlation-id:
-      - 6ead2c0a-a8e7-4e12-b211-4a9a67fe3ced
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A56Z&sr=b&sp=r&sig=YNGaG9gXsMsWfcu2q4mzW2wxcSwjYQ0umSKthpBpV08%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:56.1666904","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A56Z&sr=b&sp=r&sig=ct7uZ64zA9Mo0qcDHmQ41V7GiqRYRKHxTr030y0JhDU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:56.1665957","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A56Z&sr=b&sp=r&sig=nRGQWcflSXKcpBfp99TOtRStI6T1iQ8be7reI36n9uM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:56.1667133","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:56 GMT
-      mise-correlation-id:
-      - f82601d6-c752-49f3-bbda-83c40af6605c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A01Z&sr=b&sp=r&sig=khS1wqE%2B4dj7D87MUhkBx%2FFJbDB79KgovImDSH75w4c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:01.440486","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A01Z&sr=b&sp=r&sig=i7R8EZ9W8aQ%2BIj8VPJZ1nmetJkR3%2FJ6qcRRJa5b%2FQEw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:01.4403976","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A01Z&sr=b&sp=r&sig=Ffq4s6bsKyBKUQ2BUWKwnvBukqxn%2B8jgtTC%2FR6TjHwg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:01.4405076","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:22:01 GMT
-      mise-correlation-id:
-      - 3f3ce8d7-98d8-41ca-9f7c-46e4e4e10d97
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A06Z&sr=b&sp=r&sig=gStCDxmcqAs5xBw4xSOq6wnNiYyMmXSAoEZfD1kCAd8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:06.6954012","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A06Z&sr=b&sp=r&sig=wK7iBoXrCUdxRHPvMaBD0uhB%2FvIyBMPEvMKKWJxcXMQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:06.69532","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A06Z&sr=b&sp=r&sig=fy7zbZ%2FdhULgJeG678Sl74Hbz411xMAWZCN51aGxxew%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:06.6954219","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:22:06 GMT
-      mise-correlation-id:
-      - ac37c1d7-68f7-4572-b539-9ea62e675e4d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A11Z&sr=b&sp=r&sig=hL%2Bn84ftWRDLY5TYUXrzVl2fj73ESvZmWz87QMoU5j8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:11.9636158","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A11Z&sr=b&sp=r&sig=mo%2BxCjbnRypu5VSAcYcIIkkEsRJxP%2Bxw1DEV235aLJA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:11.9635407","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A11Z&sr=b&sp=r&sig=c8pa9PKmMHYsZjA%2B3SLoivPhOW1XK7mx4009UbADMxk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:11.9636303","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:22:11 GMT
-      mise-correlation-id:
-      - 3cf05923-0471-4693-8535-d75554e6ee9d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A17Z&sr=b&sp=r&sig=52mXsGFTtOSlvQfs79A4S4FglEgAAEkm2bREERK9WWo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:17.2211012","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A17Z&sr=b&sp=r&sig=s%2FMYxhcLuqPy2oHEdOL8iYcPMlH%2B7JgfwDy6YSA6buo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:17.2210204","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A17Z&sr=b&sp=r&sig=%2BNasrjjKUO%2FC%2FqG0BU4B0zlHIRd1wUzi4fLhn0raHpk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:17.2211152","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:22:17 GMT
-      mise-correlation-id:
-      - a8914906-8135-4b1d-8a9c-845afca8a767
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A22Z&sr=b&sp=r&sig=LxGldI67BzO9jK8Hqw47zFs3Tfk%2BYuar8aQmcm6gnjo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:22.4912025","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A22Z&sr=b&sp=r&sig=posnQgGdHC4yuWXy8xu2t3do4z9bHQDFqMbTY0ZBZAs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:22.4911276","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A22Z&sr=b&sp=r&sig=68GPTRZtiRoA25KHJCe5MS2KWdFR8zT2dquO7z%2FZxsQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:22.4912173","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:22:22 GMT
-      mise-correlation-id:
-      - d1aaa8ad-c59a-4fe9-b853-f688b8087846
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A27Z&sr=b&sp=r&sig=oGvmUy4rC8fPQgtnf%2B4%2F7AdhMo7xYfhH3fRoPYdA5f8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:27.7883079","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A27Z&sr=b&sp=r&sig=lzhoQ9juc3LZ1x4xCpIJyKDnffuMouBLHTzbjsdO0F4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:27.7882385","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A27Z&sr=b&sp=r&sig=8AZ%2BDxfxMMVbV2ibj7DzPdSeIC4iE0ZYQkng2mukiss%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:27.7883228","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:22:27 GMT
-      mise-correlation-id:
-      - 0144d3ea-4f44-413b-abb0-cd28ae64a66f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A33Z&sr=b&sp=r&sig=yAwkLEGehuXaTGo3Rqi0Mm%2BegO4yyT%2FDMA%2FPG4Apt7U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:33.1065867","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A33Z&sr=b&sp=r&sig=G6LfnS975BHKGcr2iCXpqeZHswTlet9wEO2XQjTLJBA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:33.1065173","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A33Z&sr=b&sp=r&sig=UMK4dsBJWs4X5MJJbuyiZv8C4XG%2BX1QxZ7tMfs4QD4c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:33.1066021","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:22:33 GMT
-      mise-correlation-id:
-      - 70e848f9-536a-4c06-be52-699b677071d9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A38Z&sr=b&sp=r&sig=K%2Fgq7hfhioGCr2sXOfdqGmkJG5D9I8038t9lsJh3%2FLU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:38.4372313","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A38Z&sr=b&sp=r&sig=Op5U8712YgLs3b5ywndseCLhXgsKWH5ZbC8ilOV%2Fm4U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:38.4371469","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A38Z&sr=b&sp=r&sig=CLJ4hB5x%2Bt2t1tWZi3vrbiUeeAx1mTQTT4rWYi0Xkag%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:38.4372582","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:22:38 GMT
-      mise-correlation-id:
-      - 60f23734-998d-4b54-9856-f72788e7be91
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A43Z&sr=b&sp=r&sig=EB%2B03ZPP8iXJ0SCIYbTa%2Feaw1aw1Z2DIQY7jxajxypE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:43.7699822","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A43Z&sr=b&sp=r&sig=QiTbuhYW1FS2qwGp61Ejpt%2B1bwuNl0NZmKGlTxkkiIc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:43.7698807","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A43Z&sr=b&sp=r&sig=yfDSyRSaW%2Byx6dxtNLOGvxYgSRNQ9%2FnhlL5l2oP2Rx8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:43.7700059","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:22:43 GMT
-      mise-correlation-id:
-      - ca630ac8-4969-4ae5-b57a-afa6cab906e8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A49Z&sr=b&sp=r&sig=aO75DWTc3fgcvBFD%2BYMzTfBZj0AMR0Ry2YIDtYKPqrg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:49.0504127","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A49Z&sr=b&sp=r&sig=b9gNoLHvovfLurE7iF14oIXPdrAlONBnvQloMlTMzPs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:49.0503312","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A49Z&sr=b&sp=r&sig=KvL3GYl1HIuwMBIVgpR8kTMNpGIvEI9bhj%2BEQjfJSPo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:49.050429","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:15.119Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.534Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A48Z&sr=b&sp=r&sig=zy7yVXH0WrmEmafTNTc41KqyblN9GjXXvOG91naXPMs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:48.8006312","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A48Z&sr=b&sp=r&sig=UgufX7gJjhQ9Ru8FsPPPrjzKPyU%2BTvOHQQ6cxDI5ueU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:48.8005532","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A48Z&sr=b&sp=r&sig=cfRwZhdoQ%2FcaivljrbNHrPADYVMieiJfWNwKmqXfwYI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:48.8006448","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:10.05Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:56.597Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +1794,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:49 GMT
+      - Fri, 13 Oct 2023 13:55:48 GMT
       mise-correlation-id:
-      - 095c550e-e3e8-42ba-9b17-c1454991bd02
+      - 21342c5b-5b33-44bd-8784-2f748a9f8e68
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1778,26 +1814,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A54Z&sr=b&sp=r&sig=86NQTDCFAzF5rmWD2NfLQmvVM6HVHVEyrOqk3ryUxQo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:54.3167215","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A54Z&sr=b&sp=r&sig=gAjxMX6QYzyBUhOVxzDq44kXsgV%2BEMgYBOnk2Ceqg2g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:54.3166362","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A54Z&sr=b&sp=r&sig=0qDcb%2FsA1v%2BS79%2BuaGNk3T%2FhSxaniJj4EHjdJriHqRM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:54.3167416","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-09T19:20:15.119Z","endDateTime":"2023-10-09T19:22:52.684Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:52.93Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A54Z&sr=b&sp=r&sig=7fNJyAWX2MzFMS5qvcQi0gUqYJA0lp1cgNwxCYqLblA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:54.0478913","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A54Z&sr=b&sp=r&sig=cXif2B0Ywt%2F7vYjyl2ZF%2Fa1Aw%2FJ8edj%2BmvOBE0jBLOg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:54.0477901","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A54Z&sr=b&sp=r&sig=nZRhGdK3kGuZ5XwT11Hzfg7cC9rW54XxdgsSZS81eSk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:54.0479123","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-13T13:53:10.05Z","endDateTime":"2023-10-13T13:55:49.449Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:52.173Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3336'
+      - '3334'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:54 GMT
+      - Fri, 13 Oct 2023 13:55:54 GMT
       mise-correlation-id:
-      - c9b5ca26-4258-4ac8-9c93-f0b60310f4e4
+      - a8b919d4-5fe7-4927-a594-984f1d870370
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,7 +1856,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:15.8114883Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:15.8114883Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:07.1706004Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:07.1706004Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1829,9 +1865,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:55 GMT
+      - Fri, 13 Oct 2023 13:55:55 GMT
       etag:
-      - '"5600d22d-0000-0100-0000-652452350000"'
+      - '"d8013df6-0000-0100-0000-65294b890000"'
       expires:
       - '-1'
       pragma:
@@ -1859,26 +1895,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"6986a558-25a2-4e7a-b03c-f83307a4a419":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"26934601-08fd-4fba-a8d0-fd388aefba0c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c735a1eb-253b-4872-8cdb-d0ed4aa5db2a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/46719fa3-b709-48c3-bca2-a62ce20812b4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A56Z&sr=b&sp=r&sig=RaDPzaNTGAkm1ZEX37tf1VPH8aRJlQOAUFC0jLn9q6Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:56.6807791","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/b06566ca-3f32-4286-a677-533b8e1a8d19?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A56Z&sr=b&sp=r&sig=zAfzeCVT4Ntuw%2FlCiVJdmj1lBWiKlDSOWYs2pwfO2Wk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:56.6807099","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/61f3c365-e3ad-45b4-8c8b-060a082bdaf1/1bf50259-35e2-4eda-a27a-048431bc2f0c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A56Z&sr=b&sp=r&sig=l5f57iuUFQ6IQj4V5mHmqMMynNEIZv7bYWXVXMmvML0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:56.680795","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-09T19:20:15.119Z","endDateTime":"2023-10-09T19:22:52.684Z","executedDateTime":"2023-10-09T19:20:14.426Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-09T19:20:14.672Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:52.93Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"95c9282c-2e6c-405d-ab78-c35409476a2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"aaedaf4c-b014-4f57-b057-4c148fa7de03":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab5435b0-bf22-4d68-b3d8-b1b953694252":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/7a824fc3-cc4b-4c3a-853d-561a1af02678?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A56Z&sr=b&sp=r&sig=ApXn%2F9fx3MkZlmSxbNwrLEbzSf9Y5Wbn6q97W4W%2FGwQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:56.8303033","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/8c843519-387c-4caa-bcce-b6beabab6e98?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A56Z&sr=b&sp=r&sig=5hy8yOGNdSQs0MjfBJmNLI96kkj%2FfMQpcRzz8BZ832E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:56.8302193","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/41a46c26-c971-49c8-b29a-e03893223ab5/86eab216-e9ae-493b-a534-b4a626e864aa?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A56Z&sr=b&sp=r&sig=yA6q1NY1nJ%2F099lV8rygAaLcWHnI1RoUcYHbQ6icEk0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:56.8303248","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-13T13:53:10.05Z","endDateTime":"2023-10-13T13:55:49.449Z","executedDateTime":"2023-10-13T13:53:07.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-13T13:53:08.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:55:52.173Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3339'
+      - '3346'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:56 GMT
+      - Fri, 13 Oct 2023 13:55:56 GMT
       mise-correlation-id:
-      - 69a03065-fa42-4e85-95f1-4ab6bc6f5604
+      - c561b56b-4b69-4061-a022-e5fe68baeedc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1901,7 +1937,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:15.8114883Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:15.8114883Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:07.1706004Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:07.1706004Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1910,9 +1946,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:58 GMT
+      - Fri, 13 Oct 2023 13:55:57 GMT
       etag:
-      - '"5600d22d-0000-0100-0000-652452350000"'
+      - '"d8013df6-0000-0100-0000-65294b890000"'
       expires:
       - '-1'
       pragma:
@@ -1942,9 +1978,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -1954,9 +1990,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Mon, 09 Oct 2023 19:22:59 GMT
+      - Fri, 13 Oct 2023 13:55:59 GMT
       mise-correlation-id:
-      - 8c8c428c-49f9-447e-b2ca-781b3112f01b
+      - 1f492117-f729-466a-a274-75e110de205a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1979,7 +2015,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:15.8114883Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:15.8114883Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:07.1706004Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:07.1706004Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1988,9 +2024,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:00 GMT
+      - Fri, 13 Oct 2023 13:55:59 GMT
       etag:
-      - '"5600d22d-0000-0100-0000-652452350000"'
+      - '"d8013df6-0000-0100-0000-65294b890000"'
       expires:
       - '-1'
       pragma:
@@ -2018,9 +2054,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ee66c3cc-991a-4138-abb9-d5751afdc802.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
+    uri: https://7e9463fb-0dc7-43af-ab94-23d4347c04d1.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -2034,9 +2070,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:01 GMT
+      - Fri, 13 Oct 2023 13:56:01 GMT
       mise-correlation-id:
-      - b3251e9c-06ac-4798-884f-5cf9173ab421
+      - d025dd30-1ee4-4cdf-b6ba-2a343d2cf76b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_delete.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_delete.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:45.5929152Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:45.5929152Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:55.9059511Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:55.9059511Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:19 GMT
+      - Mon, 30 Oct 2023 07:22:30 GMT
       etag:
-      - '"3c006929-0000-0100-0000-653edafb0000"'
+      - '"3f00d46b-0000-0100-0000-653f59950000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:22:21 GMT
+      - Mon, 30 Oct 2023 07:22:31 GMT
       mise-correlation-id:
-      - d1dda3a1-5f07-4566-945a-594bcf568b18
+      - ce40b484-bc51-4bd4-bc08-806afa08d802
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"ea1fbfa8-0fe7-473e-b316-d6d20eacd390": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "dec2f4f6-0237-4e02-ad8f-3107c1a1000d":
+      {"passFailMetrics": {"36a15b60-dbb6-421b-91fb-b05f0765cf57": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "01430d40-cf88-4d64-b6fe-3566ca773815": {"aggregate": "avg", "clientMetric":
+      "50"}, "6a81bbfc-6a7c-40af-8c42-efa439caf8a1": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:22:21.482Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:21.482Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:22:32.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:32.019Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:21 GMT
+      - Mon, 30 Oct 2023 07:22:32 GMT
       location:
-      - https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+      - https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 42ff8190-5e32-475e-affe-aa5dfb7d9911
+      - a0adcd81-4705-4767-842f-eae68420d73a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:21 GMT
+      - Mon, 30 Oct 2023 07:22:32 GMT
       mise-correlation-id:
-      - 7e5c8117-e34d-418a-ad3c-f8501dfe6a73
+      - 76e5058a-d133-48e3-a713-b4b31d089837
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A22Z&sr=b&sp=r&sig=LzmkYLCO7WwyvTvTNk04Yb08ChObDSK1Ca0A8Ae1mLU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:22.883974","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A32%3A32Z&sr=b&sp=r&sig=j36tiOSmftgrGs%2BeRD%2BFDm4TLrF7FXmVP8jg5P9ykic%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:32:32.9098249","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '548'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:22 GMT
+      - Mon, 30 Oct 2023 07:22:32 GMT
       location:
-      - https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 241791bb-fbca-4bbc-8e82-1a3a48690031
+      - 3f735c68-8711-4ad4-af67-2a1718eb3314
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A23Z&sr=b&sp=r&sig=Q6MP18Eii6BlvP%2FncZ2Q2LbO8T4KqI4zcqyRfMf6BHk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:23.2060432","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A32%3A33Z&sr=b&sp=r&sig=eBS7YhbOdqOfxDkHdzjXCeH3ubIo%2BBj12G%2FArmsfCAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:32:33.162528","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '552'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:23 GMT
+      - Mon, 30 Oct 2023 07:22:33 GMT
       mise-correlation-id:
-      - b5dbd993-4e5e-4a31-bea8-49772b325e78
+      - 0b250bb2-8b35-4f72-926f-15ebc4262013
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,10 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A28Z&sr=b&sp=r&sig=V2dcgmx6czfUHsbvubZNZI5bitVJAkOnlay11LZRHvY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:28.5061705","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A32%3A38Z&sr=b&sp=r&sig=je48uJEQrSE4UyRT4hIqXqoDvDlv2OJLy3WmOdFdhE0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:32:38.4735126","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:28 GMT
+      - Mon, 30 Oct 2023 07:22:38 GMT
       mise-correlation-id:
-      - 61af8020-11da-43d1-99c4-def288764a07
+      - 58c1036f-38ed-4fe5-a1c2-4976dbe89c76
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A33Z&sr=b&sp=r&sig=EbRvyc77VMtV%2F0Z0zVLBVOr5MvKR%2FeLFotoCsxz3yWs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:33.7656034","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A32%3A43Z&sr=b&sp=r&sig=s4zj0ZMMmTgiek7X60ADRtZpnS3gY7Q9TsNheb1BhT0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:32:43.8124183","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:33 GMT
+      - Mon, 30 Oct 2023 07:22:43 GMT
       mise-correlation-id:
-      - 0025b330-d769-4ad9-a119-d9b0abc80b09
+      - 35caa728-7f9c-4570-bb67-3f050f0a00f9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,10 +421,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A39Z&sr=b&sp=r&sig=YEZpI5LKKIEPROp6rV52qY16tFMJ7a5BsFDbbFdgv2A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:39.0180364","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A32%3A49Z&sr=b&sp=r&sig=kRaT8Ng1lH5F4BddMYHgos2NMld6Iiz1Vy2gC6JFM9E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:32:49.1374864","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:39 GMT
+      - Mon, 30 Oct 2023 07:22:49 GMT
       mise-correlation-id:
-      - d4823493-e605-4a06-ada9-47b95ca117e7
+      - 8b236fff-6867-401f-a4da-56fe5dc3a6a3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A39Z&sr=b&sp=r&sig=cf507KyYUWi0wHseBjjHcbvbWFbwhgVZxusdIkTBiYI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:39.2571479","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:22:21.482Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:34.586Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A49Z&sr=b&sp=r&sig=7WKSOt13RsPk%2BlC6%2FM61u2jcww%2BuFVk7wMjZVKQ9IMY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:49.3935322","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:22:32.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:45.831Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1577'
+      - '1583'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:39 GMT
+      - Mon, 30 Oct 2023 07:22:49 GMT
       mise-correlation-id:
-      - b1a9b5e5-2fea-48af-a319-7a9597c432e7
+      - 7f462a15-200f-4c94-9ba7-8e8b059940d9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:45.5929152Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:45.5929152Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:55.9059511Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:55.9059511Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:40 GMT
+      - Mon, 30 Oct 2023 07:22:50 GMT
       etag:
-      - '"3c006929-0000-0100-0000-653edafb0000"'
+      - '"3f00d46b-0000-0100-0000-653f59950000"'
       expires:
       - '-1'
       pragma:
@@ -538,11 +538,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A41Z&sr=b&sp=r&sig=y2ifA7U60M7IemTgnFkc%2FTwemLeSHwDeH8XYXf37FSM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:41.5383209","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:22:21.482Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:34.586Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A52Z&sr=b&sp=r&sig=%2FWmbAMfY6UZgSzLyfT9e1MKk39P0B8cySsJgKxTmeaM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:52.2838645","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:22:32.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:45.831Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:41 GMT
+      - Mon, 30 Oct 2023 07:22:52 GMT
       mise-correlation-id:
-      - 0f895543-df7e-4ac8-a73a-e698d7fe811e
+      - 62458d1e-f599-465e-bc6d-276aebf1881e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:45.5929152Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:45.5929152Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:55.9059511Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:55.9059511Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:42 GMT
+      - Mon, 30 Oct 2023 07:22:53 GMT
       etag:
-      - '"3c006929-0000-0100-0000-653edafb0000"'
+      - '"3f00d46b-0000-0100-0000-653f59950000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:22:43 GMT
+      - Mon, 30 Oct 2023 07:22:54 GMT
       mise-correlation-id:
-      - dbebb625-a3f9-41dd-bf29-9caaddc4c5a1
+      - 8510ef65-e588-4b4f-b30f-2ff758801ff5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A44Z&sr=b&sp=r&sig=OIq8DXl2Vwq%2FW5rPb%2B5UIFYmkC%2BsrA%2Bpx6ix%2BdbXmxM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:44.6295054","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A44Z&sr=b&sp=r&sig=Lt2j%2B1sZuVfX8dr1OZfRgM0zLieH0WiftWT%2FJFivAio%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:44.6294052","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A44Z&sr=b&sp=r&sig=92lBRn8bDKn13ZOFmapGjPdWgeGbGj%2B%2FWtOIVFEuwJE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:44.6295288","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:44.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A55Z&sr=b&sp=r&sig=hw%2FdDuuufYtrEVLQ9DnZAvC5V6hoyOU1EMjjiJQsInE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:55.8107025","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A55Z&sr=b&sp=r&sig=rIyNO060TyF2NQDLgAYQDbWfwRdiAptezKiyd83emq8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:55.8105762","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A55Z&sr=b&sp=r&sig=BNdYJzt32H4UZZpxsMXjh6Fa%2B7XqwIpsfksK7nv9qJo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:55.8107263","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:55.721Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3166'
+      - '3152'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:44 GMT
+      - Mon, 30 Oct 2023 07:22:56 GMT
       location:
-      - https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+      - https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 261b300a-45e8-4497-b359-c6a5a7405262
+      - 8a63603d-4e94-4a42-b814-36fe90c6cb9a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,334 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A45Z&sr=b&sp=r&sig=aZj1tCwTwe271rCSCMgL11ukVSLgHGOQby2MocMJXE8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:45.2887735","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A45Z&sr=b&sp=r&sig=jmAgzLVTwGvrIiCvtqpD88pqH9hP1njHw2cRWwC40SU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:45.2886863","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A45Z&sr=b&sp=r&sig=jThdHBt0a8TiIu8sDc5RQ0k0QkD0%2FtI%2Ba3Ks2ER9hrc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:45.2887963","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"NOTSTARTED","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:45.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:22:45 GMT
-      mise-correlation-id:
-      - 67ae14ca-3f4a-4234-9722-aad7f31b0b6d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A50Z&sr=b&sp=r&sig=sIoVBWgqDg5eeTtdNgLyqL6%2F3yyoS5NPJY0may6jHS0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:50.5632223","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A50Z&sr=b&sp=r&sig=x2G%2FUDDMQNNKhy2UO0068wsZxL24XzMGq4uYVl2B7mA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:50.5631372","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A50Z&sr=b&sp=r&sig=dp0TUmdTG%2Fn67fbdkcEUpGryDXXeMUtQn1%2FBoo%2F4Khs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:50.5632367","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:45.29Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:22:50 GMT
-      mise-correlation-id:
-      - 07d43ff4-9d70-4e9b-afd3-a8f2e82a337d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A55Z&sr=b&sp=r&sig=xMsNZcZvbQ39AV7xYGUJsrQdSrGeXNZpOx4%2FR88sboU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:55.8677315","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A55Z&sr=b&sp=r&sig=vC%2FhyL5Vmw1EuJZ%2FOsPqcT8QN%2FrsprABS9AjdkcYXog%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:55.867665","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A55Z&sr=b&sp=r&sig=B7F2eMCeCXCma91AWqOvDMBbI5WZCri0nkdu5NwWxEI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:55.8677455","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:45.29Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:22:55 GMT
-      mise-correlation-id:
-      - 8f4d805b-92e9-4784-9a3d-3ee754fcd2ab
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A01Z&sr=b&sp=r&sig=2FsNcq0vCuMaFcocdYtBFr2%2BpnuqxUAqeOxt4tC%2B2DE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:01.2089772","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A01Z&sr=b&sp=r&sig=I1pwjiTwe560JJd%2FH37bg%2Fl0C0qnEDl6rg6birdToAU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:01.2088913","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A01Z&sr=b&sp=r&sig=gY8VSb%2BYgsQfDBv41ux4IZt44OfQpJOq9zaxuJXYMvo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:01.2089929","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:45.29Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:01 GMT
-      mise-correlation-id:
-      - 8ce938d1-7ef9-4acf-82f6-2eaab9f109cf
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A06Z&sr=b&sp=r&sig=sQkYFb8AbJHgnzY9Kj%2FH7QbfhzBdVos%2BkPJ5CK20L6k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:06.4597426","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A06Z&sr=b&sp=r&sig=fQR3aDqVnVINQwEbXapgV13OWCFj5N21eT%2BM1fsi4wI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:06.4596736","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A06Z&sr=b&sp=r&sig=J207Or7JgoVb71DeewAh%2BDK3FTRITQIvw6p%2FvrEZ72U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:06.4597579","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:45.29Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:06 GMT
-      mise-correlation-id:
-      - 1a3e3c62-c952-4174-9ff0-34baee9ab335
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A11Z&sr=b&sp=r&sig=gFzsur2a1WmkyElD3vOKljhtD%2B90lyENxCcYBtypUPQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:11.7470949","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A11Z&sr=b&sp=r&sig=%2F1pF0MscyWMpSNV625UN1eXem8W2ei2sFM3YSrVRNxY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:11.7470085","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A11Z&sr=b&sp=r&sig=TA9pwnJGyYhGfnpy6Vh2l5QGN7sEv4vuGVWDXMt%2FwJA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:11.7471163","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:45.29Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:11 GMT
-      mise-correlation-id:
-      - afd77a85-4463-4be7-9cde-5d2acf647510
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A17Z&sr=b&sp=r&sig=4qFN%2ByyMKuswoaSfMRtPeKu76Gg6442UMYhc8Dmf8UM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:17.6064334","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A17Z&sr=b&sp=r&sig=wK8yOqbnwA3vKGOExjnlVHPl7QNsMrbU%2BZE4Bgev%2FJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:17.6063594","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A17Z&sr=b&sp=r&sig=iztho5tXkkyXl1ngQSTUxwKh7hDa1n9aMxbKISdn%2Fzo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:17.6064474","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:45.29Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:17 GMT
-      mise-correlation-id:
-      - 7c7b9018-9387-45a5-8cb5-b5d8f224f73b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A22Z&sr=b&sp=r&sig=HlpbKyDbx1KoZOti6MD2MPGHhgEzpryFhBLXodwAjgY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:22.8589159","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A22Z&sr=b&sp=r&sig=I6Z%2FJTzw92noBe%2B29%2FJDwY3FZJXVoNkz58VDzvRtBkA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:22.8588263","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A22Z&sr=b&sp=r&sig=G3JDHtTel9Byg512rSNIzOchv3qlVc8Lr27IiObARf4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:22.8589379","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:45.29Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:22 GMT
-      mise-correlation-id:
-      - 2dc3ec7c-be14-437e-b1e3-b4dc712fee50
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A28Z&sr=b&sp=r&sig=7kbCYMsbYAX6XDM%2F7mBaYNWSksSPXzsZ233jVMR0wCw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:28.1066728","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A28Z&sr=b&sp=r&sig=CKyXhWYeIHsUt33Ci9tyGWLRPojGMvIOFuuWvoaaxZc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:28.1065864","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A28Z&sr=b&sp=r&sig=ENyZUYBcTioxXRRnCrheCvwToKcEzGBXpUIh8zZzvS4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:28.1066949","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"CONFIGURING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:27.387Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:28 GMT
-      mise-correlation-id:
-      - 9bcde095-aeaa-42ed-b729-8d4e98b86d9e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A33Z&sr=b&sp=r&sig=YXY2gJz3o8c4qYlX055%2BfEzUiRwncMtgkATCHVMoZ2U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:33.357903","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A33Z&sr=b&sp=r&sig=rKsXW5SS3YnLjXegtT7makADfgi9nrAVAg3F%2B9YmfCk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:33.35783","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A33Z&sr=b&sp=r&sig=tM3xQAwnh9QjpdjE34ScPyB%2Fg4BU5YhULo78FgYNa44%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:33.3579166","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A56Z&sr=b&sp=r&sig=5ph3OUpZNT2uZeG6igZeEiNXMrawpeykqeP7XRrDplU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:56.3246708","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A56Z&sr=b&sp=r&sig=x0eyJoJZp5E59wUek6UyP0wVJS0jPwWdBqb73DWNlkM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:56.3246017","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A56Z&sr=b&sp=r&sig=QWVcFM2SzJ1xm5i3jPM53IInrRryQ9aqTnBSapK3CgI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:56.3246865","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:56.294Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1038,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:33 GMT
+      - Mon, 30 Oct 2023 07:22:56 GMT
       mise-correlation-id:
-      - 8408f3a9-63e0-410b-8900-1bc9cbcab8b9
+      - 491f6cb2-e1be-47a7-8ede-b3435e438ec0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,514 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A38Z&sr=b&sp=r&sig=by%2BixTOj%2B5Wee6rb2aJWu%2B46o3zHWmgn9r%2FWjz8Teb8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:38.6763689","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A38Z&sr=b&sp=r&sig=6SgzfCTAKXIpJ%2FD1HLQad8cpgP2I9mGQPvfbIMWSg5I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:38.6763015","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A38Z&sr=b&sp=r&sig=fkigXJGbsE%2F96rp2ccMR%2BZ09WZsTuywwpQu10sb4rj8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:38.6763835","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:38 GMT
-      mise-correlation-id:
-      - 996b2bcd-f5e5-4bb8-835d-1cfdcdfc7b9f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A43Z&sr=b&sp=r&sig=5p%2F638nJO5biVCB7gXi0y6IkVq6FbnDdzyFdqN9Y8rQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:43.9303992","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A43Z&sr=b&sp=r&sig=T7TlsEMIuhJOzYctVbk9No1%2FdWiZwJW%2BVC2SqpRG8Oo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:43.9303271","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A43Z&sr=b&sp=r&sig=%2FMgeUQ0WNIlJ%2BJcYlDtfzEB7KJFQc%2FqRW9Pi8X%2F0Q%2FY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:43.9304156","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3208'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:43 GMT
-      mise-correlation-id:
-      - 2806e2bb-ca3b-487f-ae65-dfb4260bbe20
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A49Z&sr=b&sp=r&sig=uviO4H39%2B2U6kYxk3U2BOMoyKmq0ijdpY94fwlLXn1k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:49.2260091","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A49Z&sr=b&sp=r&sig=zcZ9LZxI25iTkq5oFWRxbtBaIXIC1dg1qCp51lEo%2FPQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:49.2259097","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A49Z&sr=b&sp=r&sig=pdgrzKeWNIFCoBQHfXwRJ%2B4X2SirRfM0KwBCVPliGcQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:49.2260336","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:49 GMT
-      mise-correlation-id:
-      - ff1bf0a1-fa99-4bae-8721-3e4880a3c98f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A54Z&sr=b&sp=r&sig=YDB%2BnEEpRp6caZaFukW8PtYUz91gWcY7T8NnOD2JBXM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:54.5562828","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A54Z&sr=b&sp=r&sig=Nin6rXecx1rRcWwiGcUGR3VadR33qvZEEdXG9mlbh%2Bo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:54.5562238","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A54Z&sr=b&sp=r&sig=7ON592N8va424KGgp0ZaaSRI%2Fdcq8D5ZZ6dumxXK0ho%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:54.5562973","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:54 GMT
-      mise-correlation-id:
-      - eb2e0f73-e1be-4e79-9ac3-0281719ddb61
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A00Z&sr=b&sp=r&sig=3g%2BwWgHtI2fs8dJzJ5yhRmHwrirT1QWfBUfHITQ%2F%2FeI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:00.0806579","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A00Z&sr=b&sp=r&sig=tfHo8EVjnFPuXmhY3rc7vRWbA4qXRt9mmdKxM7rttbc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:00.0805518","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A00Z&sr=b&sp=r&sig=HqMudgULd8mJ44t%2BFRvzpav3Plcj0bfri69oKDtKRTU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:00.0806863","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:00 GMT
-      mise-correlation-id:
-      - 491c0794-3cfb-46df-b8a6-4dae84bbf802
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A05Z&sr=b&sp=r&sig=9ku74xoSWf%2BtW%2FdfYXtOzfhVJF8C1sppuu%2F9CiEE15k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:05.3254026","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A05Z&sr=b&sp=r&sig=l7apEt4XpomXAGjBp1OuLuHK%2BEX2wilrFS%2FCdFMLzKU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:05.3253353","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A05Z&sr=b&sp=r&sig=ZCB3VSVBVho%2FOicgrLRw%2BEOi7Ko4BKmQC%2FoAxpyC%2FGc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:05.3254173","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3210'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:05 GMT
-      mise-correlation-id:
-      - 97ad5fb7-4086-4b50-b26e-7ccc17c500a2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A11Z&sr=b&sp=r&sig=C6T8KK54qTSda4U7hYwYG%2F%2FmQK1NgR0DdGx5CTjbK6s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:11.1170841","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A11Z&sr=b&sp=r&sig=KWpGKs8waMFbwXzks0JeKg4jHs3sYufppzYu3IzDK08%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:11.1169916","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A11Z&sr=b&sp=r&sig=mgzEXhOQvDxHbfEUQuMVEii4xgkMUbIB0m5zMR3FRIY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:11.1171144","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:11 GMT
-      mise-correlation-id:
-      - cd8a9997-4f86-42cb-b825-9843b991b11b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A16Z&sr=b&sp=r&sig=2Vsr%2Fp7NngSPQ9FmcSvC6QWsa3zAFTHfPGO8ubTcNu8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:16.3699368","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A16Z&sr=b&sp=r&sig=2X7kb%2FrszJLWa%2F%2BHAtGyEfE%2BmXiPbsbxZDI%2FthLje3c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:16.3698653","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A16Z&sr=b&sp=r&sig=Hoeb83n0NWPkaxBO6DVqpF7CQBGQdhdTAT5FyGaKEZY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:16.3699509","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:16 GMT
-      mise-correlation-id:
-      - b952137b-2f6d-4ac7-9c71-31a0a029b651
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A21Z&sr=b&sp=r&sig=4Br6DmwDeZPJ12r2MjVvHtl7TjETYWpVLjVZNcx%2FPrw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:21.6945079","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A21Z&sr=b&sp=r&sig=JW80izEw4NSqnFMtQ8%2FLiDLCpnE9JikAsqDwDV6pJ1o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:21.6944235","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A21Z&sr=b&sp=r&sig=da56g8e83UXZL7utf4J%2FxbcRVXKsEKgyzNQitQ0x%2FuU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:21.6945218","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:21 GMT
-      mise-correlation-id:
-      - 5d3c965b-2576-49d7-bf36-e03d4ca6522c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A26Z&sr=b&sp=r&sig=aXMt0vh3N3%2BXoAbyu5y6mMOSflCszhDEmWySMZuKFmA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:26.9453163","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A26Z&sr=b&sp=r&sig=xACJi2LRTSTz%2FuOQ9SqlX8sAC1cp5glJ%2FDsPT0h3bWQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:26.9452262","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A26Z&sr=b&sp=r&sig=oWf0Hwo0eQJn8qkTEkxT5wbfdXUvLSCJ8IebFBXGX1A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:26.945339","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:26 GMT
-      mise-correlation-id:
-      - ed3ab39a-c0bf-4d19-b85f-09f45e1a9822
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A32Z&sr=b&sp=r&sig=X%2FjWChjAHYDA76mY4FylFQ1kxpshspkG3zTqjdvVSeM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:32.1883376","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A32Z&sr=b&sp=r&sig=6yYrrKQFe%2B0nlZvnich2tAbOhVOrPNIldtIN3Qi3G8M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:32.1882234","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A32Z&sr=b&sp=r&sig=A4F3FMFQRrlm%2FJkNxZknvlLDVlqCSsb54W%2F50lx8itE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:32.1883579","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:32 GMT
-      mise-correlation-id:
-      - 2f0e3f29-438a-48d4-adc7-60a567910130
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A37Z&sr=b&sp=r&sig=FEcvCPyipSY1wraQPyTOw6IF0CCk1IPkkdK2CgjdORE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:37.4607273","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A37Z&sr=b&sp=r&sig=Vap6EKo6VjJ8cFz1U1wuncVpxtT03id128%2F1H6pAB5o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:37.4606413","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A37Z&sr=b&sp=r&sig=%2FLuyACR4MkQYUOEieMYio6sEEQyvpySarDUifeOp104%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:37.460741","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3195'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:37 GMT
-      mise-correlation-id:
-      - 2591f1c5-99cd-41da-a338-e8c312a1f41f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A42Z&sr=b&sp=r&sig=8yRoHUgqI4X98cH5it2VoxDEryaFs8UfeyOKMpnXBzc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:42.7129827","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A42Z&sr=b&sp=r&sig=zma%2Fye1jqVLfrEp9yc74yJwJeGcAStby8tpG79eZATo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:42.712892","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A42Z&sr=b&sp=r&sig=vRPJlSdIUcGM7zDTdDod8QM1Ga2Eq7mUuuIJo%2BCzX2g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:42.7130076","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3195'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:42 GMT
-      mise-correlation-id:
-      - bde15944-5b24-4af8-8044-962484582ebe
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A47Z&sr=b&sp=r&sig=kBdiJpmlzcaKX4eXl%2BOUCqVw%2BxGWltJcafvBHQXfx84%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:47.9991434","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A47Z&sr=b&sp=r&sig=hdZlHoMFNXcEsR6bfDmQ%2FucYBOWajApsszIGpzAn4tw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:47.9990406","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A47Z&sr=b&sp=r&sig=AN%2FEMZvwNI8ptBJLOXG1dQ3d3DSIrwzzmZIlq4fIY1c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:47.99916","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:48 GMT
-      mise-correlation-id:
-      - 8bf9c0f8-0ffe-40ff-b18f-c5f936b04336
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A53Z&sr=b&sp=r&sig=xjvg8WbR8nvufOpoWm%2FlQNPvVQfjfSa%2F4oQD%2FdL98Gg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:53.325728","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A53Z&sr=b&sp=r&sig=IP046XVQw5uPbGP1ukn9edtc5lvrwxg45Vn26%2FpyCGw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:53.3256578","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A53Z&sr=b&sp=r&sig=G6DdhXjdnfPDvF7Dymwi3RRToM87GU6VwM2lPlITBlQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:53.3257438","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A01Z&sr=b&sp=r&sig=AYc7EzEQBEzK6fHRjRxKOBC7yRz2NAHju%2BeIJHFtOCo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:01.6505068","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A01Z&sr=b&sp=r&sig=iMJdwC2LhD9ktRB63xMWEHou6NPY4NJ2WrM7m2wicSM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:01.6504412","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A01Z&sr=b&sp=r&sig=yJGKSf2HFVwnRrnRy1OoINj1kiV75ijN%2BFz6ArscwX0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:01.6505213","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:56.294Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1578,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:53 GMT
+      - Mon, 30 Oct 2023 07:23:01 GMT
       mise-correlation-id:
-      - d7f4a633-c224-4ffd-8c76-c8968f5c3f0c
+      - e0b00d6f-b18a-43e7-8d22-ab5a73aecef8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,10 +772,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A58Z&sr=b&sp=r&sig=PgtQGeeqRO%2FgiHpS5QxGRwzhvHFynKR8%2Fz94jPVV5UQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:58.6025973","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A58Z&sr=b&sp=r&sig=3ZYt%2BxVnaJuLeCWwfu5JSyg6wYzyCNvi9vYgzAt4qvE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:58.6025248","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A58Z&sr=b&sp=r&sig=9BI56%2FQivbmNtZ7il%2FkoPKbOLNWa7mi%2F4zNOtkgMSoo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:58.6026132","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A06Z&sr=b&sp=r&sig=fOpB9wIc4FUk4cBx1RTxGTIUgDl0mmIdStkRxcz%2BYFw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:06.9606723","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A06Z&sr=b&sp=r&sig=LvzzS6xV1mWt0cANQ9NlD2%2B5imcDLI2lGFlwt2jhNGs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:06.9605883","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A06Z&sr=b&sp=r&sig=RFcikpqbbUkjw1dJH9osReZrL%2BIsfQMXyZnMk4737nA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:06.9606941","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:56.294Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:06 GMT
+      mise-correlation-id:
+      - cac4eed9-03ee-41b1-afb5-8980f47c930e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A12Z&sr=b&sp=r&sig=EkrLKNywVKYs0HScyqW44tABfaXrQmrB3mvPp03ecnE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:12.2318832","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A12Z&sr=b&sp=r&sig=LGLeHaG5IWe8NAmTb6uxX%2FhbPgbltzOB9LDqWhZbM8o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:12.2317965","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A12Z&sr=b&sp=r&sig=jlnBuEKRCjK37zfl4YSie5QbFW2EMpMrTd5bttJodWA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:12.2319066","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:56.294Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:12 GMT
+      mise-correlation-id:
+      - e47003da-e44a-401c-9f47-aa1ac6c425cf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A17Z&sr=b&sp=r&sig=h8L1M1dTTVUHbxs2q0K79d3fbG5YYO%2FlAxOUaMq5174%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:17.5133429","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A17Z&sr=b&sp=r&sig=I5GDF4XxaxihpAMGVZoR1by8WV4pIe5V2s1Fib7oyIg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:17.5132729","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A17Z&sr=b&sp=r&sig=ulNqrV4beFY4XQWyxlV1Iv88gqtMsVH3HccaQcab2lI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:17.5133578","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:56.294Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:17 GMT
+      mise-correlation-id:
+      - 3f1025cf-b4cf-4de2-91ca-ebc94ff6aae0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A22Z&sr=b&sp=r&sig=Fs1n9LqMebep1u75mNpS3mKfevlPzJWjKmx5kzE6vp8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:22.836125","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A22Z&sr=b&sp=r&sig=RgHAzEwaRuTwemgxnmOLFD8sIrD9t9%2BsGhXlRFV%2BfOU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:22.8360246","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A22Z&sr=b&sp=r&sig=VRE%2B%2BdnMv4rJJLuch01j%2FPUsVCjD7wqOTXesg06bSzE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:22.8361422","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:56.294Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1614,9 +894,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:58 GMT
+      - Mon, 30 Oct 2023 07:23:22 GMT
       mise-correlation-id:
-      - fb3f68bf-75a6-4faf-81f6-91fc6a7fd3fc
+      - 38f8938a-77ac-4040-8887-cae91b273a19
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,23 +916,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A04Z&sr=b&sp=r&sig=EbuqiRDfXhnJIJiwKrsmWhBIglC1xKA4eoSRcC63m4Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:04.1180956","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A04Z&sr=b&sp=r&sig=pHKeCSrH9ipSXZF8UE1kwAiPGgT3or%2Fdchsm25Xkaj0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:04.1180252","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A04Z&sr=b&sp=r&sig=wApkGKPqV7L93%2BFMSWDffxHu%2BrI9FAuf7f7zyaHTB2M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:04.1181098","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A28Z&sr=b&sp=r&sig=wA53o6i1nAJfBkDQMIxE3svyjDuiTeGD%2FeW5JcKC80k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:28.1749249","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A28Z&sr=b&sp=r&sig=%2FjbfN7f8ViJ0u3hphGrEUaqTi25eR6reoxXFwnKk%2Fw8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:28.1748338","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A28Z&sr=b&sp=r&sig=oVz3YgW4201eIjY4uo1wt115en6RnZOfm7XzCZyA3vg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:28.1749476","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:56.294Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3198'
+      - '3201'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:04 GMT
+      - Mon, 30 Oct 2023 07:23:28 GMT
       mise-correlation-id:
-      - 39f8992f-7147-45d9-9121-255a27f9be22
+      - 6d9de0f8-0769-4990-990b-0b40f580a168
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,10 +952,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A09Z&sr=b&sp=r&sig=LuYl9oONDsOIS9lGhcpGp0eaudplDH30uFG9LEwNrx4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:09.3958533","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A09Z&sr=b&sp=r&sig=X4HcPbZhvtARF0eEO3ztnXNNnsI3LSnexGe%2F515FdBw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:09.3957616","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A09Z&sr=b&sp=r&sig=mCdulV8LIooX63HN1UyNBY3ywqIT0UG9A4r9Xm9hj08%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:09.3958757","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A33Z&sr=b&sp=r&sig=NB6w25qsdlb3Q7WCCdmz5qOsl4rDqaWhXq4TMDs0s1g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:33.4972297","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A33Z&sr=b&sp=r&sig=MGsrtwas5cI9jwr0dPDCH1nRl8N5QpY9z4Ah5eG0310%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:33.4971438","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A33Z&sr=b&sp=r&sig=5SgOWXuEz%2FFcUpGrN9iT8YuPURNZSBF29HruBdAgZBg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:33.4972519","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:56.294Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:33 GMT
+      mise-correlation-id:
+      - cab62855-d89e-42bd-8df1-767d36ee96d6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A38Z&sr=b&sp=r&sig=2hkvS3hd66wQbf%2BXnGW41W%2Fv5YlaoED4mES1VbUsybg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:38.8143322","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A38Z&sr=b&sp=r&sig=LGahYxcS7OzU1eKTVutNxm%2FmRrIWzTKFsStPZftRxdo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:38.8142436","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A38Z&sr=b&sp=r&sig=boAMnwsUa%2BG7%2BkojmwO6pSIhFdwLDDwk%2BkEFgXTh%2Bzo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:38.8143537","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:56.294Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3209'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:38 GMT
+      mise-correlation-id:
+      - 815136cb-470f-4416-874b-231be023a3dc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A44Z&sr=b&sp=r&sig=Av79ueZkgTE5vqKF%2FAEAWyCKmNG7cjZsxnkbuoxjYJU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:44.0922757","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A44Z&sr=b&sp=r&sig=OurLdFP6K8NNmcoamHn02oT3m25wxDMu73kj6B%2BzVY8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:44.0921819","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A44Z&sr=b&sp=r&sig=VCXTlEZfOLlxAfnH7Y%2FHAKI9GjijPBnPid7AiTta%2BKo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:44.0922978","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"CONFIGURING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:44.017Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:44 GMT
+      mise-correlation-id:
+      - eefaf512-d2fd-4f2e-8c2b-9ace30a51a43
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A49Z&sr=b&sp=r&sig=8l1eAOHv6G9HPoRlKjvFlwuvZOIjdsS6f97bCYbjSzE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:49.3844763","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A49Z&sr=b&sp=r&sig=k3jmto%2B8cvXJl45iSqiLyCsBwSRx4OWJDZl5Aubrn30%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:49.3843883","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A49Z&sr=b&sp=r&sig=tpZTNmEijmt9CISSU72FltCVBiDTvvt6mNTm4QIGzhk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:49.3844924","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1686,9 +1074,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:09 GMT
+      - Mon, 30 Oct 2023 07:23:49 GMT
       mise-correlation-id:
-      - e5cecda8-2535-4c14-9472-67c1ca86697b
+      - 9bb547de-6184-4b06-8fe6-793d391d3e5c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,10 +1096,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A14Z&sr=b&sp=r&sig=VBZx0Jg3rdcB98ccF5%2B2UDXsWdUfKcapv6eoYczlRyk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:14.6569854","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A14Z&sr=b&sp=r&sig=p%2BQ1Ar8IFV3W2bPTtVuKYMtm%2Bc0xnLYOZIZADHRL0EU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:14.6569146","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A14Z&sr=b&sp=r&sig=MpxyxZyfRwbsQGVLxfcuNRN0bs%2BcXaURZaSVUz8oREA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:14.6570001","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A54Z&sr=b&sp=r&sig=1ac3SoT4UKw8ZOrSzMbUIL1266Adx1qeas71Jau4y98%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:54.7022863","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A54Z&sr=b&sp=r&sig=NeZRFDHcapvrBEhJd6zy8nEloEsTnW7wdigiKvmj0nw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:54.702219","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A54Z&sr=b&sp=r&sig=GpzEqFSXBwSD5FnntWFS87NVio6nWh8egPq%2FoDZA4hs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:54.7023014","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:23:54 GMT
+      mise-correlation-id:
+      - aff0b36e-52c4-4400-8e4b-a1fb6af645f0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A00Z&sr=b&sp=r&sig=PXu04r3bUfO7ZeAk4Bk%2Bbo%2B662YSzcZKfbmKKZ2j%2BvA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:00.1801248","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A00Z&sr=b&sp=r&sig=Sx6cDTuHpJ56QRz9OQaWfABIbek6aDx4%2FuV3w9qV3Z0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:00.1800113","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A00Z&sr=b&sp=r&sig=vLLLV9bVKaggpTrHkhR494AISilayitDFw4ESJ6u688%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:00.1801464","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1722,9 +1146,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:14 GMT
+      - Mon, 30 Oct 2023 07:24:00 GMT
       mise-correlation-id:
-      - e5a0b508-e748-4ba2-9550-bb9317363f69
+      - 4a5b718a-1450-48ad-aa5e-39303dd84513
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,23 +1168,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A19Z&sr=b&sp=r&sig=WFC9MhYJTdKiMQOwYK%2BIf1Qj8zKWDoTEZkcDB8NO%2FQY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:19.9420442","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A19Z&sr=b&sp=r&sig=FdX7upPJk0fPUzFnTUZs30iYBOFyyXpcWGLyYdzD6T0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:19.941976","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A19Z&sr=b&sp=r&sig=CI0hzg9KWfMK5dShu64BJLsDe5h2fklpkPZggzXlThE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:19.9420598","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A06Z&sr=b&sp=r&sig=dW1JP73UtfvbEP1R8tCZrLFKGKNUBY2AvHWM%2BNlvhwk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:06.4628249","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A06Z&sr=b&sp=r&sig=cBiX3oKXoo3x1OULyikAtAxI2Y%2FnKgWcZPQi5ktuasE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:06.4627381","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A06Z&sr=b&sp=r&sig=%2Bkqkvvo%2F3uonyugZRP%2BbsVBEI0N1UwMIbRQvR8iPILs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:06.4628387","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3195'
+      - '3202'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:19 GMT
+      - Mon, 30 Oct 2023 07:24:06 GMT
       mise-correlation-id:
-      - 7442698f-af32-4b32-8a65-07ae3776ccc5
+      - 8d2808c7-7d4b-4725-b6fb-79d406a9b56d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,11 +1204,623 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A25Z&sr=b&sp=r&sig=tX1sWO%2B0BlzxYq0xM%2Fx7tWQUPbODkPv8iJ3AreA6qhk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:25.1912594","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A25Z&sr=b&sp=r&sig=4wiKej4JuExZblKlcsihb%2Fzf7y%2FR9voy0mXRkxy%2FvX0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:25.1911828","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A25Z&sr=b&sp=r&sig=oxnPkuNImlL2q7oJVVZ8Kt5wG5Bt77nPU6Bvo3K%2Fr2Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:25.1912747","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-29T22:22:45.056Z","endDateTime":"2023-10-29T22:25:23.633Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:23.722Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A11Z&sr=b&sp=r&sig=qR4kQp9ynU7oPUy7T1A2k1D6cRB0%2FQZhtmIGwo7kUbM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:11.7713286","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A11Z&sr=b&sp=r&sig=OcgynMeJKCkCcN2D8tJctE7Q5YR0d5ZxSmqCVGr%2FM%2Bs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:11.7712586","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A11Z&sr=b&sp=r&sig=Gli2r7KbFRYfUpYZPziiI7%2BX034e8in4U4WdK%2FCoGGI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:11.7713431","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:11 GMT
+      mise-correlation-id:
+      - 1b975df4-0206-4292-b679-347fa68a713f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A17Z&sr=b&sp=r&sig=P4yT1A%2FeytyQGDLY1LzRKgv0mBNGICJkUU%2BEXIIrGVU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:17.1113997","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A17Z&sr=b&sp=r&sig=Jcbta8JDfz9%2FmVY%2BNdxqPOJQCn2OwNQwWF6rFTw5sNs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:17.1113117","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A17Z&sr=b&sp=r&sig=C1eLlPFimc4M0DzEoH3rYnE4Q0E6FSGPtBLfcLYVn6Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:17.1114223","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:17 GMT
+      mise-correlation-id:
+      - c6ea0c34-3f79-4c6f-8617-7cce79423074
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A22Z&sr=b&sp=r&sig=iWzkiQC2fKKEKcFvDoSm2glQhRQKzUIQLCMtAdemexg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:22.4348264","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A22Z&sr=b&sp=r&sig=8rwBiVHIcbgYhr0iyXiUknsDZjDOJXMC2z%2FsgnYlkIg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:22.4347559","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A22Z&sr=b&sp=r&sig=ipks%2F86RhD1U%2FWtIF5bzsNG%2FHfQsouQyoIZhiuoBMsA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:22.4348402","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:22 GMT
+      mise-correlation-id:
+      - fbab0841-a908-4f69-948c-5a215263734e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A27Z&sr=b&sp=r&sig=Naf7jA7l227vTzjMjCd4q%2Fw2VrU%2FF%2Fx%2FqB4TR52Y%2Blo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:27.7547455","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A27Z&sr=b&sp=r&sig=OV8CQQv2jhkrb0kuqbpg5MEBOrcQ%2BkZcQhKKvyYF6ro%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:27.7546745","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A27Z&sr=b&sp=r&sig=ML1xWdezDZYvSssiwjmVGjaYDWTpKbVFi4Z%2FsocJmho%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:27.7547604","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:27 GMT
+      mise-correlation-id:
+      - 806b1505-165f-4a62-8c79-c4a944ffd306
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A33Z&sr=b&sp=r&sig=24zzBZ7O4mYfoKkaY5QSJorXMQG%2FmWRWswstUVoMjho%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:33.1036795","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A33Z&sr=b&sp=r&sig=k2R%2FzRHvj3IrF4m5w45aPtqUhQsrjWSLOA3zpXgBZto%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:33.1035606","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A33Z&sr=b&sp=r&sig=7o5Ln2TIypOucyrsQL7lafxNwaDE7l26zvvT9oM8ijA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:33.1037089","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:33 GMT
+      mise-correlation-id:
+      - 209e7f94-2459-4e3f-ae08-e43ece54a60d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A38Z&sr=b&sp=r&sig=9lOy07ZRUQhx8FtW4jNOY6h0pedXAAa7iWAWl4GDozI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:38.4235917","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A38Z&sr=b&sp=r&sig=z4G9BHCgHF1txucawXz5kWKh3ba7IpLb%2FKMvv1a0cCQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:38.4235038","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A38Z&sr=b&sp=r&sig=U1GriIPSSw8xOwK8lWgRPZsElhvXy0wUFE8zBOn%2Beh4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:38.4236158","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:38 GMT
+      mise-correlation-id:
+      - 7ce3ea9e-b139-4592-a154-04ff754ff607
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A44Z&sr=b&sp=r&sig=3Mr%2FXlDyLlMscAFq98%2BmetzJx50kGZ3nP6asHY%2FWf%2FI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:44.1042021","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A44Z&sr=b&sp=r&sig=7wF%2FayiHWaPplPz%2FvVDovG%2BW6gzdh%2FymkteYmwit1rI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:44.1041361","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A44Z&sr=b&sp=r&sig=fykGWFVjkKgmBeUvVs3nDe%2F1tGBnlH6m0a3FDLtWWzg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:44.1042172","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:44 GMT
+      mise-correlation-id:
+      - bfbdbbb6-c90b-4111-ac5c-bf96afbb7d3c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A49Z&sr=b&sp=r&sig=qoPj6Mp1OeyCtfxPebfbVQ48tFfpH0PZ53%2FC10ShloQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:49.4497782","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A49Z&sr=b&sp=r&sig=RMsiquYxLpodi9JGH4P9XDMvmmFuAj4bUPx76%2FP4uhg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:49.4497089","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A49Z&sr=b&sp=r&sig=96mDFML1GDRr4CnJFdG3n7HwWlMPbpV1SOMtofrHaQs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:49.4497925","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:49 GMT
+      mise-correlation-id:
+      - 54c8662a-7f3b-4649-8eca-eec0d89d95fd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A54Z&sr=b&sp=r&sig=N%2FqE1nWvflUXunpG5KdXjgZD4lYQD3uy3c3mtJoI1QE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:54.7724495","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A54Z&sr=b&sp=r&sig=yWhJziUGorylDOyvRb1O%2BYtb70a7FspOq4VL1zTFlYk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:54.7723663","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A54Z&sr=b&sp=r&sig=h%2Fz9x1%2BFMhkPicXk5KI%2Bv0UkqUVs4ZvxcQ8wCgQ9EDg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:54.7724712","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:54 GMT
+      mise-correlation-id:
+      - 74cf7966-8742-4833-931a-67f56fdb3d39
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A00Z&sr=b&sp=r&sig=ua70mW5kXrNIAk00EdcVZK7kRkXOx5kLOhyGSAnvX%2FM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:00.0420895","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A00Z&sr=b&sp=r&sig=g0KKPYulvyaoe7R3H0ngjyslnoy1hEJXkYXV0owCR8c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:00.0419668","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A00Z&sr=b&sp=r&sig=sjgEr5AxpnNkDIOoMfNYEZvP5HrTp5ytURQa3LyIkqM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:00.0421154","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:25:00 GMT
+      mise-correlation-id:
+      - 7c2c3320-1e68-49f7-91d2-585e67aac22c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A05Z&sr=b&sp=r&sig=QY8Jki1kzQrfAb8ys1SwN7QihnF3c0gwkgXc5Chcj24%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:05.3253915","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A05Z&sr=b&sp=r&sig=KlkggjuXUe%2BLpMNgUE4zQYt6kUVBltYt2udYMhF1YYI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:05.3253255","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A05Z&sr=b&sp=r&sig=VHaTsSPVQOjKcCDG3vOC%2BrMuZJvPRJMLwnZ3nnxZk%2FY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:05.3254058","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:25:05 GMT
+      mise-correlation-id:
+      - db13e651-8f5e-40e1-a9e1-f3092b8bb342
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A10Z&sr=b&sp=r&sig=k1nxnkfEw50%2Bzfy6%2Fr%2FV%2Bu%2BXgEK5PSIYg%2BtGvvgvQhU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:10.5950575","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A10Z&sr=b&sp=r&sig=plYic0KUi%2FEWBraac8q0oRPQszeF8c0EoE5xjncaRi4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:10.5949867","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A10Z&sr=b&sp=r&sig=yPUSaA3vZIwSW0xu4m63GEl8w01BziJNcfsfqI6Gy2M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:10.5950726","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:25:10 GMT
+      mise-correlation-id:
+      - d1a461cf-ee93-44de-a86b-73fe44834b17
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A15Z&sr=b&sp=r&sig=4cshQg4lvBsjpO246HThkv%2BD0cXMhFBfPp%2BCN8ECnc0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:15.9165628","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A15Z&sr=b&sp=r&sig=8UMR%2Fuj6UPZ40Uxxu%2Fy%2BTk566F2Ql8Mr1tcYr5Gl9MM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:15.9164951","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A15Z&sr=b&sp=r&sig=PRcVAj2m5pUaMU79XOAq4lx0JQM4RjwFHpUTkjfSHac%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:15.9165769","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:25:15 GMT
+      mise-correlation-id:
+      - f54d8519-05e1-4dcf-88bb-c69b139aa168
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A21Z&sr=b&sp=r&sig=%2FReLgdnpDIzupA2zpfNbL%2FpLkctaqPAHgq9TdTlpcJU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:21.300703","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A21Z&sr=b&sp=r&sig=w3k9Ub8gqqma3GdUOHI%2BewcK5U4VZWaXn5S6vvxvwXw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:21.3006202","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A21Z&sr=b&sp=r&sig=jgdZhufFx9o%2BJqIJdaMmDpGUUByBI828cr%2BefSgS4rE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:21.3007186","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:25:21 GMT
+      mise-correlation-id:
+      - 0f0bc199-1c1d-47fb-bb19-b14786ad60b1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A26Z&sr=b&sp=r&sig=ttnwZhcpahAHDEus1qIYqPXv3BVnjVL3rLA5vOGYe9o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:26.6154401","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A26Z&sr=b&sp=r&sig=KMM1xztdV2Pohgzij0qHTkhaf50d52rt%2BdblvXfJdIw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:26.6153743","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A26Z&sr=b&sp=r&sig=lbEABiXENXsS6%2FW1l%2BZcD6sCrLi0noN%2BkLkf0zW34ag%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:26.6154542","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:25:26 GMT
+      mise-correlation-id:
+      - 9974af14-0e19-46e3-8803-468ee8d9622a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A31Z&sr=b&sp=r&sig=y%2B4SvjSm0ufcjhO36bkOJfGkSVJYBPYXAjbfjeBQD%2Bc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:31.8843198","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A31Z&sr=b&sp=r&sig=4eApCBdCKrLfpyaXBP%2BINj%2FtQlEr%2FYBAOK8gnt7QACM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:31.8841859","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A31Z&sr=b&sp=r&sig=oZ4eTJgg6i1hJ%2Bugtwb0Et4r91KPCwGnTbc51nwX390%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:31.8843517","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:25:31 GMT
+      mise-correlation-id:
+      - 65b0a74e-2e75-4b0a-b742-ec3afcc30edc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A37Z&sr=b&sp=r&sig=ZIO2SzXREzdWGsVdn%2FboxK3%2B1GQItYp2dhsmMVhIuO8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:37.1378472","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A37Z&sr=b&sp=r&sig=a%2B2gyL0vSjb5oIINhc5%2BzqCCOhM3bVUqAqqMZ04Oq1I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:37.137762","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A37Z&sr=b&sp=r&sig=6OlH1D%2BKMxtLEyRmNucJ0R3MMvXNCBVx8RCOXYuN6h8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:37.1378687","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:56.145Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:47.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:25:37 GMT
+      mise-correlation-id:
+      - 3ba87745-af0f-4433-b32d-428cc8fb8630
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A42Z&sr=b&sp=r&sig=bkfGtmp9Nbz5VZPOeAabJdzLAOEQY1SNeXdrXLv7AAs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:42.3838925","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A42Z&sr=b&sp=r&sig=46HMl%2FsI41J2D%2BhdbO5RH6Plpl75v1sC3EFUOfaXgNI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:42.3838128","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A42Z&sr=b&sp=r&sig=lFSo96zNVFk%2FywU%2FaxXjoLmTL9aOkD%2BlR%2FfSyBdWWXU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:42.3839072","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-30T07:22:56.145Z","endDateTime":"2023-10-30T07:25:37.751Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:25:37.847Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1795,9 +1831,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:25 GMT
+      - Mon, 30 Oct 2023 07:25:42 GMT
       mise-correlation-id:
-      - 9203f7e4-92b9-46f9-9489-17185ac4f462
+      - c9927b96-e2f9-4983-b589-47cd50d9197a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,7 +1856,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:45.5929152Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:45.5929152Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:55.9059511Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:55.9059511Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1829,9 +1865,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:26 GMT
+      - Mon, 30 Oct 2023 07:25:43 GMT
       etag:
-      - '"3c006929-0000-0100-0000-653edafb0000"'
+      - '"3f00d46b-0000-0100-0000-653f59950000"'
       expires:
       - '-1'
       pragma:
@@ -1861,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A27Z&sr=b&sp=r&sig=t9nd5P7R1qkuVjXsIz3UHgkokOd%2Be%2FCDBPurxqrCdy4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:27.2498994","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A27Z&sr=b&sp=r&sig=KkbS6tZ5SGgnZpSyZLje8uXoohZdESGZrJ4WfV0v5FE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:27.2498085","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A27Z&sr=b&sp=r&sig=eb5kD74OL95D1JqFAnk24FIXFfBUL895SZ0ss7kPNmY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:27.2499227","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-29T22:22:45.056Z","endDateTime":"2023-10-29T22:25:23.633Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:25.809Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"36a15b60-dbb6-421b-91fb-b05f0765cf57":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45fb0997-53d7-4b68-9fce-6d5de7fc8c6d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6a81bbfc-6a7c-40af-8c42-efa439caf8a1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/ddf3acfb-c892-407e-9fc2-226e90b954bf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A44Z&sr=b&sp=r&sig=bl5xgDdR%2B1y8%2FJA%2BKb2gF0ZioyR87wVF8EYu3tpRpJE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:44.6573388","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/4c09bbe6-a743-422a-973c-838ebfa986fe?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A44Z&sr=b&sp=r&sig=J9LpMoREdJXvdt6iIxPobRVcPJaLArV%2BcuVLtoP1xew%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:44.6572811","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0c3b5d6f-0fc4-4118-b1d3-072cd4087319/e87f565e-fbc1-43fa-a653-84320752d5df?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A44Z&sr=b&sp=r&sig=KQINg8hUe9pWGzUK6MJZaC47hDRN7N1cnvUWKGARG9U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:44.6573531","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-30T07:22:56.145Z","endDateTime":"2023-10-30T07:25:37.751Z","executedDateTime":"2023-10-30T07:22:55.437Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-30T07:22:55.721Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:25:37.847Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3343'
+      - '3347'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:27 GMT
+      - Mon, 30 Oct 2023 07:25:44 GMT
       mise-correlation-id:
-      - 3d5c0cbf-4a7e-4833-8a0f-dc6f80c941b4
+      - 97f375ba-2b3b-4a01-ba82-be1edd51cf43
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1901,7 +1937,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:45.5929152Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:45.5929152Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:55.9059511Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:55.9059511Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1910,9 +1946,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:30 GMT
+      - Mon, 30 Oct 2023 07:25:46 GMT
       etag:
-      - '"3c006929-0000-0100-0000-653edafb0000"'
+      - '"3f00d46b-0000-0100-0000-653f59950000"'
       expires:
       - '-1'
       pragma:
@@ -1944,7 +1980,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -1954,9 +1990,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Sun, 29 Oct 2023 22:25:32 GMT
+      - Mon, 30 Oct 2023 07:25:47 GMT
       mise-correlation-id:
-      - 1d5c6902-874d-4cec-96cc-e9af1eee86f1
+      - e2326800-3c2c-4161-a02a-c72f1ab5770c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1979,7 +2015,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:45.5929152Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:45.5929152Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:55.9059511Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:55.9059511Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1988,9 +2024,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:33 GMT
+      - Mon, 30 Oct 2023 07:25:48 GMT
       etag:
-      - '"3c006929-0000-0100-0000-653edafb0000"'
+      - '"3f00d46b-0000-0100-0000-653f59950000"'
       expires:
       - '-1'
       pragma:
@@ -2020,7 +2056,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
+    uri: https://15e5c48f-0620-4d6b-8eab-34d000f19287.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -2034,9 +2070,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:35 GMT
+      - Mon, 30 Oct 2023 07:25:49 GMT
       mise-correlation-id:
-      - 3fdee9d3-4dab-4705-beb7-38188ea35409
+      - 2963f358-51a5-428a-977f-348f423c785c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_delete.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_delete.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:54.2589267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:54.2589267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:45.5929152Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:45.5929152Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:26 GMT
+      - Sun, 29 Oct 2023 22:22:19 GMT
       etag:
-      - '"d300a43d-0000-0100-0000-6537b8870000"'
+      - '"3c006929-0000-0100-0000-653edafb0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:29:27 GMT
+      - Sun, 29 Oct 2023 22:22:21 GMT
       mise-correlation-id:
-      - eeaff721-5b91-4b2c-a6a0-5fe47db16d5d
+      - d1dda3a1-5f07-4566-945a-594bcf568b18
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"762b94d9-7054-4c80-a066-90da8932b523": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "fd473a70-3e78-4a18-bd11-234a91ae5024":
+      {"passFailMetrics": {"ea1fbfa8-0fe7-473e-b316-d6d20eacd390": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "dec2f4f6-0237-4e02-ad8f-3107c1a1000d":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "03c9f4a7-edd4-4584-a436-a4d050ff2742": {"aggregate": "avg", "clientMetric":
+      "50"}, "01430d40-cf88-4d64-b6fe-3566ca773815": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:29:28.343Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:28.343Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:22:21.482Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:21.482Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:28 GMT
+      - Sun, 29 Oct 2023 22:22:21 GMT
       location:
-      - https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+      - https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 36bba253-2701-4498-b521-93cb8b19a240
+      - 42ff8190-5e32-475e-affe-aa5dfb7d9911
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:28 GMT
+      - Sun, 29 Oct 2023 22:22:21 GMT
       mise-correlation-id:
-      - 15495cbf-a2db-4efe-9259-5077310eb9e2
+      - 7e5c8117-e34d-418a-ad3c-f8501dfe6a73
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A30Z&sr=b&sp=r&sig=oEijXBADOS%2BBetlgz7rLx%2FWjYlkd5M93m8PCfKVm0O0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:30.0326766","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A22Z&sr=b&sp=r&sig=LzmkYLCO7WwyvTvTNk04Yb08ChObDSK1Ca0A8Ae1mLU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:22.883974","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '548'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:30 GMT
+      - Sun, 29 Oct 2023 22:22:22 GMT
       location:
-      - https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - aa7cb081-7606-493f-b213-b3e99e94e909
+      - 241791bb-fbca-4bbc-8e82-1a3a48690031
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A30Z&sr=b&sp=r&sig=sjQsFMSlhPN1BeyNCiHjCmL2pF33UNJLGyOnBy6PKdk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:30.3833039","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:29:30 GMT
-      mise-correlation-id:
-      - 960eaf2f-8374-45ed-a382-5ed5be9fb28f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A36Z&sr=b&sp=r&sig=5hAkvV2P0q42KsJuccx3r9iCO5NkQ%2FHaLaaVYqhtlWw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:36.054114","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '550'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:29:36 GMT
-      mise-correlation-id:
-      - aa0c504a-1fa1-46fe-b68e-652ae69f8dbc
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A41Z&sr=b&sp=r&sig=KLvtBe0dCeKG%2BIxwb2hF9w8bP4JHTk9wD3atclq4BU8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:41.3235205","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A23Z&sr=b&sp=r&sig=Q6MP18Eii6BlvP%2FncZ2Q2LbO8T4KqI4zcqyRfMf6BHk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:23.2060432","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:41 GMT
+      - Sun, 29 Oct 2023 22:22:23 GMT
       mise-correlation-id:
-      - 7c1f4720-df8d-40ae-b5de-a1cbbd15cd6e
+      - b5dbd993-4e5e-4a31-bea8-49772b325e78
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,10 +349,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A47Z&sr=b&sp=r&sig=q%2BYl%2B09%2FCzm1nTuQMSm4Gl8NTOJI3iOrEsmXe4fliZg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:47.0174882","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A28Z&sr=b&sp=r&sig=V2dcgmx6czfUHsbvubZNZI5bitVJAkOnlay11LZRHvY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:28.5061705","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:22:28 GMT
+      mise-correlation-id:
+      - 61af8020-11da-43d1-99c4-def288764a07
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A33Z&sr=b&sp=r&sig=EbRvyc77VMtV%2F0Z0zVLBVOr5MvKR%2FeLFotoCsxz3yWs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:33.7656034","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:47 GMT
+      - Sun, 29 Oct 2023 22:22:33 GMT
       mise-correlation-id:
-      - bee46778-ca4f-462c-acdd-88525abbd7d5
+      - 0025b330-d769-4ad9-a119-d9b0abc80b09
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,11 +421,47 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A47Z&sr=b&sp=r&sig=VBHk1SpABVGnlYgUd4Yz1tCKQjJ614QyTFio6xCABtA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:47.2857954","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:29:28.343Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:42.887Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A39Z&sr=b&sp=r&sig=YEZpI5LKKIEPROp6rV52qY16tFMJ7a5BsFDbbFdgv2A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:39.0180364","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '547'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:22:39 GMT
+      mise-correlation-id:
+      - d4823493-e605-4a06-ada9-47b95ca117e7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests/delete-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A39Z&sr=b&sp=r&sig=cf507KyYUWi0wHseBjjHcbvbWFbwhgVZxusdIkTBiYI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:39.2571479","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:22:21.482Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:34.586Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,9 +472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:47 GMT
+      - Sun, 29 Oct 2023 22:22:39 GMT
       mise-correlation-id:
-      - 9b867eb1-f101-4c28-8cae-065a9ec2288f
+      - b1a9b5e5-2fea-48af-a319-7a9597c432e7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:54.2589267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:54.2589267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:45.5929152Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:45.5929152Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:49 GMT
+      - Sun, 29 Oct 2023 22:22:40 GMT
       etag:
-      - '"d300a43d-0000-0100-0000-6537b8870000"'
+      - '"3c006929-0000-0100-0000-653edafb0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A50Z&sr=b&sp=r&sig=Wcotj2b4AxATbANWsQqCtJcCc%2BL4qG%2BouXA9TgXrbGE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:50.0375588","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:29:28.343Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:42.887Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A41Z&sr=b&sp=r&sig=y2ifA7U60M7IemTgnFkc%2FTwemLeSHwDeH8XYXf37FSM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:41.5383209","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"delete-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:22:21.482Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:34.586Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1593'
+      - '1591'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:50 GMT
+      - Sun, 29 Oct 2023 22:22:41 GMT
       mise-correlation-id:
-      - 78643d53-55bc-4ce6-b272-9ab649ade8aa
+      - 0f895543-df7e-4ac8-a73a-e698d7fe811e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:54.2589267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:54.2589267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:45.5929152Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:45.5929152Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:50 GMT
+      - Sun, 29 Oct 2023 22:22:42 GMT
       etag:
-      - '"d300a43d-0000-0100-0000-6537b8870000"'
+      - '"3c006929-0000-0100-0000-653edafb0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:29:51 GMT
+      - Sun, 29 Oct 2023 22:22:43 GMT
       mise-correlation-id:
-      - 8ff5bec5-096e-4c34-9963-a6c79fef1445
+      - dbebb625-a3f9-41dd-bf29-9caaddc4c5a1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A54Z&sr=b&sp=r&sig=KSyldyJiMJaesXuFBaPpKPokPR%2B8Zt%2BDa7p%2FDdNu6mk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:54.3606334","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A54Z&sr=b&sp=r&sig=rz3RswYuEVoUor3OVD2hud8DKAC%2FZlsFEw3TnviZC9s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:54.3605202","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A54Z&sr=b&sp=r&sig=0FDBRkRDNt7YtC86BDsDH9UWqokvY9FHJ4%2BWjp9z8Tw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:54.3606621","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:54.28Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A44Z&sr=b&sp=r&sig=OIq8DXl2Vwq%2FW5rPb%2B5UIFYmkC%2BsrA%2Bpx6ix%2BdbXmxM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:44.6295054","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A44Z&sr=b&sp=r&sig=Lt2j%2B1sZuVfX8dr1OZfRgM0zLieH0WiftWT%2FJFivAio%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:44.6294052","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A44Z&sr=b&sp=r&sig=92lBRn8bDKn13ZOFmapGjPdWgeGbGj%2B%2FWtOIVFEuwJE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:44.6295288","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:44.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3156'
+      - '3166'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:54 GMT
+      - Sun, 29 Oct 2023 22:22:44 GMT
       location:
-      - https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+      - https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 00c7886e-2a3c-494a-bd09-dfe73c397aeb
+      - 261b300a-45e8-4497-b359-c6a5a7405262
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A54Z&sr=b&sp=r&sig=KSyldyJiMJaesXuFBaPpKPokPR%2B8Zt%2BDa7p%2FDdNu6mk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:54.8279702","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A54Z&sr=b&sp=r&sig=rz3RswYuEVoUor3OVD2hud8DKAC%2FZlsFEw3TnviZC9s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:54.8279041","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A54Z&sr=b&sp=r&sig=0FDBRkRDNt7YtC86BDsDH9UWqokvY9FHJ4%2BWjp9z8Tw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:54.8279846","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"NOTSTARTED","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:54.723Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A45Z&sr=b&sp=r&sig=aZj1tCwTwe271rCSCMgL11ukVSLgHGOQby2MocMJXE8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:45.2887735","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A45Z&sr=b&sp=r&sig=jmAgzLVTwGvrIiCvtqpD88pqH9hP1njHw2cRWwC40SU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:45.2886863","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A45Z&sr=b&sp=r&sig=jThdHBt0a8TiIu8sDc5RQ0k0QkD0%2FtI%2Ba3Ks2ER9hrc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:45.2887963","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"NOTSTARTED","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:45.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3202'
+      - '3197'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:54 GMT
+      - Sun, 29 Oct 2023 22:22:45 GMT
       mise-correlation-id:
-      - ca6f2532-4da7-4c61-ab63-daf825c98287
+      - 67ae14ca-3f4a-4234-9722-aad7f31b0b6d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,298 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A00Z&sr=b&sp=r&sig=BSrFsGCLbipAVw5yPrbQzEpoi8E7uwH%2FT2bRRIE1l7s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:00.1012143","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A00Z&sr=b&sp=r&sig=sADcuwv1wiKTvVwTU2WzuaHRe4J1m2Txki2uVouyyZg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:00.1008721","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A00Z&sr=b&sp=r&sig=kczGCr%2B%2BLM8JvLOVA0hJaS0is%2FQwUctJfIC%2BvpVAuPY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:00.1012385","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:54.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:00 GMT
-      mise-correlation-id:
-      - 86cae9bf-392c-45be-849b-a3f30e5f663b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A06Z&sr=b&sp=r&sig=o%2F0h%2F2QZHV0mVND8R1SEP8HZu3cyaD18GBi03cPqcT8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:06.0655278","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A06Z&sr=b&sp=r&sig=%2B7eysEHi%2FP430oTPPZ9%2Fhx9NibmchIk3h2%2FITW%2Bbpcg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:06.0654285","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A06Z&sr=b&sp=r&sig=xVTvg7jH0KIGlTjmxUeeO8B14bZxz86XubHpBb3zdXo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:06.0655517","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:54.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3208'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:06 GMT
-      mise-correlation-id:
-      - 80a5b818-1a7d-4c1c-9c44-6836a06dc9ae
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A11Z&sr=b&sp=r&sig=LQFJ48C7m4t%2FLdKJqn3%2Fnw%2BaD4pDsNl2Ehk3Q39K%2BTI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:11.4501887","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A11Z&sr=b&sp=r&sig=k%2Fl2EHVQg%2Bj2vrsAxjlClRnoguQ5ldVNZvTTIVyzhuQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:11.4500891","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A11Z&sr=b&sp=r&sig=2S2y%2Bo6W5ZXsa%2BpLABgttUnRTLp4SyT003MjZZtzlZs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:11.4502135","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:54.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3210'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:11 GMT
-      mise-correlation-id:
-      - c72d8873-5394-438f-957a-eec0f06e42fd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A16Z&sr=b&sp=r&sig=wMYC7GxyAAGvzUusdO4FIDFZdtTmz3IzB8BO6djRsdA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:16.7568198","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A16Z&sr=b&sp=r&sig=QggVIecfdmUzKScz010ckUSuzARBChe2HGx55oniQYA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:16.7567511","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A16Z&sr=b&sp=r&sig=WXoOHs3vSdvTuLHQ6wxgMgZv%2FhTlTchm%2FchXmibDSp0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:16.7568334","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:54.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:16 GMT
-      mise-correlation-id:
-      - 8d8e6f7d-a802-48e2-95e8-b3a4d1d1d613
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A22Z&sr=b&sp=r&sig=IbrBCQw81Iz6fRdNSy0FK6JT303LXsbQHKyQY82FGO4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:22.0358442","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A22Z&sr=b&sp=r&sig=MWgjHdgEVadFCaaVorTnapdCUl2qmdcwx6GE9BJpGcE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:22.0357761","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A22Z&sr=b&sp=r&sig=90u1juppSWkpCYhJfZobqc7HYQGCfdddV3iPUgkvOu4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:22.0358589","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:54.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:22 GMT
-      mise-correlation-id:
-      - 3deca25d-853d-400b-ac66-c7943d22fd11
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A27Z&sr=b&sp=r&sig=HPe47vzR8mxdp2EtxS9PuXRnPVgiLmKiEKNrVvJtnfY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:27.3606466","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A27Z&sr=b&sp=r&sig=CBPnZ6lnsemQ%2Fkmxr%2FUWiYff0TEDGeOZ9gvvuaAtIr8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:27.3605651","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A27Z&sr=b&sp=r&sig=0TUw19OglNyQjMsh6ayFKWezMukJn1FvsESC3Laulss%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:27.3606611","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:54.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:27 GMT
-      mise-correlation-id:
-      - f9500dd3-18ce-46e5-8c79-5f68da780d4a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A32Z&sr=b&sp=r&sig=SSlA8SP7DS3Lc3QBTXMuexqj%2BRH6z9VtALpm7%2B3SKTo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:32.6430327","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A32Z&sr=b&sp=r&sig=W13Ab90e7NU5IIIGdXjJ7BnrfdpT0XIVkLF9v4SGxi8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:32.6429622","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A32Z&sr=b&sp=r&sig=YFyFcYLdOMjNI5EH%2BHZslGYpaDGVan1mN8pKeEcgRlM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:32.6430471","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:54.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:32 GMT
-      mise-correlation-id:
-      - 7bbf9998-8e0f-42e2-97cc-e7e109e42bcb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A37Z&sr=b&sp=r&sig=SyfjmUUC%2B14kHrs2xwq8mj9YKx9k0Zr872lHroCiwso%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:37.9659114","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A37Z&sr=b&sp=r&sig=Pz%2BZJM9jeae%2BGybrPSdEjLYz4g1OurfJvBspUgNMBCY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:37.9658421","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A37Z&sr=b&sp=r&sig=Q%2BHWQ8w3EsXrYfamqsCRX92VpPu37pW3qSOuu%2F6%2BEJI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:37.9659259","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"CONFIGURING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:35.595Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:37 GMT
-      mise-correlation-id:
-      - 5d4c2579-ab44-409e-8444-bb748876571b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A43Z&sr=b&sp=r&sig=XKGLlqF2%2Fym%2FZ7fAepPnl%2F0f9OpQjjYkpcOJN%2BTWSgk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:43.2901791","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A43Z&sr=b&sp=r&sig=4n0pHD%2B1sVUN0MQUcihJ8YTQwcl2sS25r2Rt3y%2BVprs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:43.290111","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A43Z&sr=b&sp=r&sig=hhH%2FWn1GHdLJluwl2gkUyZlnoAGSUUJKIzKlbHcbUHU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:43.2901934","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A50Z&sr=b&sp=r&sig=sIoVBWgqDg5eeTtdNgLyqL6%2F3yyoS5NPJY0may6jHS0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:50.5632223","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A50Z&sr=b&sp=r&sig=x2G%2FUDDMQNNKhy2UO0068wsZxL24XzMGq4uYVl2B7mA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:50.5631372","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A50Z&sr=b&sp=r&sig=dp0TUmdTG%2Fn67fbdkcEUpGryDXXeMUtQn1%2FBoo%2F4Khs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:50.5632367","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:45.29Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1038,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:30:43 GMT
+      - Sun, 29 Oct 2023 22:22:50 GMT
       mise-correlation-id:
-      - efe85f64-5fc3-447f-b5dd-581d10e7c8ae
+      - 07d43ff4-9d70-4e9b-afd3-a8f2e82a337d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,10 +772,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A48Z&sr=b&sp=r&sig=Dr%2BcySZxIkdBDUW2Fozl13VEgTk%2B9FypMAEisoIANns%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:48.6065181","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A48Z&sr=b&sp=r&sig=rfHR9bPmy0LvxBWUb%2BgzMgSkIAAJKThcdnuMC3bRl9o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:48.6064473","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A48Z&sr=b&sp=r&sig=gMjocM5pEsSGuG%2FsaYzRpXsuS8v53up8%2F8lv7jezqgk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:48.6065324","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A55Z&sr=b&sp=r&sig=xMsNZcZvbQ39AV7xYGUJsrQdSrGeXNZpOx4%2FR88sboU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:55.8677315","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A55Z&sr=b&sp=r&sig=vC%2FhyL5Vmw1EuJZ%2FOsPqcT8QN%2FrsprABS9AjdkcYXog%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:55.867665","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A55Z&sr=b&sp=r&sig=B7F2eMCeCXCma91AWqOvDMBbI5WZCri0nkdu5NwWxEI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:22:55.8677455","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:45.29Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1074,9 +786,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:30:48 GMT
+      - Sun, 29 Oct 2023 22:22:55 GMT
       mise-correlation-id:
-      - ed96abfe-6df4-447e-b9b9-1e37d34e0073
+      - 8f4d805b-92e9-4784-9a3d-3ee754fcd2ab
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1096,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A53Z&sr=b&sp=r&sig=WQnjwMHR5wVKSErDIvn8I6mbQyFHP2CcTGWXLMVcMGY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:53.9383748","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A53Z&sr=b&sp=r&sig=ri9UU2MZuHwBBt5%2BdBZTAKu5iPQV7EYZwLHIvbSXt%2FA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:53.9382993","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A53Z&sr=b&sp=r&sig=m0Y7by9q7Yj3%2B0WT2GlrfzhvkSxyCSanIwDgzydqwrA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:53.9383895","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A01Z&sr=b&sp=r&sig=2FsNcq0vCuMaFcocdYtBFr2%2BpnuqxUAqeOxt4tC%2B2DE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:01.2089772","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A01Z&sr=b&sp=r&sig=I1pwjiTwe560JJd%2FH37bg%2Fl0C0qnEDl6rg6birdToAU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:01.2088913","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A01Z&sr=b&sp=r&sig=gY8VSb%2BYgsQfDBv41ux4IZt44OfQpJOq9zaxuJXYMvo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:01.2089929","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:45.29Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3197'
+      - '3204'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:30:53 GMT
+      - Sun, 29 Oct 2023 22:23:01 GMT
       mise-correlation-id:
-      - 34db3efb-5d86-4283-adbd-86de1ec2b5db
+      - 8ce938d1-7ef9-4acf-82f6-2eaab9f109cf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1132,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A59Z&sr=b&sp=r&sig=wIr%2F2wArWJvXWN11w3ogrCUr4fbA7CxkfaL7SvHwo74%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:59.4267373","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A59Z&sr=b&sp=r&sig=hJFUg9G96i%2FDVbXSR1xUJj1ZC7JW0HgEBRsXgJ4UqZs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:59.4266131","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A59Z&sr=b&sp=r&sig=N6NfW8kcTatoOaPs3HiFHKSVJRO6HfG0%2BBIy1ctuIn4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:59.4267659","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A06Z&sr=b&sp=r&sig=sQkYFb8AbJHgnzY9Kj%2FH7QbfhzBdVos%2BkPJ5CK20L6k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:06.4597426","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A06Z&sr=b&sp=r&sig=fQR3aDqVnVINQwEbXapgV13OWCFj5N21eT%2BM1fsi4wI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:06.4596736","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A06Z&sr=b&sp=r&sig=J207Or7JgoVb71DeewAh%2BDK3FTRITQIvw6p%2FvrEZ72U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:06.4597579","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:45.29Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3197'
+      - '3204'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:30:59 GMT
+      - Sun, 29 Oct 2023 22:23:06 GMT
       mise-correlation-id:
-      - 61f1448d-0fcf-4c5a-a7a5-01e818404e87
+      - 1a3e3c62-c952-4174-9ff0-34baee9ab335
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1168,10 +880,154 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A05Z&sr=b&sp=r&sig=ysOYVlZqKBIoyVo8lO%2F96SJWKL%2Fddz5uHzEuySGTANc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:05.0750281","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A05Z&sr=b&sp=r&sig=iGir4Ane8hsZyBiRi1hoNrOjabYtUnVifESBCiLpuaE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:05.0749442","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A05Z&sr=b&sp=r&sig=oZnjK4TiWgLXpXAws7ldJoOKb0UmgWljzt%2BFRV03v7c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:05.07505","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A11Z&sr=b&sp=r&sig=gFzsur2a1WmkyElD3vOKljhtD%2B90lyENxCcYBtypUPQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:11.7470949","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A11Z&sr=b&sp=r&sig=%2F1pF0MscyWMpSNV625UN1eXem8W2ei2sFM3YSrVRNxY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:11.7470085","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A11Z&sr=b&sp=r&sig=TA9pwnJGyYhGfnpy6Vh2l5QGN7sEv4vuGVWDXMt%2FwJA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:11.7471163","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:45.29Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:11 GMT
+      mise-correlation-id:
+      - afd77a85-4463-4be7-9cde-5d2acf647510
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A17Z&sr=b&sp=r&sig=4qFN%2ByyMKuswoaSfMRtPeKu76Gg6442UMYhc8Dmf8UM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:17.6064334","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A17Z&sr=b&sp=r&sig=wK8yOqbnwA3vKGOExjnlVHPl7QNsMrbU%2BZE4Bgev%2FJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:17.6063594","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A17Z&sr=b&sp=r&sig=iztho5tXkkyXl1ngQSTUxwKh7hDa1n9aMxbKISdn%2Fzo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:17.6064474","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:45.29Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:17 GMT
+      mise-correlation-id:
+      - 7c7b9018-9387-45a5-8cb5-b5d8f224f73b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A22Z&sr=b&sp=r&sig=HlpbKyDbx1KoZOti6MD2MPGHhgEzpryFhBLXodwAjgY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:22.8589159","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A22Z&sr=b&sp=r&sig=I6Z%2FJTzw92noBe%2B29%2FJDwY3FZJXVoNkz58VDzvRtBkA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:22.8588263","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A22Z&sr=b&sp=r&sig=G3JDHtTel9Byg512rSNIzOchv3qlVc8Lr27IiObARf4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:22.8589379","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:45.29Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:22 GMT
+      mise-correlation-id:
+      - 2dc3ec7c-be14-437e-b1e3-b4dc712fee50
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A28Z&sr=b&sp=r&sig=7kbCYMsbYAX6XDM%2F7mBaYNWSksSPXzsZ233jVMR0wCw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:28.1066728","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A28Z&sr=b&sp=r&sig=CKyXhWYeIHsUt33Ci9tyGWLRPojGMvIOFuuWvoaaxZc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:28.1065864","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A28Z&sr=b&sp=r&sig=ENyZUYBcTioxXRRnCrheCvwToKcEzGBXpUIh8zZzvS4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:28.1066949","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"CONFIGURING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:27.387Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:28 GMT
+      mise-correlation-id:
+      - 9bcde095-aeaa-42ed-b729-8d4e98b86d9e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A33Z&sr=b&sp=r&sig=YXY2gJz3o8c4qYlX055%2BfEzUiRwncMtgkATCHVMoZ2U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:33.357903","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A33Z&sr=b&sp=r&sig=rKsXW5SS3YnLjXegtT7makADfgi9nrAVAg3F%2B9YmfCk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:33.35783","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A33Z&sr=b&sp=r&sig=tM3xQAwnh9QjpdjE34ScPyB%2Fg4BU5YhULo78FgYNa44%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:33.3579166","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1182,9 +1038,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:05 GMT
+      - Sun, 29 Oct 2023 22:23:33 GMT
       mise-correlation-id:
-      - 4ee7d74e-4484-43b5-938a-87efd85feac9
+      - 8408f3a9-63e0-410b-8900-1bc9cbcab8b9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1204,23 +1060,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A10Z&sr=b&sp=r&sig=5BYWefmSxmCg4SfWz35hinvCrPjcjPqtJlmu141TF9I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:10.351031","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A10Z&sr=b&sp=r&sig=r8%2B3MwtoG%2Ft0uABI%2FWMXF%2FbPFzehR1DfTYdOe1Ouc%2BA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:10.3509599","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A10Z&sr=b&sp=r&sig=yrRuXMaFNB4nS%2BBbHhxpmr0Modg6rqutKBEGuD9PUj0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:10.351045","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A38Z&sr=b&sp=r&sig=by%2BixTOj%2B5Wee6rb2aJWu%2B46o3zHWmgn9r%2FWjz8Teb8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:38.6763689","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A38Z&sr=b&sp=r&sig=6SgzfCTAKXIpJ%2FD1HLQad8cpgP2I9mGQPvfbIMWSg5I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:38.6763015","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A38Z&sr=b&sp=r&sig=fkigXJGbsE%2F96rp2ccMR%2BZ09WZsTuywwpQu10sb4rj8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:38.6763835","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3201'
+      - '3206'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:10 GMT
+      - Sun, 29 Oct 2023 22:23:38 GMT
       mise-correlation-id:
-      - 8c4a8dd1-18b9-4ee9-808a-db0c63017891
+      - 996b2bcd-f5e5-4bb8-835d-1cfdcdfc7b9f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1240,10 +1096,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A15Z&sr=b&sp=r&sig=aL17KL9DqA%2Bnjs54rTP%2FgELfRD%2BEKcA8yrtNK91h6EI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:15.6530872","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A15Z&sr=b&sp=r&sig=v9tWS5QwlWpHEoCUbClIq59slTDwXCW8Hnwphrvte0k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:15.653018","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A15Z&sr=b&sp=r&sig=P99ZGvAvNNH8177Umlm%2B4bGrGTYV0TlCxpI%2BdzMv0Z8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:15.6531018","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A43Z&sr=b&sp=r&sig=5p%2F638nJO5biVCB7gXi0y6IkVq6FbnDdzyFdqN9Y8rQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:43.9303992","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A43Z&sr=b&sp=r&sig=T7TlsEMIuhJOzYctVbk9No1%2FdWiZwJW%2BVC2SqpRG8Oo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:43.9303271","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A43Z&sr=b&sp=r&sig=%2FMgeUQ0WNIlJ%2BJcYlDtfzEB7KJFQc%2FqRW9Pi8X%2F0Q%2FY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:43.9304156","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:43 GMT
+      mise-correlation-id:
+      - 2806e2bb-ca3b-487f-ae65-dfb4260bbe20
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A49Z&sr=b&sp=r&sig=uviO4H39%2B2U6kYxk3U2BOMoyKmq0ijdpY94fwlLXn1k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:49.2260091","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A49Z&sr=b&sp=r&sig=zcZ9LZxI25iTkq5oFWRxbtBaIXIC1dg1qCp51lEo%2FPQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:49.2259097","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A49Z&sr=b&sp=r&sig=pdgrzKeWNIFCoBQHfXwRJ%2B4X2SirRfM0KwBCVPliGcQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:49.2260336","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:49 GMT
+      mise-correlation-id:
+      - ff1bf0a1-fa99-4bae-8721-3e4880a3c98f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A54Z&sr=b&sp=r&sig=YDB%2BnEEpRp6caZaFukW8PtYUz91gWcY7T8NnOD2JBXM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:54.5562828","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A54Z&sr=b&sp=r&sig=Nin6rXecx1rRcWwiGcUGR3VadR33qvZEEdXG9mlbh%2Bo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:54.5562238","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A54Z&sr=b&sp=r&sig=7ON592N8va424KGgp0ZaaSRI%2Fdcq8D5ZZ6dumxXK0ho%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:54.5562973","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:54 GMT
+      mise-correlation-id:
+      - eb2e0f73-e1be-4e79-9ac3-0281719ddb61
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A00Z&sr=b&sp=r&sig=3g%2BwWgHtI2fs8dJzJ5yhRmHwrirT1QWfBUfHITQ%2F%2FeI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:00.0806579","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A00Z&sr=b&sp=r&sig=tfHo8EVjnFPuXmhY3rc7vRWbA4qXRt9mmdKxM7rttbc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:00.0805518","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A00Z&sr=b&sp=r&sig=HqMudgULd8mJ44t%2BFRvzpav3Plcj0bfri69oKDtKRTU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:00.0806863","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1254,9 +1218,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:15 GMT
+      - Sun, 29 Oct 2023 22:24:00 GMT
       mise-correlation-id:
-      - 71f9283d-c681-4c46-9d6d-94f8c35067b2
+      - 491c0794-3cfb-46df-b8a6-4dae84bbf802
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1276,23 +1240,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A21Z&sr=b&sp=r&sig=KymMkw4YfzhGZtMirwxr5omTq%2FYsYKwtkFZpHmbIlgo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:21.3505262","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A21Z&sr=b&sp=r&sig=bdTHj2Ew3EXRVsbyaEQnQV5z0VYUqaLxL3RPgrd1Leo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:21.350436","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A21Z&sr=b&sp=r&sig=mFPSRbqIUp%2B2dB6tsPqKRoMNKFbFSnZ6MDqox123MQw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:21.3505484","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A05Z&sr=b&sp=r&sig=9ku74xoSWf%2BtW%2FdfYXtOzfhVJF8C1sppuu%2F9CiEE15k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:05.3254026","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A05Z&sr=b&sp=r&sig=l7apEt4XpomXAGjBp1OuLuHK%2BEX2wilrFS%2FCdFMLzKU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:05.3253353","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A05Z&sr=b&sp=r&sig=ZCB3VSVBVho%2FOicgrLRw%2BEOi7Ko4BKmQC%2FoAxpyC%2FGc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:05.3254173","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3194'
+      - '3210'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:21 GMT
+      - Sun, 29 Oct 2023 22:24:05 GMT
       mise-correlation-id:
-      - f1cb8bf8-1de0-47a4-ad0e-3e7f4c6f57db
+      - 97ad5fb7-4086-4b50-b26e-7ccc17c500a2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1312,46 +1276,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A26Z&sr=b&sp=r&sig=1dBRy3lC4zUlt5FaMFrmllTEySt8AxF9PxAA4dPvNuw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:26.6949839","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A26Z&sr=b&sp=r&sig=of4Mqtigpi9fkVIeNOHrWVNemTJ0NEl9NMKtqGFAajk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:26.6949143","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A26Z&sr=b&sp=r&sig=WuT4kAvSGD9bL%2BimOZNDxBxied4zpiSykMEkZqarX1E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:26.6949981","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:26 GMT
-      mise-correlation-id:
-      - 38ed80d5-3ec2-44f5-9584-d7dbf050b545
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A32Z&sr=b&sp=r&sig=nlZo5QkQfJAdaPEYvhPYWn33CYw98rKwnH72yUpPbgg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:32.0436505","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A32Z&sr=b&sp=r&sig=WHmU4jLZkYXK9qvfT6QhQH0nqt3%2FJ9hCcEBHR%2BBOc6w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:32.043582","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A32Z&sr=b&sp=r&sig=G059UKEQDr6pSNFnzXzTq%2FNYjQcs6AS80M6k9nsB8a4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:32.0436651","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A11Z&sr=b&sp=r&sig=C6T8KK54qTSda4U7hYwYG%2F%2FmQK1NgR0DdGx5CTjbK6s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:11.1170841","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A11Z&sr=b&sp=r&sig=KWpGKs8waMFbwXzks0JeKg4jHs3sYufppzYu3IzDK08%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:11.1169916","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A11Z&sr=b&sp=r&sig=mgzEXhOQvDxHbfEUQuMVEii4xgkMUbIB0m5zMR3FRIY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:11.1171144","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1362,9 +1290,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:32 GMT
+      - Sun, 29 Oct 2023 22:24:11 GMT
       mise-correlation-id:
-      - 91f429c7-debf-486f-890b-fe20916926a0
+      - cd8a9997-4f86-42cb-b825-9843b991b11b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1384,23 +1312,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A37Z&sr=b&sp=r&sig=%2FyKKZNlwrLGaHhCTBV%2F5koM0OjRE845o8AlzfA6dHyg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:37.3691561","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A37Z&sr=b&sp=r&sig=XHY0ttymHkwjZKx0brgYEfvnvPpHgt%2B4VfbcQlaqtN0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:37.3690863","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A37Z&sr=b&sp=r&sig=BMe14AFJSM2BQxaFPFpAl%2FvW9ET4%2FlKs%2BLwcseIuNAE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:37.3691709","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A16Z&sr=b&sp=r&sig=2Vsr%2Fp7NngSPQ9FmcSvC6QWsa3zAFTHfPGO8ubTcNu8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:16.3699368","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A16Z&sr=b&sp=r&sig=2X7kb%2FrszJLWa%2F%2BHAtGyEfE%2BmXiPbsbxZDI%2FthLje3c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:16.3698653","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A16Z&sr=b&sp=r&sig=Hoeb83n0NWPkaxBO6DVqpF7CQBGQdhdTAT5FyGaKEZY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:16.3699509","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3203'
+      - '3204'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:37 GMT
+      - Sun, 29 Oct 2023 22:24:16 GMT
       mise-correlation-id:
-      - 30fc68fd-fb85-4121-bd16-8dd8660cd846
+      - b952137b-2f6d-4ac7-9c71-31a0a029b651
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1420,23 +1348,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A42Z&sr=b&sp=r&sig=x8B5zr4Zul%2BpprTv2LShd7htXiD13ZtR28Xe8AC4lVg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:42.6631614","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A42Z&sr=b&sp=r&sig=pOcoRYwlFdTi4RzMi6VYzI9Kjq4ouZ73rtjyzdWg6yk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:42.6630869","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A42Z&sr=b&sp=r&sig=ZKrThpbqo65Qr2rIEEctpQTp1bxMi9rbsQo7fTXbgQQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:42.6631768","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A21Z&sr=b&sp=r&sig=4Br6DmwDeZPJ12r2MjVvHtl7TjETYWpVLjVZNcx%2FPrw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:21.6945079","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A21Z&sr=b&sp=r&sig=JW80izEw4NSqnFMtQ8%2FLiDLCpnE9JikAsqDwDV6pJ1o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:21.6944235","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A21Z&sr=b&sp=r&sig=da56g8e83UXZL7utf4J%2FxbcRVXKsEKgyzNQitQ0x%2FuU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:21.6945218","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3193'
+      - '3200'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:42 GMT
+      - Sun, 29 Oct 2023 22:24:21 GMT
       mise-correlation-id:
-      - a6d560b2-1947-4ad9-848a-33ce844e945f
+      - 5d3c965b-2576-49d7-bf36-e03d4ca6522c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1456,10 +1384,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A47Z&sr=b&sp=r&sig=k8sILWs4lUuf3Yh6VZ93kh0ZyV2nN8k5c7SKByenZxQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:47.9557949","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A47Z&sr=b&sp=r&sig=OJ14ShDczNz1RoE%2BRNdhj2zOVpdms4ZLohGec6%2Fcgr8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:47.9557199","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A47Z&sr=b&sp=r&sig=wv9SqsAClkgu5OetBEBrh7hc%2F4LwxETRTC6ZF7wOa30%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:47.9558088","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A26Z&sr=b&sp=r&sig=aXMt0vh3N3%2BXoAbyu5y6mMOSflCszhDEmWySMZuKFmA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:26.9453163","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A26Z&sr=b&sp=r&sig=xACJi2LRTSTz%2FuOQ9SqlX8sAC1cp5glJ%2FDsPT0h3bWQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:26.9452262","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A26Z&sr=b&sp=r&sig=oWf0Hwo0eQJn8qkTEkxT5wbfdXUvLSCJ8IebFBXGX1A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:26.945339","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1470,9 +1398,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:47 GMT
+      - Sun, 29 Oct 2023 22:24:26 GMT
       mise-correlation-id:
-      - d85e79bc-8fbd-4fb3-ab32-04e28764b1a3
+      - ed3ab39a-c0bf-4d19-b85f-09f45e1a9822
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1492,23 +1420,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A53Z&sr=b&sp=r&sig=G%2BvZiLAdYh9R47QZfADuvV%2FdarZ%2FVmVaqJxaHXuWxBg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:53.3056699","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A53Z&sr=b&sp=r&sig=3FKJvzLBxEVK11EFkJCwYgwVT5VJO1sI0QR1UccN2l0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:53.3055874","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A53Z&sr=b&sp=r&sig=%2Bg8%2BFwKYkFayyyFdDAnA2YeOT77JK%2BwO2HbaUSLOBGs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:53.3056857","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A32Z&sr=b&sp=r&sig=X%2FjWChjAHYDA76mY4FylFQ1kxpshspkG3zTqjdvVSeM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:32.1883376","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A32Z&sr=b&sp=r&sig=6yYrrKQFe%2B0nlZvnich2tAbOhVOrPNIldtIN3Qi3G8M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:32.1882234","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A32Z&sr=b&sp=r&sig=A4F3FMFQRrlm%2FJkNxZknvlLDVlqCSsb54W%2F50lx8itE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:32.1883579","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3203'
+      - '3200'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:53 GMT
+      - Sun, 29 Oct 2023 22:24:32 GMT
       mise-correlation-id:
-      - 129ae57b-c999-4495-805e-11741764130c
+      - 2f0e3f29-438a-48d4-adc7-60a567910130
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1528,10 +1456,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A59Z&sr=b&sp=r&sig=BJlk4GDn%2F6qZNd5JlZes9t0KDuPCBK23p2n3%2ByL4dLA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:59.0069443","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A59Z&sr=b&sp=r&sig=i%2Fze5ujvj8sEQk4RA%2FUD5nkyeswpdNhmaQ0KCuM3MRU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:59.0068368","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A59Z&sr=b&sp=r&sig=gcoio1W3o5liYWazAXNnQ4ZFYZ3fR1Q0jOIikrkkDEc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:59.0069731","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A37Z&sr=b&sp=r&sig=FEcvCPyipSY1wraQPyTOw6IF0CCk1IPkkdK2CgjdORE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:37.4607273","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A37Z&sr=b&sp=r&sig=Vap6EKo6VjJ8cFz1U1wuncVpxtT03id128%2F1H6pAB5o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:37.4606413","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A37Z&sr=b&sp=r&sig=%2FLuyACR4MkQYUOEieMYio6sEEQyvpySarDUifeOp104%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:37.460741","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:37 GMT
+      mise-correlation-id:
+      - 2591f1c5-99cd-41da-a338-e8c312a1f41f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A42Z&sr=b&sp=r&sig=8yRoHUgqI4X98cH5it2VoxDEryaFs8UfeyOKMpnXBzc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:42.7129827","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A42Z&sr=b&sp=r&sig=zma%2Fye1jqVLfrEp9yc74yJwJeGcAStby8tpG79eZATo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:42.712892","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A42Z&sr=b&sp=r&sig=vRPJlSdIUcGM7zDTdDod8QM1Ga2Eq7mUuuIJo%2BCzX2g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:42.7130076","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:42 GMT
+      mise-correlation-id:
+      - bde15944-5b24-4af8-8044-962484582ebe
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A47Z&sr=b&sp=r&sig=kBdiJpmlzcaKX4eXl%2BOUCqVw%2BxGWltJcafvBHQXfx84%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:47.9991434","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A47Z&sr=b&sp=r&sig=hdZlHoMFNXcEsR6bfDmQ%2FucYBOWajApsszIGpzAn4tw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:47.9990406","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A47Z&sr=b&sp=r&sig=AN%2FEMZvwNI8ptBJLOXG1dQ3d3DSIrwzzmZIlq4fIY1c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:47.99916","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:48 GMT
+      mise-correlation-id:
+      - 8bf9c0f8-0ffe-40ff-b18f-c5f936b04336
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A53Z&sr=b&sp=r&sig=xjvg8WbR8nvufOpoWm%2FlQNPvVQfjfSa%2F4oQD%2FdL98Gg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:53.325728","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A53Z&sr=b&sp=r&sig=IP046XVQw5uPbGP1ukn9edtc5lvrwxg45Vn26%2FpyCGw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:53.3256578","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A53Z&sr=b&sp=r&sig=G6DdhXjdnfPDvF7Dymwi3RRToM87GU6VwM2lPlITBlQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:53.3257438","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1542,9 +1578,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:59 GMT
+      - Sun, 29 Oct 2023 22:24:53 GMT
       mise-correlation-id:
-      - db640b76-1df4-4240-8cac-10708d75de8a
+      - d7f4a633-c224-4ffd-8c76-c8968f5c3f0c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,23 +1600,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A04Z&sr=b&sp=r&sig=CdJj6pX%2Bwo%2BKOQ5dfpcMLzTj0nTWJrK%2F7vwazFdd1Ms%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:04.3416785","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A04Z&sr=b&sp=r&sig=yLDicFoUef1OTyDHVYciXl8sJkCEswBNBi3vNGPJ%2BcI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:04.3415935","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A04Z&sr=b&sp=r&sig=tjAOB13GXOkcJWH8H6hQ9Z5e0dfWGFI3vMG0hqpEs%2FA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:04.3416928","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A58Z&sr=b&sp=r&sig=PgtQGeeqRO%2FgiHpS5QxGRwzhvHFynKR8%2Fz94jPVV5UQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:58.6025973","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A58Z&sr=b&sp=r&sig=3ZYt%2BxVnaJuLeCWwfu5JSyg6wYzyCNvi9vYgzAt4qvE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:58.6025248","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A58Z&sr=b&sp=r&sig=9BI56%2FQivbmNtZ7il%2FkoPKbOLNWa7mi%2F4zNOtkgMSoo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:58.6026132","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3201'
+      - '3204'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:04 GMT
+      - Sun, 29 Oct 2023 22:24:58 GMT
       mise-correlation-id:
-      - 894e4608-44c3-4ffe-acac-19a7cd76c3aa
+      - fb3f68bf-75a6-4faf-81f6-91fc6a7fd3fc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,23 +1636,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A09Z&sr=b&sp=r&sig=SSXVYbtJlPuI2A2Fct12lLjDZ4oRdHu2QuJ1KmAm%2FME%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:09.6139571","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A09Z&sr=b&sp=r&sig=cpAxo7Ke6FODvmv%2B1mBDFblKkceJ%2F%2F9ZELwaTcGX1yc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:09.6138864","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A09Z&sr=b&sp=r&sig=x21pRi5sIjmpHubAf3XLPgrRAFQr9amwP3DI4%2Fq3sVs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:09.6139714","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A04Z&sr=b&sp=r&sig=EbuqiRDfXhnJIJiwKrsmWhBIglC1xKA4eoSRcC63m4Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:04.1180956","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A04Z&sr=b&sp=r&sig=pHKeCSrH9ipSXZF8UE1kwAiPGgT3or%2Fdchsm25Xkaj0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:04.1180252","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A04Z&sr=b&sp=r&sig=wApkGKPqV7L93%2BFMSWDffxHu%2BrI9FAuf7f7zyaHTB2M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:04.1181098","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3201'
+      - '3198'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:09 GMT
+      - Sun, 29 Oct 2023 22:25:04 GMT
       mise-correlation-id:
-      - f03e212b-1ce4-433c-b403-06ebd5d147bf
+      - 39f8992f-7147-45d9-9121-255a27f9be22
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,23 +1672,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A14Z&sr=b&sp=r&sig=tYVZpA9F%2BknEAM8pIKK9t2mRbQ2jAUxaO3aKdGFoGtI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:14.9291989","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A14Z&sr=b&sp=r&sig=WUBlitougDuTCcUTLbI%2BYjK%2BsPfk6Q2BGEao6eGA0aQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:14.9290974","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A14Z&sr=b&sp=r&sig=5TqZCpK5EYrLJcxOS34ABOoFnIEFX01oNU4EGre3xJM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:14.9292233","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A09Z&sr=b&sp=r&sig=LuYl9oONDsOIS9lGhcpGp0eaudplDH30uFG9LEwNrx4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:09.3958533","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A09Z&sr=b&sp=r&sig=X4HcPbZhvtARF0eEO3ztnXNNnsI3LSnexGe%2F515FdBw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:09.3957616","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A09Z&sr=b&sp=r&sig=mCdulV8LIooX63HN1UyNBY3ywqIT0UG9A4r9Xm9hj08%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:09.3958757","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3197'
+      - '3194'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:14 GMT
+      - Sun, 29 Oct 2023 22:25:09 GMT
       mise-correlation-id:
-      - 6567b80a-cdc7-4039-9d30-8f81c733e359
+      - e5cecda8-2535-4c14-9472-67c1ca86697b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,23 +1708,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A20Z&sr=b&sp=r&sig=N7sLC36kNZNZJ9alhWalNr0ThVjJRPc91RWMuW%2BOhO8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:20.8162945","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A20Z&sr=b&sp=r&sig=iL3FLdksMWTj1gEEbAS1TqEGl%2F7qzk7Dis%2Fb1%2Fw3OQg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:20.8162272","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A20Z&sr=b&sp=r&sig=BcsewyQUdipQ%2FhsUgn7hyK%2BFNKuu9sqrF9xkOusWEI4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:20.8163101","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A14Z&sr=b&sp=r&sig=VBZx0Jg3rdcB98ccF5%2B2UDXsWdUfKcapv6eoYczlRyk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:14.6569854","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A14Z&sr=b&sp=r&sig=p%2BQ1Ar8IFV3W2bPTtVuKYMtm%2Bc0xnLYOZIZADHRL0EU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:14.6569146","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A14Z&sr=b&sp=r&sig=MpxyxZyfRwbsQGVLxfcuNRN0bs%2BcXaURZaSVUz8oREA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:14.6570001","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3203'
+      - '3200'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:20 GMT
+      - Sun, 29 Oct 2023 22:25:14 GMT
       mise-correlation-id:
-      - a4a29bfa-3f0e-4fea-b6dd-cc373e504c7b
+      - e5a0b508-e748-4ba2-9550-bb9317363f69
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,23 +1744,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A26Z&sr=b&sp=r&sig=O%2FCsxxPlM1SD7DsJOgCFdDysACmZRTtjS0T%2FllKBilA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:26.089868","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A26Z&sr=b&sp=r&sig=yRCeU7A6LPaszh638PVdiS10J3Hj5DrQSKGeqhzG2JQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:26.0897929","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A26Z&sr=b&sp=r&sig=iy6jsWwmSEczm8HT1t8zdYrHneYZwQ%2F2HHLaUySRzFs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:26.0898842","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A19Z&sr=b&sp=r&sig=WFC9MhYJTdKiMQOwYK%2BIf1Qj8zKWDoTEZkcDB8NO%2FQY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:19.9420442","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A19Z&sr=b&sp=r&sig=FdX7upPJk0fPUzFnTUZs30iYBOFyyXpcWGLyYdzD6T0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:19.941976","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A19Z&sr=b&sp=r&sig=CI0hzg9KWfMK5dShu64BJLsDe5h2fklpkPZggzXlThE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:19.9420598","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:22:45.056Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:31.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3196'
+      - '3195'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:26 GMT
+      - Sun, 29 Oct 2023 22:25:19 GMT
       mise-correlation-id:
-      - c4b18d14-c858-4ff3-836b-83d04557150d
+      - 7442698f-af32-4b32-8a65-07ae3776ccc5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,60 +1780,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A31Z&sr=b&sp=r&sig=Wi0O8krQSIE%2BAT3yKeEGCUEG5snJQ6gRdCp%2FRDxsbLA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:31.416712","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A31Z&sr=b&sp=r&sig=Wqsm%2Bw0Tr8np2%2FYpSdCgJ9riFEWeQ%2FGc7ydPZwOAmXo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:31.4166207","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A31Z&sr=b&sp=r&sig=jJf8f4M6E8xOvjLgxGcCCDtGaDMuc7y37ei2b8eN%2F7I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:31.4167282","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:54.723Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.712Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A25Z&sr=b&sp=r&sig=tX1sWO%2B0BlzxYq0xM%2Fx7tWQUPbODkPv8iJ3AreA6qhk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:25.1912594","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A25Z&sr=b&sp=r&sig=4wiKej4JuExZblKlcsihb%2Fzf7y%2FR9voy0mXRkxy%2FvX0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:25.1911828","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A25Z&sr=b&sp=r&sig=oxnPkuNImlL2q7oJVVZ8Kt5wG5Bt77nPU6Bvo3K%2Fr2Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:25.1912747","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-29T22:22:45.056Z","endDateTime":"2023-10-29T22:25:23.633Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:23.722Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3202'
+      - '3339'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:31 GMT
+      - Sun, 29 Oct 2023 22:25:25 GMT
       mise-correlation-id:
-      - 2e1bbc00-90e2-4bb8-b72b-35a0248dbedb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A36Z&sr=b&sp=r&sig=hO%2BhE2dbCVZ1i8%2Fj88C%2B7GgotOR2vOIfoxuUMcZTAL0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:36.6789605","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A36Z&sr=b&sp=r&sig=09rNT4JiWeckjDwXXEYzwc8qsPfVP4hgdE6Wup5Vtnk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:36.6788786","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A36Z&sr=b&sp=r&sig=NCu2RiaRAt%2Fz1UhMBltfg3PkgshYZjxT%2BtBLKmXtdKw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:36.6789759","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-24T12:29:54.723Z","endDateTime":"2023-10-24T12:32:32.726Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:35.478Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3336'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:32:36 GMT
-      mise-correlation-id:
-      - 589f48f9-7663-4455-ba69-9f4bb6573fe1
+      - 9203f7e4-92b9-46f9-9489-17185ac4f462
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,18 +1820,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:54.2589267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:54.2589267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:45.5929152Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:45.5929152Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:38 GMT
+      - Sun, 29 Oct 2023 22:25:26 GMT
       etag:
-      - '"d300a43d-0000-0100-0000-6537b8870000"'
+      - '"3c006929-0000-0100-0000-653edafb0000"'
       expires:
       - '-1'
       pragma:
@@ -1861,24 +1861,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"762b94d9-7054-4c80-a066-90da8932b523":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fd473a70-3e78-4a18-bd11-234a91ae5024":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"03c9f4a7-edd4-4584-a436-a4d050ff2742":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3ce9038e-90fc-4b0f-9cf1-369eef4634a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A39Z&sr=b&sp=r&sig=zL6%2B24pIgl9J9sBqKLjb98MYPGjPbrLTySnaziDLkJg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:39.1024045","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/3e117983-104e-4a7d-acd6-89d25af4a2ad?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A39Z&sr=b&sp=r&sig=TQUa0yPfL%2F7Rg7ZiGC7E7%2BH6qr%2F0NitYEhJnCldd7RI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:39.1023333","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1132f0f0-ec0f-4a91-9029-3b9531252ba8/4f795428-9e6e-4ae1-88e3-9ac9bf9ddd39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A39Z&sr=b&sp=r&sig=3qFfR2tqhaKHsSXjCrfoRIlv3ib%2Bh6YOG7LmDavpKR4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:39.1024186","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-24T12:29:54.723Z","endDateTime":"2023-10-24T12:32:32.726Z","executedDateTime":"2023-10-24T12:29:53.031Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-24T12:29:54.28Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:35.478Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ea1fbfa8-0fe7-473e-b316-d6d20eacd390":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"dec2f4f6-0237-4e02-ad8f-3107c1a1000d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01430d40-cf88-4d64-b6fe-3566ca773815":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/58ec69e7-1bc6-421c-825e-e684d9f63d7c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A27Z&sr=b&sp=r&sig=t9nd5P7R1qkuVjXsIz3UHgkokOd%2Be%2FCDBPurxqrCdy4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:27.2498994","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/2311f828-b330-493d-852c-28775077e77f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A27Z&sr=b&sp=r&sig=KkbS6tZ5SGgnZpSyZLje8uXoohZdESGZrJ4WfV0v5FE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:27.2498085","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27be8aaa-5654-40f3-af1d-df2eccc89efb/8a5e1596-dfe8-4044-95fc-be6af10d917e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A27Z&sr=b&sp=r&sig=eb5kD74OL95D1JqFAnk24FIXFfBUL895SZ0ss7kPNmY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:27.2499227","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"delete-test-run-case","displayName":"delete-test-run-case","testId":"delete-test-case","status":"FAILED","startDateTime":"2023-10-29T22:22:45.056Z","endDateTime":"2023-10-29T22:25:23.633Z","executedDateTime":"2023-10-29T22:22:44.244Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/delete-test-case/testRunId/delete-test-run-case","createdDateTime":"2023-10-29T22:22:44.536Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:25.809Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3348'
+      - '3343'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:39 GMT
+      - Sun, 29 Oct 2023 22:25:27 GMT
       mise-correlation-id:
-      - be5fbbcd-d11f-4166-bb14-fd66112ddd2c
+      - 3d5c0cbf-4a7e-4833-8a0f-dc6f80c941b4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1901,18 +1901,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:54.2589267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:54.2589267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:45.5929152Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:45.5929152Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:39 GMT
+      - Sun, 29 Oct 2023 22:25:30 GMT
       etag:
-      - '"d300a43d-0000-0100-0000-6537b8870000"'
+      - '"3c006929-0000-0100-0000-653edafb0000"'
       expires:
       - '-1'
       pragma:
@@ -1944,7 +1944,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs/delete-test-run-case?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -1954,9 +1954,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Tue, 24 Oct 2023 12:32:41 GMT
+      - Sun, 29 Oct 2023 22:25:32 GMT
       mise-correlation-id:
-      - d28564e8-85ac-4274-a482-afb24ebdec9a
+      - 1d5c6902-874d-4cec-96cc-e9af1eee86f1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1979,18 +1979,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:54.2589267Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:54.2589267Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:45.5929152Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:45.5929152Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:42 GMT
+      - Sun, 29 Oct 2023 22:25:33 GMT
       etag:
-      - '"d300a43d-0000-0100-0000-6537b8870000"'
+      - '"3c006929-0000-0100-0000-653edafb0000"'
       expires:
       - '-1'
       pragma:
@@ -2020,7 +2020,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://75b7c60b-f5c4-411b-ad50-787ea52833f4.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
+    uri: https://e097d4d4-5111-4a94-b340-9a6fb476d5a5.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=delete-test-case&api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -2034,9 +2034,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:43 GMT
+      - Sun, 29 Oct 2023 22:25:35 GMT
       mise-correlation-id:
-      - 6bbe74fd-89af-4896-a7f5-870cec2f942d
+      - 3fdee9d3-4dab-4705-beb7-38188ea35409
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_download_files.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_download_files.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:22.0199528Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:22.0199528Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:52:29.3800691Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:52:29.3800691Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:56 GMT
+      - Wed, 18 Oct 2023 20:53:02 GMT
       etag:
-      - '"d80153fb-0000-0100-0000-65294b990000"'
+      - '"75009653-0000-0100-0000-6530458f0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:52:57 GMT
+      - Wed, 18 Oct 2023 20:53:04 GMT
       mise-correlation-id:
-      - ad70a149-cab7-43c4-b04f-59472da587a0
+      - 25a323b0-973f-44b8-b027-277ac18f71de
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"5ab853c8-30d1-4dfb-aef0-916256c71cd2": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "f648a763-1709-461c-8c58-cf9cd0161426":
+      {"passFailMetrics": {"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "4dfa8516-8306-461b-ab3e-d2c6d2279374":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "ea858bcd-2d1d-458f-8f53-9aed3d809347": {"aggregate": "avg", "clientMetric":
+      "50"}, "57356505-50a7-4bab-b5a2-d49f09179356": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:58.342Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:58.342Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:53:04.984Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:04.984Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:58 GMT
+      - Wed, 18 Oct 2023 20:53:05 GMT
       location:
-      - https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+      - https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 8f565631-d031-4a40-af9b-b508612a4774
+      - 2ee6420f-be05-4dcb-87be-953353ac49cd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:58 GMT
+      - Wed, 18 Oct 2023 20:53:05 GMT
       mise-correlation-id:
-      - df382072-ea90-4e33-94a2-00fad7fb1245
+      - 902014d2-9a0a-4059-8850-7e0bd9caadc0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A59Z&sr=b&sp=r&sig=ZtTy45%2F5h0IiIXvmldnCuxcYjHPxs35LxrNNLosstqQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:59.1670467","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A03%3A07Z&sr=b&sp=r&sig=l%2FM%2FY%2B%2B5LbjB23vUup%2BTqRIfHfAu6WJkDD5oyJ%2BGOGA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:03:07.7716357","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '561'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:59 GMT
+      - Wed, 18 Oct 2023 20:53:07 GMT
       location:
-      - https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 2ce64733-dc7b-4a8c-a4f2-065aec47dfa6
+      - c0199788-229a-4f10-b9ea-5b5cc587e271
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A59Z&sr=b&sp=r&sig=C9GCzyQvnAH7TDU2hAl3qlywozyw7lToUpvrIV%2B3Tqo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:59.4572392","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:52:59 GMT
-      mise-correlation-id:
-      - b6405a80-8e23-4464-b433-2167007fe520
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A03%3A04Z&sr=b&sp=r&sig=8%2BD56AAAkE46pS4fhao9vf3COjCeiZY0CedXINYbI4c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:03:04.7100726","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:04 GMT
-      mise-correlation-id:
-      - a1b4644c-813e-4be9-8d10-cde6bd86c78b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A03%3A10Z&sr=b&sp=r&sig=D8Q6lNBFJtSSUr29gI%2B21k9Mqp6Vwo5%2BBzkgZEYF8r0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:03:10.0387289","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A03%3A08Z&sr=b&sp=r&sig=y55p0abc3ak4rq%2FxtEayYsuntUTWc4DgQrjZ%2BcKyhnE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:03:08.0886859","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:10 GMT
+      - Wed, 18 Oct 2023 20:53:08 GMT
       mise-correlation-id:
-      - 432afb36-5a46-4f5a-ad50-c7852cc49e1c
+      - 30e593e8-1c5d-4217-83f5-f04eac8a8cd2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A03%3A15Z&sr=b&sp=r&sig=mjGmkknCkE5BHo5abmlfFn9MoqH64aOiJGDD%2B1BhtUE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:03:15.3591202","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A03%3A13Z&sr=b&sp=r&sig=3IbPBannLAQFcbGqk6%2BM88KiCgDL6EbclN08W79quV8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:03:13.411184","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:15 GMT
+      - Wed, 18 Oct 2023 20:53:13 GMT
       mise-correlation-id:
-      - 35a73915-3b0d-4a5d-8527-bfda6c68e0d3
+      - 7c1b745c-c9e9-4cf4-861b-d15f9385b1c2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +385,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A15Z&sr=b&sp=r&sig=YcvBzlsN6Au0jiwMFfnSJ79CmIpxVcJyQ61m4AOkQ1E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:15.6823491","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:58.342Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:12.118Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A03%3A18Z&sr=b&sp=r&sig=cMCbT6%2BLtJNziNIzDPCOeO5yk2R7f3kmtzNDijfS5fo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:03:18.7391551","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1579'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:15 GMT
+      - Wed, 18 Oct 2023 20:53:18 GMT
       mise-correlation-id:
-      - af52b428-bccf-41b5-9465-bded65caf2fd
+      - 66285994-7fc0-4eab-b9a6-c55e1ca0cd95
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A03%3A24Z&sr=b&sp=r&sig=h5lp4iR1IsfboYKdaaiutkXR3cDgU6tQvUV3Toq1vFI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:03:24.103396","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '546'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:24 GMT
+      mise-correlation-id:
+      - be336926-79af-4a83-8256-e6a99f3f68ba
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A24Z&sr=b&sp=r&sig=Ic6zZo4flF8fLBbE76%2BJTKEFPvzj72tyLyfcPHzZiNY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:24.3841771","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:53:04.984Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:20.91Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1580'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:53:24 GMT
+      mise-correlation-id:
+      - a821823c-c5ee-44a2-9f19-107680fbf5dd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:22.0199528Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:22.0199528Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:52:29.3800691Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:52:29.3800691Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:16 GMT
+      - Wed, 18 Oct 2023 20:53:25 GMT
       etag:
-      - '"d80153fb-0000-0100-0000-65294b990000"'
+      - '"75009653-0000-0100-0000-6530458f0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A17Z&sr=b&sp=r&sig=r2blfeze2jJ1hTeMjT0O3iXpniUlKxkzSsNI%2FCk8uxc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:17.9723061","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:58.342Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:12.118Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A26Z&sr=b&sp=r&sig=I4%2B4taiK2yjEzKozbbAZ67WH3WIkYzUfcLaKLIOsQhI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:26.7165644","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:53:04.984Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:20.91Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1593'
+      - '1592'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:18 GMT
+      - Wed, 18 Oct 2023 20:53:26 GMT
       mise-correlation-id:
-      - d280e19e-fd50-490d-832a-1de2aa4a1e26
+      - 6a4248fd-059b-414c-8243-8e1c92356848
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:22.0199528Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:22.0199528Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:52:29.3800691Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:52:29.3800691Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:18 GMT
+      - Wed, 18 Oct 2023 20:53:27 GMT
       etag:
-      - '"d80153fb-0000-0100-0000-65294b990000"'
+      - '"75009653-0000-0100-0000-6530458f0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:53:19 GMT
+      - Wed, 18 Oct 2023 20:53:28 GMT
       mise-correlation-id:
-      - 0dacdb0b-1e7d-4598-a3d7-b25c2564ec45
+      - bf1082bf-8940-4632-b0ed-2aa289a469cf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A20Z&sr=b&sp=r&sig=F0fThIJ%2BJpjIZ41Ge7fwB5dR7JdR9pN9Pq6KJBTNNHw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:20.5338605","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A20Z&sr=b&sp=r&sig=Z5PteR8OFR%2BIB477OWZGhTW6NRy%2FHCQ9kg2QOosCqRg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:20.5337778","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A20Z&sr=b&sp=r&sig=osEEunxQNQF60e04wiU6HyjRrtDroMHDdtUuUvtrhDw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:20.5338862","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:20.467Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A29Z&sr=b&sp=r&sig=4o%2Bn3GJADei0s%2B6SPSibvux1f3BgLQ1D%2Bt1Dtv5ZFdo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:29.7568544","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A29Z&sr=b&sp=r&sig=GSC2OwTJEqRnStabesg4aOSNqVcL4LDyKoauwF76c%2Fc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:29.7567301","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A29Z&sr=b&sp=r&sig=FI6qYr0QhoXsUpjkUaDoujyFU58%2F5QESEmvxmU9EP%2BE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:29.7568801","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:29.686Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3164'
+      - '3170'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:20 GMT
+      - Wed, 18 Oct 2023 20:53:30 GMT
       location:
-      - https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+      - https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - dd2e9de2-2714-4848-a5eb-569c1887525e
+      - e4eb30a7-7316-4567-974c-54fc6208349b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A21Z&sr=b&sp=r&sig=OnTp3XL0IhmBT3xIJytM8Rf99f%2FSGU52REwLd5les40%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:21.0809734","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A21Z&sr=b&sp=r&sig=I84SUQTm0F47Mn3mhrioujgQsqpdUzie7y5YjUtRmy8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:21.080899","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A21Z&sr=b&sp=r&sig=2kLigLn0yVuPM69XjCJnIkXx0DrEFNp%2FxU%2FssE9fwTI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:21.0809872","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:20.467Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A30Z&sr=b&sp=r&sig=g7L8aV1kZdx4pl0Xvm7Pdn8scA5bEs3fU0%2FL6%2Bc09Sw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:30.3101343","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A30Z&sr=b&sp=r&sig=VgV%2Fw4I1PxqN7mc7zkP5ee1pK1reG8aVQtZUMTEUM7E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:30.3100637","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A30Z&sr=b&sp=r&sig=CbX4Dd%2FDvKLRjaVABAvqCB26Ar%2BjJ%2F0xizhiX7XlWtw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:30.3101496","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"NOTSTARTED","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:30.208Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3163'
+      - '3215'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:21 GMT
+      - Wed, 18 Oct 2023 20:53:30 GMT
       mise-correlation-id:
-      - d5fdb46f-e839-41b6-99a3-775d9f01f595
+      - 8460faa9-292c-4df4-96b7-06df0c96a7b1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A26Z&sr=b&sp=r&sig=ErAWBSIax%2Fpigd1eFWrDff9zmb%2BcQnT%2FGjLoJegqgzw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:26.3609856","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A26Z&sr=b&sp=r&sig=Qh0%2BVwUG5ep%2FMVC%2F60NWz12vFkvVWwOYqxSyBOvoSPM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:26.3609151","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A26Z&sr=b&sp=r&sig=xcXaF%2FSl9uTtyafTPX%2BZ3QejuSzKbOZzzVxc%2B%2B%2BUz8I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:26.3610019","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:22.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A35Z&sr=b&sp=r&sig=i2dcmTa3CjPoVLS%2BJBgNjD5TLqkjWrB0SCvlloMEsR8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:35.5726764","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A35Z&sr=b&sp=r&sig=ErAemf90BQxzP1N726oaGNMBjfp9JtBvsGqzi1L9GaQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:35.5725937","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A35Z&sr=b&sp=r&sig=qfw3mmr%2FOlfLUpQBqInLnHVdw2zoeYh%2Fg%2FKRwURaOW0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:35.572701","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:30.389Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3227'
+      - '3212'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:53:26 GMT
+      - Wed, 18 Oct 2023 20:53:35 GMT
       mise-correlation-id:
-      - 2806a5ba-13fd-4819-bd42-be543e90bb31
+      - 8ba16667-89ad-4e03-9697-9273d11f0bb1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,226 +772,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A31Z&sr=b&sp=r&sig=yMf1HZVlNUo3BJk5QnWkTQ0GlUddkrtENgXQpKmuVeQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:31.6278517","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A31Z&sr=b&sp=r&sig=snG%2BSUMFaLdZFlf8nqt3HlVLdMZufK8ht7ZuYRU4Tco%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:31.6277784","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A31Z&sr=b&sp=r&sig=I7N71q4ZYGzMB4G%2BB%2FfUAde2A2nHRb341Cua4qGaZi4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:31.6278666","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:22.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3211'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:31 GMT
-      mise-correlation-id:
-      - 8472a47e-ae2c-4d91-88f4-55257bb95079
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A36Z&sr=b&sp=r&sig=3SH1qS1gFrfC%2BdCLYVCA1SrGLB1o46d4JJMbFJpXdlg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:36.9274529","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A36Z&sr=b&sp=r&sig=PSuFeWdB6f5T2YqRBfBZIReY7HauxPDrS5Iin2aRet4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:36.9273778","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A36Z&sr=b&sp=r&sig=E6c4GsXgA6%2BZGnVJaAAEmx6P4MvIk9IqpAc9A4xNv4g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:36.9274676","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:22.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3209'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:36 GMT
-      mise-correlation-id:
-      - 16e96b1f-119f-4145-8691-fd1f750b84db
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A42Z&sr=b&sp=r&sig=RMFRMh3ygpWoGFF7P4WvYb2obX8SE33vgXJS0WarVSE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:42.1829839","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A42Z&sr=b&sp=r&sig=DtzplhUoYUU2kTZYHaMIsHfShWvr24sNu7Wbe32dzhM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:42.182916","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A42Z&sr=b&sp=r&sig=YknB9M65S1IdqzC%2BknldLbtmNhCOYtDZRi%2F%2FtWg6ofQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:42.183","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:22.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:42 GMT
-      mise-correlation-id:
-      - 294ec3c7-42a4-4eee-8040-9e881eb4f193
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A47Z&sr=b&sp=r&sig=amvF%2FQV2Xytk7A0%2FipNrQu8VJaAnD4K62G2WVuMcN80%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:47.5426739","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A47Z&sr=b&sp=r&sig=%2F95f6x%2BakJCIVBcZpqt7LV3qim0L8G6pqIjnTWvyT14%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:47.5425879","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A47Z&sr=b&sp=r&sig=RDYtlMKO0YG1VQSiLR8nmYzJia4Xy%2FzPgs%2BLUOpc30Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:47.5426884","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:22.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3217'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:47 GMT
-      mise-correlation-id:
-      - 2e38e823-dfc3-4cd3-95b2-17a7563f6b29
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A52Z&sr=b&sp=r&sig=K7aGSSK5Gom%2BxAGS9aoumNa%2BEtUD1au2DsQa%2FVwMChg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:52.804645","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A52Z&sr=b&sp=r&sig=%2FZK%2Bhg3dbbmxnIKsfqrzcyUwGcy7IVJpgoI8qc8MYzQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:52.8045474","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A52Z&sr=b&sp=r&sig=%2Bv8pVkkraJHkHQUOibpsy8zIENY20HnUd6CB8MwbHwM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:52.8046676","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:22.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3216'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:52 GMT
-      mise-correlation-id:
-      - 9b262b0a-be4a-48b5-ba2e-0654824fb55b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A58Z&sr=b&sp=r&sig=pUAGn5l9sPtPh4s36LGODKsp9BYjFrAo2XG8tJ2R%2Bm8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:58.0531103","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A58Z&sr=b&sp=r&sig=FMSJe1fVXg%2By0IGKVSztpwS2zQgTWL2mLldNQD696ak%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:58.0530429","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A58Z&sr=b&sp=r&sig=U0zMDOp34aEFaFlx%2F3gE5jwYI2hRYAeqINfBogctqEQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:58.0531249","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:22.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3211'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:53:58 GMT
-      mise-correlation-id:
-      - 06fd1ff5-e321-4ec6-9b4c-49acea54163f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A03Z&sr=b&sp=r&sig=JC%2FyeKM587dSLJJatJYJztTO9RqgvZzjUMPBYoqnB14%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:03.3127535","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A03Z&sr=b&sp=r&sig=GoueIXYfJ3meJr5PlZc4rgso6m7Cv2MUMlQ8Voyg4%2FA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:03.312685","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A03Z&sr=b&sp=r&sig=ALgNyPmZzy6LSct5F2aZyWTUWPYwUhyyeVNa2fkvYwA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:03.312767","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:22.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A40Z&sr=b&sp=r&sig=vy04cYjrWsHd81zG4fOYIwbPRXtIqwGqcUTqqXGY0ow%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:40.8722356","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A40Z&sr=b&sp=r&sig=%2FDQOd9QPDjMOvRI%2F7d212AaP4moluSrbAXDLwfmx3DA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:40.8721629","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A40Z&sr=b&sp=r&sig=9g6Dhq9gLiUf8VsjUSaJV3aRjyUArgkdVeyMTmdH5fw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:40.87225","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:30.389Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1002,9 +786,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:54:03 GMT
+      - Wed, 18 Oct 2023 20:53:40 GMT
       mise-correlation-id:
-      - 63b65594-671e-415d-881f-7c55fe21fd07
+      - 90d4ec25-b275-412d-81eb-6caf6da68709
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1024,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A08Z&sr=b&sp=r&sig=ns4r8GYhLRn9wUVcTFZg4QcyPzHlbNShtajNAkDzups%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:08.6392613","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A08Z&sr=b&sp=r&sig=99Cfld6Wgm9fDvnJ09FTt4Xr6VUFJCDOYxoELBIKxOg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:08.6391905","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A08Z&sr=b&sp=r&sig=l7v2ucFboZL1WbuqB9zqxFGV%2FiVI5FEvbQL1mTqY6qE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:08.6392743","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A46Z&sr=b&sp=r&sig=r3M7gxWjgap4cVNzl2BVbhQcHetw5WG9V%2BDwMpD4pQA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:46.2033735","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A46Z&sr=b&sp=r&sig=e1aqMkBY00Mg12SLhK0iktCr9Qi9cmSxx96LdZ%2B26BQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:46.2032812","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A46Z&sr=b&sp=r&sig=yarYI%2FgFdR4lTVzCviMZDbEVnUKi17umyhVPEKDYNV0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:46.2033963","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:30.389Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3204'
+      - '3211'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:54:08 GMT
+      - Wed, 18 Oct 2023 20:53:46 GMT
       mise-correlation-id:
-      - 461e89d8-5854-4dc6-91c4-98a5bc8c7d59
+      - 001fd94a-6ab6-4e35-ba1e-cbf95a3d8589
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,622 +844,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A13Z&sr=b&sp=r&sig=pKUYy4qnAZnPmmWvdncwfm2kWbHJG7lidDoNgsJd314%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:13.8935262","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A13Z&sr=b&sp=r&sig=oqGelMg4o2i98i6AGHZNwV2xhAS1qPHEaY55WjANrIA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:13.8934393","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A13Z&sr=b&sp=r&sig=3yZLVLAMDc%2Fd1BmlX3u1AjwK6lIGNkGi8QbYy%2FjkvqQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:13.8935481","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:13 GMT
-      mise-correlation-id:
-      - 6cd13030-8fef-4125-bfa0-960ab822c35e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A19Z&sr=b&sp=r&sig=bnetqtDbzv076GnLQC7cR5AostmbVteZbSvWm0fOYPA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:19.1781808","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A19Z&sr=b&sp=r&sig=dhcbE1PmtnAgwp6cAhaogXGM9gynLvMtLoPHMr46l5s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:19.1780954","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A19Z&sr=b&sp=r&sig=20v6ltBAb4EyLFG%2Bo0zMECaTsqXFnc309pQyyCw46sg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:19.1782016","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:19 GMT
-      mise-correlation-id:
-      - fd243e52-a5d0-43d2-9134-1da2f229159c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A24Z&sr=b&sp=r&sig=R2rtS14Kw%2FYJ8a1Rp%2FBddqPMf7ZxdLW5JFflduNkouI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:24.4380739","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A24Z&sr=b&sp=r&sig=g%2Fh49llQhfmXAwZlCrWvWso1J3gOVh3xRl4fG38z%2FAE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:24.4380025","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A24Z&sr=b&sp=r&sig=phYl26DuB%2Bn874O%2Bzo45DeN%2Fqp5Hz%2FYvjBmaVWZGXko%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:24.4380874","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3218'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:24 GMT
-      mise-correlation-id:
-      - e41a17c1-c1f9-4ae1-aa37-f629b56b3ff5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A29Z&sr=b&sp=r&sig=Wzl9XGQM%2BLoAyOwIqqVvz7ImM56uwBrU34IKjp0pPQ0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:29.7099073","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A29Z&sr=b&sp=r&sig=tqAuK3XB2dgXtksH01Qq%2FGZ23bowFSWerMp0eGRDhR4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:29.7098394","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A29Z&sr=b&sp=r&sig=wAkxDVl1zmP9F55iNUk5gp1DrcDTlUkqC8pSobG0HbA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:29.7099221","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:29 GMT
-      mise-correlation-id:
-      - 36fa93db-6b69-466b-b1c0-1b10a6456f16
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A35Z&sr=b&sp=r&sig=VRJIjvt%2F9HRR4z3%2BWu8RFA%2BaKcmKNGfaFVCeWZVOxN8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:35.0562366","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A35Z&sr=b&sp=r&sig=lkWiav6xaV7WbsX%2FR4nEy5LZwCD48imkutkukqU2038%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:35.0561481","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A35Z&sr=b&sp=r&sig=as4j0SZA43rQ4xAYgp4o6urtfoJGHpYOJlIjoWlANW4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:35.0562513","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3210'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:35 GMT
-      mise-correlation-id:
-      - 1ef25302-7e75-4376-8f44-1000a03c1e58
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A40Z&sr=b&sp=r&sig=bGGafou8iplS%2FLPJbj1UqQrUp4D9VE%2BubIqjnihwLw8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:40.3029999","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A40Z&sr=b&sp=r&sig=j4Xls4Uoj1zZcLdRPhHBKt1cvJKh%2BturO2%2BymweT%2FJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:40.3029316","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A40Z&sr=b&sp=r&sig=Y2OzDzDrJN1NOMH8uY6wa9A7t2TCwSLWmBegHhdBVEY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:40.3030145","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3212'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:40 GMT
-      mise-correlation-id:
-      - 0d1781a1-daad-4877-8d80-016fe1b20eb4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A45Z&sr=b&sp=r&sig=SZDpjCyLYEurycEIygx4atTCbegUS4vIuJX7xtbiuLg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:45.5955496","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A45Z&sr=b&sp=r&sig=1Nk1nbZCxgjmG8%2FeNwwigK3jh5wDsCYN0rbF0r29R9k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:45.5954608","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A45Z&sr=b&sp=r&sig=E3bwq7zaCSXBuqIbHLgAruoCAJjePXo8zDeh4qGOFhM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:45.5955729","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:45 GMT
-      mise-correlation-id:
-      - 8fe28dd3-155e-4ed5-af27-2b12c176ba96
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A50Z&sr=b&sp=r&sig=gVP8HJi7yWBZ8sBFlPTPQr8NTSXVfFi%2F%2FFFBuS%2BM0Fo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:50.8373273","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A50Z&sr=b&sp=r&sig=vR45rRuQ0iO%2Bgu0n5j7Y7nm95eeUFxzwa3n0HOQXyH8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:50.8372451","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A50Z&sr=b&sp=r&sig=R6mPshmptj0FBdLgttvqLwshus5EQ%2FCjfS%2BMXTff7Vk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:50.8373464","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3214'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:50 GMT
-      mise-correlation-id:
-      - 6a305630-bf24-4d05-9bfe-50654eb0fe9f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A56Z&sr=b&sp=r&sig=HYOyRBYFbvyy29JggFNeyAa9TpE8CKILymZ6XiyCgEg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:56.1511038","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A56Z&sr=b&sp=r&sig=PGeR3D4DBVV1k1mBlsJgApqhmP4nVH%2FnuIVMO9nawec%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:56.1510284","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A56Z&sr=b&sp=r&sig=9IP8YR2wJD%2BLA99cILHK77koSxJvgoYe%2B4KkZ0JKVfg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:56.1511172","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3208'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:54:56 GMT
-      mise-correlation-id:
-      - 37e0304c-ed8a-4fd8-ab96-f63c66ef2601
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A01Z&sr=b&sp=r&sig=W84ap9E03pw0YZr4uAfI9Mng95JOm5IeQdyzx9PPETk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:01.4803431","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A01Z&sr=b&sp=r&sig=W%2B2bzTXl3HsSDzvPA3pzDHO%2FDNfPtJL3%2BL0xMNMmWWM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:01.4802008","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A01Z&sr=b&sp=r&sig=PieQGDoPfURC7zTkJ1ysubN1ZfNuY3ENmiFGIomcUeQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:01.4803661","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3208'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:55:01 GMT
-      mise-correlation-id:
-      - 7a5d5e88-6d40-4f9a-a11a-a9ebea2cfd00
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A06Z&sr=b&sp=r&sig=9Nj7Jiio%2B5PxTwH2XYejm%2FInO2MY%2BkTqWCOA%2FrY4SE4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:06.7501404","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A06Z&sr=b&sp=r&sig=4gL3bVWDlfp791elg89iDduGhb%2BKLG4pkF9iVClJgK0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:06.7500655","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A06Z&sr=b&sp=r&sig=l%2FZOxPCWwimGlUGvrjsqDiQC%2FRltWm6l1JHg7WMyUe8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:06.7501553","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3216'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:55:06 GMT
-      mise-correlation-id:
-      - a864e6c9-c4d0-47c2-b17f-0cf11e284215
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A12Z&sr=b&sp=r&sig=3MIdhGdio5ukmXWJ70Ba8nfm0WnVo8WQzWskwygR2bA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:12.0108747","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A12Z&sr=b&sp=r&sig=E11NI8jMgbuzCk%2BfRYwaZjzTdXDuQ6vi8AI0kXcneYo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:12.0107881","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A12Z&sr=b&sp=r&sig=mmFBO%2FZF1P2090tuoJM3i1ef8BkGWOGC09Ne3f4biro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:12.0108964","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:55:12 GMT
-      mise-correlation-id:
-      - 82b475a5-022e-41e0-b903-5422b7c75283
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A17Z&sr=b&sp=r&sig=m%2BkpXJRb%2FYAVUK5xF0PGiBVyAHBeT%2FrBzZ55QiDbDYY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:17.5924588","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A17Z&sr=b&sp=r&sig=07sq4NZeHre%2F%2B5dmEgnD22BIp7vm81497GphMlfvFAA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:17.5923792","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A17Z&sr=b&sp=r&sig=y1JcMrIv63Gx%2F4nu8NXoqZWKe5rv4ziI5YVEclUSHMw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:17.5924816","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3214'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:55:17 GMT
-      mise-correlation-id:
-      - 30201f53-c379-4bc8-af7a-57a81db88443
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A22Z&sr=b&sp=r&sig=SX17lRIoSv8AOGPkneMNpiuaNbzEwgfcLi2ymhpSlgM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:22.854803","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A22Z&sr=b&sp=r&sig=sk3OzkobVepC5dHma1P0k4E8kyDWd8GwpfRkclysG9o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:22.8547024","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A22Z&sr=b&sp=r&sig=83AOhGVZDxNEdQBun7X5DuC0ZMjaH7maQW%2BettU0eFM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:22.8548233","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:55:22 GMT
-      mise-correlation-id:
-      - 296e2bcb-ae7f-472e-a9cf-15172825dd92
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A28Z&sr=b&sp=r&sig=InPjcUy187Tz8my43b%2F3sLTrAo9e6I7U8ZhSxfNKt5M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:28.143778","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A28Z&sr=b&sp=r&sig=xKsrC3%2F20o%2Flb8PLLdvSMvVjLVqJPn7MENzEMGcN2PA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:28.1437073","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A28Z&sr=b&sp=r&sig=9%2B3%2FzL0FcuJ9QMRIK0W5kES6qsN%2BPRwFjhnPUichzX8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:28.1437919","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3213'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:55:28 GMT
-      mise-correlation-id:
-      - 31639580-518b-4265-ba8a-4fb5838bad46
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A33Z&sr=b&sp=r&sig=zLfcM6ddFj%2BTEA0hHrA%2BRiTsU8gDD7k0AfW%2B8DQOLZE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:33.410465","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A33Z&sr=b&sp=r&sig=duvuEpMImyaCBo97HWrD8A4M0%2Ft4c2DaQu9qkLAYgtc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:33.410371","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A33Z&sr=b&sp=r&sig=Tb%2FOegQUqCOYJSI8QcTbvdzu42Yyi%2FZSu4aicJlEOwA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:33.4104846","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3212'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:55:33 GMT
-      mise-correlation-id:
-      - ce3313dd-0d1b-4bb9-856b-bf865653a5c4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A38Z&sr=b&sp=r&sig=z18ziSzXEXlh9Zjbre4gPjlvdE7zW0XVmpBBieiTNGY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:38.6496375","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A38Z&sr=b&sp=r&sig=yQ9bVYx%2B9BYTy9XJ5Ma89VySCRDAAPSWV7lWUHjSZdo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:38.6495719","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A38Z&sr=b&sp=r&sig=s73EvekuucMibA%2FnGVmWTp9Oc%2FaJBvSkVVuj%2FTpxO7E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:38.6496511","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3210'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:55:38 GMT
-      mise-correlation-id:
-      - 9d0fe5fa-8111-42e0-8880-16169f2bd437
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A44Z&sr=b&sp=r&sig=5bVid0rLzLbnAu5shgZmjH9yuP9tlSCMqwc7W%2FHSx2o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:44.00104","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A44Z&sr=b&sp=r&sig=SJeJG70doTl1Q3X1%2BeTwNm8FV4W%2FC6w1qjOVc5Ta7UA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:44.0009484","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A44Z&sr=b&sp=r&sig=wxMlDjW%2F3apEm7hB5FraMhzJFz49jRXAFg1VZ%2Fo9cY0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:44.001061","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A51Z&sr=b&sp=r&sig=Wcgms1itTXFo1kSWD64LhJmg511ikbehVadCT4hPYX8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:51.5261493","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A51Z&sr=b&sp=r&sig=kOKCURjJsoR8dMZjKF60%2Fg97FnBPhmIoVgbbNQYkSKU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:51.5260711","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A51Z&sr=b&sp=r&sig=rvyOA4XdvG9%2BUSobBByFQITX7cqj6nSQXjYdVQTLaYE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:51.5261636","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:30.389Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1686,9 +858,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:43 GMT
+      - Wed, 18 Oct 2023 20:53:51 GMT
       mise-correlation-id:
-      - 4f2ddaf7-b4db-4d63-99e4-e6e403e3469f
+      - b8010f7d-e3c1-4003-b0b5-ae23d06bd68b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,23 +880,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A49Z&sr=b&sp=r&sig=N75VzgkfP4AsmjbfpT%2BfubZ13YeNyoWURk25F5tdRL0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:49.2531177","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A49Z&sr=b&sp=r&sig=oE7oMszZ1bUkddVdrSauRQsaIG47CJ8Brua0nIKd7nc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:49.2530288","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A49Z&sr=b&sp=r&sig=5RmqnGudituIiRe77VvDXDfBGbnfd%2BR9%2Fonis66cfzM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:49.2531369","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A56Z&sr=b&sp=r&sig=8UC%2BCvHnQmaIBoR%2F%2FaW41Cxk9NVWwonJMgktaTjG6ak%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:56.8391999","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A56Z&sr=b&sp=r&sig=atNtyNkYDBAaOHf%2BDkub7ytYgsvteCLpjH5aXSxuBQI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:56.83913","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A56Z&sr=b&sp=r&sig=CTbqr0LgH5TedNbu5E3ziwJMwZhNl67e4elm%2B1Y0CCo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:56.8392147","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:30.389Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3208'
+      - '3213'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:49 GMT
+      - Wed, 18 Oct 2023 20:53:56 GMT
       mise-correlation-id:
-      - a99e8f82-de78-467d-ac5f-e6c1fb2a989d
+      - 2d53e6d2-4ff0-4824-a6ae-da21e1e97efa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,23 +916,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A54Z&sr=b&sp=r&sig=W1xXO8tYQLV1aupbE1EhhdA3cIMMoukNf2XENzvJp3Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:54.5030651","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A54Z&sr=b&sp=r&sig=g1VNZuxFDo0BiCl1u4KTYMkh%2FsOnmHFpEbRiOIaujKA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:54.5029975","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A54Z&sr=b&sp=r&sig=1zuadd1TkqzX1CXegxVds%2BXhcldI6DlmjCIt4zpNuJg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:54.5030787","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A02Z&sr=b&sp=r&sig=VQn49HJbY7OEBGoizKpjQ0JiW%2F0xzv8Syp2E51aTrmY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:02.1659121","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A02Z&sr=b&sp=r&sig=nvwK0UnjOOboSitf7nFKZevzlTmkyOh5UEl2XFDkeWY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:02.1658191","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A02Z&sr=b&sp=r&sig=VAST38McImRewqTrTw2LyJS%2FYpK%2BIoxATeFhVR1NZNA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:02.1659328","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:30.389Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3206'
+      - '3211'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:54 GMT
+      - Wed, 18 Oct 2023 20:54:02 GMT
       mise-correlation-id:
-      - 613bcc88-f61d-49f9-b8b9-621baf3aa01a
+      - e9a8b629-11bb-4b37-83a0-010b5cdd1b28
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,10 +952,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A59Z&sr=b&sp=r&sig=f16%2FKY1QLF4YAp8wQAgkvo8LBTlLXrUDnE%2F3szBSCmM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:59.7383411","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A59Z&sr=b&sp=r&sig=VJjZir9HzzpPJKtqIJ6O2pyIbrNWYA1dCBCDU7hMdVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:59.7382483","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A59Z&sr=b&sp=r&sig=l6cEj%2FcGXt4EA%2Bu6Gf7YaS1iGlz5OfUFq3bCL55DHms%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:59.7383634","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A07Z&sr=b&sp=r&sig=aFFzNcFWqJB927tCH31eHEv22dOaje6WK%2BMShMeRMwM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:07.4965305","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A07Z&sr=b&sp=r&sig=lOabLhBunMOY4GsoWdmajF%2BqdUSPM2Xknilt5gP%2Fx1w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:07.4964536","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A07Z&sr=b&sp=r&sig=tL4NKUjOhmwx1HtR3C6rP0gRj3mOgV9R9ngOHSGa1Rg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:07.4965457","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:30.389Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3211'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:07 GMT
+      mise-correlation-id:
+      - c6a263d4-acdf-42aa-8236-e22a311f1609
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A12Z&sr=b&sp=r&sig=HBXykokMk8CqkOl%2F%2F2baleZzBNdEe%2B%2FwiHn5vhYKK9M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:12.7757668","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A12Z&sr=b&sp=r&sig=O9CVtCmT0aDPwj8j%2FH0YMgwJy37iRAtgG7RnANayz%2BU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:12.7756896","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A12Z&sr=b&sp=r&sig=KIvXqfzVo58OrdZrm0gQYg3aMXYBGHb5HdqlnI7%2FKXM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:12.7757838","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"CONFIGURING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:08.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3218'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:12 GMT
+      mise-correlation-id:
+      - 863551bb-6636-45dd-85a1-868fc1f5f10f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A18Z&sr=b&sp=r&sig=f7g74ZQ5Pyg9VXuwsCWiKOhhZHF0PTikeH%2BYqt%2FnTkg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:18.0382034","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A18Z&sr=b&sp=r&sig=kRL9H69X8LHGa9OMkAGLouE89jtdEdM9SAfELX3%2FI2A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:18.0381004","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A18Z&sr=b&sp=r&sig=qYfhPhIOLIBCIGOvzAIcrbsPwyYSxCJf%2BUbP0iM3S3g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:18.0382262","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1794,9 +1038,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:55:59 GMT
+      - Wed, 18 Oct 2023 20:54:18 GMT
       mise-correlation-id:
-      - 4eff34d5-c4c9-4ef4-a033-4f6338302efe
+      - 82a3d383-1744-4331-9984-92a6148798d4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1816,24 +1060,744 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A05Z&sr=b&sp=r&sig=9Sn%2B27Rb4jJE2P31Da6MhTfBLN4WWj6xF9Q%2FGtjg4aI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:05.0794583","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A05Z&sr=b&sp=r&sig=iL%2BSx%2BidXYwTQc%2FS5d7X5YlXrAyoEvUb3NkYMjyn9zY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:05.0793887","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A05Z&sr=b&sp=r&sig=dG6a2tSwlzdZCiWsUYNyuLDaK0o0oppUF4G8dQNKKfE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:05.0794734","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-13T13:53:22.268Z","endDateTime":"2023-10-13T13:55:59.836Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:03.566Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A23Z&sr=b&sp=r&sig=n1pjDKRnm2CfCm48DlGqVO%2FanNRSZwI2jLtKMh3lzc4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:23.3670368","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A23Z&sr=b&sp=r&sig=clcsg4lwq5QayD4EXtlTzNiZKb52l2mbF3nPxBMTabA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:23.3668696","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A23Z&sr=b&sp=r&sig=y0sza0csaVkhUJE7uNDJwoR6sYNm2xIkM3lewDPakyU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:23.3670684","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3347'
+      - '3204'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:05 GMT
+      - Wed, 18 Oct 2023 20:54:23 GMT
       mise-correlation-id:
-      - 47619fb5-c8ae-43ef-bc72-cbb3cdb3c979
+      - 6dfc44b2-aa52-458b-8d04-dabd2515f450
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A28Z&sr=b&sp=r&sig=rKcLypvyDN5kE3J4f6Dw%2F%2BJLmzhVGkVm3IpFQpbK0Kg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:28.6847102","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A28Z&sr=b&sp=r&sig=JW1OwbL%2Bv1FPyWqk1Xl1%2B0eTLoj6XE0yNuTfQbqy7AA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:28.6846193","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A28Z&sr=b&sp=r&sig=sghXLBDaEopBkuuIggxkkL80Q20%2FyKxwhZ7AjdG9ank%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:28.6847312","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3212'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:28 GMT
+      mise-correlation-id:
+      - 4438be32-2ea8-4045-bcd7-f2d6bbe592e4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A34Z&sr=b&sp=r&sig=ZTOdKv25nGTS2wXUvasvyZCOrt%2B6CZPgLQbRTtwWNw8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:34.0154438","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A34Z&sr=b&sp=r&sig=l3nCsPvvlGHB%2BEaPUQdVIefioToiHnWDvtuJt6qudDM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:34.0153488","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A34Z&sr=b&sp=r&sig=rzZfu7C%2Fmynucd7uFcg1UDzkCTiIsq5gOmPqnD8I%2Btk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:34.015463","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3209'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:34 GMT
+      mise-correlation-id:
+      - 4741620d-c655-4b74-8b03-d75de094724d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A39Z&sr=b&sp=r&sig=KYD8vlIpGWYqDdBo2ZspopBWGACTsvfUL7HUKQsU1%2Bc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:39.2904879","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A39Z&sr=b&sp=r&sig=vzzZwpUG6RF7mgr5Byq8SGuHs8l0YpDjrKRyQnKilbM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:39.2904177","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A39Z&sr=b&sp=r&sig=Br0zfJLPGXpfp7fCw8NToT%2FKMueT%2F6PKG%2BG2Au39NKw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:39.2905014","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:39 GMT
+      mise-correlation-id:
+      - 765c2620-51cd-47f8-9ac5-3f863447792b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A44Z&sr=b&sp=r&sig=C6hSrEzJOUJXUMsv4K7mUrG9f4NKUj6aQQvBFCC%2BseM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:44.5668283","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A44Z&sr=b&sp=r&sig=B8ncahr5ls33Wx%2BUBHTb603ID45xD3Bly%2FW%2FfktXALQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:44.5667445","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A44Z&sr=b&sp=r&sig=zpLOgnGB0BBbSpj57XZ3kC6LgFOaba4f3uAwjzA0J%2BY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:44.5668427","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3212'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:44 GMT
+      mise-correlation-id:
+      - af9c7c8e-4aa2-46af-b94c-6c64b4c4880e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A49Z&sr=b&sp=r&sig=vqct2eQDYyYhDDbCZjH4sON2qlIkpeRSfOzT5i9U480%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:49.8849308","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A49Z&sr=b&sp=r&sig=5bGtrHga4OQN87lvVLnIShqFDZm0UXCrF0GqqCgkz%2Fk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:49.8848159","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A49Z&sr=b&sp=r&sig=RtQtFBLdoQMyaCtHmVfwWHOBtnUSuyrbrZybiutyS%2Bw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:49.8849569","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:49 GMT
+      mise-correlation-id:
+      - 26933098-e92f-417e-b88d-e2f371281474
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A55Z&sr=b&sp=r&sig=4guOxd84tIqCie4j9TMMCZeCj1dUnutYZ0enTNvWW68%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:55.1516266","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A55Z&sr=b&sp=r&sig=%2BUsCzPqEgG4ACSabJ73sE69F%2F8Q%2BRpKx%2FGxRuV%2F6JRU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:55.1515215","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A55Z&sr=b&sp=r&sig=%2BQRsFlUFHTJuR2dq0WpuiapaalvxE8qnWjIQs1TkdGI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:55.1516407","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3214'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:54:55 GMT
+      mise-correlation-id:
+      - 710f4107-1341-4443-8b2b-40e549c34670
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A00Z&sr=b&sp=r&sig=ToZ640OmnhT8O8Jivfhc18W95oqDy0snQYNLbxB7VQs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:00.4469515","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A00Z&sr=b&sp=r&sig=sCnV1A4yXGIXIo1u9O%2FGkkjAct8iEjRwpEgWDGRV6WU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:00.4468772","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A00Z&sr=b&sp=r&sig=QenY53BhBe9l1eOLFEUC9DdnRJ5yLCNrEoxQin2Et20%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:00.4469654","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:00 GMT
+      mise-correlation-id:
+      - 40418267-3f01-46c4-8969-099894f249e2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A05Z&sr=b&sp=r&sig=LETC3gVP%2BGJLRgqxo%2FMHaaRluHu7Tr6C%2FJT%2Btg%2FER3E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:05.7500087","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A05Z&sr=b&sp=r&sig=68c%2BX4ySqk4%2BKTy9LhgUSHKk34qVYs3dewCf5BpJlQI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:05.7499305","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A05Z&sr=b&sp=r&sig=UgBdWqNHY6LCGOQRT%2FQm30ULcvl7AxanGj%2F4sZ61tM0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:05.7500234","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:05 GMT
+      mise-correlation-id:
+      - c25ed923-9e76-4cd6-806d-39a86d7de62e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A11Z&sr=b&sp=r&sig=Tx4zSx5pjZFOhOLSOlUcbd25GzEqzC3%2BfmSG3JJRNuc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:11.0702842","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A11Z&sr=b&sp=r&sig=O8%2BKgsrAvcUnfIUDB9xUGZmQFq82%2F3FN5wlsVyYvVss%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:11.0701855","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A11Z&sr=b&sp=r&sig=Np%2Foecd%2BiiuHa9aX1%2BEStZfDgxVOfXwhPUvD8pFqJOs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:11.0702989","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3214'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:11 GMT
+      mise-correlation-id:
+      - f39e306e-d6e4-4748-ae71-9c551fa47e1f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A16Z&sr=b&sp=r&sig=5rw8c8ZHBPlebJnHpfIYuwNW2QqS4LnH4SBQkWBPnd4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:16.8224884","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A16Z&sr=b&sp=r&sig=X6sbAspAPg1aoR0%2F4%2FL1kUznUH%2FZmxm7PXP5y3ryYyY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:16.8223944","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A16Z&sr=b&sp=r&sig=30xOrSihBuSt2mhV4dbI22wWqqlhA9Lk%2B1H1aoT26Q4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:16.8225106","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:16 GMT
+      mise-correlation-id:
+      - 4215d189-302b-41fe-babe-b511118f6114
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A22Z&sr=b&sp=r&sig=lifGhx8mSTtJZJgAbJPu%2B1%2FP3Ryx3F1%2BfPES8sFWnqY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:22.3165083","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A22Z&sr=b&sp=r&sig=8kbtQt2VcZXQ8bzln5A%2BBDw5nyebI2vpCgQepJDExlw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:22.3164244","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A22Z&sr=b&sp=r&sig=2Z%2BOoKfmBoaELQ%2B5%2FLWqcHspmCQoIRfBQzasx45FHJ4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:22.3165221","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3216'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:22 GMT
+      mise-correlation-id:
+      - 86522ea9-5b83-4c2e-80ce-d96366e7c755
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A27Z&sr=b&sp=r&sig=lmBF11OjSh%2F8lr5jyDZPordFVFksaG8ZkYLEkKj6zFA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:27.582953","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A27Z&sr=b&sp=r&sig=M1fYti5mjZ8xBzx5a4qerdVzfQH9S1B9uLLw%2Bkdm4YM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:27.5828604","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A27Z&sr=b&sp=r&sig=qGGQXKOnbT9hqZUgIaZ%2BpgrkqmB%2B0DIr7p9N%2B2NtVtY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:27.5829752","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3211'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:27 GMT
+      mise-correlation-id:
+      - d0ce9c5b-be49-4be3-b624-41c6fbd7a21b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A32Z&sr=b&sp=r&sig=a8jnHrQVOYt0lSekWiM5qXDlcjDUUAZvtSyGC7fCARo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:32.8994243","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A32Z&sr=b&sp=r&sig=WzNBUf4t36HKEZY7OPU5MLw%2BvJWGkBQL1RAuEWwAu8k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:32.899326","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A32Z&sr=b&sp=r&sig=8MxArQJIxHNBKt27FitaV8r%2Bjk3yG5oP7rRf9V%2BnsLU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:32.8994517","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3207'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:32 GMT
+      mise-correlation-id:
+      - 81c0142e-1b93-4c37-b369-72e35281d3bd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A38Z&sr=b&sp=r&sig=sI8Ntye5goV3szBQCTWRS0v2fvDf6%2FSXDaBoXQpZzH8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:38.5341401","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A38Z&sr=b&sp=r&sig=g3R1qCalzhP44eJAYhsGvH4REHWFjyn9hSYFQxreq0s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:38.5340747","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A38Z&sr=b&sp=r&sig=cyy6bVFDLm5fv00cXp%2BYvrI4EdjC9SSFz9KRqppeh%2FY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:38.5341596","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:38 GMT
+      mise-correlation-id:
+      - 62691d80-157a-4e2a-9d6d-749529a197c6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A43Z&sr=b&sp=r&sig=ZW8PtOpuF%2BpMaie78hg2tG79hr90FoQCLxqq6Uh%2BLtU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:43.8363825","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A43Z&sr=b&sp=r&sig=aPE2HuLXQnD4j1BNPRba4k7NXtzNRjrbhiZU8cx%2Fmwo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:43.8363052","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A43Z&sr=b&sp=r&sig=cCo4JBqFfs%2B3%2FyJs%2BqdQYfyJ1kFOrAmB%2FUMUl1PJkK4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:43.8363981","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3216'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:43 GMT
+      mise-correlation-id:
+      - a5d2c53c-31a9-461f-a2be-b1da41ad3167
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A49Z&sr=b&sp=r&sig=Ru34kexm8ARfwK7I9bEjMCv3jepPYj9UWMiPsizGWZw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:49.8183757","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A49Z&sr=b&sp=r&sig=5Obb2c%2FlB%2BLmPpXloTTImifNBvzZ4N6viPFe0WLbovc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:49.8183008","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A49Z&sr=b&sp=r&sig=m0ZmGVaFMl37BST95jPjB40Db%2BXuyLKEk9ztf7UgFi0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:49.8183905","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:49 GMT
+      mise-correlation-id:
+      - 334aa3d2-b1c8-444d-a429-71b130ef57da
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A55Z&sr=b&sp=r&sig=%2BhuxaYG64C7BeTO35N%2FfS0mx1l3a0SkvcuuOIc9sFmk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:55.0999857","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A55Z&sr=b&sp=r&sig=IR3LvgImER0Deg62%2BkgQRGLw1h1fPOw6bOOArxY47pE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:55.0998802","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A55Z&sr=b&sp=r&sig=TRLo%2FQMhKrRDpxlABcAeuqs13P3XHZCycdQ4N4Gpp00%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:55.1000076","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:55:55 GMT
+      mise-correlation-id:
+      - 6fc5dd29-2383-49f8-9861-3bd6fc53a8ce
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A00Z&sr=b&sp=r&sig=f0A%2FbHkvPLyL6WTceSszbsLGj5Xmtg2Mia3MRsazLt8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:00.3543807","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A00Z&sr=b&sp=r&sig=wwrKpS1ssPK%2FOj7WqSZkcjkMH%2FaZCfOngdd12aoQiB8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:00.3543038","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A00Z&sr=b&sp=r&sig=vVGx85fcCo8dJ0WsCenvUdlpjVkYd%2F9LrOk0UVrbmTA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:00.3543946","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:56:00 GMT
+      mise-correlation-id:
+      - 7ddb5498-09c9-4b4e-9fe5-fb71c7c42522
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A05Z&sr=b&sp=r&sig=5xQfCUtcMM52tynIoWcCzN%2BmKfRkMKB8a5r8cMF7zOQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:05.8490488","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A05Z&sr=b&sp=r&sig=usLgAT02IHF4Y3q4cBphH%2FiopIvAONyKPzubpXsL6RM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:05.848954","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A05Z&sr=b&sp=r&sig=TrJRvRbYn1ovsFw7p6LSMEK0sHN2qILeP3h5b0w%2Bg74%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:05.8490652","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3207'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:56:05 GMT
+      mise-correlation-id:
+      - 952ea9c2-b716-401d-9168-133c4f7b5071
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A11Z&sr=b&sp=r&sig=EdxxFD4%2FOjWdHmSqf6AWPWxQQAhKxJv%2Fi%2BeAdlzJCsQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:11.1848962","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A11Z&sr=b&sp=r&sig=ejRjeAkU0KCRL%2BdJusgbnPjRAfEj5yHXsYrDvQmvq7c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:11.184784","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A11Z&sr=b&sp=r&sig=iMVKIcwQjVRYr%2B%2BdoC8NpXOwFITQQDNU2sj5B79Gp0g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:11.1849195","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-18T20:53:30.208Z","endDateTime":"2023-10-18T20:56:06.292Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:10.272Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3348'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:56:11 GMT
+      mise-correlation-id:
+      - 698ae27b-f8a3-4657-bba2-09439d9d7b2f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1856,7 +1820,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:22.0199528Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:22.0199528Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:52:29.3800691Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:52:29.3800691Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1865,9 +1829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:06 GMT
+      - Wed, 18 Oct 2023 20:56:11 GMT
       etag:
-      - '"d80153fb-0000-0100-0000-65294b990000"'
+      - '"75009653-0000-0100-0000-6530458f0000"'
       expires:
       - '-1'
       pragma:
@@ -1897,11 +1861,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=download-test-case&api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=download-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A07Z&sr=b&sp=r&sig=gBlp0jA5FuwFlpVWU%2BqIrJLr9w7HYjj7Par%2FOsr1n54%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:07.4850663","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A07Z&sr=b&sp=r&sig=E923Q89Nr0LYW2SYwIIBdNZ3WtiQCqYKm8SEVyxA0M8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:07.4849976","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A07Z&sr=b&sp=r&sig=1f8wgGSEA3CZNVXmenutu69Vk59ybGB%2FAeKiOLo%2F4yY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:07.4850805","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-13T13:53:22.268Z","endDateTime":"2023-10-13T13:55:59.836Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:03.566Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A13Z&sr=b&sp=r&sig=Qwm%2F%2BL%2Fded488AZXXuwXz8Fral32OpbUsZQQtkav8Jg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:13.3387928","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A13Z&sr=b&sp=r&sig=QWMjf7s2VqKes2ogaOb9tzowt4kHJRLrEXcEpTFcrE0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:13.3387199","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A13Z&sr=b&sp=r&sig=OVI090yWnOWBH0nJzNDjFoTfzYhwxDGXcvXpHzzX%2BjA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:13.3388075","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-18T20:53:30.208Z","endDateTime":"2023-10-18T20:56:06.292Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:11.591Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1912,9 +1876,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:07 GMT
+      - Wed, 18 Oct 2023 20:56:13 GMT
       mise-correlation-id:
-      - 7907bb9f-1443-4fa6-9382-a0186ded7b95
+      - 6e1fed3d-73fa-4b12-8747-be4850a64fcf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1937,7 +1901,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:22.0199528Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:22.0199528Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:52:29.3800691Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:52:29.3800691Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1946,9 +1910,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:09 GMT
+      - Wed, 18 Oct 2023 20:56:13 GMT
       etag:
-      - '"d80153fb-0000-0100-0000-65294b990000"'
+      - '"75009653-0000-0100-0000-6530458f0000"'
       expires:
       - '-1'
       pragma:
@@ -1978,24 +1942,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A09Z&sr=b&sp=r&sig=bmOH5ov%2BuN5c6UV6IzXmbE%2FNWWB8xyj6ZfuAbcvVlFo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:09.7681172","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A09Z&sr=b&sp=r&sig=0McKWTkGz7DrwRAFZrVrhWZ8QiFANhrE%2FBUOlo8glME%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:09.7680275","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A09Z&sr=b&sp=r&sig=ZrcBLmMrdZSVwr7C8D%2FTRIAsEkGeRTtMFe%2FQ77u5z%2F0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:09.7681355","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-13T13:53:22.268Z","endDateTime":"2023-10-13T13:55:59.836Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:03.566Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A14Z&sr=b&sp=r&sig=LjA%2BbqA9weciNgHSarLWmkV3aFYhhwpR3ul3UJCYI3M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:14.9801245","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A14Z&sr=b&sp=r&sig=5oL6dTshM1N6G9zwvIPuGEX6L11yYGvz%2FF%2FPVSX1l6Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:14.9800221","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A14Z&sr=b&sp=r&sig=O2yp5RHuhm%2BFwfx5w2BiwfB8eFZ%2F1V2H4k6dmCZeUeY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:14.9801549","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-18T20:53:30.208Z","endDateTime":"2023-10-18T20:56:06.292Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:11.591Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3349'
+      - '3347'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:09 GMT
+      - Wed, 18 Oct 2023 20:56:14 GMT
       mise-correlation-id:
-      - b40533cf-aa57-4899-967c-ef39be1d606b
+      - 7e8757a6-ba3a-4127-a59d-c6267c1a97f0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2015,7 +1979,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A09Z&sr=b&sp=r&sig=bmOH5ov%2BuN5c6UV6IzXmbE%2FNWWB8xyj6ZfuAbcvVlFo%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A14Z&sr=b&sp=r&sig=LjA%2BbqA9weciNgHSarLWmkV3aFYhhwpR3ul3UJCYI3M%3D
   response:
     body:
       string: "displayName: CLI-Test\ntestPlan: sample-JMX-file.jmx\ndescription:
@@ -2033,17 +1997,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 13 Oct 2023 13:56:10 GMT
+      - Wed, 18 Oct 2023 20:56:16 GMT
       etag:
-      - '"0x8DBCBF3C265AB54"'
+      - '"0x8DBD01C485A914D"'
       last-modified:
-      - Fri, 13 Oct 2023 13:53:20 GMT
+      - Wed, 18 Oct 2023 20:53:29 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 13 Oct 2023 13:53:20 GMT
+      - Wed, 18 Oct 2023 20:53:29 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2073,7 +2037,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A09Z&sr=b&sp=r&sig=0McKWTkGz7DrwRAFZrVrhWZ8QiFANhrE%2FBUOlo8glME%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A14Z&sr=b&sp=r&sig=5oL6dTshM1N6G9zwvIPuGEX6L11yYGvz%2FF%2FPVSX1l6Y%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -2146,17 +2110,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 13 Oct 2023 13:56:11 GMT
+      - Wed, 18 Oct 2023 20:56:18 GMT
       etag:
-      - '"0x8DBCBF3B5CD1C6D"'
+      - '"0x8DBD01C3AE25937"'
       last-modified:
-      - Fri, 13 Oct 2023 13:52:59 GMT
+      - Wed, 18 Oct 2023 20:53:06 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 13 Oct 2023 13:52:59 GMT
+      - Wed, 18 Oct 2023 20:53:06 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2186,18 +2150,18 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A09Z&sr=b&sp=r&sig=ZrcBLmMrdZSVwr7C8D%2FTRIAsEkGeRTtMFe%2FQ77u5z%2F0%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A14Z&sr=b&sp=r&sig=O2yp5RHuhm%2BFwfx5w2BiwfB8eFZ%2F1V2H4k6dmCZeUeY%3D
   response:
     body:
       string: !!binary |
-        UEsDBC0AAAAIAKpuTVcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
+        UEsDBC0AAAAIAK6mUlcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
         AAAAAAFZAab+ZGlzcGxheU5hbWU6IENMSS1UZXN0CnRlc3RQbGFuOiBzYW1wbGUtSk1YLWZpbGUu
         am14CmRlc2NyaXB0aW9uOiBUZXN0IGNyZWF0ZWQgZnJvbSBheiBsb2FkIHRlc3QgY29tbWFuZApl
         bmdpbmVJbnN0YW5jZXM6IDEKdGVzdElkOiBkb3dubG9hZC10ZXN0LWNhc2UKc3BsaXRBbGxDU1Zz
         OiBGYWxzZQpmYWlsdXJlQ3JpdGVyaWE6Ci0gYXZnKHJlcXVlc3RzX3Blcl9zZWMpID4gNzgKLSBw
         ZXJjZW50YWdlKGVycm9yKSA+IDUwCi0gR2V0Q3VzdG9tZXJEZXRhaWxzOiBhdmcobGF0ZW5jeSkg
         PiAyMDAKZW52OgotIG5hbWU6IHJwcwogIHZhbHVlOiAxCi0gbmFtZTogZHVyYXRpb25faW5fc2Vj
-        CiAgdmFsdWU6IDEKUEsDBC0AAAAIAKpuTVfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
+        CiAgdmFsdWU6IDEKUEsDBC0AAAAIAK6mUlfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
         LmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAAQYT+ew8P3htbCB2ZXJzaW9uPSIxLjAiIGVuY29kaW5n
         PSJVVEYtOCI/Pg0KPGptZXRlclRlc3RQbGFuIHZlcnNpb249IjEuMiIgcHJvcGVydGllcz0iNS4w
         IiBqbWV0ZXI9IjUuNSI+DQogIDxoYXNoVHJlZT4NCiAgICA8VGVzdFBsYW4gZ3VpY2xhc3M9IlRl
@@ -2284,8 +2248,8 @@ interactions:
         ZT0iSFRUUFNhbXBsZXIucmVzcG9uc2VfdGltZW91dCI+PC9zdHJpbmdQcm9wPg0KICAgICAgICA8
         L0hUVFBTYW1wbGVyUHJveHk+DQogICAgICAgIDxoYXNoVHJlZS8+DQogICAgICA8L2hhc2hUcmVl
         Pg0KICAgIDwvaGFzaFRyZWU+DQogIDwvaGFzaFRyZWU+DQo8L2ptZXRlclRlc3RQbGFuPg0KUEsB
-        AjMALQAAAAgAqm5NVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
-        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACACqbk1X8Zv7b///////////EwAUAAAAAAAAAAAA
+        AjMALQAAAAgArqZSVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
+        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACACuplJX8Zv7b///////////EwAUAAAAAAAAAAAA
         AACbAQAAc2FtcGxlLUpNWC1maWxlLmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAUEsFBgAAAAACAAIA
         ogAAAOsUAAAAAA==
     headers:
@@ -2294,21 +2258,21 @@ interactions:
       content-length:
       - '5539'
       content-md5:
-      - lIk+qyTiOFlIQ5Nx6AB2EQ==
+      - uOXBML9owCbiX1Y2jy0JPQ==
       content-type:
       - application/octet-stream
       date:
-      - Fri, 13 Oct 2023 13:56:12 GMT
+      - Wed, 18 Oct 2023 20:56:19 GMT
       etag:
-      - '"0x8DBCBF3C26F6DD9"'
+      - '"0x8DBD01C48647AEF"'
       last-modified:
-      - Fri, 13 Oct 2023 13:53:20 GMT
+      - Wed, 18 Oct 2023 20:53:29 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 13 Oct 2023 13:53:20 GMT
+      - Wed, 18 Oct 2023 20:53:29 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2341,7 +2305,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:22.0199528Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:22.0199528Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:52:29.3800691Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:52:29.3800691Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2350,9 +2314,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:13 GMT
+      - Wed, 18 Oct 2023 20:56:20 GMT
       etag:
-      - '"d80153fb-0000-0100-0000-65294b990000"'
+      - '"75009653-0000-0100-0000-6530458f0000"'
       expires:
       - '-1'
       pragma:
@@ -2382,24 +2346,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=noS3%2BlbrqUyCLYp3DbvacakCEPa7j7MA9Pre5as1zsI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:14.6768475","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=%2FC1%2BMQZtL4rHE0kcYhQypiD6h5GyY7PZc8S5MG%2BHKl0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:14.6767653","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=mgn0w%2F6GPOiJ4wLXDoKKwghPAB44YXPSB7vfet06WHY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:14.6768643","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/bbbdcc9c-1b07-4579-8c59-8f95c248ad79_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=ta5BXpbXuwE5DaE85z1AYGuooIRx6uO0lfk9jaLrCzI%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:14.6768797","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/bbbdcc9c-1b07-4579-8c59-8f95c248ad79_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=IWgR9pHRYhAGsk9XDDX0E5V%2FBuDK%2FrEUNTXj2PmNk88%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:14.6768962","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-13T13:53:22.268Z","endDateTime":"2023-10-13T13:55:59.836Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:10.12Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=hL5CHxBODR%2B%2Fha4srFaE62px%2FFem0bD66Ej9zoj2uI8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:22.1023439","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=yy7I%2F3x9s71wM6DVnhcx8dBhj%2BiZpLfy4Pof5i6%2BVOo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:22.1022648","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=nqx6ouihXuUVslUsTJ3E9uTObdC0%2FqSJ0T6Mz%2B8qeH8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:22.1023595","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/dcaeb21f-830b-4d83-bfd4-0900c817c0f9_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=%2FkEYPrutkXaA2mgGsTgGUO%2BIEnILoAQW9XFhlTUPYqY%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:22.1023737","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/dcaeb21f-830b-4d83-bfd4-0900c817c0f9_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=tAZsA95JZ9Wl8u5wafrp4u481xG8IfvJdBA08GsvlyM%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:22.1023881","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-18T20:53:30.208Z","endDateTime":"2023-10-18T20:56:06.292Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:18.48Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4509'
+      - '4515'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:14 GMT
+      - Wed, 18 Oct 2023 20:56:22 GMT
       mise-correlation-id:
-      - 21c2e7fc-cd9e-44f5-a400-ef5b7da544f0
+      - a706db1c-d17e-48e4-8354-401e38c76861
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2419,7 +2383,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=noS3%2BlbrqUyCLYp3DbvacakCEPa7j7MA9Pre5as1zsI%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=hL5CHxBODR%2B%2Fha4srFaE62px%2FFem0bD66Ej9zoj2uI8%3D
   response:
     body:
       string: "displayName: CLI-Test\ntestPlan: sample-JMX-file.jmx\ndescription:
@@ -2437,17 +2401,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 13 Oct 2023 13:56:15 GMT
+      - Wed, 18 Oct 2023 20:56:22 GMT
       etag:
-      - '"0x8DBCBF3C265AB54"'
+      - '"0x8DBD01C485A914D"'
       last-modified:
-      - Fri, 13 Oct 2023 13:53:20 GMT
+      - Wed, 18 Oct 2023 20:53:29 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 13 Oct 2023 13:53:20 GMT
+      - Wed, 18 Oct 2023 20:53:29 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2477,7 +2441,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=%2FC1%2BMQZtL4rHE0kcYhQypiD6h5GyY7PZc8S5MG%2BHKl0%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=yy7I%2F3x9s71wM6DVnhcx8dBhj%2BiZpLfy4Pof5i6%2BVOo%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -2550,17 +2514,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 13 Oct 2023 13:56:15 GMT
+      - Wed, 18 Oct 2023 20:56:24 GMT
       etag:
-      - '"0x8DBCBF3B5CD1C6D"'
+      - '"0x8DBD01C3AE25937"'
       last-modified:
-      - Fri, 13 Oct 2023 13:52:59 GMT
+      - Wed, 18 Oct 2023 20:53:06 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 13 Oct 2023 13:52:59 GMT
+      - Wed, 18 Oct 2023 20:53:06 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2590,18 +2554,18 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=mgn0w%2F6GPOiJ4wLXDoKKwghPAB44YXPSB7vfet06WHY%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=nqx6ouihXuUVslUsTJ3E9uTObdC0%2FqSJ0T6Mz%2B8qeH8%3D
   response:
     body:
       string: !!binary |
-        UEsDBC0AAAAIAKpuTVcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
+        UEsDBC0AAAAIAK6mUlcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
         AAAAAAFZAab+ZGlzcGxheU5hbWU6IENMSS1UZXN0CnRlc3RQbGFuOiBzYW1wbGUtSk1YLWZpbGUu
         am14CmRlc2NyaXB0aW9uOiBUZXN0IGNyZWF0ZWQgZnJvbSBheiBsb2FkIHRlc3QgY29tbWFuZApl
         bmdpbmVJbnN0YW5jZXM6IDEKdGVzdElkOiBkb3dubG9hZC10ZXN0LWNhc2UKc3BsaXRBbGxDU1Zz
         OiBGYWxzZQpmYWlsdXJlQ3JpdGVyaWE6Ci0gYXZnKHJlcXVlc3RzX3Blcl9zZWMpID4gNzgKLSBw
         ZXJjZW50YWdlKGVycm9yKSA+IDUwCi0gR2V0Q3VzdG9tZXJEZXRhaWxzOiBhdmcobGF0ZW5jeSkg
         PiAyMDAKZW52OgotIG5hbWU6IHJwcwogIHZhbHVlOiAxCi0gbmFtZTogZHVyYXRpb25faW5fc2Vj
-        CiAgdmFsdWU6IDEKUEsDBC0AAAAIAKpuTVfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
+        CiAgdmFsdWU6IDEKUEsDBC0AAAAIAK6mUlfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
         LmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAAQYT+ew8P3htbCB2ZXJzaW9uPSIxLjAiIGVuY29kaW5n
         PSJVVEYtOCI/Pg0KPGptZXRlclRlc3RQbGFuIHZlcnNpb249IjEuMiIgcHJvcGVydGllcz0iNS4w
         IiBqbWV0ZXI9IjUuNSI+DQogIDxoYXNoVHJlZT4NCiAgICA8VGVzdFBsYW4gZ3VpY2xhc3M9IlRl
@@ -2688,8 +2652,8 @@ interactions:
         ZT0iSFRUUFNhbXBsZXIucmVzcG9uc2VfdGltZW91dCI+PC9zdHJpbmdQcm9wPg0KICAgICAgICA8
         L0hUVFBTYW1wbGVyUHJveHk+DQogICAgICAgIDxoYXNoVHJlZS8+DQogICAgICA8L2hhc2hUcmVl
         Pg0KICAgIDwvaGFzaFRyZWU+DQogIDwvaGFzaFRyZWU+DQo8L2ptZXRlclRlc3RQbGFuPg0KUEsB
-        AjMALQAAAAgAqm5NVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
-        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACACqbk1X8Zv7b///////////EwAUAAAAAAAAAAAA
+        AjMALQAAAAgArqZSVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
+        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACACuplJX8Zv7b///////////EwAUAAAAAAAAAAAA
         AACbAQAAc2FtcGxlLUpNWC1maWxlLmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAUEsFBgAAAAACAAIA
         ogAAAOsUAAAAAA==
     headers:
@@ -2698,21 +2662,21 @@ interactions:
       content-length:
       - '5539'
       content-md5:
-      - lIk+qyTiOFlIQ5Nx6AB2EQ==
+      - uOXBML9owCbiX1Y2jy0JPQ==
       content-type:
       - application/octet-stream
       date:
-      - Fri, 13 Oct 2023 13:56:17 GMT
+      - Wed, 18 Oct 2023 20:56:24 GMT
       etag:
-      - '"0x8DBCBF3C26F6DD9"'
+      - '"0x8DBD01C48647AEF"'
       last-modified:
-      - Fri, 13 Oct 2023 13:53:20 GMT
+      - Wed, 18 Oct 2023 20:53:29 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 13 Oct 2023 13:53:20 GMT
+      - Wed, 18 Oct 2023 20:53:29 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2742,41 +2706,41 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/bbbdcc9c-1b07-4579-8c59-8f95c248ad79_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=IWgR9pHRYhAGsk9XDDX0E5V%2FBuDK%2FrEUNTXj2PmNk88%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/dcaeb21f-830b-4d83-bfd4-0900c817c0f9_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=tAZsA95JZ9Wl8u5wafrp4u481xG8IfvJdBA08GsvlyM%3D
   response:
     body:
       string: !!binary |
-        UEsDBBQAAAAIAAJvTVdBUfnWUAEAAHADAAASABwAZW5naW5lMV93b3JrZXIubG9nVVQJAAN0TCll
-        dEwpZXV4CwABBAAAAAAEAAAAAKWSUWuDMBDH3/sp7mWwjemisWoDexBqYUMdVFmfxaYuRU1JUrd9
-        +0XrKGwKpTtCOC75/+64OxvZ2LCQYWGwMJk7BPkPvuvCJlgnwM3c3JsvMVVUEIh4GdGWVgSek9Xr
-        zP6ttNCDhf2TstDKQmv3+o6DKIuYVLTpKFmYZpBmwToLlxC+hUkGBghaUNbS7SgU2+44dMUquhFM
-        F3fGrwcShC1tFCgqVapyoabYUwUHR8Wl4oczuYtCPoR7MMgTGT6YegcqBBcgckVhgWCnfRdJczSr
-        4+GL2hQmy0ub5C6cK5DHQ8XzLWtK2NfdkM2Kl7DTbR3N4VnXlF3w+lDRqQF41v+GGzbbKbKN+kUd
-        tliY6bGuc8FkR5K9/wVP0BsC1gBCpD86eN/bo4SgLcnwI2YNgYVtY6zJ2PXnjufNfeRBnH8SMP6+
-        +BAK8aO+RSZCN3ezb1BLAQIeAxQAAAAIAAJvTVdBUfnWUAEAAHADAAASABgAAAAAAAEAAACkgQAA
-        AABlbmdpbmUxX3dvcmtlci5sb2dVVAUAA3RMKWV1eAsAAQQAAAAABAAAAABQSwUGAAAAAAEAAQBY
-        AAAAnAEAAAAA
+        UEsDBBQAAAAIAAanUlchSIaSUwEAAHADAAASABwAZW5naW5lMV93b3JrZXIubG9nVVQJAANsRjBl
+        bEYwZXV4CwABBAAAAAAEAAAAAKWS32uDMBDH3/dX3MtgG9XFn1FhD0JT2NAOqqzPYlOXoqYkqdv+
+        +0Xr6EMtlO4I4bjk+7nj7mxkO4aFDCsAG0WeG1nuLHQDWMerJXCzMHfmW0oVFREkvEpoR+sIXpeL
+        9zv7TOnPHGwflaVWllq703caJ3nCpKJtT8lJlkOWx6uczIF8kGUOBghaUtbRzSTUR+40dMFquhZM
+        F3fCr0YSkI62ChSVKlOFUJfYljfNjg+KS8X3J3IfhWIMD2CQRzJ8MfUJVAguQBSKQohgq30fSXMy
+        Kw7Cq9pElvPrmoRnyMU3IA/7mhcb1lawa/ohmzWvYKvbOp3DvyVHyZt9TacHoJnY+tdwSbu5SPaG
+        RR23WJjZoWkKwWRPkoP/Ay8wGALWAkLRcHTwabBnCXFXReOPlLURhLbt6CVHjh94LsZegDCkxXcE
+        xvlLAESIP/UDMhG6f7z7BVBLAQIeAxQAAAAIAAanUlchSIaSUwEAAHADAAASABgAAAAAAAEAAACk
+        gQAAAABlbmdpbmUxX3dvcmtlci5sb2dVVAUAA2xGMGV1eAsAAQQAAAAABAAAAABQSwUGAAAAAAEA
+        AQBYAAAAnwEAAAAA
     headers:
       accept-ranges:
       - bytes
       content-length:
-      - '522'
+      - '525'
       content-md5:
-      - GTEfychG/+tYQaiLiLbCpw==
+      - 1F5xWLsaLDr80D6Uc4gYIw==
       content-type:
       - application/octet-stream
       date:
-      - Fri, 13 Oct 2023 13:56:18 GMT
+      - Wed, 18 Oct 2023 20:56:26 GMT
       etag:
-      - '"0x8DBCBF4243BD94E"'
+      - '"0x8DBD01CA98019F8"'
       last-modified:
-      - Fri, 13 Oct 2023 13:56:04 GMT
+      - Wed, 18 Oct 2023 20:56:12 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 13 Oct 2023 13:56:04 GMT
+      - Wed, 18 Oct 2023 20:56:12 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2800,15 +2764,15 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/bbbdcc9c-1b07-4579-8c59-8f95c248ad79_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=ta5BXpbXuwE5DaE85z1AYGuooIRx6uO0lfk9jaLrCzI%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/dcaeb21f-830b-4d83-bfd4-0900c817c0f9_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=%2FkEYPrutkXaA2mgGsTgGUO%2BIEnILoAQW9XFhlTUPYqY%3D
   response:
     body:
       string: !!binary |
-        UEsDBBQAAAAIAAJvTVc8lqSAdQAAAKMAAAATABwAZW5naW5lMV9yZXN1bHRzLmNzdlVUCQADdEwp
-        ZXRMKWV1eAsAAQQAAAAABAAAAAA9jjsOwkAQQ3vO4lOQCilQwHKAya4JkWY/2pkUuT1RJNI9y8+S
+        UEsDBBQAAAAIAAanUlc8lqSAdQAAAKMAAAATABwAZW5naW5lMV9yZXN1bHRzLmNzdlVUCQADbEYw
+        ZWxGMGV1eAsAAQQAAAAABAAAAAA9jjsOwkAQQ3vO4lOQCilQwHKAya4JkWY/2pkUuT1RJNI9y8+S
         fcl8ueQGqjRjgspERae1WoxDTTzDnWYyE/7tlPSQTCRxCVsjbI1xr/GRRdd+qtPmNBiLXw+aewvH
-        2iCqf3w/R4ziLHHDLSnD/gpDLYXRLz9QSwECHgMUAAAACAACb01XPJakgHUAAACjAAAAEwAYAAAA
-        AAABAAAApIEAAAAAZW5naW5lMV9yZXN1bHRzLmNzdlVUBQADdEwpZXV4CwABBAAAAAAEAAAAAFBL
+        2iCqf3w/R4ziLHHDLSnD/gpDLYXRLz9QSwECHgMUAAAACAAGp1JXPJakgHUAAACjAAAAEwAYAAAA
+        AAABAAAApIEAAAAAZW5naW5lMV9yZXN1bHRzLmNzdlVUBQADbEYwZXV4CwABBAAAAAAEAAAAAFBL
         BQYAAAAAAQABAFkAAADCAAAAAAA=
     headers:
       accept-ranges:
@@ -2816,21 +2780,21 @@ interactions:
       content-length:
       - '305'
       content-md5:
-      - IA+PP1cP6xnCvw3XNqHzCg==
+      - YqqqI4Nj7HjfdP5gbMh22g==
       content-type:
       - application/octet-stream
       date:
-      - Fri, 13 Oct 2023 13:56:19 GMT
+      - Wed, 18 Oct 2023 20:56:27 GMT
       etag:
-      - '"0x8DBCBF4244574CD"'
+      - '"0x8DBD01CA98A9FCB"'
       last-modified:
-      - Fri, 13 Oct 2023 13:56:04 GMT
+      - Wed, 18 Oct 2023 20:56:12 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 13 Oct 2023 13:56:04 GMT
+      - Wed, 18 Oct 2023 20:56:12 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_download_files.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_download_files.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:52:29.3800691Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:52:29.3800691Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:56.8808228Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:56.8808228Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:02 GMT
+      - Tue, 24 Oct 2023 12:29:29 GMT
       etag:
-      - '"75009653-0000-0100-0000-6530458f0000"'
+      - '"d300dd3d-0000-0100-0000-6537b88a0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:53:04 GMT
+      - Tue, 24 Oct 2023 12:29:31 GMT
       mise-correlation-id:
-      - 25a323b0-973f-44b8-b027-277ac18f71de
+      - 46f20e1b-90b1-4c54-9f31-f3372b7d0144
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "4dfa8516-8306-461b-ab3e-d2c6d2279374":
+      {"passFailMetrics": {"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "9cde26e4-7d07-418a-9e51-249b880ea1d2":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "57356505-50a7-4bab-b5a2-d49f09179356": {"aggregate": "avg", "clientMetric":
+      "50"}, "76c59287-ff07-4c68-b1c0-13f5de9950b6": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:53:04.984Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:04.984Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:29:31.528Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:31.528Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:05 GMT
+      - Tue, 24 Oct 2023 12:29:31 GMT
       location:
-      - https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+      - https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 2ee6420f-be05-4dcb-87be-953353ac49cd
+      - 7baaa190-0230-4e72-94ed-e11175d319a8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:05 GMT
+      - Tue, 24 Oct 2023 12:29:31 GMT
       mise-correlation-id:
-      - 902014d2-9a0a-4059-8850-7e0bd9caadc0
+      - fa38b17d-86fa-4fef-b5ac-5276a79a9f17
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A03%3A07Z&sr=b&sp=r&sig=l%2FM%2FY%2B%2B5LbjB23vUup%2BTqRIfHfAu6WJkDD5oyJ%2BGOGA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:03:07.7716357","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A33Z&sr=b&sp=r&sig=tPLUKIVGFX99f4YGN2kBVLiwjHynTyK6mfq3zee2MZ8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:33.1582806","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '561'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:07 GMT
+      - Tue, 24 Oct 2023 12:29:33 GMT
       location:
-      - https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - c0199788-229a-4f10-b9ea-5b5cc587e271
+      - ecdcd2ac-aadc-4198-8246-230811f9657b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A03%3A08Z&sr=b&sp=r&sig=y55p0abc3ak4rq%2FxtEayYsuntUTWc4DgQrjZ%2BcKyhnE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:03:08.0886859","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A33Z&sr=b&sp=r&sig=TGaGpmpR2gkMOfuzZWa8XVqWKvZo8mEBf7166m%2B%2FGb0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:33.4656428","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:08 GMT
+      - Tue, 24 Oct 2023 12:29:33 GMT
       mise-correlation-id:
-      - 30e593e8-1c5d-4217-83f5-f04eac8a8cd2
+      - 93074567-cfe9-4aae-9b7b-ce33a8598121
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,46 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A03%3A13Z&sr=b&sp=r&sig=3IbPBannLAQFcbGqk6%2BM88KiCgDL6EbclN08W79quV8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:03:13.411184","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '550'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:13 GMT
-      mise-correlation-id:
-      - 7c1b745c-c9e9-4cf4-861b-d15f9385b1c2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A03%3A18Z&sr=b&sp=r&sig=cMCbT6%2BLtJNziNIzDPCOeO5yk2R7f3kmtzNDijfS5fo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:03:18.7391551","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A38Z&sr=b&sp=r&sig=Fj2RDAX0L5vfe3Hqe%2FESxHqKSxc5xh6HjKt6rY2K9NA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:38.7545358","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:18 GMT
+      - Tue, 24 Oct 2023 12:29:38 GMT
       mise-correlation-id:
-      - 66285994-7fc0-4eab-b9a6-c55e1ca0cd95
+      - fd7b1ab5-35ff-4802-bd4f-9b5da8fbd9f1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A03%3A24Z&sr=b&sp=r&sig=h5lp4iR1IsfboYKdaaiutkXR3cDgU6tQvUV3Toq1vFI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:03:24.103396","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A44Z&sr=b&sp=r&sig=DqQyG4fyWbLi9bBkv%2BHZxFz7kQstni6HBbDHhvvRWic%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:44.0922781","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '546'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:24 GMT
+      - Tue, 24 Oct 2023 12:29:44 GMT
       mise-correlation-id:
-      - be336926-79af-4a83-8256-e6a99f3f68ba
+      - 540f15a0-6904-46fc-a094-a7f5c33ab8b7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +421,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A24Z&sr=b&sp=r&sig=Ic6zZo4flF8fLBbE76%2BJTKEFPvzj72tyLyfcPHzZiNY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:24.3841771","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:53:04.984Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:20.91Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A49Z&sr=b&sp=r&sig=cgSpEG%2FSn0Gwfq64986rKC2AZPlXkLu1QsnnDjERZJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:49.4231895","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1580'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:24 GMT
+      - Tue, 24 Oct 2023 12:29:49 GMT
       mise-correlation-id:
-      - a821823c-c5ee-44a2-9f19-107680fbf5dd
+      - cc0184be-02d4-4f38-9b73-8cb270fc6fb2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A49Z&sr=b&sp=r&sig=1tusYDvku7sPrB4arhSMzVAnDsOPV7CnIHcMP%2BEW7gk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:49.6682579","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:29:31.528Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:47.495Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1581'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:29:49 GMT
+      mise-correlation-id:
+      - d962efd6-2ec8-479b-8ccf-190cd06b379a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:52:29.3800691Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:52:29.3800691Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:56.8808228Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:56.8808228Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:25 GMT
+      - Tue, 24 Oct 2023 12:29:51 GMT
       etag:
-      - '"75009653-0000-0100-0000-6530458f0000"'
+      - '"d300dd3d-0000-0100-0000-6537b88a0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A26Z&sr=b&sp=r&sig=I4%2B4taiK2yjEzKozbbAZ67WH3WIkYzUfcLaKLIOsQhI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:26.7165644","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:53:04.984Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:20.91Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A52Z&sr=b&sp=r&sig=%2BDFEqDemqPg8yIObjlwdSpsxCotKJTRmO7pjyqBdRSw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:52.7894904","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:29:31.528Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:47.495Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1592'
+      - '1593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:26 GMT
+      - Tue, 24 Oct 2023 12:29:52 GMT
       mise-correlation-id:
-      - 6a4248fd-059b-414c-8243-8e1c92356848
+      - e58a7884-f482-481e-8965-8c03fa23931c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:52:29.3800691Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:52:29.3800691Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:56.8808228Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:56.8808228Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:27 GMT
+      - Tue, 24 Oct 2023 12:29:54 GMT
       etag:
-      - '"75009653-0000-0100-0000-6530458f0000"'
+      - '"d300dd3d-0000-0100-0000-6537b88a0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:53:28 GMT
+      - Tue, 24 Oct 2023 12:29:55 GMT
       mise-correlation-id:
-      - bf1082bf-8940-4632-b0ed-2aa289a469cf
+      - dc9efe7a-5052-4d89-9fb5-ff087499c394
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A29Z&sr=b&sp=r&sig=4o%2Bn3GJADei0s%2B6SPSibvux1f3BgLQ1D%2Bt1Dtv5ZFdo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:29.7568544","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A29Z&sr=b&sp=r&sig=GSC2OwTJEqRnStabesg4aOSNqVcL4LDyKoauwF76c%2Fc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:29.7567301","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A29Z&sr=b&sp=r&sig=FI6qYr0QhoXsUpjkUaDoujyFU58%2F5QESEmvxmU9EP%2BE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:29.7568801","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:29.686Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A56Z&sr=b&sp=r&sig=1vNNYSsVESmRZnbIRIXS5u995otKiltGdhi1hZc%2FuAM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:56.109952","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A56Z&sr=b&sp=r&sig=UGqVWfhrgejsQh%2BkM%2F%2BERo8b8X9SXcJBoD4OtMEXr1g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:56.1097971","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A56Z&sr=b&sp=r&sig=yCxj0JXfKRc0MebYcMnHyulLwYLS7RFqOum2QwDtwmk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:56.1099791","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.037Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3170'
+      - '3165'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:30 GMT
+      - Tue, 24 Oct 2023 12:29:56 GMT
       location:
-      - https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+      - https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - e4eb30a7-7316-4567-974c-54fc6208349b
+      - b8e2b069-4433-42bc-82b7-11928122ccd8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,10 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A30Z&sr=b&sp=r&sig=g7L8aV1kZdx4pl0Xvm7Pdn8scA5bEs3fU0%2FL6%2Bc09Sw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:30.3101343","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A30Z&sr=b&sp=r&sig=VgV%2Fw4I1PxqN7mc7zkP5ee1pK1reG8aVQtZUMTEUM7E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:30.3100637","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A30Z&sr=b&sp=r&sig=CbX4Dd%2FDvKLRjaVABAvqCB26Ar%2BjJ%2F0xizhiX7XlWtw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:30.3101496","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"NOTSTARTED","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:30.208Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A56Z&sr=b&sp=r&sig=PpV6H5VYsg3VVegZ0VbIsH%2B4OM96e9FOPepreuQOj3s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:56.5545797","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A56Z&sr=b&sp=r&sig=WjWvmvGg1HzypvjwwpQkt1crFjV7yqOX6P75w97LkDY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:56.5545069","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A56Z&sr=b&sp=r&sig=yMX4KhqYFTToBv25eLz%2B7TywxV330Nz%2B%2Fc1J214%2F9kw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:56.5545942","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.546Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -714,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:30 GMT
+      - Tue, 24 Oct 2023 12:29:56 GMT
       mise-correlation-id:
-      - 8460faa9-292c-4df4-96b7-06df0c96a7b1
+      - e2ebde3d-78d6-4c61-b382-243209fa178e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A35Z&sr=b&sp=r&sig=i2dcmTa3CjPoVLS%2BJBgNjD5TLqkjWrB0SCvlloMEsR8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:35.5726764","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A35Z&sr=b&sp=r&sig=ErAemf90BQxzP1N726oaGNMBjfp9JtBvsGqzi1L9GaQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:35.5725937","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A35Z&sr=b&sp=r&sig=qfw3mmr%2FOlfLUpQBqInLnHVdw2zoeYh%2Fg%2FKRwURaOW0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:35.572701","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:30.389Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A01Z&sr=b&sp=r&sig=rdd2cuv2gnoBvhn8QLmsERPRhlE%2BVRwuuYyhE1v4ijM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:01.8454763","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A01Z&sr=b&sp=r&sig=WryXF%2FZE90WoOud%2FjvMTiNS9gls3A0gtvs8UCRD58CM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:01.8454064","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A01Z&sr=b&sp=r&sig=8fCCrcZ6xD%2F1K8QgjebsNYsXs4RMUl4f8wr%2FMBcG9cw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:01.8454912","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3212'
+      - '3215'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:35 GMT
+      - Tue, 24 Oct 2023 12:30:01 GMT
       mise-correlation-id:
-      - 8ba16667-89ad-4e03-9697-9273d11f0bb1
+      - 62592452-e9e1-4649-bbe1-0f901413581e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A40Z&sr=b&sp=r&sig=vy04cYjrWsHd81zG4fOYIwbPRXtIqwGqcUTqqXGY0ow%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:40.8722356","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A40Z&sr=b&sp=r&sig=%2FDQOd9QPDjMOvRI%2F7d212AaP4moluSrbAXDLwfmx3DA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:40.8721629","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A40Z&sr=b&sp=r&sig=9g6Dhq9gLiUf8VsjUSaJV3aRjyUArgkdVeyMTmdH5fw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:40.87225","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:30.389Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A07Z&sr=b&sp=r&sig=Ro5GeCArdrCzy0BikxLah%2B6651aSdD9NCg9g19RTJDU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:07.1498099","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A07Z&sr=b&sp=r&sig=dXBBJQLWiXauRbBdJC%2B9k8uFuSWcHLms6YfGAeyetCY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:07.1496447","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A07Z&sr=b&sp=r&sig=eMFMG%2FLVduk1tRx%2FlfV%2BuhOaQvh%2BqUkiOFJX7l84CQI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:07.1498294","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3207'
+      - '3217'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:40 GMT
+      - Tue, 24 Oct 2023 12:30:07 GMT
       mise-correlation-id:
-      - 90d4ec25-b275-412d-81eb-6caf6da68709
+      - ebbc59b5-450b-4d84-a3f0-8b75a5d20ba5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,46 +808,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A46Z&sr=b&sp=r&sig=r3M7gxWjgap4cVNzl2BVbhQcHetw5WG9V%2BDwMpD4pQA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:46.2033735","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A46Z&sr=b&sp=r&sig=e1aqMkBY00Mg12SLhK0iktCr9Qi9cmSxx96LdZ%2B26BQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:46.2032812","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A46Z&sr=b&sp=r&sig=yarYI%2FgFdR4lTVzCviMZDbEVnUKi17umyhVPEKDYNV0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:46.2033963","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:30.389Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3211'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:53:46 GMT
-      mise-correlation-id:
-      - 001fd94a-6ab6-4e35-ba1e-cbf95a3d8589
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A51Z&sr=b&sp=r&sig=Wcgms1itTXFo1kSWD64LhJmg511ikbehVadCT4hPYX8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:51.5261493","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A51Z&sr=b&sp=r&sig=kOKCURjJsoR8dMZjKF60%2Fg97FnBPhmIoVgbbNQYkSKU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:51.5260711","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A51Z&sr=b&sp=r&sig=rvyOA4XdvG9%2BUSobBByFQITX7cqj6nSQXjYdVQTLaYE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:51.5261636","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:30.389Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A12Z&sr=b&sp=r&sig=tG628sPybP3TWpVXGYto4izskPfYJV%2BsbSg5VqiTQZI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:12.4824367","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A12Z&sr=b&sp=r&sig=mqa499RefFHjYmlEez93%2F1SCtxsWopf4F4X5OaZ4ZPI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:12.4822563","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A12Z&sr=b&sp=r&sig=bSs5Y3GFJfRcdSkouX1QauJh0bsTKgrZJI7zXPUHpvg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:12.4824647","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -858,9 +822,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:51 GMT
+      - Tue, 24 Oct 2023 12:30:12 GMT
       mise-correlation-id:
-      - b8010f7d-e3c1-4003-b0b5-ae23d06bd68b
+      - a4e80270-4b4f-4368-b62d-67f97e063324
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -880,10 +844,154 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A56Z&sr=b&sp=r&sig=8UC%2BCvHnQmaIBoR%2F%2FaW41Cxk9NVWwonJMgktaTjG6ak%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:56.8391999","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A56Z&sr=b&sp=r&sig=atNtyNkYDBAaOHf%2BDkub7ytYgsvteCLpjH5aXSxuBQI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:53:56.83913","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A53%3A56Z&sr=b&sp=r&sig=CTbqr0LgH5TedNbu5E3ziwJMwZhNl67e4elm%2B1Y0CCo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:53:56.8392147","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:30.389Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A17Z&sr=b&sp=r&sig=eqhn1WJ%2F9ehGm%2FdTAxsdEZ6uceb6eW5ctdMk0GCzhHQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:17.8313252","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A17Z&sr=b&sp=r&sig=n6M9cTb%2BEGIGrNJXan8JVmH08RhDCqIBQg6IId19ZiU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:17.8312343","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A17Z&sr=b&sp=r&sig=K2izR13WcweShruhwlUO5AIe7I4qPq3wUDuRZDfQTZg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:17.8313465","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3211'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:17 GMT
+      mise-correlation-id:
+      - 7d3d6bb1-ff36-40be-999c-9a204aca6433
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A23Z&sr=b&sp=r&sig=vi4ulbhcdje9ez2k4YHMluPkJ1RMzdvhpsU9pD4Ig%2FI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:23.1286527","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A23Z&sr=b&sp=r&sig=itIn7Q4Fj7DPLLCarEwP8RQDKjYjxmuXdsYfo6T8cRI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:23.1285712","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A23Z&sr=b&sp=r&sig=wkmpwHVGAByGIo9O6B5HMExPIV1Z6%2FVSq23WjFVvrnw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:23.1286677","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3209'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:23 GMT
+      mise-correlation-id:
+      - 9bd38ee1-892d-46d5-9799-6d0d5fa4f5ce
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A28Z&sr=b&sp=r&sig=oEFEk5J7OhYEuUYN%2BVpaiT1xKEceRkPHUj552Wmr0PQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:28.4261817","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A28Z&sr=b&sp=r&sig=FJrf8fsd3ugIS9VSIi61D70CXATFMjDCWqtgTA%2Fb2sI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:28.426088","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A28Z&sr=b&sp=r&sig=tw6X%2F%2FrhSzuolEHGnpiboO%2FtiAPpaMbG4v%2Bk3Ki84yg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:28.426197","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3215'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:28 GMT
+      mise-correlation-id:
+      - d40232aa-bb09-409f-9762-3c3650e7b12b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A33Z&sr=b&sp=r&sig=h2uvOeucEAHLdu%2BnUBfC4dGciI6uo4DIAmiE8Sq6nYM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:33.7303343","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A33Z&sr=b&sp=r&sig=DOjKGa6mTqLHHYMdEFdhvtCUoKpjli3ywetkFyZRzVM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:33.7302679","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A33Z&sr=b&sp=r&sig=l2ZrGy7Zb9KEcS9moTcydFolH6eX1JTddGxZ5dDJDaU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:33.7303486","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3207'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:30:33 GMT
+      mise-correlation-id:
+      - 48dbc54b-ad02-4ba6-8f94-9506319b37c5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A39Z&sr=b&sp=r&sig=tzbT7CVFey7Zemf8i12woZo8%2BCxZgQ%2FRNi%2FzBH8Ao5c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:39.0188307","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A39Z&sr=b&sp=r&sig=xjzm85sJwqHvypRCN3XuiEXzgdolTuJwILHpykkipf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:39.0187367","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A39Z&sr=b&sp=r&sig=8ZwL8Da58%2BecwHJh7tMnaHZ3tIqB4WgQLawZDcwb2bI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:39.0188526","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -894,9 +1002,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:53:56 GMT
+      - Tue, 24 Oct 2023 12:30:39 GMT
       mise-correlation-id:
-      - 2d53e6d2-4ff0-4824-a6ae-da21e1e97efa
+      - c65e6378-32af-4790-b6cf-275b765c892f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -916,23 +1024,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A02Z&sr=b&sp=r&sig=VQn49HJbY7OEBGoizKpjQ0JiW%2F0xzv8Syp2E51aTrmY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:02.1659121","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A02Z&sr=b&sp=r&sig=nvwK0UnjOOboSitf7nFKZevzlTmkyOh5UEl2XFDkeWY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:02.1658191","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A02Z&sr=b&sp=r&sig=VAST38McImRewqTrTw2LyJS%2FYpK%2BIoxATeFhVR1NZNA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:02.1659328","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:30.389Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A44Z&sr=b&sp=r&sig=r6lx3kGOI2dM9Op2hrlISZHPp9rWhq%2F1Ep6zEz3yQUo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:44.2908999","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A44Z&sr=b&sp=r&sig=O5SjLAUuR%2BrNxhQm9JuIwhiFyZS05ubTZFPNCRq%2FqhE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:44.2907504","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A44Z&sr=b&sp=r&sig=8wowlaFOCzRja8YGvg%2FrQHPLmsSq9ov%2FWHAQtXRp3as%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:44.2909236","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"CONFIGURING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.586Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3211'
+      - '3214'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:02 GMT
+      - Tue, 24 Oct 2023 12:30:44 GMT
       mise-correlation-id:
-      - e9a8b629-11bb-4b37-83a0-010b5cdd1b28
+      - adebca25-910f-4a77-bfe6-37a23c7b36fc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -952,82 +1060,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A07Z&sr=b&sp=r&sig=aFFzNcFWqJB927tCH31eHEv22dOaje6WK%2BMShMeRMwM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:07.4965305","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A07Z&sr=b&sp=r&sig=lOabLhBunMOY4GsoWdmajF%2BqdUSPM2Xknilt5gP%2Fx1w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:07.4964536","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A07Z&sr=b&sp=r&sig=tL4NKUjOhmwx1HtR3C6rP0gRj3mOgV9R9ngOHSGa1Rg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:07.4965457","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:53:30.389Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3211'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:07 GMT
-      mise-correlation-id:
-      - c6a263d4-acdf-42aa-8236-e22a311f1609
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A12Z&sr=b&sp=r&sig=HBXykokMk8CqkOl%2F%2F2baleZzBNdEe%2B%2FwiHn5vhYKK9M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:12.7757668","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A12Z&sr=b&sp=r&sig=O9CVtCmT0aDPwj8j%2FH0YMgwJy37iRAtgG7RnANayz%2BU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:12.7756896","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A12Z&sr=b&sp=r&sig=KIvXqfzVo58OrdZrm0gQYg3aMXYBGHb5HdqlnI7%2FKXM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:12.7757838","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"CONFIGURING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:08.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3218'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:12 GMT
-      mise-correlation-id:
-      - 863551bb-6636-45dd-85a1-868fc1f5f10f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A18Z&sr=b&sp=r&sig=f7g74ZQ5Pyg9VXuwsCWiKOhhZHF0PTikeH%2BYqt%2FnTkg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:18.0382034","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A18Z&sr=b&sp=r&sig=kRL9H69X8LHGa9OMkAGLouE89jtdEdM9SAfELX3%2FI2A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:18.0381004","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A18Z&sr=b&sp=r&sig=qYfhPhIOLIBCIGOvzAIcrbsPwyYSxCJf%2BUbP0iM3S3g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:18.0382262","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A49Z&sr=b&sp=r&sig=pOZZgnfKYJ8ruRKPVqFVqpqZ99Rh1NEGIgeZBWNELz4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:49.6143317","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A49Z&sr=b&sp=r&sig=oIynXqcYGlYxOJ7j%2BmL1rg38Y92ACe7zf01X7mfIvA4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:49.6142584","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A49Z&sr=b&sp=r&sig=%2FBXk%2FyKgitWYA4gQbb%2BXzkAogOOFhbRrxCsADwicmDg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:49.6143469","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1038,9 +1074,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:18 GMT
+      - Tue, 24 Oct 2023 12:30:49 GMT
       mise-correlation-id:
-      - 82a3d383-1744-4331-9984-92a6148798d4
+      - c8c0c279-af3b-4940-af42-6c7f9a484f93
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,46 +1096,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A23Z&sr=b&sp=r&sig=n1pjDKRnm2CfCm48DlGqVO%2FanNRSZwI2jLtKMh3lzc4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:23.3670368","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A23Z&sr=b&sp=r&sig=clcsg4lwq5QayD4EXtlTzNiZKb52l2mbF3nPxBMTabA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:23.3668696","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A23Z&sr=b&sp=r&sig=y0sza0csaVkhUJE7uNDJwoR6sYNm2xIkM3lewDPakyU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:23.3670684","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:23 GMT
-      mise-correlation-id:
-      - 6dfc44b2-aa52-458b-8d04-dabd2515f450
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A28Z&sr=b&sp=r&sig=rKcLypvyDN5kE3J4f6Dw%2F%2BJLmzhVGkVm3IpFQpbK0Kg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:28.6847102","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A28Z&sr=b&sp=r&sig=JW1OwbL%2Bv1FPyWqk1Xl1%2B0eTLoj6XE0yNuTfQbqy7AA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:28.6846193","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A28Z&sr=b&sp=r&sig=sghXLBDaEopBkuuIggxkkL80Q20%2FyKxwhZ7AjdG9ank%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:28.6847312","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A54Z&sr=b&sp=r&sig=Cgvu%2BxARwskp84j9INiKQWB%2BJHILZxYgTTS5%2FFyA1bo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:54.9568902","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A54Z&sr=b&sp=r&sig=d5og9ezdT957dPXdBlUsWPWpVnsEpGGGaStdb%2FI6j1o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:54.9568191","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A54Z&sr=b&sp=r&sig=ws5mc6zDgiWEuxpMmD8oO%2F3B4QjRYmbzOlWNTnP1dQ4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:54.9569043","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1110,9 +1110,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:28 GMT
+      - Tue, 24 Oct 2023 12:30:54 GMT
       mise-correlation-id:
-      - 4438be32-2ea8-4045-bcd7-f2d6bbe592e4
+      - 6b44b238-eb80-4dc3-b90c-824ce2eb3d28
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1132,118 +1132,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A34Z&sr=b&sp=r&sig=ZTOdKv25nGTS2wXUvasvyZCOrt%2B6CZPgLQbRTtwWNw8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:34.0154438","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A34Z&sr=b&sp=r&sig=l3nCsPvvlGHB%2BEaPUQdVIefioToiHnWDvtuJt6qudDM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:34.0153488","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A34Z&sr=b&sp=r&sig=rzZfu7C%2Fmynucd7uFcg1UDzkCTiIsq5gOmPqnD8I%2Btk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:34.015463","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3209'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:34 GMT
-      mise-correlation-id:
-      - 4741620d-c655-4b74-8b03-d75de094724d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A39Z&sr=b&sp=r&sig=KYD8vlIpGWYqDdBo2ZspopBWGACTsvfUL7HUKQsU1%2Bc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:39.2904879","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A39Z&sr=b&sp=r&sig=vzzZwpUG6RF7mgr5Byq8SGuHs8l0YpDjrKRyQnKilbM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:39.2904177","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A39Z&sr=b&sp=r&sig=Br0zfJLPGXpfp7fCw8NToT%2FKMueT%2F6PKG%2BG2Au39NKw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:39.2905014","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3210'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:39 GMT
-      mise-correlation-id:
-      - 765c2620-51cd-47f8-9ac5-3f863447792b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A44Z&sr=b&sp=r&sig=C6hSrEzJOUJXUMsv4K7mUrG9f4NKUj6aQQvBFCC%2BseM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:44.5668283","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A44Z&sr=b&sp=r&sig=B8ncahr5ls33Wx%2BUBHTb603ID45xD3Bly%2FW%2FfktXALQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:44.5667445","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A44Z&sr=b&sp=r&sig=zpLOgnGB0BBbSpj57XZ3kC6LgFOaba4f3uAwjzA0J%2BY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:44.5668427","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3212'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:54:44 GMT
-      mise-correlation-id:
-      - af9c7c8e-4aa2-46af-b94c-6c64b4c4880e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A49Z&sr=b&sp=r&sig=vqct2eQDYyYhDDbCZjH4sON2qlIkpeRSfOzT5i9U480%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:49.8849308","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A49Z&sr=b&sp=r&sig=5bGtrHga4OQN87lvVLnIShqFDZm0UXCrF0GqqCgkz%2Fk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:49.8848159","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A49Z&sr=b&sp=r&sig=RtQtFBLdoQMyaCtHmVfwWHOBtnUSuyrbrZybiutyS%2Bw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:49.8849569","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A00Z&sr=b&sp=r&sig=%2FxcoFmLtrnmDDACpjbkOhsdNuEwBT8mBIKniG3HGXCo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:00.2884444","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A00Z&sr=b&sp=r&sig=1dwm47sSuZk3LG3oU3wf8J1Lh6UG533RTZEniTeu4EI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:00.2883625","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A00Z&sr=b&sp=r&sig=nhvy8jmtwL%2FlRJFonlEVK2KhCn3eW9LFB71unvvTP6w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:00.2884587","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1254,9 +1146,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:49 GMT
+      - Tue, 24 Oct 2023 12:31:00 GMT
       mise-correlation-id:
-      - 26933098-e92f-417e-b88d-e2f371281474
+      - 70e4e92e-0f12-4939-b264-984774330c48
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1276,23 +1168,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A55Z&sr=b&sp=r&sig=4guOxd84tIqCie4j9TMMCZeCj1dUnutYZ0enTNvWW68%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:55.1516266","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A55Z&sr=b&sp=r&sig=%2BUsCzPqEgG4ACSabJ73sE69F%2F8Q%2BRpKx%2FGxRuV%2F6JRU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:54:55.1515215","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A54%3A55Z&sr=b&sp=r&sig=%2BQRsFlUFHTJuR2dq0WpuiapaalvxE8qnWjIQs1TkdGI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:54:55.1516407","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A05Z&sr=b&sp=r&sig=3CC4QdUj27OA1zR7RBOIh0mOvKds7G4%2BC2%2F0GAMBTIM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:05.624515","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A05Z&sr=b&sp=r&sig=6Jl%2BHH%2BnPZAaeX8qpCvdVzt4uQ00odC%2BT9mX8rHb3bg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:05.6244545","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A05Z&sr=b&sp=r&sig=ui4PxPYxS8PnkZGrdbGVmeG5q9jTHB3YNji34fz%2BRAM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:05.6245304","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3214'
+      - '3213'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:54:55 GMT
+      - Tue, 24 Oct 2023 12:31:05 GMT
       mise-correlation-id:
-      - 710f4107-1341-4443-8b2b-40e549c34670
+      - a67b8764-eb3b-4ada-88e3-409a34fe4e3e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1312,23 +1204,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A00Z&sr=b&sp=r&sig=ToZ640OmnhT8O8Jivfhc18W95oqDy0snQYNLbxB7VQs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:00.4469515","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A00Z&sr=b&sp=r&sig=sCnV1A4yXGIXIo1u9O%2FGkkjAct8iEjRwpEgWDGRV6WU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:00.4468772","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A00Z&sr=b&sp=r&sig=QenY53BhBe9l1eOLFEUC9DdnRJ5yLCNrEoxQin2Et20%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:00.4469654","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A10Z&sr=b&sp=r&sig=S2rIDWrHJmu%2BcfHVQYRjoKX3chup2YbtoPwuOftXtdI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:10.9470887","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A10Z&sr=b&sp=r&sig=GXL7Y7BzgP81YHrD6Not8O7GBkwr7zZXfMT8VQU0%2F0I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:10.947018","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A10Z&sr=b&sp=r&sig=3GmV9jxoDFtMUlMBydPxawm9vPU00ZyrSu0WacIquhA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:10.9471022","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3204'
+      - '3205'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:00 GMT
+      - Tue, 24 Oct 2023 12:31:10 GMT
       mise-correlation-id:
-      - 40418267-3f01-46c4-8969-099894f249e2
+      - 7dbb9dc7-5e16-41d2-b84c-be0d62c07cdc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1348,154 +1240,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A05Z&sr=b&sp=r&sig=LETC3gVP%2BGJLRgqxo%2FMHaaRluHu7Tr6C%2FJT%2Btg%2FER3E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:05.7500087","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A05Z&sr=b&sp=r&sig=68c%2BX4ySqk4%2BKTy9LhgUSHKk34qVYs3dewCf5BpJlQI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:05.7499305","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A05Z&sr=b&sp=r&sig=UgBdWqNHY6LCGOQRT%2FQm30ULcvl7AxanGj%2F4sZ61tM0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:05.7500234","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3220'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:55:05 GMT
-      mise-correlation-id:
-      - c25ed923-9e76-4cd6-806d-39a86d7de62e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A11Z&sr=b&sp=r&sig=Tx4zSx5pjZFOhOLSOlUcbd25GzEqzC3%2BfmSG3JJRNuc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:11.0702842","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A11Z&sr=b&sp=r&sig=O8%2BKgsrAvcUnfIUDB9xUGZmQFq82%2F3FN5wlsVyYvVss%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:11.0701855","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A11Z&sr=b&sp=r&sig=Np%2Foecd%2BiiuHa9aX1%2BEStZfDgxVOfXwhPUvD8pFqJOs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:11.0702989","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3214'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:55:11 GMT
-      mise-correlation-id:
-      - f39e306e-d6e4-4748-ae71-9c551fa47e1f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A16Z&sr=b&sp=r&sig=5rw8c8ZHBPlebJnHpfIYuwNW2QqS4LnH4SBQkWBPnd4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:16.8224884","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A16Z&sr=b&sp=r&sig=X6sbAspAPg1aoR0%2F4%2FL1kUznUH%2FZmxm7PXP5y3ryYyY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:16.8223944","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A16Z&sr=b&sp=r&sig=30xOrSihBuSt2mhV4dbI22wWqqlhA9Lk%2B1H1aoT26Q4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:16.8225106","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3210'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:55:16 GMT
-      mise-correlation-id:
-      - 4215d189-302b-41fe-babe-b511118f6114
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A22Z&sr=b&sp=r&sig=lifGhx8mSTtJZJgAbJPu%2B1%2FP3Ryx3F1%2BfPES8sFWnqY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:22.3165083","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A22Z&sr=b&sp=r&sig=8kbtQt2VcZXQ8bzln5A%2BBDw5nyebI2vpCgQepJDExlw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:22.3164244","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A22Z&sr=b&sp=r&sig=2Z%2BOoKfmBoaELQ%2B5%2FLWqcHspmCQoIRfBQzasx45FHJ4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:22.3165221","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3216'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:55:22 GMT
-      mise-correlation-id:
-      - 86522ea9-5b83-4c2e-80ce-d96366e7c755
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A27Z&sr=b&sp=r&sig=lmBF11OjSh%2F8lr5jyDZPordFVFksaG8ZkYLEkKj6zFA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:27.582953","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A27Z&sr=b&sp=r&sig=M1fYti5mjZ8xBzx5a4qerdVzfQH9S1B9uLLw%2Bkdm4YM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:27.5828604","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A27Z&sr=b&sp=r&sig=qGGQXKOnbT9hqZUgIaZ%2BpgrkqmB%2B0DIr7p9N%2B2NtVtY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:27.5829752","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A16Z&sr=b&sp=r&sig=%2B02EF%2FAB9fFBelCDe4DIH4WcMiZH8vBcflX9m32itk8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:16.26238","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A16Z&sr=b&sp=r&sig=G8%2FwQLug7FrnYE2sn137%2BOt36iVRrtKX5mrfZMwqZhI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:16.262328","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A16Z&sr=b&sp=r&sig=VmHD%2B6uzBAdnWNHcJLYYCf%2FMh8aSO36mP0FA1W52lnk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:16.2623938","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1506,9 +1254,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:27 GMT
+      - Tue, 24 Oct 2023 12:31:16 GMT
       mise-correlation-id:
-      - d0ce9c5b-be49-4be3-b624-41c6fbd7a21b
+      - 4d3f8dcc-c97b-437e-a193-ee1d0f35915a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1528,23 +1276,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A32Z&sr=b&sp=r&sig=a8jnHrQVOYt0lSekWiM5qXDlcjDUUAZvtSyGC7fCARo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:32.8994243","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A32Z&sr=b&sp=r&sig=WzNBUf4t36HKEZY7OPU5MLw%2BvJWGkBQL1RAuEWwAu8k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:32.899326","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A32Z&sr=b&sp=r&sig=8MxArQJIxHNBKt27FitaV8r%2Bjk3yG5oP7rRf9V%2BnsLU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:32.8994517","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A22Z&sr=b&sp=r&sig=RX9gi5dahobkgolFtKcaPqlfm5KAw%2FGe8vuzTnG%2Fq1o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:22.3930245","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A22Z&sr=b&sp=r&sig=OXKUDz2kEGorufnuBe4RDEiAM%2FdS66JXsHwUoA6DMig%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:22.3929138","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A22Z&sr=b&sp=r&sig=LJcF1AIgj%2BitRqdRXjWtyMGf0S0SauwOB%2F2q%2F2WpsFs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:22.3930524","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3207'
+      - '3214'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:32 GMT
+      - Tue, 24 Oct 2023 12:31:22 GMT
       mise-correlation-id:
-      - 81c0142e-1b93-4c37-b369-72e35281d3bd
+      - f9a89f93-3e59-4ff2-be22-d623dc89b0e2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,10 +1312,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A38Z&sr=b&sp=r&sig=sI8Ntye5goV3szBQCTWRS0v2fvDf6%2FSXDaBoXQpZzH8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:38.5341401","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A38Z&sr=b&sp=r&sig=g3R1qCalzhP44eJAYhsGvH4REHWFjyn9hSYFQxreq0s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:38.5340747","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A38Z&sr=b&sp=r&sig=cyy6bVFDLm5fv00cXp%2BYvrI4EdjC9SSFz9KRqppeh%2FY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:38.5341596","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A27Z&sr=b&sp=r&sig=7sU6U0z2PQ4DLbAgFjZnsoAvBYXqIdmlAcpDjPEb3OA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:27.7227954","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A27Z&sr=b&sp=r&sig=FtAFTKsa%2Bwac0ItctUnY0jKIIsQImnFLWWCaJpFsQJE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:27.7227244","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A27Z&sr=b&sp=r&sig=kAzNKxre55DMhinq0CHJ9P9HdeWDWMT4Xyl1OCFtWuY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:27.7228102","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:27 GMT
+      mise-correlation-id:
+      - bc89b2d7-4cf0-4fbe-8832-e5fb369909b0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A33Z&sr=b&sp=r&sig=2NwFLMR5Zj9H5cnrX2fUiWmp2HwPzm1M7ymcVQGMCZo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:33.0693615","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A33Z&sr=b&sp=r&sig=f%2BRkQgngSWRzWnLtARYlTYvLLi2UCN0Egk%2FeCeK9Mwo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:33.0692673","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A33Z&sr=b&sp=r&sig=osLZ4TU3RfqB8btfLc7X%2Fc4V64QjHL3MZZZW3k2ASa8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:33.0693841","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1578,9 +1362,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:38 GMT
+      - Tue, 24 Oct 2023 12:31:33 GMT
       mise-correlation-id:
-      - 62691d80-157a-4e2a-9d6d-749529a197c6
+      - 69546933-47b0-4421-9faf-901bfe59197b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,10 +1384,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A43Z&sr=b&sp=r&sig=ZW8PtOpuF%2BpMaie78hg2tG79hr90FoQCLxqq6Uh%2BLtU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:43.8363825","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A43Z&sr=b&sp=r&sig=aPE2HuLXQnD4j1BNPRba4k7NXtzNRjrbhiZU8cx%2Fmwo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:43.8363052","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A43Z&sr=b&sp=r&sig=cCo4JBqFfs%2B3%2FyJs%2BqdQYfyJ1kFOrAmB%2FUMUl1PJkK4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:43.8363981","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A38Z&sr=b&sp=r&sig=s5DqhJswAmWDV8H1Lr0agupgeZ5c9NJK6NzmIFlIUCE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:38.3476049","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A38Z&sr=b&sp=r&sig=DOA7hCWc29OXl7TCgrzWsslT2CRhEWQooQcDHfyl8CA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:38.347528","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A38Z&sr=b&sp=r&sig=VwB3f6LXBPBeNYS30wry%2B%2F3NlBCEJlMWVMsjKdgfplI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:38.3476193","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:38 GMT
+      mise-correlation-id:
+      - 71bc09dd-04bd-4052-b831-9a44189b6296
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A43Z&sr=b&sp=r&sig=ZNn6gMNWXdZhcRtmCoUHYI87ib%2FLDTI%2BizJjiZB%2FhJk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:43.7089864","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A43Z&sr=b&sp=r&sig=o2Qu5kfkIPcXwBpQFYaGfrx9Q04mbXM%2BAtQq4TuMTHY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:43.70891","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A43Z&sr=b&sp=r&sig=AGGFkv%2BOK50jz%2F%2F1RZoflYDEzXXmT1bPQgeKv%2B5Ur00%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:43.7090015","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1614,9 +1434,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:43 GMT
+      - Tue, 24 Oct 2023 12:31:43 GMT
       mise-correlation-id:
-      - a5d2c53c-31a9-461f-a2be-b1da41ad3167
+      - fc224f43-a008-4b6b-9e3f-f31232ff66b2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,10 +1456,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A49Z&sr=b&sp=r&sig=Ru34kexm8ARfwK7I9bEjMCv3jepPYj9UWMiPsizGWZw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:49.8183757","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A49Z&sr=b&sp=r&sig=5Obb2c%2FlB%2BLmPpXloTTImifNBvzZ4N6viPFe0WLbovc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:49.8183008","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A49Z&sr=b&sp=r&sig=m0ZmGVaFMl37BST95jPjB40Db%2BXuyLKEk9ztf7UgFi0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:49.8183905","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A49Z&sr=b&sp=r&sig=ybsegq2Jx8ENUulb3lqv0%2FS8PwPqcY7w%2BF3n1TEMndA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:49.0066526","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A49Z&sr=b&sp=r&sig=P9BhVEQ0Z9aQXfPhp5d40H5HZar9IeFKelOys86ffHo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:49.0065653","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A49Z&sr=b&sp=r&sig=UKDyGTfcGzys%2FAsK5zTSQaADoDMIu8hFCrqcnvxtbDE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:49.0066769","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1650,9 +1470,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:49 GMT
+      - Tue, 24 Oct 2023 12:31:49 GMT
       mise-correlation-id:
-      - 334aa3d2-b1c8-444d-a429-71b130ef57da
+      - 88234c62-c1ef-4c1a-9dba-957ddea2406e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,10 +1492,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A55Z&sr=b&sp=r&sig=%2BhuxaYG64C7BeTO35N%2FfS0mx1l3a0SkvcuuOIc9sFmk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:55.0999857","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A55Z&sr=b&sp=r&sig=IR3LvgImER0Deg62%2BkgQRGLw1h1fPOw6bOOArxY47pE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:55:55.0998802","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A55%3A55Z&sr=b&sp=r&sig=TRLo%2FQMhKrRDpxlABcAeuqs13P3XHZCycdQ4N4Gpp00%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:55:55.1000076","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A54Z&sr=b&sp=r&sig=s2dDtM9lH8aSy40Mc6X7xfgvDk14%2FzmCBHEJ1qKSqzM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:54.3650395","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A54Z&sr=b&sp=r&sig=5eARfDKr58m5CqdAT7jCMaFrbhzeQfaRx5Aq%2F8H%2BZ5o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:54.3649408","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A54Z&sr=b&sp=r&sig=6SRoeTgZRqgDhxF00x%2Fu3nmhL%2B4lntF89Hw6bduP%2F8M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:54.3650574","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3214'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:54 GMT
+      mise-correlation-id:
+      - fce956b8-8923-4529-8ea3-5f3a524c390c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A59Z&sr=b&sp=r&sig=zYUiRwmihu8TWY2%2FAte4DZR64%2BeD7WueFuNP37VSMSA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:59.6725329","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A59Z&sr=b&sp=r&sig=NqTOFLh6kqzZkrNxJeae9X5voxPVHDGTUud00ik67d4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:59.6724642","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A59Z&sr=b&sp=r&sig=FkRZtWjgINBVf0BVum23Gqd9up3tiuvLXVlT7nH9KnA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:59.6725465","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:31:59 GMT
+      mise-correlation-id:
+      - 50b88ba8-064e-4772-9279-18949e47f794
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A05Z&sr=b&sp=r&sig=6waiHuh4%2FMao%2BJ%2BVAZgB19EvazO2mi1%2FRlbsLSY1W3w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:05.3529461","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A05Z&sr=b&sp=r&sig=s2fGefU7q744d0jGZada1s4yJ8Mdy4jeNbo9aitMtuY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:05.3528509","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A05Z&sr=b&sp=r&sig=4s7PJS9gVEQ1uM8PBRIdUSakyhDS6jggTlLarHBXgvo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:05.3529664","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1686,9 +1578,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:55:55 GMT
+      - Tue, 24 Oct 2023 12:32:05 GMT
       mise-correlation-id:
-      - 6fc5dd29-2383-49f8-9861-3bd6fc53a8ce
+      - 3a1f6a72-7d3c-427a-a891-4457ee5d5117
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,23 +1600,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A00Z&sr=b&sp=r&sig=f0A%2FbHkvPLyL6WTceSszbsLGj5Xmtg2Mia3MRsazLt8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:00.3543807","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A00Z&sr=b&sp=r&sig=wwrKpS1ssPK%2FOj7WqSZkcjkMH%2FaZCfOngdd12aoQiB8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:00.3543038","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A00Z&sr=b&sp=r&sig=vVGx85fcCo8dJ0WsCenvUdlpjVkYd%2F9LrOk0UVrbmTA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:00.3543946","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A10Z&sr=b&sp=r&sig=Q7r3kEm%2BIGBCkdtxm6s5RZm%2FrRBsqgKWYnKor6hK5AI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:10.6343621","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A10Z&sr=b&sp=r&sig=pVBTBjZb0%2BV%2BuMqZb2bqLyaX599jJ%2F0HnIzxvG4z060%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:10.6342761","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A10Z&sr=b&sp=r&sig=tvDSiI2D8kT4Yxpp316XJihxAdMu%2FARkUh%2BdA68tiik%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:10.6343843","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3210'
+      - '3216'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:00 GMT
+      - Tue, 24 Oct 2023 12:32:10 GMT
       mise-correlation-id:
-      - 7ddb5498-09c9-4b4e-9fe5-fb71c7c42522
+      - ffdca35a-33d2-44e8-9725-7039d824be67
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,23 +1636,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A05Z&sr=b&sp=r&sig=5xQfCUtcMM52tynIoWcCzN%2BmKfRkMKB8a5r8cMF7zOQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:05.8490488","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A05Z&sr=b&sp=r&sig=usLgAT02IHF4Y3q4cBphH%2FiopIvAONyKPzubpXsL6RM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:05.848954","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A05Z&sr=b&sp=r&sig=TrJRvRbYn1ovsFw7p6LSMEK0sHN2qILeP3h5b0w%2Bg74%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:05.8490652","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:53:30.208Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:54:13.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A15Z&sr=b&sp=r&sig=1lDrDHCiv7T%2FbFbA9iAhYdi9u9ddGwANyNV6%2FO6Y4UQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:15.8747606","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A15Z&sr=b&sp=r&sig=b93KT0pBoCcE2i%2BalkjS%2BZpR1wvfuI3mFSOvQT6WXDs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:15.874678","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A15Z&sr=b&sp=r&sig=WkDGzJZwFl%2B5R04esCvVrCaqPpOQ1uVRCS64xIlicTk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:15.8747765","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3207'
+      - '3211'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:05 GMT
+      - Tue, 24 Oct 2023 12:32:15 GMT
       mise-correlation-id:
-      - 952ea9c2-b716-401d-9168-133c4f7b5071
+      - 9cd79991-d171-4d1d-a497-feb202571742
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,24 +1672,168 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A11Z&sr=b&sp=r&sig=EdxxFD4%2FOjWdHmSqf6AWPWxQQAhKxJv%2Fi%2BeAdlzJCsQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:11.1848962","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A11Z&sr=b&sp=r&sig=ejRjeAkU0KCRL%2BdJusgbnPjRAfEj5yHXsYrDvQmvq7c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:11.184784","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A11Z&sr=b&sp=r&sig=iMVKIcwQjVRYr%2B%2BdoC8NpXOwFITQQDNU2sj5B79Gp0g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:11.1849195","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-18T20:53:30.208Z","endDateTime":"2023-10-18T20:56:06.292Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:10.272Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A21Z&sr=b&sp=r&sig=jqbo9zwOcDQ4JltKl8wUera2pV35gO7eXxMlgsUoMKY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:21.1931854","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A21Z&sr=b&sp=r&sig=4bmKFArsHQwQSLFG3whjbINs2EgRxoyGPuHPQRsIYt0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:21.1931004","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A21Z&sr=b&sp=r&sig=zWUC0PnSuPq3rO4itScID10AOcogZrextC8Z%2FFYZUdQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:21.1932073","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3348'
+      - '3204'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:11 GMT
+      - Tue, 24 Oct 2023 12:32:21 GMT
       mise-correlation-id:
-      - 698ae27b-f8a3-4657-bba2-09439d9d7b2f
+      - 315bbb3d-571c-499b-996d-5df0edce94f0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A26Z&sr=b&sp=r&sig=x%2BcjWiTWt6j6o0yFMIG%2B3AXLdvqPm0ZXHEZrcwaN4nY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:26.4795647","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A26Z&sr=b&sp=r&sig=UCgey7fyIx74%2BPPJAsbA%2FLGdUiBbetDi1FF0cltThig%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:26.4794722","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A26Z&sr=b&sp=r&sig=4Di1%2BKR3T4KqI0acnBqHymsKgD5Hfk8E6Gih55uMt48%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:26.4795843","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3212'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:32:26 GMT
+      mise-correlation-id:
+      - f0909aad-bb63-4316-a215-21e4118ef790
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A31Z&sr=b&sp=r&sig=%2BrSxyDh68b%2B9RR9OI1ZYvBdXfRH4hqOttSDt%2Bov%2F1WM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:31.7574517","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A31Z&sr=b&sp=r&sig=yWZIZHkngZ59sRiaJAHGfgCsfR4p11HoeZANZnM4VGE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:31.7573804","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A31Z&sr=b&sp=r&sig=qA62KSj5zU1o1cJMtutCFw3035zLldE4BuB%2F5useIMU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:31.7574662","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3212'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:32:31 GMT
+      mise-correlation-id:
+      - 8fbee0ae-4c68-4af1-9028-f6ddcba30b4c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A37Z&sr=b&sp=r&sig=DaaVFbQK%2FM42MD7VbAD66f6P8mKqkfKreN0oBpO4kig%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:37.0195067","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A37Z&sr=b&sp=r&sig=TiEF9XFqrb62pgenEmul%2F8viVllONMDyvm9bJHgGOWs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:37.0194199","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A37Z&sr=b&sp=r&sig=%2F563ACqKn9yhgvwMio4FDWMScgmUTWN%2BHLkGY%2BXd1fE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:37.0195218","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3212'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:32:37 GMT
+      mise-correlation-id:
+      - 5626e2a3-c5d3-43a9-b2da-c7413e030c28
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A42Z&sr=b&sp=r&sig=mjAKYHAe56KI4Wh0e60tfkMu7Av%2BiuAVdcGaqoqW7lg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:42.2742666","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A42Z&sr=b&sp=r&sig=X7Myw7mV3qLFYtYM9q%2FfYVFLsotDc5f4qor8eB5ZWno%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:42.2741495","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A42Z&sr=b&sp=r&sig=xiL8fJyYvaLNfWm4VdKaj6uPPm5nHciOS37IlKeAvPQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:42.274281","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-24T12:29:56.407Z","endDateTime":"2023-10-24T12:32:38.524Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:38.631Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3340'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:32:42 GMT
+      mise-correlation-id:
+      - 3582b256-9491-45b9-9505-63d34a3b7221
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,7 +1856,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:52:29.3800691Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:52:29.3800691Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:56.8808228Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:56.8808228Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1829,9 +1865,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:11 GMT
+      - Tue, 24 Oct 2023 12:32:42 GMT
       etag:
-      - '"75009653-0000-0100-0000-6530458f0000"'
+      - '"d300dd3d-0000-0100-0000-6537b88a0000"'
       expires:
       - '-1'
       pragma:
@@ -1861,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=download-test-case&api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=download-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A13Z&sr=b&sp=r&sig=Qwm%2F%2BL%2Fded488AZXXuwXz8Fral32OpbUsZQQtkav8Jg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:13.3387928","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A13Z&sr=b&sp=r&sig=QWMjf7s2VqKes2ogaOb9tzowt4kHJRLrEXcEpTFcrE0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:13.3387199","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A13Z&sr=b&sp=r&sig=OVI090yWnOWBH0nJzNDjFoTfzYhwxDGXcvXpHzzX%2BjA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:13.3388075","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-18T20:53:30.208Z","endDateTime":"2023-10-18T20:56:06.292Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:11.591Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A43Z&sr=b&sp=r&sig=vD5h75dryJbwEujvMIeWJEdbRhkb7LmkGd77VFBt%2BWs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:43.846732","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A43Z&sr=b&sp=r&sig=mHTiKBafKQFA5ALyMePf6jbWapBJA5ZDPe660WI2a7w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:43.8466642","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A43Z&sr=b&sp=r&sig=NANZH8sn5wQMV0iM%2BPs3S2Ny2INuzsvwnop2m9k4S9o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:43.8467485","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-24T12:29:56.407Z","endDateTime":"2023-10-24T12:32:38.524Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:38.631Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3357'
+      - '3352'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:13 GMT
+      - Tue, 24 Oct 2023 12:32:43 GMT
       mise-correlation-id:
-      - 6e1fed3d-73fa-4b12-8747-be4850a64fcf
+      - 98a88529-5d92-4d5c-87ab-3de413e580d4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1901,7 +1937,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:52:29.3800691Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:52:29.3800691Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:56.8808228Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:56.8808228Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1910,9 +1946,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:13 GMT
+      - Tue, 24 Oct 2023 12:32:45 GMT
       etag:
-      - '"75009653-0000-0100-0000-6530458f0000"'
+      - '"d300dd3d-0000-0100-0000-6537b88a0000"'
       expires:
       - '-1'
       pragma:
@@ -1942,24 +1978,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A14Z&sr=b&sp=r&sig=LjA%2BbqA9weciNgHSarLWmkV3aFYhhwpR3ul3UJCYI3M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:14.9801245","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A14Z&sr=b&sp=r&sig=5oL6dTshM1N6G9zwvIPuGEX6L11yYGvz%2FF%2FPVSX1l6Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:14.9800221","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A14Z&sr=b&sp=r&sig=O2yp5RHuhm%2BFwfx5w2BiwfB8eFZ%2F1V2H4k6dmCZeUeY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:14.9801549","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-18T20:53:30.208Z","endDateTime":"2023-10-18T20:56:06.292Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:11.591Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A46Z&sr=b&sp=r&sig=q07G%2BVVkWmE995oL%2BHQSiJouWFTxPyoQ3xevwpOFyBg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:46.5000856","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A46Z&sr=b&sp=r&sig=xvpAQBnziNA%2BjHAmkY6hRWDWa9Lf0%2FkUXijd18h3l%2Fw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:46.5000152","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A46Z&sr=b&sp=r&sig=JexKD0TKKw%2Fp14bHVq7v%2Fk1ixBc9lvGk39vKaiehtHg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:46.5000999","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-24T12:29:56.407Z","endDateTime":"2023-10-24T12:32:38.524Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:38.631Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3347'
+      - '3351'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:14 GMT
+      - Tue, 24 Oct 2023 12:32:46 GMT
       mise-correlation-id:
-      - 7e8757a6-ba3a-4127-a59d-c6267c1a97f0
+      - 642e9673-927e-40a6-b040-39d7c729f6dc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1979,7 +2015,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A14Z&sr=b&sp=r&sig=LjA%2BbqA9weciNgHSarLWmkV3aFYhhwpR3ul3UJCYI3M%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A46Z&sr=b&sp=r&sig=q07G%2BVVkWmE995oL%2BHQSiJouWFTxPyoQ3xevwpOFyBg%3D
   response:
     body:
       string: "displayName: CLI-Test\ntestPlan: sample-JMX-file.jmx\ndescription:
@@ -1997,17 +2033,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 18 Oct 2023 20:56:16 GMT
+      - Tue, 24 Oct 2023 12:32:47 GMT
       etag:
-      - '"0x8DBD01C485A914D"'
+      - '"0x8DBD48CEE1A9262"'
       last-modified:
-      - Wed, 18 Oct 2023 20:53:29 GMT
+      - Tue, 24 Oct 2023 12:29:55 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 18 Oct 2023 20:53:29 GMT
+      - Tue, 24 Oct 2023 12:29:55 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2037,7 +2073,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A14Z&sr=b&sp=r&sig=5oL6dTshM1N6G9zwvIPuGEX6L11yYGvz%2FF%2FPVSX1l6Y%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A46Z&sr=b&sp=r&sig=xvpAQBnziNA%2BjHAmkY6hRWDWa9Lf0%2FkUXijd18h3l%2Fw%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -2110,17 +2146,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 18 Oct 2023 20:56:18 GMT
+      - Tue, 24 Oct 2023 12:32:48 GMT
       etag:
-      - '"0x8DBD01C3AE25937"'
+      - '"0x8DBD48CE082C78B"'
       last-modified:
-      - Wed, 18 Oct 2023 20:53:06 GMT
+      - Tue, 24 Oct 2023 12:29:33 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 18 Oct 2023 20:53:06 GMT
+      - Tue, 24 Oct 2023 12:29:33 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2150,18 +2186,18 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A14Z&sr=b&sp=r&sig=O2yp5RHuhm%2BFwfx5w2BiwfB8eFZ%2F1V2H4k6dmCZeUeY%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A46Z&sr=b&sp=r&sig=JexKD0TKKw%2Fp14bHVq7v%2Fk1ixBc9lvGk39vKaiehtHg%3D
   response:
     body:
       string: !!binary |
-        UEsDBC0AAAAIAK6mUlcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
+        UEsDBC0AAAAIALtjWFcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
         AAAAAAFZAab+ZGlzcGxheU5hbWU6IENMSS1UZXN0CnRlc3RQbGFuOiBzYW1wbGUtSk1YLWZpbGUu
         am14CmRlc2NyaXB0aW9uOiBUZXN0IGNyZWF0ZWQgZnJvbSBheiBsb2FkIHRlc3QgY29tbWFuZApl
         bmdpbmVJbnN0YW5jZXM6IDEKdGVzdElkOiBkb3dubG9hZC10ZXN0LWNhc2UKc3BsaXRBbGxDU1Zz
         OiBGYWxzZQpmYWlsdXJlQ3JpdGVyaWE6Ci0gYXZnKHJlcXVlc3RzX3Blcl9zZWMpID4gNzgKLSBw
         ZXJjZW50YWdlKGVycm9yKSA+IDUwCi0gR2V0Q3VzdG9tZXJEZXRhaWxzOiBhdmcobGF0ZW5jeSkg
         PiAyMDAKZW52OgotIG5hbWU6IHJwcwogIHZhbHVlOiAxCi0gbmFtZTogZHVyYXRpb25faW5fc2Vj
-        CiAgdmFsdWU6IDEKUEsDBC0AAAAIAK6mUlfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
+        CiAgdmFsdWU6IDEKUEsDBC0AAAAIALtjWFfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
         LmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAAQYT+ew8P3htbCB2ZXJzaW9uPSIxLjAiIGVuY29kaW5n
         PSJVVEYtOCI/Pg0KPGptZXRlclRlc3RQbGFuIHZlcnNpb249IjEuMiIgcHJvcGVydGllcz0iNS4w
         IiBqbWV0ZXI9IjUuNSI+DQogIDxoYXNoVHJlZT4NCiAgICA8VGVzdFBsYW4gZ3VpY2xhc3M9IlRl
@@ -2248,8 +2284,8 @@ interactions:
         ZT0iSFRUUFNhbXBsZXIucmVzcG9uc2VfdGltZW91dCI+PC9zdHJpbmdQcm9wPg0KICAgICAgICA8
         L0hUVFBTYW1wbGVyUHJveHk+DQogICAgICAgIDxoYXNoVHJlZS8+DQogICAgICA8L2hhc2hUcmVl
         Pg0KICAgIDwvaGFzaFRyZWU+DQogIDwvaGFzaFRyZWU+DQo8L2ptZXRlclRlc3RQbGFuPg0KUEsB
-        AjMALQAAAAgArqZSVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
-        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACACuplJX8Zv7b///////////EwAUAAAAAAAAAAAA
+        AjMALQAAAAgAu2NYVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
+        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACAC7Y1hX8Zv7b///////////EwAUAAAAAAAAAAAA
         AACbAQAAc2FtcGxlLUpNWC1maWxlLmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAUEsFBgAAAAACAAIA
         ogAAAOsUAAAAAA==
     headers:
@@ -2258,21 +2294,21 @@ interactions:
       content-length:
       - '5539'
       content-md5:
-      - uOXBML9owCbiX1Y2jy0JPQ==
+      - QVvWLUBmRF+bvS5b8w+nrQ==
       content-type:
       - application/octet-stream
       date:
-      - Wed, 18 Oct 2023 20:56:19 GMT
+      - Tue, 24 Oct 2023 12:32:48 GMT
       etag:
-      - '"0x8DBD01C48647AEF"'
+      - '"0x8DBD48CEE234396"'
       last-modified:
-      - Wed, 18 Oct 2023 20:53:29 GMT
+      - Tue, 24 Oct 2023 12:29:55 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 18 Oct 2023 20:53:29 GMT
+      - Tue, 24 Oct 2023 12:29:55 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2305,7 +2341,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:52:29.3800691Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:52:29.3800691Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:56.8808228Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:56.8808228Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2314,9 +2350,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:20 GMT
+      - Tue, 24 Oct 2023 12:32:50 GMT
       etag:
-      - '"75009653-0000-0100-0000-6530458f0000"'
+      - '"d300dd3d-0000-0100-0000-6537b88a0000"'
       expires:
       - '-1'
       pragma:
@@ -2346,24 +2382,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://102aa3fb-e29f-4038-984d-ca93cc6ee8f6.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aa5fcf33-02b9-4af1-a96b-aa0eefd20b68":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4dfa8516-8306-461b-ab3e-d2c6d2279374":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57356505-50a7-4bab-b5a2-d49f09179356":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=hL5CHxBODR%2B%2Fha4srFaE62px%2FFem0bD66Ej9zoj2uI8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:22.1023439","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=yy7I%2F3x9s71wM6DVnhcx8dBhj%2BiZpLfy4Pof5i6%2BVOo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:22.1022648","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=nqx6ouihXuUVslUsTJ3E9uTObdC0%2FqSJ0T6Mz%2B8qeH8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:22.1023595","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/dcaeb21f-830b-4d83-bfd4-0900c817c0f9_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=%2FkEYPrutkXaA2mgGsTgGUO%2BIEnILoAQW9XFhlTUPYqY%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:22.1023737","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/dcaeb21f-830b-4d83-bfd4-0900c817c0f9_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=tAZsA95JZ9Wl8u5wafrp4u481xG8IfvJdBA08GsvlyM%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:22.1023881","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-18T20:53:30.208Z","endDateTime":"2023-10-18T20:56:06.292Z","executedDateTime":"2023-10-18T20:53:29.423Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-18T20:53:29.686Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:18.48Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A51Z&sr=b&sp=r&sig=Og5MgrV5rM%2FNC6Lsn3aSKlW38xicFHcLbE5J76zvO%2BA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:51.8233616","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A51Z&sr=b&sp=r&sig=X6j2y%2BduY9shp6e19IvCsVdzCwxQH%2BO3J3MWvoMVlqc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:51.8232766","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A51Z&sr=b&sp=r&sig=hX4GQ25yDzroicwLFAo79ZECZeAv0HhXMv1gohTqRbQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:51.8233774","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-24T12:29:56.407Z","endDateTime":"2023-10-24T12:32:38.524Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:38.631Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4515'
+      - '3345'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:22 GMT
+      - Tue, 24 Oct 2023 12:32:51 GMT
       mise-correlation-id:
-      - a706db1c-d17e-48e4-8354-401e38c76861
+      - 33910c52-80d2-4636-bd94-ddc5a0a31b19
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2383,7 +2419,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/1b9892f1-362a-4d2c-ba92-82e6a5d66441?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=hL5CHxBODR%2B%2Fha4srFaE62px%2FFem0bD66Ej9zoj2uI8%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A51Z&sr=b&sp=r&sig=Og5MgrV5rM%2FNC6Lsn3aSKlW38xicFHcLbE5J76zvO%2BA%3D
   response:
     body:
       string: "displayName: CLI-Test\ntestPlan: sample-JMX-file.jmx\ndescription:
@@ -2401,17 +2437,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 18 Oct 2023 20:56:22 GMT
+      - Tue, 24 Oct 2023 12:32:52 GMT
       etag:
-      - '"0x8DBD01C485A914D"'
+      - '"0x8DBD48CEE1A9262"'
       last-modified:
-      - Wed, 18 Oct 2023 20:53:29 GMT
+      - Tue, 24 Oct 2023 12:29:55 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 18 Oct 2023 20:53:29 GMT
+      - Tue, 24 Oct 2023 12:29:55 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2441,7 +2477,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/3f65ca19-31a2-4f1d-90ba-0bb0a1791d38?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=yy7I%2F3x9s71wM6DVnhcx8dBhj%2BiZpLfy4Pof5i6%2BVOo%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A51Z&sr=b&sp=r&sig=X6j2y%2BduY9shp6e19IvCsVdzCwxQH%2BO3J3MWvoMVlqc%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -2514,17 +2550,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 18 Oct 2023 20:56:24 GMT
+      - Tue, 24 Oct 2023 12:32:53 GMT
       etag:
-      - '"0x8DBD01C3AE25937"'
+      - '"0x8DBD48CE082C78B"'
       last-modified:
-      - Wed, 18 Oct 2023 20:53:06 GMT
+      - Tue, 24 Oct 2023 12:29:33 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 18 Oct 2023 20:53:06 GMT
+      - Tue, 24 Oct 2023 12:29:33 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2554,18 +2590,18 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/a10ebd9a-fa73-4788-a887-9aa2ac1ecf0e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=nqx6ouihXuUVslUsTJ3E9uTObdC0%2FqSJ0T6Mz%2B8qeH8%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A51Z&sr=b&sp=r&sig=hX4GQ25yDzroicwLFAo79ZECZeAv0HhXMv1gohTqRbQ%3D
   response:
     body:
       string: !!binary |
-        UEsDBC0AAAAIAK6mUlcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
+        UEsDBC0AAAAIALtjWFcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
         AAAAAAFZAab+ZGlzcGxheU5hbWU6IENMSS1UZXN0CnRlc3RQbGFuOiBzYW1wbGUtSk1YLWZpbGUu
         am14CmRlc2NyaXB0aW9uOiBUZXN0IGNyZWF0ZWQgZnJvbSBheiBsb2FkIHRlc3QgY29tbWFuZApl
         bmdpbmVJbnN0YW5jZXM6IDEKdGVzdElkOiBkb3dubG9hZC10ZXN0LWNhc2UKc3BsaXRBbGxDU1Zz
         OiBGYWxzZQpmYWlsdXJlQ3JpdGVyaWE6Ci0gYXZnKHJlcXVlc3RzX3Blcl9zZWMpID4gNzgKLSBw
         ZXJjZW50YWdlKGVycm9yKSA+IDUwCi0gR2V0Q3VzdG9tZXJEZXRhaWxzOiBhdmcobGF0ZW5jeSkg
         PiAyMDAKZW52OgotIG5hbWU6IHJwcwogIHZhbHVlOiAxCi0gbmFtZTogZHVyYXRpb25faW5fc2Vj
-        CiAgdmFsdWU6IDEKUEsDBC0AAAAIAK6mUlfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
+        CiAgdmFsdWU6IDEKUEsDBC0AAAAIALtjWFfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
         LmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAAQYT+ew8P3htbCB2ZXJzaW9uPSIxLjAiIGVuY29kaW5n
         PSJVVEYtOCI/Pg0KPGptZXRlclRlc3RQbGFuIHZlcnNpb249IjEuMiIgcHJvcGVydGllcz0iNS4w
         IiBqbWV0ZXI9IjUuNSI+DQogIDxoYXNoVHJlZT4NCiAgICA8VGVzdFBsYW4gZ3VpY2xhc3M9IlRl
@@ -2652,8 +2688,8 @@ interactions:
         ZT0iSFRUUFNhbXBsZXIucmVzcG9uc2VfdGltZW91dCI+PC9zdHJpbmdQcm9wPg0KICAgICAgICA8
         L0hUVFBTYW1wbGVyUHJveHk+DQogICAgICAgIDxoYXNoVHJlZS8+DQogICAgICA8L2hhc2hUcmVl
         Pg0KICAgIDwvaGFzaFRyZWU+DQogIDwvaGFzaFRyZWU+DQo8L2ptZXRlclRlc3RQbGFuPg0KUEsB
-        AjMALQAAAAgArqZSVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
-        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACACuplJX8Zv7b///////////EwAUAAAAAAAAAAAA
+        AjMALQAAAAgAu2NYVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
+        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACAC7Y1hX8Zv7b///////////EwAUAAAAAAAAAAAA
         AACbAQAAc2FtcGxlLUpNWC1maWxlLmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAUEsFBgAAAAACAAIA
         ogAAAOsUAAAAAA==
     headers:
@@ -2662,21 +2698,21 @@ interactions:
       content-length:
       - '5539'
       content-md5:
-      - uOXBML9owCbiX1Y2jy0JPQ==
+      - QVvWLUBmRF+bvS5b8w+nrQ==
       content-type:
       - application/octet-stream
       date:
-      - Wed, 18 Oct 2023 20:56:24 GMT
+      - Tue, 24 Oct 2023 12:32:54 GMT
       etag:
-      - '"0x8DBD01C48647AEF"'
+      - '"0x8DBD48CEE234396"'
       last-modified:
-      - Wed, 18 Oct 2023 20:53:29 GMT
+      - Tue, 24 Oct 2023 12:29:55 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 18 Oct 2023 20:53:29 GMT
+      - Tue, 24 Oct 2023 12:29:55 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2687,118 +2723,6 @@ interactions:
       - ADDITIONAL_ARTIFACTS
       x-ms-meta-isencoded:
       - 'true'
-      x-ms-server-encrypted:
-      - 'true'
-      x-ms-version:
-      - '2021-10-04'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.31.0
-    method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/dcaeb21f-830b-4d83-bfd4-0900c817c0f9_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=tAZsA95JZ9Wl8u5wafrp4u481xG8IfvJdBA08GsvlyM%3D
-  response:
-    body:
-      string: !!binary |
-        UEsDBBQAAAAIAAanUlchSIaSUwEAAHADAAASABwAZW5naW5lMV93b3JrZXIubG9nVVQJAANsRjBl
-        bEYwZXV4CwABBAAAAAAEAAAAAKWS32uDMBDH3/dX3MtgG9XFn1FhD0JT2NAOqqzPYlOXoqYkqdv+
-        +0Xr6EMtlO4I4bjk+7nj7mxkO4aFDCsAG0WeG1nuLHQDWMerJXCzMHfmW0oVFREkvEpoR+sIXpeL
-        9zv7TOnPHGwflaVWllq703caJ3nCpKJtT8lJlkOWx6uczIF8kGUOBghaUtbRzSTUR+40dMFquhZM
-        F3fCr0YSkI62ChSVKlOFUJfYljfNjg+KS8X3J3IfhWIMD2CQRzJ8MfUJVAguQBSKQohgq30fSXMy
-        Kw7Cq9pElvPrmoRnyMU3IA/7mhcb1lawa/ohmzWvYKvbOp3DvyVHyZt9TacHoJnY+tdwSbu5SPaG
-        RR23WJjZoWkKwWRPkoP/Ay8wGALWAkLRcHTwabBnCXFXReOPlLURhLbt6CVHjh94LsZegDCkxXcE
-        xvlLAESIP/UDMhG6f7z7BVBLAQIeAxQAAAAIAAanUlchSIaSUwEAAHADAAASABgAAAAAAAEAAACk
-        gQAAAABlbmdpbmUxX3dvcmtlci5sb2dVVAUAA2xGMGV1eAsAAQQAAAAABAAAAABQSwUGAAAAAAEA
-        AQBYAAAAnwEAAAAA
-    headers:
-      accept-ranges:
-      - bytes
-      content-length:
-      - '525'
-      content-md5:
-      - 1F5xWLsaLDr80D6Uc4gYIw==
-      content-type:
-      - application/octet-stream
-      date:
-      - Wed, 18 Oct 2023 20:56:26 GMT
-      etag:
-      - '"0x8DBD01CA98019F8"'
-      last-modified:
-      - Wed, 18 Oct 2023 20:56:12 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-blob-type:
-      - BlockBlob
-      x-ms-creation-time:
-      - Wed, 18 Oct 2023 20:56:12 GMT
-      x-ms-lease-state:
-      - available
-      x-ms-lease-status:
-      - unlocked
-      x-ms-server-encrypted:
-      - 'true'
-      x-ms-version:
-      - '2021-10-04'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.31.0
-    method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/baa587a0-cb9e-4b4a-b7b4-91571e2a05d8/dcaeb21f-830b-4d83-bfd4-0900c817c0f9_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A22Z&sr=b&sp=r&sig=%2FkEYPrutkXaA2mgGsTgGUO%2BIEnILoAQW9XFhlTUPYqY%3D
-  response:
-    body:
-      string: !!binary |
-        UEsDBBQAAAAIAAanUlc8lqSAdQAAAKMAAAATABwAZW5naW5lMV9yZXN1bHRzLmNzdlVUCQADbEYw
-        ZWxGMGV1eAsAAQQAAAAABAAAAAA9jjsOwkAQQ3vO4lOQCilQwHKAya4JkWY/2pkUuT1RJNI9y8+S
-        fcl8ueQGqjRjgspERae1WoxDTTzDnWYyE/7tlPSQTCRxCVsjbI1xr/GRRdd+qtPmNBiLXw+aewvH
-        2iCqf3w/R4ziLHHDLSnD/gpDLYXRLz9QSwECHgMUAAAACAAGp1JXPJakgHUAAACjAAAAEwAYAAAA
-        AAABAAAApIEAAAAAZW5naW5lMV9yZXN1bHRzLmNzdlVUBQADbEYwZXV4CwABBAAAAAAEAAAAAFBL
-        BQYAAAAAAQABAFkAAADCAAAAAAA=
-    headers:
-      accept-ranges:
-      - bytes
-      content-length:
-      - '305'
-      content-md5:
-      - YqqqI4Nj7HjfdP5gbMh22g==
-      content-type:
-      - application/octet-stream
-      date:
-      - Wed, 18 Oct 2023 20:56:27 GMT
-      etag:
-      - '"0x8DBD01CA98A9FCB"'
-      last-modified:
-      - Wed, 18 Oct 2023 20:56:12 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-blob-type:
-      - BlockBlob
-      x-ms-creation-time:
-      - Wed, 18 Oct 2023 20:56:12 GMT
-      x-ms-lease-state:
-      - available
-      x-ms-lease-status:
-      - unlocked
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_download_files.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_download_files.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:59.6197453Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:59.6197453Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:42.8269258Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:42.8269258Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:34 GMT
+      - Mon, 30 Oct 2023 07:22:17 GMT
       etag:
-      - '"3c00f229-0000-0100-0000-653edb0a0000"'
+      - '"3f009e6b-0000-0100-0000-653f598a0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:22:35 GMT
+      - Mon, 30 Oct 2023 07:22:19 GMT
       mise-correlation-id:
-      - 1861d41f-d150-4b6b-b46e-e460acd32c06
+      - cfe502b2-4586-4fe5-86b8-4a102875e05a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"b67ab143-afca-44bc-8ce9-7f41fe096879": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "244b313f-8b61-46a1-9311-e0205d00f16c":
+      {"passFailMetrics": {"a21b0c0b-b7d4-4648-b179-e15c9e729b08": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "0c60c49a-c22d-4b3f-9859-2c715b21d3ea":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "229243ef-e4e3-4ff0-8822-c9755465e287": {"aggregate": "avg", "clientMetric":
+      "50"}, "e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,26 +106,26 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:22:36.46Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:36.46Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:22:20.182Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:20.182Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1008'
+      - '1010'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:36 GMT
+      - Mon, 30 Oct 2023 07:22:20 GMT
       location:
-      - https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+      - https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - b4e8bebe-7620-4f63-ad1e-50159e8618bb
+      - bdf5cf22-9513-42bd-931a-c155596de06f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:36 GMT
+      - Mon, 30 Oct 2023 07:22:20 GMT
       mise-correlation-id:
-      - 06e069e7-dd45-4c9c-8cf1-be19a70d508f
+      - c5f69f7f-2469-4827-b30d-fe5d48db3029
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,10 +275,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A37Z&sr=b&sp=r&sig=tk%2Fs4o6u8nMl7DXK%2BVl921klDzgRPhIJp4wWgqEWRsE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:37.3113696","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A32%3A22Z&sr=b&sp=r&sig=Kodu4G%2B2YkUtc1shpdLiNG7%2Fu3b7pnSvSyBqHKUl4sI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:32:22.6437714","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -289,11 +289,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:37 GMT
+      - Mon, 30 Oct 2023 07:22:22 GMT
       location:
-      - https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 3da9c7f6-f900-4f11-9b1a-95b77c08a39a
+      - 313a6cc5-5931-43b7-85c4-ae732ea4143e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A37Z&sr=b&sp=r&sig=e3Ys2SJNI4LgqAkfvKx4Z1%2BXBwYe5sINFQ%2FIkj8wqVg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:37.6524629","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A32%3A22Z&sr=b&sp=r&sig=o1fafE9yxMdshMhsF7tloDSuELDjb1dVidlFdYObX70%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:32:22.9344251","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:22:22 GMT
+      mise-correlation-id:
+      - e3bc1e86-769c-4ab0-b37e-b6903564cb53
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A32%3A28Z&sr=b&sp=r&sig=NM4t1hs3EBynAdAtBZgON4gTal4V1GsX%2BByi%2FZ7jKNk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:32:28.1971296","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:37 GMT
+      - Mon, 30 Oct 2023 07:22:28 GMT
       mise-correlation-id:
-      - 14287a34-4f7e-4644-baf2-f57b4558236e
+      - 5e6868d4-2c32-4a0f-aa40-93f49b4ac6ce
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A42Z&sr=b&sp=r&sig=l61lMOOtp%2FRCO%2F88GMifpyvXgG1DiHZBEpwhzFRklbw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:42.9612144","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A32%3A33Z&sr=b&sp=r&sig=q%2FF%2FeUt%2FDquO5P4MykG31LgOnKF2PTKtFOCbYOx3s5E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:32:33.4623556","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:42 GMT
+      - Mon, 30 Oct 2023 07:22:33 GMT
       mise-correlation-id:
-      - 84f3d997-78ce-4488-9b1d-20c028ec7474
+      - b7cb40f0-f542-4830-a04b-09651a04365f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A48Z&sr=b&sp=r&sig=fvOOs36uyQ%2F%2B25LYeTzRNlYJ8cukGT6KgwtErIfk9wg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:48.5610588","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A32%3A38Z&sr=b&sp=r&sig=c2mV0ASmDKZ4v0WMeWwtihTXBaExc0Qd5EeC3sK%2Bnmw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:32:38.79925","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:48 GMT
+      - Mon, 30 Oct 2023 07:22:38 GMT
       mise-correlation-id:
-      - 7264cb39-bfe6-47a8-a0af-a7e0a35584dd
+      - 96448fec-81cd-4839-8cb4-e332ed9760d2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +457,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A54Z&sr=b&sp=r&sig=AZvXSOcWMOMDQd8L6u3KBxqAWJaROUYw0hH9uhsDvrQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:54.0465242","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A32%3A44Z&sr=b&sp=r&sig=KpZ74dD6FMPr9CdinKJ%2BlDb6BayAWsRTPYE613HQ9do%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:32:44.1122247","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:54 GMT
+      - Mon, 30 Oct 2023 07:22:44 GMT
       mise-correlation-id:
-      - 75a2fcd7-f0f8-4839-a65d-adc6e7608873
+      - 5fb6d56c-b776-479b-92ab-e0e242d393e1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +493,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A54Z&sr=b&sp=r&sig=9GyeQmyswlKxH1x4p1xZ2MfDCaYtbejOsIt5yGytmd0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:54.2902352","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:22:36.46Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:49.36Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A44Z&sr=b&sp=r&sig=OA3TUJOJZEGOqJQ28fKIDm20wkY%2FCF7KeAj86lbAxjc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:44.4405363","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:22:20.182Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:39.525Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1577'
+      - '1581'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:54 GMT
+      - Mon, 30 Oct 2023 07:22:44 GMT
       mise-correlation-id:
-      - 03c463d3-955d-4616-9d1b-359cf1148058
+      - cf987207-9f3e-4966-9f79-62db954160cb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +533,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:59.6197453Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:59.6197453Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:42.8269258Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:42.8269258Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +542,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:55 GMT
+      - Mon, 30 Oct 2023 07:22:45 GMT
       etag:
-      - '"3c00f229-0000-0100-0000-653edb0a0000"'
+      - '"3f009e6b-0000-0100-0000-653f598a0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +574,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A57Z&sr=b&sp=r&sig=4bHE3OOzoIxbMp3dqKf7W4XTffC64sH9ZFZVAnJ3iC0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:57.0021623","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:22:36.46Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:49.36Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A46Z&sr=b&sp=r&sig=OC2Lx2RdRD7vxIsOXKWaV0ACd4l4XfGssTDuATWk3Qo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:46.9952785","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:22:20.182Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:39.525Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1589'
+      - '1591'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:57 GMT
+      - Mon, 30 Oct 2023 07:22:47 GMT
       mise-correlation-id:
-      - ecbead00-f99b-46f4-b6f7-066d8c998f6e
+      - eeba8e8f-5ce9-4a1b-b747-beed14806436
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +614,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:59.6197453Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:59.6197453Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:42.8269258Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:42.8269258Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +623,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:22:57 GMT
+      - Mon, 30 Oct 2023 07:22:48 GMT
       etag:
-      - '"3c00f229-0000-0100-0000-653edb0a0000"'
+      - '"3f009e6b-0000-0100-0000-653f598a0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +655,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +668,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:22:59 GMT
+      - Mon, 30 Oct 2023 07:22:49 GMT
       mise-correlation-id:
-      - 46631057-5994-4e9e-bf6b-5a91a6732de1
+      - 7c0ec32e-5696-401c-af5e-7e1291d714cd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +698,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A00Z&sr=b&sp=r&sig=s9xCzX4l81BXJHW4azKrb69yhI%2BQRDsaVF%2Fpd3%2BybKA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:00.8804821","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A00Z&sr=b&sp=r&sig=epWmQrIz4c%2B%2FQAKsCPSM%2BCheumkLdoqczR%2BnnCPmXWg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:00.8803821","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A00Z&sr=b&sp=r&sig=SIhoxqrN0Il5RIl6E9nnRnzftXI6QShP05YFvFFyIbI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:00.8804982","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:00.789Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A50Z&sr=b&sp=r&sig=LJ9O7yV9Nj4UcR74k32%2FFUCmihrmOqCHTldqobdZpYc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:50.577097","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A50Z&sr=b&sp=r&sig=3LwIJQg%2BR3DfExReTJr5RNZ92uDbeTWPpOf718wV0hQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:50.5768441","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A50Z&sr=b&sp=r&sig=KF2tOJM4fBXQmQXQe%2B%2Fwj473gVLp%2BE66HfBKmPdi9Ek%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:50.5771283","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"ACCEPTED","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:50.481Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3172'
+      - '3166'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:01 GMT
+      - Mon, 30 Oct 2023 07:22:50 GMT
       location:
-      - https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+      - https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - f3e8aed2-271f-4788-a148-665157bb9587
+      - 2553e92c-4b00-41bb-9f0f-58e90b698ce4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,46 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A01Z&sr=b&sp=r&sig=QB0BiZJl3kgqI7pyCGsmEvLT3HZ%2BgeFTnKn3hV49xfI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:01.3997324","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A01Z&sr=b&sp=r&sig=Mrw0hGpaeKqC%2Fw8qtuVTN4pOhUvbJjh3%2B2zmbXv7L5Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:01.3996373","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A01Z&sr=b&sp=r&sig=cPKrD5ulBXyLwufxv3LjVJ8p2KDNqBdhgcfc40Umefg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:01.399753","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:00.789Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3163'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:01 GMT
-      mise-correlation-id:
-      - 0c956524-5b47-4f4a-b468-54be9fff4508
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A06Z&sr=b&sp=r&sig=weXYPMA6wdVP3h5LCxONFlv%2Bc6mynd9272Eozzncw9w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:06.7325962","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A06Z&sr=b&sp=r&sig=mmc7TA9Lk%2BvfJ6wSl5jHAdUwKspdkUuGfSmo9HD3BF8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:06.7324902","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A06Z&sr=b&sp=r&sig=S%2B4tGgOe9531Y7QIz52Ic%2FcPLBRjqXUte2UnRk96rs0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:06.7326203","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:01.571Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A51Z&sr=b&sp=r&sig=9j2%2FOVEQp1VdFHZlspElOzZXzwGtaK1cZULoQkCtRPs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:51.0450577","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A51Z&sr=b&sp=r&sig=waCKykcEpEjwffdNAM%2F1ckLc2stdEkiay6yw272ZXiE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:51.0449564","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A51Z&sr=b&sp=r&sig=OzIDG%2B37%2BuD%2B1579stRZIfN4%2BGVqMIBTXcf2ir4MnlU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:51.045079","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"NOTSTARTED","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:50.914Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -750,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:06 GMT
+      - Mon, 30 Oct 2023 07:22:51 GMT
       mise-correlation-id:
-      - 531db4d6-b6ba-43cf-98bc-bfefe5351ee9
+      - ed88ab56-3f46-4324-8aa0-b4580fb6b3ca
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A12Z&sr=b&sp=r&sig=BXq5bHXF1dwlOGeVyR9E%2FUJxq%2BBgvGHreLbnbBEmnpg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:12.0490957","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A12Z&sr=b&sp=r&sig=Mp0m4qtROo7s18iTdL%2BkeKEoYrckPizQbEQj48aUGOE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:12.0490264","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A12Z&sr=b&sp=r&sig=r11LUetBVKrEqRjvMkyerf30KZx%2F1QJEIK90AjWkYho%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:12.0491096","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:01.571Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A56Z&sr=b&sp=r&sig=MYRZlLlWfImGGjQlO8MGk5f6rmyp4vqEeMLpB0Hd6i8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:56.3301444","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A56Z&sr=b&sp=r&sig=smKwY9EFeRjuvWjmgRqoWGpUIBeavvxg698DvoaZZYs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:22:56.3300236","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A22%3A56Z&sr=b&sp=r&sig=IQxEREqSyzd6LSj8qvaNF%2BN8tARB3r2y0tCb6KBe8bs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:22:56.3301688","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.177Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3213'
+      - '3206'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:12 GMT
+      - Mon, 30 Oct 2023 07:22:56 GMT
       mise-correlation-id:
-      - 91669978-9ef0-4e68-8800-5c61cfb329cc
+      - 9310978f-bdea-4856-84f7-7b88a408379c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A17Z&sr=b&sp=r&sig=e0KGc1D0Kw3%2BohBtgs9BEnHPhA%2BoaS03ypNO9fDCiYM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:17.3305051","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A17Z&sr=b&sp=r&sig=%2FUxRqa90bVjA1xx596dObN4TuF%2Bc72R7%2F5AW4bQ6OHs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:17.330413","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A17Z&sr=b&sp=r&sig=fd%2BU46BSHw3u%2FLb95h6APEtNImpQTgzmk2DzS%2BePOUY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:17.3305281","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:01.571Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A01Z&sr=b&sp=r&sig=quoeuL4vlnb8OZrqqhvXJp3TOQ4cMx%2BUmwIGFd0sVzI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:01.6510147","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A01Z&sr=b&sp=r&sig=7PZqviWWMoiU25GuCfvb0QvU75cxcu2gIAVWXej5Ckw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:01.6509406","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A01Z&sr=b&sp=r&sig=vURYXuV8C9UW2xL8nBYVeAgNuvilQsqaOHtbo2JBPv8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:01.651029","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.177Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3220'
+      - '3205'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:17 GMT
+      - Mon, 30 Oct 2023 07:23:01 GMT
       mise-correlation-id:
-      - 6ee6012d-a51f-42fb-ac0e-2dd5febc811c
+      - 5ef85486-4807-4c33-89ce-2ef95261b0f5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,190 +844,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A22Z&sr=b&sp=r&sig=BHzotRBj13nzYE1qEXQ1sNq%2B0VBjzaCdLQ%2FoyT7SzCY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:22.6014858","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A22Z&sr=b&sp=r&sig=%2BZDiyQ%2BeC7rgsOILKFsK1rjqfFlrRvvMipjafKe1bHQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:22.6014189","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A22Z&sr=b&sp=r&sig=lsJFm55jV1mdtXNc%2FP3K7kOHbojQzDqCRAY1nJhmGaw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:22.6015002","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:01.571Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3215'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:22 GMT
-      mise-correlation-id:
-      - ea0336ea-768e-4842-aa79-0ebd33c9cbd7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A27Z&sr=b&sp=r&sig=F0pM4XsFj%2BkAJE8YY%2BQk0vXB1%2BS4qeoGgo48D0CqpNo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:27.8924487","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A27Z&sr=b&sp=r&sig=dH7F3Ca%2FlIKG0BtWBPZUXSZIBRHwNQdwTjahtPRpruM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:27.8923741","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A27Z&sr=b&sp=r&sig=u0hi5E1Rfm6dHVa%2FQpagL8VDdt3SS%2BuNk%2F0XyszXdyM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:27.8924641","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:01.571Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3219'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:27 GMT
-      mise-correlation-id:
-      - 5d95279f-2f9f-4f93-af0b-400296d28306
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A33Z&sr=b&sp=r&sig=zGlLCCyinm9TUZMg4i9HD%2FgHBNjWSgXPZREc3D1dyfc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:33.1469654","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A33Z&sr=b&sp=r&sig=MtaNfC207mCP0NKw7ZimsfJ8mMJSAuRcSKd8VP9jhT8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:33.1468945","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A33Z&sr=b&sp=r&sig=E9Wg0SCe3kSx6s5z%2BzWQbtNv9Bwqr0%2Fx4wPCSV95AWE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:33.1469788","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:01.571Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3211'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:33 GMT
-      mise-correlation-id:
-      - 7c8e9dfc-dc14-49ff-80d1-8cdfbdde6f41
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A38Z&sr=b&sp=r&sig=c0B05J%2B7TLJMb5x4o0WAJW19FTVbup4%2FU5ahvFFdRqg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:38.3966503","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A38Z&sr=b&sp=r&sig=KSUjy%2F0SAD68YwetNLkby7F66FTwhJiXRQ%2BsjFQJO%2FU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:38.3965641","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A38Z&sr=b&sp=r&sig=gC241JEqkc%2F7XfEY7mS5nnNbMhe5soyuki2bxgrMTdY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:38.3966775","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:01.571Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3217'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:38 GMT
-      mise-correlation-id:
-      - 639bd821-4ea8-466e-aa8e-7b61b8b76c08
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A43Z&sr=b&sp=r&sig=d1KSeB0tjoZFUQmjKpLiLX8HYNrzoNvwhznVoQlfujo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:43.6584117","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A43Z&sr=b&sp=r&sig=F7YNq2yVV2NP6adxxYsTjqRdg9hninhYEnjUEvjf9Io%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:43.6583383","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A43Z&sr=b&sp=r&sig=I2IvI%2FZvRdy2Wm9%2B9UnlLpxgoILLc9pMkke2mvz9KBc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:43.6584255","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:01.571Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3209'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:23:43 GMT
-      mise-correlation-id:
-      - f20299ff-c7b6-460b-9306-c080400a2826
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A48Z&sr=b&sp=r&sig=WEUgnWCpEaWQB5ZT7OkCnJkB%2Bgnn%2Fxv%2BpLaxd8W7YCA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:48.9096776","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A48Z&sr=b&sp=r&sig=olMTHvMiKCJNmJX72NjIG4%2BYvxdwlsmw2rEmmiBiMkw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:48.9096106","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A48Z&sr=b&sp=r&sig=VkiohbmID6XJjYqpP%2BKvEKx9erz%2BDiDGNSuIJ7QICew%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:48.9096912","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"CONFIGURING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:47.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A06Z&sr=b&sp=r&sig=BDRH%2FE6Vvf4F0niAyikVn0suBLVmp6T8l4AUFSWTgjE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:06.9601896","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A06Z&sr=b&sp=r&sig=qCzPHwJdQITsneoEcLOqP%2B0K4xdr1y%2Fg646WvOLiY1U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:06.9601085","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A06Z&sr=b&sp=r&sig=0OHd%2BQ5BNOb3PLf7wyXwlAR%2F7t1%2FWtUq7CqzpcrWxpY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:06.9602066","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.177Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1038,9 +858,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:48 GMT
+      - Mon, 30 Oct 2023 07:23:06 GMT
       mise-correlation-id:
-      - 22e3b457-8b2c-4f99-a770-16419c32d555
+      - 8518e0f8-bdf8-4310-a146-0fcc37b5b555
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,23 +880,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A55Z&sr=b&sp=r&sig=1k2wWMd%2F4D%2Bjfnfz9JoDvroETbnzV0wCibjqr0pn0A4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:55.2695812","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A55Z&sr=b&sp=r&sig=NiqnDiT%2FbnVRnWfCq1vCj%2B4DDbf4Xevybgr2K9REams%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:55.2695029","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A55Z&sr=b&sp=r&sig=IZdzzK2p2txTj6%2F0ufDda8qaW%2BlCsf0dEqEtI3FZYhY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:55.2695968","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A12Z&sr=b&sp=r&sig=5yROf9GKsEk3FSaHaEzyZh2LrELiV%2BadQXVP%2FdVmADw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:12.2303036","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A12Z&sr=b&sp=r&sig=h102o3Qs3SXjIvSEar%2FsPBZHV3b6DbTlb5G5drrojZA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:12.2302151","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A12Z&sr=b&sp=r&sig=ebK0ZlLaGFvZuCzJhIyy0TZuLGZRHRYvNUY1eTORUBs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:12.2303246","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.177Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3214'
+      - '3210'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:23:55 GMT
+      - Mon, 30 Oct 2023 07:23:12 GMT
       mise-correlation-id:
-      - acea92c3-47cf-4c44-96e9-0f358aa15ac4
+      - 577a9393-739c-42c3-ac00-46ad00594511
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1096,23 +916,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A00Z&sr=b&sp=r&sig=mrUbWfqsfD2zDkFrdiwcCuoiTTJACqQyvy4rhXiJxpU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:00.5211905","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A00Z&sr=b&sp=r&sig=pFshFWLf5jupbZ2Dh5mUnQnyMydz3O57hvkTHzmZCGY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:00.5211185","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A00Z&sr=b&sp=r&sig=%2BqqlF3P9SPHTgqblx9cA3EJyS%2FyWzxNqI71WkzvaKVo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:00.5212042","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A17Z&sr=b&sp=r&sig=P36dG8FYmdiGVllvzlifBcy78W7n63W3eZ1TmUqVdZk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:17.5128505","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A17Z&sr=b&sp=r&sig=1bVC9TN7tpWD5R6f6r4qveKyHThgiQmdlniNgY6htcU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:17.5127636","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A17Z&sr=b&sp=r&sig=Cesmvq8mEn3DS%2Bv4bubNwtsfH6Sx9WpQdDkeRsbyOc0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:17.512874","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.177Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3206'
+      - '3205'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:00 GMT
+      - Mon, 30 Oct 2023 07:23:17 GMT
       mise-correlation-id:
-      - 25b08a1b-6e3c-4f27-83a4-52fb6820c65e
+      - b5b3c007-72f7-4f40-aafd-e3e6e81a7c9f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1132,23 +952,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A06Z&sr=b&sp=r&sig=NbLMOjzRBVzN4PwWbX9cAd4RfkGvlZ6%2BFgc%2BhDAigHY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:06.0698973","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A06Z&sr=b&sp=r&sig=zkxRwLX6FPlNu55REL%2FFRQnwGGbN%2Fg7tFm%2FGj7FkqYg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:06.0698214","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A06Z&sr=b&sp=r&sig=9X2HZaDww1zvJPIMtVzMUNo1BACtiVHSxoPjFMK6Jug%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:06.0699111","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A22Z&sr=b&sp=r&sig=l2bWzCt5r8THtct0Hv7lg2FRwbqx6ZVkAMhPvMvH73A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:22.8339078","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A22Z&sr=b&sp=r&sig=ySbH1cZO5%2Fy5yt5tRWIBRgPXPdJQ5%2FjjjaXJgBJAQqY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:22.8338248","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A22Z&sr=b&sp=r&sig=b3nHwZFwBhW%2Fx%2B%2FlpeWQfoFSqT%2FAEeNaqKUT2e2y%2B6Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:22.8339292","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.177Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3212'
+      - '3218'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:06 GMT
+      - Mon, 30 Oct 2023 07:23:22 GMT
       mise-correlation-id:
-      - 6ba6e0bb-97d3-4488-b0f9-2ac9892dea35
+      - 40ab1c31-cb65-40e3-bf91-7d8e4d455a2e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1168,154 +988,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A12Z&sr=b&sp=r&sig=KkP%2BNcZ3bITblRgsykK8BLNVDzXKiv1yS7UG5CFQwTA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:12.0406437","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A12Z&sr=b&sp=r&sig=6KCS%2FFnRkCSboELZFpFkRghk8xVmN%2B87mkFqBLZESto%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:12.0405818","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A12Z&sr=b&sp=r&sig=QXGr7ZTutSN5aBHLTf4vsWQQPYfNtubHr7a76GRfQNg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:12.0406592","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3208'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:12 GMT
-      mise-correlation-id:
-      - 99d4acf1-8e02-4209-8a84-e89fc39957da
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A17Z&sr=b&sp=r&sig=ksEoXJc8eDKx4mrHEdcJQv5SFdOo7KC%2FWYISiHCCmYE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:17.2783752","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A17Z&sr=b&sp=r&sig=mHy0gNmKqHp75kAnilREcFI5jF6X1gZM6rgqAziiigA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:17.2782767","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A17Z&sr=b&sp=r&sig=fwbWIFiRVUtoCG9RvCOlZ2to2gpYiVsIPTWu8lX%2FgY4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:17.2784015","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:17 GMT
-      mise-correlation-id:
-      - ea9203fe-281c-492b-94a2-5db053f9c047
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A22Z&sr=b&sp=r&sig=Y7AEzKCXPwY0CDUReB5NO3OCrEEODNOuykL%2F%2FItd%2B50%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:22.6375228","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A22Z&sr=b&sp=r&sig=c0IvxkFJoNHMAD7iq0647KI9omF3uIRbMujIKoGZ6CY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:22.6373451","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A22Z&sr=b&sp=r&sig=YMU%2BAA%2FJjiAxhX3NBycwpcuD8H7HjOzOw%2Bygv5bYja8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:22.6375928","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3214'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:22 GMT
-      mise-correlation-id:
-      - d8b745c2-e648-4627-bd98-dd9f1bc1b9bc
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A28Z&sr=b&sp=r&sig=4qnnkUgF7q2eFVQmFkJKENSNp7cB96aAFolnGTa%2BSIk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:28.1608884","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A28Z&sr=b&sp=r&sig=8C8hT2OMXoRb0fG%2FSncnH7UoXzOchs10aOxX2dX3530%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:28.1608178","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A28Z&sr=b&sp=r&sig=ALCD7yhkAaxPYVZ8HbTjHjYYDj3%2FSEt8Lem1RHlY1Gk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:28.1609029","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3208'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:28 GMT
-      mise-correlation-id:
-      - 22027699-90f7-4737-9195-1432632c3eca
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A33Z&sr=b&sp=r&sig=TvgNGitfxxx63TAeqPTQnkBl2wLlp3cOPmCDQaRuEiQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:33.402952","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A33Z&sr=b&sp=r&sig=%2FTo%2Ffj4W9u4xKdAaiY6Eiq4xjA8PPWP%2BICg%2BJ5qJMrI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:33.4028707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A33Z&sr=b&sp=r&sig=XR0NFuerFS4eqaWJfF6ZSdUoyVmkr%2BC9umyinBt%2BCEs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:33.402969","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A28Z&sr=b&sp=r&sig=9WJIVMQn4jVufHE26nDH8j7b%2FlRwIJ0lfdwAZPSbPbM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:28.1755057","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A28Z&sr=b&sp=r&sig=r9MuoWk7HbHHGmHnvDtluTMl0vWfmtMBG7GQZIA818o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:28.1754033","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A28Z&sr=b&sp=r&sig=wCDKr%2FhDaI9q4bHtMgEMOT6HrewQ%2BFFMXljM%2F1XySZA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:28.1755331","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.177Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1326,9 +1002,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:33 GMT
+      - Mon, 30 Oct 2023 07:23:28 GMT
       mise-correlation-id:
-      - 70c8fa40-e8b8-4f6c-8ec4-34216481851c
+      - e2c69073-7fb0-4002-b1db-ef1742793c81
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1348,82 +1024,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A38Z&sr=b&sp=r&sig=TVDI8OwW64p7aAvC47N7yg0q6wUPLe4emR3t4rnSknk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:38.6794765","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A38Z&sr=b&sp=r&sig=exX3KmdI34rO6DI0UrTK%2BiM3PoQqnHIz9YHrOF1PPrM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:38.6793747","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A38Z&sr=b&sp=r&sig=ieUTyW9HKkHSkU4KW14CCALMzLCj9B%2BQHhtMq9TUL7I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:38.6794993","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:38 GMT
-      mise-correlation-id:
-      - de3d6c9c-1bb8-4181-9a29-a2036f292a92
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A43Z&sr=b&sp=r&sig=qZ8OzkJQUYgYIXbgrrzmlukOInbNfyi6rGZoVLVxGe8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:43.9242291","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A43Z&sr=b&sp=r&sig=zDNiiSh22nc%2FoX3E0ryll21z5R0HzeJLPQSZK4tgIoc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:43.9241589","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A43Z&sr=b&sp=r&sig=f9kLNr6hYQ%2FVi9Smo995oaUPMrTaXOObkog5YV8uUCg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:43.9242434","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:24:43 GMT
-      mise-correlation-id:
-      - 7e2e80f1-f887-4990-ad41-607fcf662f64
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A49Z&sr=b&sp=r&sig=ZmG6iooRZbUMys2T4eh4skY%2FgDErQvNSm764jRMGsmY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:49.1769925","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A49Z&sr=b&sp=r&sig=jZEjyOkbmPt9Zh3Epp6adbxfncOd6qjZ6Kc62F5BYEY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:49.1769022","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A49Z&sr=b&sp=r&sig=Vaky4nX1pzsU0UNvHu84SM2U68WUJIuZ3Wvkt1Hov4k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:49.1770145","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A33Z&sr=b&sp=r&sig=2zEZ0jE09hb9EyJ6HPTRmSQkW8pk9ghjDb5fonlYkF8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:33.4998482","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A33Z&sr=b&sp=r&sig=bekj51b0Wj9ntba56pueaoYxxLvw4LWsMsjteJ9asLY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:33.4997764","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A33Z&sr=b&sp=r&sig=7eCh3l9J2WuxOqM48uJYWqei0CNYSlMXZN2g8tL3CWs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:33.4998623","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.177Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1434,9 +1038,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:49 GMT
+      - Mon, 30 Oct 2023 07:23:33 GMT
       mise-correlation-id:
-      - 8ed20d47-390c-4a40-8211-62534a82a5b6
+      - d3818810-0949-4f2e-86ea-a7b85c2fcc64
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1456,23 +1060,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A54Z&sr=b&sp=r&sig=DrjUmQpwMXqVxx%2F9d4jLU%2FA2iQekrrXxzXTaSJzApNk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:54.7075525","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A54Z&sr=b&sp=r&sig=XEOiGJV629kk%2Fa13ogal%2FxsyaAFRy6Q%2Bi6eUwo3731w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:54.7074648","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A54Z&sr=b&sp=r&sig=XR4WlAiV9UfTtJzIp0KvvJgzleZ%2BsDTsgyUC4fRi04o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:54.7075741","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A38Z&sr=b&sp=r&sig=vt1dsWky0hGZemcfQZ5Tqw756l1%2FVqxNml%2Fbbk0vrMk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:38.8150649","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A38Z&sr=b&sp=r&sig=0%2F%2FGTpPK3Otn%2B%2F4x5CuDPL50Rb8q%2FjIlySi1wehQfbE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:38.814948","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A38Z&sr=b&sp=r&sig=CoCx14T313%2BSGFFv2RIMHPMXtPBzyGvXdFcvvhkiSyk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:38.8150962","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:22:51.177Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3214'
+      - '3219'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:24:54 GMT
+      - Mon, 30 Oct 2023 07:23:38 GMT
       mise-correlation-id:
-      - 284de6c9-e6fc-49dc-9330-cae027a13cf8
+      - 8436eee9-2c61-4523-9eba-44bb561d9259
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1492,23 +1096,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A00Z&sr=b&sp=r&sig=gmuTfBKPsQ9TumJIK8ybWSgzrTSJYFhc3mKrxaTNwNI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:00.2823467","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A00Z&sr=b&sp=r&sig=Upib2PLO72fs%2BzhOELJWT8LdFQctf9wm0DDq6f5Bj50%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:00.2822782","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A00Z&sr=b&sp=r&sig=s2bMET6NUWS5BuDxmBucjJJDZoBYmZ%2BJNpDQ0NiOFfM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:00.2823613","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A44Z&sr=b&sp=r&sig=1F%2FmAfOPLAaD8U0SHpAycAe%2FfRnDqZFlR9xpgdIIzXI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:44.0934115","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A44Z&sr=b&sp=r&sig=m2Z8%2BqWl5skHAdF%2FzjWkXmtNsPgZ0VzjkQ7wMqWgvHg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:44.0933236","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A44Z&sr=b&sp=r&sig=0PiMly7rZY0%2BbY6mpwc3hzi40oWNPdFmVGC9bVsGGfE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:44.0934328","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3206'
+      - '3211'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:00 GMT
+      - Mon, 30 Oct 2023 07:23:44 GMT
       mise-correlation-id:
-      - 8a344f27-10a2-47f7-bcbf-cca855c27e86
+      - 80a0b8d2-7762-4c5c-982c-136d32792531
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1528,23 +1132,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A05Z&sr=b&sp=r&sig=GibAP67kDfeAnNoWs1MbVRm9N7XlMEDXydj6XOZOEu8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:05.6136792","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A05Z&sr=b&sp=r&sig=2WWXz%2BvH7h1I28g21YJpmlFBiJLIXREFqRG2l1RRUkg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:05.6136055","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A05Z&sr=b&sp=r&sig=Lt364%2BGqOLTgsiqOrD%2B9QF9OeR%2FYmkzM%2Bp86J8%2FjVUo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:05.6136939","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A49Z&sr=b&sp=r&sig=I05Q29amDJgdEPVkO8PWFxL%2F6Ki%2ByCC3xcEMB6qklCM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:49.3685268","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A49Z&sr=b&sp=r&sig=fg9cp8ljEdXg9gL7wM1YmmT1oZLQq8XaIlkwGu%2F%2Fz5k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:49.3684356","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A49Z&sr=b&sp=r&sig=GBKSb00ex4CO96BZeQfuDlALU5wmWzNqHP7Ddiix2XI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:49.3685492","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3214'
+      - '3209'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:05 GMT
+      - Mon, 30 Oct 2023 07:23:49 GMT
       mise-correlation-id:
-      - 9782eca0-b0f3-4149-a6c3-e5b38d577ae2
+      - d96b2c74-2fa7-4e1c-baaa-5c1bdbdbad9e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,23 +1168,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A10Z&sr=b&sp=r&sig=VRSY%2BBjM7oe5I7Q6DT5rlk%2ByL0jEaQeeB1ypqNHckTg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:10.9415153","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A10Z&sr=b&sp=r&sig=UIr90VMfa83OszyFmgyv7rBuY8bfU9uAK4hQgTthXjM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:10.9414161","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A10Z&sr=b&sp=r&sig=%2BtOju%2FmWnXsTCr3Bf1IFEa6tn0lvq5Jg%2B7lAaV5%2Bzfs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:10.9415439","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A54Z&sr=b&sp=r&sig=t6ggkWAVwi%2FSnG%2FgfXcczsiVlynuPESQ6kf1Qx4NtNo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:54.7032417","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A54Z&sr=b&sp=r&sig=p7WTgMY2J3BYgR%2BKiRo5rhCta4ZCyO84RgvUj35pWxU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:23:54.7031632","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A23%3A54Z&sr=b&sp=r&sig=90OzSorKhYcm8qqBcwPkvLwAYjL7Lq1tx9MVgBy%2F0Bw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:23:54.7032557","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3214'
+      - '3209'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:10 GMT
+      - Mon, 30 Oct 2023 07:23:54 GMT
       mise-correlation-id:
-      - 99a96a87-0988-42fe-8c3f-7644e205afa6
+      - eeec2434-eb02-4f58-81fe-f348f3c03564
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,23 +1204,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A16Z&sr=b&sp=r&sig=6bsJfTlJCgYAilpv%2F5SfFQmQS2UYSQVH3e27x7SG3F8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:16.1980659","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A16Z&sr=b&sp=r&sig=QQGxqlQXeWrzvvpFuBNX%2BHek%2B1RJLSxXVQCmjrIZQYk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:16.1979965","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A16Z&sr=b&sp=r&sig=NdPxGEGFqZ%2F1Dx5St%2FFh1pIW59o7NSnlNNv1bSw7LA4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:16.19808","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A00Z&sr=b&sp=r&sig=GIv%2Bhbm6X81VfwlYdnYDFuz9co6X4VkvNh1BhiAPrww%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:00.1800192","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A00Z&sr=b&sp=r&sig=amBMY9R1oXMAkU3i%2B8ClXicB52z7gG%2BBK7nQJ76TCwI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:00.1799294","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A00Z&sr=b&sp=r&sig=EGROwH8QibEwKZs3oRY4lKOeeOtNWT2kpicxZmDjRIc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:00.1800408","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3210'
+      - '3207'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:16 GMT
+      - Mon, 30 Oct 2023 07:24:00 GMT
       mise-correlation-id:
-      - 4003df36-d503-4e10-8f98-d25488533d8a
+      - 83c5abaf-a477-43e7-9aa7-547883a9ab5f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,23 +1240,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A21Z&sr=b&sp=r&sig=0S7opID8%2BiD2sFMO2up%2FsTZDiJLAfRSq1wD3IOGJMlo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:21.44894","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A21Z&sr=b&sp=r&sig=mM5MvJKahlH2QPwGc7lWwFAoXDyt4Iv7J2zAr%2BKLlUI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:21.4488557","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A21Z&sr=b&sp=r&sig=LPOxXyUQKXQNLql%2Fgu1IjrsobWr%2FY8micdiS8hJhuIA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:21.4489619","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A05Z&sr=b&sp=r&sig=iWTdMGkO1ZBCj1egaqHeJXyIwm3M0beiEhy4W5a81PM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:05.550583","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A05Z&sr=b&sp=r&sig=ptbl2dEPpLTGcQn3OVXg2WTgTYf0AOwVqbL1lZL3FGI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:05.5505153","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A05Z&sr=b&sp=r&sig=zji4ShOMr1S78dt2UOEBt0rlP5uauvkywrbpQeY62Y8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:05.5505976","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3210'
+      - '3200'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:21 GMT
+      - Mon, 30 Oct 2023 07:24:05 GMT
       mise-correlation-id:
-      - 36847d83-1de0-49a2-bfb5-02df84f80be3
+      - e8f8fe09-2b01-4a3a-b963-8a659645fcc7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,23 +1276,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A26Z&sr=b&sp=r&sig=ckFYubz4aSseay9AqUDiqfTIqvhHtjA%2FZMJqApBLN2Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:26.7009334","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A26Z&sr=b&sp=r&sig=w4oiKIbxbK5AVBD0uyI27oZUiQq5Vp0W6psC55SDT0s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:26.7008671","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A26Z&sr=b&sp=r&sig=V6PD7rZZauAVWym01jdn5rtDa1pTVtf%2BzW%2BlAxsSKb4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:26.7009475","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A10Z&sr=b&sp=r&sig=EUteUua86JPzJ9YhpUEWV3%2FInNZfpHO9ErcNF6PLIxs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:10.85257","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A10Z&sr=b&sp=r&sig=EL7HmXzAlRd8VQ73l3j2sTh9%2BZbP2ngeQml8fE%2B%2Fpr0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:10.8525017","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A10Z&sr=b&sp=r&sig=MMIHE%2Byvc9Voz5J25NQqIpjki7F1nV3cxQCKHhSS3%2FE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:10.8525852","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3208'
+      - '3211'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:26 GMT
+      - Mon, 30 Oct 2023 07:24:10 GMT
       mise-correlation-id:
-      - 9a60abac-5d14-47e4-98c2-5d887516e708
+      - 6dd12f4f-6c7e-4366-9385-e31bf49ba14d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,23 +1312,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A31Z&sr=b&sp=r&sig=hRe33xv5OG87b8f6BFca8L4KOQ1rIW4%2FJ67R7su6%2F38%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:31.9464715","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A31Z&sr=b&sp=r&sig=eUs9UK2k0md1JszazfeQGIU0Hp%2BX7Sj64%2FqebLG7nuM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:31.9463905","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A31Z&sr=b&sp=r&sig=qVEaqUt%2BZIw5QmDvo%2Fl9BwHdvV3BZi1aDDis36AtA2w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:31.9464896","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A16Z&sr=b&sp=r&sig=cVIDavLItnOZ4xbTeF12LBh9VGoJ8gU%2BT7a375qFFMY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:16.1899379","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A16Z&sr=b&sp=r&sig=7zUZtSfF1GgTKXUurmZ0FvOhL7abN0YYREyhjIrI6o4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:16.1898469","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A16Z&sr=b&sp=r&sig=hXVQkYizDpGWdxJE1PBKRXV%2FaUdvMh0qqNFb9D230lc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:16.1899601","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3214'
+      - '3205'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:31 GMT
+      - Mon, 30 Oct 2023 07:24:16 GMT
       mise-correlation-id:
-      - e42e28a6-8ae0-469a-9fb3-0f69400fbcd4
+      - d0b317be-4f51-436b-a6ce-6e83205ba436
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,23 +1348,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A37Z&sr=b&sp=r&sig=QFEbbK4CkgT9XBSuQG09P3FIGzySOWQu0J88aM3kOKo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:37.2031335","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A37Z&sr=b&sp=r&sig=Bw07U%2B6iELNLlBEGUcreXT%2BgFwlzDY7roTtaKwJvdoI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:37.2030399","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A37Z&sr=b&sp=r&sig=jJwpFxMhb8aoTGRynG5%2BVUuhbKFJzpCHHf4dGjmvISs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:37.2031568","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A21Z&sr=b&sp=r&sig=cvgCYPGIrU3RFYplDHGK7AF0c9FUxRSP3dOBehLSmU8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:21.5161061","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A21Z&sr=b&sp=r&sig=uhfs%2BP00%2FxSppFF9%2F4NeQYyS6NxRJ%2FsTFGLtXgFW5SE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:21.5160116","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A21Z&sr=b&sp=r&sig=UwJWNNRwMw4SmU0BJpKVBp16%2B3qmKIU0osDq1jDSVKA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:21.5161208","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3208'
+      - '3211'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:37 GMT
+      - Mon, 30 Oct 2023 07:24:21 GMT
       mise-correlation-id:
-      - f879f458-3afd-4c3c-b74d-938fd5b37534
+      - b07f8bc3-fde3-4982-9832-6170b7094427
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,10 +1384,442 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A42Z&sr=b&sp=r&sig=MLY9lDJzVy0xxM%2F5vN53TEfiO%2F6DvsMnc1MscLGUqz0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:42.4506754","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A42Z&sr=b&sp=r&sig=zx3Be9H%2BvGPVDN4MPRyrZGaCZaeuJS%2B9YgP30yHk3Dc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:42.4505932","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A42Z&sr=b&sp=r&sig=guaB0jLkv9Jn5%2FBrZA8qWIM7ma6y4VYK7ffyQII2h8g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:42.4506904","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A26Z&sr=b&sp=r&sig=o0VKMX0L8cPQ4X1Zcshe%2BWsDYvAb4gIRN39bULE299M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:26.7828044","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A26Z&sr=b&sp=r&sig=p0Ax9iM4n8pmWXgzWDE3EO1ovnROA2m2xCTCJIRQ%2BmQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:26.7827291","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A26Z&sr=b&sp=r&sig=nvonfoO6kgFG3AmykFu4d5WLmjjo1NBQ3G2luBFLmAM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:26.7828189","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:26 GMT
+      mise-correlation-id:
+      - 3bfc0221-af45-413e-ae9c-247ca000f7f0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A32Z&sr=b&sp=r&sig=kOwulXZz%2BxqV%2B3LDfnD0neAwn2G1hmZsUwlVV6g4sWo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:32.0610754","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A32Z&sr=b&sp=r&sig=PcxUqVfocqASWOcBWymUWsXHB4KuMMsmD93kTi3UNfE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:32.0610041","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A32Z&sr=b&sp=r&sig=b91eBEg7fV21EYVwmJEFtnbfhi%2FW3mDypZqkBOAlAy4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:32.0610894","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3207'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:32 GMT
+      mise-correlation-id:
+      - c216773d-3c06-4020-813e-582be49a54d9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A37Z&sr=b&sp=r&sig=brZN7ld2HBxbD1BDBmvfq86QBnl2veWYSde4%2F6yxybY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:37.3171194","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A37Z&sr=b&sp=r&sig=xeSSaLi%2FSHzP59rBEN%2F11hingLorBS8InxyN%2Fn5MqCw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:37.3170513","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A37Z&sr=b&sp=r&sig=PEW4YTW0%2Ffh95ytLs3vx%2BRHRil7Y27f5kqMNeeCZKqs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:37.3171331","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3213'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:37 GMT
+      mise-correlation-id:
+      - 8778cc02-1393-4f88-95ca-b4333447eca7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A42Z&sr=b&sp=r&sig=VxsEdN37pRDUIz4GWnaop3MFZz3EfIwHZebm0v%2BuRZg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:42.6126635","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A42Z&sr=b&sp=r&sig=C%2FyLwpRSWn06bBJamlNcZbxpgIlB1Lspa3UJekVKPbU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:42.6125928","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A42Z&sr=b&sp=r&sig=40SIZlxJm2ZtR5xUHVtoPRYFUnZcLpLxI5MZiXjeIbE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:42.6126784","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:42 GMT
+      mise-correlation-id:
+      - f56686b6-aadd-4cf2-af33-8ab4aa2e7b98
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A47Z&sr=b&sp=r&sig=6ghb7KWpnIp35CvmxhIL3%2FTNBTOEmPfIACcgP2Ul7Us%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:47.9434147","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A47Z&sr=b&sp=r&sig=EfrLi0gKLv%2FGOQ5mBM%2BClLhM5oaURHZxyKwmy3tjp5E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:47.9433236","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A47Z&sr=b&sp=r&sig=HR7WELTnd%2B4ZQO8aVSrqd6bSxYj6a9dpURisp9jDR2A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:47.9434344","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3209'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:47 GMT
+      mise-correlation-id:
+      - 626798bb-ed0f-4404-a1c3-4e1ab6d6fdc0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A53Z&sr=b&sp=r&sig=IAMcRcZtjNpGlCzV2iIm%2BSBObkGs1XzDyxQ1bt56bvQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:53.2019636","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A53Z&sr=b&sp=r&sig=VrwAtkOS6YuspkzqvqCmpJacmlpol9jKwiA8H%2By97lc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:53.2018765","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A53Z&sr=b&sp=r&sig=SImQrjqMJU3sJMyyQNVkoif0Jf3PQdG9Lhb1P9B09Y0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:53.2019856","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:53 GMT
+      mise-correlation-id:
+      - b180169f-cfd1-4148-9972-5085d73abe88
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A58Z&sr=b&sp=r&sig=0QzbWy%2FMCnWJdFYko16RdqugHA5VLSQsGaSZ1NCCq6E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:58.4574621","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A58Z&sr=b&sp=r&sig=HOwhpbRCWFqsxJJ%2FwTH83NwuqPNnDHO9kCxhBTPw9d8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:24:58.4573755","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A24%3A58Z&sr=b&sp=r&sig=Vwm9iZfcsz%2B4IXTQj%2FN%2FSE3fOYglUNHuAvLuvhzn8Ww%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:24:58.4574844","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3211'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:24:58 GMT
+      mise-correlation-id:
+      - 30f5b02d-d309-422d-8b6b-e87828e12844
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A03Z&sr=b&sp=r&sig=tGwzKwG8yLh1f7uaDH9T3l4uuRXibcXW4fvjN2GZ9Pg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:03.7183322","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A03Z&sr=b&sp=r&sig=VUzj7AP2rRtmvd1Od%2BIX10gjPRHEmQtEWCO7jfj5hSY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:03.718258","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A03Z&sr=b&sp=r&sig=7dlH5jQyMX3UtdtuKSt1i4rlx5aOvLnwhu%2F7tOfV7v0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:03.7183485","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:25:03 GMT
+      mise-correlation-id:
+      - 761661b5-79da-419b-a66c-4280c33db780
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A09Z&sr=b&sp=r&sig=de11%2FOu64VjJOad4GGXCErZhqxbjiPCylbje62P%2BSyE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:09.0077731","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A09Z&sr=b&sp=r&sig=03PCYcl%2BvlNkU1kEMOilBp3eWFvs6seoh9XQY7UswNU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:09.0076946","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A09Z&sr=b&sp=r&sig=Bg%2FePcFon8FObJbBx%2FDIHx1UpH3eK5uQfuqR%2Bd0nSX8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:09.0077883","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3213'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:25:09 GMT
+      mise-correlation-id:
+      - 0280567e-9959-44ef-82ab-e6837de76c11
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A14Z&sr=b&sp=r&sig=Kr3iNsh42QfCfOcpl5OUH6WeQJBVGrDXrzA5brDSAt8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:14.2780231","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A14Z&sr=b&sp=r&sig=jF%2F9spzdQtKIRfZHg3QzoUppmTDGZdDCgfQFpWsgf9M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:14.2779356","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A14Z&sr=b&sp=r&sig=vmFyuwUGuxBnM9F4K62dH0q5PBNPoJFbZP8Pmwky93c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:14.2780447","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:25:14 GMT
+      mise-correlation-id:
+      - d6d29a08-6413-441b-9138-3b473c3f6115
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A19Z&sr=b&sp=r&sig=f%2Fffpq3Qs5TmCtTHlD8bkvHjj%2FivGap1U%2BfKrdU8KL8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:19.5461401","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A19Z&sr=b&sp=r&sig=Y%2BHohs4KEUGYnYxVPn44gHqZNr%2FKsBZmyOJHQLvIu1s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:19.5460428","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A19Z&sr=b&sp=r&sig=11h9KESNlxJGXTrt1DACT8DV2UFpC%2FNOR51ZZM5Cb%2Fk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:19.5461593","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3215'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:25:19 GMT
+      mise-correlation-id:
+      - a8f7d013-cff2-4e82-a731-b675dd63cb8a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A24Z&sr=b&sp=r&sig=SZyGQCxPy0Owoxz82hIwXZvZ8E34Z%2Fu2Laj%2FPyivsMQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:24.873311","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A24Z&sr=b&sp=r&sig=3V7cJJp6Z3r7iRssGnwNjZd1aeeOGayGyyygQqV3oFs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:24.8732264","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A24Z&sr=b&sp=r&sig=CTqKvlWzV55xzxHMQzOR5OUdZNssCiZmDYgyEuglA8w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:24.8733328","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:25:24 GMT
+      mise-correlation-id:
+      - 4650ee56-b591-4848-80e7-d8354cadc4cd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A30Z&sr=b&sp=r&sig=eHrtfdYiQmEbjQQbv%2F9WR8a7d1VkS8TiPbRfJe%2BCVb4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:30.135175","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A30Z&sr=b&sp=r&sig=MMnt%2F%2FyPC51RjFazgpaAeHT70qy633hpPjAlIUbVWJ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:30.1351065","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A30Z&sr=b&sp=r&sig=mtRD0YFtQu%2FGfzceREV0lhquxAjauje%2FqS4TbYXSH5I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:30.1351888","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:22:50.914Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:23:42.098Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1794,9 +1830,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:42 GMT
+      - Mon, 30 Oct 2023 07:25:30 GMT
       mise-correlation-id:
-      - 7c899323-9933-4046-bc80-1bf74aea5a24
+      - dde78ef7-3a4d-44cf-9eb4-9f073d4bc17b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1816,24 +1852,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A47Z&sr=b&sp=r&sig=6VAFfzi76gMfV6e0NftBlBuaBHI%2FLzPCKb7qVKVz2Y8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:47.70348","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A47Z&sr=b&sp=r&sig=yyC6elxlygMvO1duBhw0scGLDCn8OaGmdSQs2VXtnkI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:47.7034012","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A47Z&sr=b&sp=r&sig=kjpQqtICkcjcFP2zZY8pcytvLusaG8k7ceuiZZ8d4b0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:47.7034939","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-29T22:23:01.496Z","endDateTime":"2023-10-29T22:25:45.508Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:45.612Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A35Z&sr=b&sp=r&sig=EGqmaxz4qW2ekbtNoKzw2a5eyo2cOg9GZpMY4YVdozg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:35.8486131","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A35Z&sr=b&sp=r&sig=hnRuvEVNawfj7mmB%2BJ2FkdXjSRMdv7qwfi7CRp65e7g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:35.8485415","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A35Z&sr=b&sp=r&sig=iDLX09uhcc80UBuequ1hsNKMWcpnj8Dmh5eW6sbRY%2Fs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:35.8486273","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-30T07:22:50.914Z","endDateTime":"2023-10-30T07:25:34.774Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:25:34.954Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3337'
+      - '3340'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:47 GMT
+      - Mon, 30 Oct 2023 07:25:35 GMT
       mise-correlation-id:
-      - 4ce90404-3bdf-4e8c-b23e-1b6bc37d2eb2
+      - 66afec5a-7715-403f-b705-31de240e9796
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1856,7 +1892,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:59.6197453Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:59.6197453Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:42.8269258Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:42.8269258Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1865,9 +1901,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:48 GMT
+      - Mon, 30 Oct 2023 07:25:35 GMT
       etag:
-      - '"3c00f229-0000-0100-0000-653edb0a0000"'
+      - '"3f009e6b-0000-0100-0000-653f598a0000"'
       expires:
       - '-1'
       pragma:
@@ -1897,24 +1933,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=download-test-case&api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=download-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A49Z&sr=b&sp=r&sig=glw9sMHRSsNwf3OK6H%2F7MRgOJiWRCSYNMYDsaElo3js%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:49.9653674","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A49Z&sr=b&sp=r&sig=hZgg%2B6JWJkLQWcmE9Rk%2FmUqpmGsBBxWHA4JmcqtEkuc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:49.9652769","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A49Z&sr=b&sp=r&sig=KbUx3vH9Yi8Unc6hybstmpI%2Buut3dtXpYhRgfBNU%2B2I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:49.9653892","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-29T22:23:01.496Z","endDateTime":"2023-10-29T22:25:45.508Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:45.612Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A37Z&sr=b&sp=r&sig=Bzma7PMQgtS5T%2FimZiLhbnsHcXiVs%2FXzdctBToAcm0Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:37.4011385","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A37Z&sr=b&sp=r&sig=hUFsBlRnwxo9aIe7bD8UJL4G4%2BLVoZwOyAF3UYfnQKE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:37.40105","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A37Z&sr=b&sp=r&sig=t9WCOx89GpH%2B%2BdXXqSbMqHB7pm490knbKYmnoWtQEH4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:37.4011601","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-30T07:22:50.914Z","endDateTime":"2023-10-30T07:25:34.774Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:25:34.954Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3359'
+      - '3356'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:49 GMT
+      - Mon, 30 Oct 2023 07:25:37 GMT
       mise-correlation-id:
-      - 3042c853-1b1a-49fa-9b6b-9b3468611f85
+      - 833ba11d-51ff-45d1-8bcf-a4c9b0d7872f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1937,7 +1973,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:59.6197453Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:59.6197453Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:42.8269258Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:42.8269258Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1946,9 +1982,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:51 GMT
+      - Mon, 30 Oct 2023 07:25:38 GMT
       etag:
-      - '"3c00f229-0000-0100-0000-653edb0a0000"'
+      - '"3f009e6b-0000-0100-0000-653f598a0000"'
       expires:
       - '-1'
       pragma:
@@ -1978,24 +2014,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A52Z&sr=b&sp=r&sig=O5SWc8ET%2BjA5nUNm%2FIgRyGrmSKbsOOzL1Yc%2B1L7BRRA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:52.2116037","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A52Z&sr=b&sp=r&sig=%2FGyOaY9creUfxpx88hfu7QYtLUxmODyFZbXSboIn%2BRo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:52.2115193","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A52Z&sr=b&sp=r&sig=tdEr8SZIqO3pwSD2cGNCG9lM01v3JOixW9rllEvQ1dI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:52.2116259","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-29T22:23:01.496Z","endDateTime":"2023-10-29T22:25:45.508Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:45.612Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A39Z&sr=b&sp=r&sig=5rg2qv9iwt6b%2BPXQy6hVobKG12fULUiihD449IYaDjU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:39.7241876","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A39Z&sr=b&sp=r&sig=0i3ZDT1Y7wmxi%2B6%2FAgvv9Sg9VIIveuPI7Gr7Puw1Gw0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:39.7241203","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A39Z&sr=b&sp=r&sig=yHYnYGEmbmqBlstpQvjU2VgsC9n0H1hs8E9sId7jVJE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:39.7242023","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-30T07:22:50.914Z","endDateTime":"2023-10-30T07:25:34.774Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:25:34.954Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3347'
+      - '3342'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:52 GMT
+      - Mon, 30 Oct 2023 07:25:39 GMT
       mise-correlation-id:
-      - ab378685-edb1-43e6-ba21-356c5d83fba7
+      - bd15c9ed-e6e1-455f-8968-e9b2f84f8296
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2015,7 +2051,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A52Z&sr=b&sp=r&sig=O5SWc8ET%2BjA5nUNm%2FIgRyGrmSKbsOOzL1Yc%2B1L7BRRA%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A39Z&sr=b&sp=r&sig=5rg2qv9iwt6b%2BPXQy6hVobKG12fULUiihD449IYaDjU%3D
   response:
     body:
       string: "displayName: CLI-Test\ntestPlan: sample-JMX-file.jmx\ndescription:
@@ -2033,17 +2069,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Sun, 29 Oct 2023 22:25:54 GMT
+      - Mon, 30 Oct 2023 07:25:39 GMT
       etag:
-      - '"0x8DBD8CD9BE2528F"'
+      - '"0x8DBD919061276F8"'
       last-modified:
-      - Sun, 29 Oct 2023 22:22:59 GMT
+      - Mon, 30 Oct 2023 07:22:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Sun, 29 Oct 2023 22:22:59 GMT
+      - Mon, 30 Oct 2023 07:22:50 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2073,7 +2109,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A52Z&sr=b&sp=r&sig=%2FGyOaY9creUfxpx88hfu7QYtLUxmODyFZbXSboIn%2BRo%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A39Z&sr=b&sp=r&sig=0i3ZDT1Y7wmxi%2B6%2FAgvv9Sg9VIIveuPI7Gr7Puw1Gw0%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -2146,17 +2182,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Sun, 29 Oct 2023 22:25:55 GMT
+      - Mon, 30 Oct 2023 07:25:41 GMT
       etag:
-      - '"0x8DBD8CD8E60618F"'
+      - '"0x8DBD918F4925232"'
       last-modified:
-      - Sun, 29 Oct 2023 22:22:37 GMT
+      - Mon, 30 Oct 2023 07:22:20 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Sun, 29 Oct 2023 22:22:37 GMT
+      - Mon, 30 Oct 2023 07:22:20 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2186,18 +2222,18 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A52Z&sr=b&sp=r&sig=tdEr8SZIqO3pwSD2cGNCG9lM01v3JOixW9rllEvQ1dI%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A39Z&sr=b&sp=r&sig=yHYnYGEmbmqBlstpQvjU2VgsC9n0H1hs8E9sId7jVJE%3D
   response:
     body:
       string: !!binary |
-        UEsDBC0AAAAIAN2yXVcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
+        UEsDBC0AAAAIANk6XlcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
         AAAAAAFZAab+ZGlzcGxheU5hbWU6IENMSS1UZXN0CnRlc3RQbGFuOiBzYW1wbGUtSk1YLWZpbGUu
         am14CmRlc2NyaXB0aW9uOiBUZXN0IGNyZWF0ZWQgZnJvbSBheiBsb2FkIHRlc3QgY29tbWFuZApl
         bmdpbmVJbnN0YW5jZXM6IDEKdGVzdElkOiBkb3dubG9hZC10ZXN0LWNhc2UKc3BsaXRBbGxDU1Zz
         OiBGYWxzZQpmYWlsdXJlQ3JpdGVyaWE6Ci0gYXZnKHJlcXVlc3RzX3Blcl9zZWMpID4gNzgKLSBw
         ZXJjZW50YWdlKGVycm9yKSA+IDUwCi0gR2V0Q3VzdG9tZXJEZXRhaWxzOiBhdmcobGF0ZW5jeSkg
         PiAyMDAKZW52OgotIG5hbWU6IHJwcwogIHZhbHVlOiAxCi0gbmFtZTogZHVyYXRpb25faW5fc2Vj
-        CiAgdmFsdWU6IDEKUEsDBC0AAAAIAN2yXVfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
+        CiAgdmFsdWU6IDEKUEsDBC0AAAAIANk6Xlfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
         LmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAAQYT+ew8P3htbCB2ZXJzaW9uPSIxLjAiIGVuY29kaW5n
         PSJVVEYtOCI/Pg0KPGptZXRlclRlc3RQbGFuIHZlcnNpb249IjEuMiIgcHJvcGVydGllcz0iNS4w
         IiBqbWV0ZXI9IjUuNSI+DQogIDxoYXNoVHJlZT4NCiAgICA8VGVzdFBsYW4gZ3VpY2xhc3M9IlRl
@@ -2284,8 +2320,8 @@ interactions:
         ZT0iSFRUUFNhbXBsZXIucmVzcG9uc2VfdGltZW91dCI+PC9zdHJpbmdQcm9wPg0KICAgICAgICA8
         L0hUVFBTYW1wbGVyUHJveHk+DQogICAgICAgIDxoYXNoVHJlZS8+DQogICAgICA8L2hhc2hUcmVl
         Pg0KICAgIDwvaGFzaFRyZWU+DQogIDwvaGFzaFRyZWU+DQo8L2ptZXRlclRlc3RQbGFuPg0KUEsB
-        AjMALQAAAAgA3bJdVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
-        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACADdsl1X8Zv7b///////////EwAUAAAAAAAAAAAA
+        AjMALQAAAAgA2TpeVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
+        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACADZOl5X8Zv7b///////////EwAUAAAAAAAAAAAA
         AACbAQAAc2FtcGxlLUpNWC1maWxlLmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAUEsFBgAAAAACAAIA
         ogAAAOsUAAAAAA==
     headers:
@@ -2294,21 +2330,21 @@ interactions:
       content-length:
       - '5539'
       content-md5:
-      - 93fq3z4MPh6ygZI9IwDVUA==
+      - uLeDrZ7akSgaFFnNeKzwvQ==
       content-type:
       - application/octet-stream
       date:
-      - Sun, 29 Oct 2023 22:25:55 GMT
+      - Mon, 30 Oct 2023 07:25:42 GMT
       etag:
-      - '"0x8DBD8CD9C5AA52A"'
+      - '"0x8DBD919061D4AC7"'
       last-modified:
-      - Sun, 29 Oct 2023 22:23:00 GMT
+      - Mon, 30 Oct 2023 07:22:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Sun, 29 Oct 2023 22:23:00 GMT
+      - Mon, 30 Oct 2023 07:22:50 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2341,7 +2377,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:59.6197453Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:59.6197453Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:21:42.8269258Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:21:42.8269258Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2350,9 +2386,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:00 GMT
+      - Mon, 30 Oct 2023 07:25:43 GMT
       etag:
-      - '"3c00f229-0000-0100-0000-653edb0a0000"'
+      - '"3f009e6b-0000-0100-0000-653f598a0000"'
       expires:
       - '-1'
       pragma:
@@ -2382,24 +2418,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://c3085669-78f4-459c-9f06-f4a48398f16c.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A02Z&sr=b&sp=r&sig=WNAsFe1Fbbr5Lr7QslNzqsUvTzTBo7jF8fd5%2F2CeQHo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:02.8168664","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A02Z&sr=b&sp=r&sig=VRpa6gQKXsswQ7TgoNIudZkNREfW3bRCzy%2F4m1nKt4k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:02.8167962","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A02Z&sr=b&sp=r&sig=0LuZco2I9NJ6G5C%2FGpN1fgDLD%2FMwDW20WmNHFooFkMc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:02.8168817","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-29T22:23:01.496Z","endDateTime":"2023-10-29T22:25:45.508Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:02.154Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"a21b0c0b-b7d4-4648-b179-e15c9e729b08":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"0c60c49a-c22d-4b3f-9859-2c715b21d3ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e7e10aae-807b-4427-a8d4-7f8e6f3ec0e0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A45Z&sr=b&sp=r&sig=JK8i7MdsMqwW7YIgfLN%2FSwowvVuiZUJEyjA7jBKWG6A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:45.1015047","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A45Z&sr=b&sp=r&sig=6cHISzdbLBsFjEyNHVuDAufS8pmhLSq%2BrDFgN4EdGj4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:25:45.1014212","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A45Z&sr=b&sp=r&sig=2iIbNSgUAn5fAtiReaIcxEW0RS6lG5sIavUPoGXyEEU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:25:45.1015268","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-30T07:22:50.914Z","endDateTime":"2023-10-30T07:25:34.774Z","executedDateTime":"2023-10-30T07:22:50.19Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-30T07:22:50.481Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:25:34.954Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3345'
+      - '3340'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:02 GMT
+      - Mon, 30 Oct 2023 07:25:45 GMT
       mise-correlation-id:
-      - 5d181af1-2433-459c-92ae-883bc5b1dd30
+      - 899c57b4-6e19-4220-a16e-5c39616d90fc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2419,7 +2455,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A02Z&sr=b&sp=r&sig=WNAsFe1Fbbr5Lr7QslNzqsUvTzTBo7jF8fd5%2F2CeQHo%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/7238cf83-be07-4b28-a559-bfcd0a2f68e2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A45Z&sr=b&sp=r&sig=JK8i7MdsMqwW7YIgfLN%2FSwowvVuiZUJEyjA7jBKWG6A%3D
   response:
     body:
       string: "displayName: CLI-Test\ntestPlan: sample-JMX-file.jmx\ndescription:
@@ -2437,17 +2473,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Sun, 29 Oct 2023 22:26:10 GMT
+      - Mon, 30 Oct 2023 07:25:45 GMT
       etag:
-      - '"0x8DBD8CD9BE2528F"'
+      - '"0x8DBD919061276F8"'
       last-modified:
-      - Sun, 29 Oct 2023 22:22:59 GMT
+      - Mon, 30 Oct 2023 07:22:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Sun, 29 Oct 2023 22:22:59 GMT
+      - Mon, 30 Oct 2023 07:22:50 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2477,7 +2513,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A02Z&sr=b&sp=r&sig=VRpa6gQKXsswQ7TgoNIudZkNREfW3bRCzy%2F4m1nKt4k%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/b5025ffc-1ff6-4805-b561-90b6afaa8f10?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A45Z&sr=b&sp=r&sig=6cHISzdbLBsFjEyNHVuDAufS8pmhLSq%2BrDFgN4EdGj4%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -2550,17 +2586,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Sun, 29 Oct 2023 22:26:11 GMT
+      - Mon, 30 Oct 2023 07:25:47 GMT
       etag:
-      - '"0x8DBD8CD8E60618F"'
+      - '"0x8DBD918F4925232"'
       last-modified:
-      - Sun, 29 Oct 2023 22:22:37 GMT
+      - Mon, 30 Oct 2023 07:22:20 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Sun, 29 Oct 2023 22:22:37 GMT
+      - Mon, 30 Oct 2023 07:22:20 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2590,18 +2626,18 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A02Z&sr=b&sp=r&sig=0LuZco2I9NJ6G5C%2FGpN1fgDLD%2FMwDW20WmNHFooFkMc%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/eb7acd2e-767f-47d4-abd7-f42b12ae3af3/c1ab1d3f-2a59-4baf-bd8c-7791926d0629?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A25%3A45Z&sr=b&sp=r&sig=2iIbNSgUAn5fAtiReaIcxEW0RS6lG5sIavUPoGXyEEU%3D
   response:
     body:
       string: !!binary |
-        UEsDBC0AAAAIAN2yXVcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
+        UEsDBC0AAAAIANk6XlcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
         AAAAAAFZAab+ZGlzcGxheU5hbWU6IENMSS1UZXN0CnRlc3RQbGFuOiBzYW1wbGUtSk1YLWZpbGUu
         am14CmRlc2NyaXB0aW9uOiBUZXN0IGNyZWF0ZWQgZnJvbSBheiBsb2FkIHRlc3QgY29tbWFuZApl
         bmdpbmVJbnN0YW5jZXM6IDEKdGVzdElkOiBkb3dubG9hZC10ZXN0LWNhc2UKc3BsaXRBbGxDU1Zz
         OiBGYWxzZQpmYWlsdXJlQ3JpdGVyaWE6Ci0gYXZnKHJlcXVlc3RzX3Blcl9zZWMpID4gNzgKLSBw
         ZXJjZW50YWdlKGVycm9yKSA+IDUwCi0gR2V0Q3VzdG9tZXJEZXRhaWxzOiBhdmcobGF0ZW5jeSkg
         PiAyMDAKZW52OgotIG5hbWU6IHJwcwogIHZhbHVlOiAxCi0gbmFtZTogZHVyYXRpb25faW5fc2Vj
-        CiAgdmFsdWU6IDEKUEsDBC0AAAAIAN2yXVfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
+        CiAgdmFsdWU6IDEKUEsDBC0AAAAIANk6Xlfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
         LmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAAQYT+ew8P3htbCB2ZXJzaW9uPSIxLjAiIGVuY29kaW5n
         PSJVVEYtOCI/Pg0KPGptZXRlclRlc3RQbGFuIHZlcnNpb249IjEuMiIgcHJvcGVydGllcz0iNS4w
         IiBqbWV0ZXI9IjUuNSI+DQogIDxoYXNoVHJlZT4NCiAgICA8VGVzdFBsYW4gZ3VpY2xhc3M9IlRl
@@ -2688,8 +2724,8 @@ interactions:
         ZT0iSFRUUFNhbXBsZXIucmVzcG9uc2VfdGltZW91dCI+PC9zdHJpbmdQcm9wPg0KICAgICAgICA8
         L0hUVFBTYW1wbGVyUHJveHk+DQogICAgICAgIDxoYXNoVHJlZS8+DQogICAgICA8L2hhc2hUcmVl
         Pg0KICAgIDwvaGFzaFRyZWU+DQogIDwvaGFzaFRyZWU+DQo8L2ptZXRlclRlc3RQbGFuPg0KUEsB
-        AjMALQAAAAgA3bJdVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
-        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACADdsl1X8Zv7b///////////EwAUAAAAAAAAAAAA
+        AjMALQAAAAgA2TpeVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
+        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACADZOl5X8Zv7b///////////EwAUAAAAAAAAAAAA
         AACbAQAAc2FtcGxlLUpNWC1maWxlLmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAUEsFBgAAAAACAAIA
         ogAAAOsUAAAAAA==
     headers:
@@ -2698,21 +2734,21 @@ interactions:
       content-length:
       - '5539'
       content-md5:
-      - 93fq3z4MPh6ygZI9IwDVUA==
+      - uLeDrZ7akSgaFFnNeKzwvQ==
       content-type:
       - application/octet-stream
       date:
-      - Sun, 29 Oct 2023 22:26:12 GMT
+      - Mon, 30 Oct 2023 07:25:47 GMT
       etag:
-      - '"0x8DBD8CD9C5AA52A"'
+      - '"0x8DBD919061D4AC7"'
       last-modified:
-      - Sun, 29 Oct 2023 22:23:00 GMT
+      - Mon, 30 Oct 2023 07:22:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Sun, 29 Oct 2023 22:23:00 GMT
+      - Mon, 30 Oct 2023 07:22:50 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_download_files.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_download_files.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:35.8868534Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:35.8868534Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:14.8313783Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:14.8313783Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:09 GMT
+      - Mon, 09 Oct 2023 19:19:48 GMT
       etag:
-      - '"920131b3-0000-0100-0000-652426750000"'
+      - '"5600672d-0000-0100-0000-652452350000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:13:11 GMT
+      - Mon, 09 Oct 2023 19:19:49 GMT
       mise-correlation-id:
-      - 71af1f94-832a-4255-9ff0-c4ce001a9767
+      - 5acbbda8-e603-4e70-b867-452866b9943d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"d449c773-04d1-4d1c-bc15-21f5cd7db421": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "bba2108c-0525-456d-a02b-d147b2abec99":
+      {"passFailMetrics": {"d8f1010f-4928-47da-8a65-e0587be59206": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "7efb4f19-9fef-4335-ad73-bd4361e600c3":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "ff8146e9-6274-498e-be31-c18794d8a4f4": {"aggregate": "avg", "clientMetric":
+      "50"}, "24d868b1-b8e0-4328-b1ef-3569f3e4267f": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:13:11.793Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:11.793Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:50.234Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:50.234Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:11 GMT
+      - Mon, 09 Oct 2023 19:19:50 GMT
       location:
-      - https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+      - https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - b7d32614-fa73-4393-801f-72ae77995b79
+      - 6b390da1-e468-4b00-ad21-1beccdeae44b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:12 GMT
+      - Mon, 09 Oct 2023 19:19:50 GMT
       mise-correlation-id:
-      - 17c11bf1-3bfc-4c1b-a1d3-02dd49054308
+      - fdc220aa-5905-45cb-80b5-7b020ced21dd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A13Z&sr=b&sp=r&sig=ll5x1c7p2meSPvhc1SlLZhZN7rgjkETuEBqGkI1%2FP2U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:13.3438032","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A51Z&sr=b&sp=r&sig=jPDH7P%2FUfqZxrpDaxPocNC5%2Bp%2BEaAjp0ZJjaBgmXuUY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:51.0467837","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:13 GMT
+      - Mon, 09 Oct 2023 19:19:51 GMT
       location:
-      - https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 4041b049-a163-46a0-b544-ef95dca13d30
+      - f4977216-0821-4f25-a916-444a56dbf095
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A13Z&sr=b&sp=r&sig=hUpNkGGeXISSR0x%2BfM9Rd9Ir3rEGs8CklkwIM3MHPcg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:13.6061207","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A51Z&sr=b&sp=r&sig=E8EnzQ4P1vOzjr3AgOi8wsFVAqKxUahXtTZqLnIovyE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:51.3157392","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:13 GMT
+      - Mon, 09 Oct 2023 19:19:51 GMT
       mise-correlation-id:
-      - 2487eebf-b7a2-433e-a0fc-849c756d22cd
+      - 8d6e8252-bc29-4cd6-a660-14b499545332
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A18Z&sr=b&sp=r&sig=8konLNDtBjXNoUsd9DmJ7%2BVD4QlEuh7zWsFEEvte9m8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:18.8893546","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A56Z&sr=b&sp=r&sig=0K9L9SSMYixg6fkR4m%2FuTpU8ZkUNzgIBUWFdFoWEST4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:56.654193","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:18 GMT
+      - Mon, 09 Oct 2023 19:19:56 GMT
       mise-correlation-id:
-      - d4c48785-e16b-49c5-b79a-d005c238eec1
+      - 37937733-8edf-42de-81dc-783e9744cd4e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A24Z&sr=b&sp=r&sig=t%2FyjgwGAfrtt2JI5ZQHYRpp4HZWv4%2FzzTWlku89u%2F0E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:24.1613117","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A30%3A01Z&sr=b&sp=r&sig=TPXsTNlXHuGmyYBiBoejO1D9daNqPz7vxVBcNf0001k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:30:01.9795438","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:24 GMT
+      - Mon, 09 Oct 2023 19:20:01 GMT
       mise-correlation-id:
-      - 197049f7-318e-4b98-93a0-955eaced6a99
+      - 85224c09-59ca-4813-a317-21a00b90c465
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A29Z&sr=b&sp=r&sig=leJQEHI%2BD59G%2BIxMMVKd1Vgd9Qmi4wOMS7t%2F4F6otNU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:29.4587981","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A30%3A07Z&sr=b&sp=r&sig=Jx16rGTi8fP9kCIiL4Xu3WueAILNezgvUqhL3r4qKOo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:30:07.2450597","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:29 GMT
+      - Mon, 09 Oct 2023 19:20:07 GMT
       mise-correlation-id:
-      - 45c183ce-47ae-4932-b228-aee95529c2c4
+      - bdcd934f-d9d7-47fc-a2d6-15c85320b090
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,11 +457,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A29Z&sr=b&sp=r&sig=O6zQcFFwQTONWj%2F7sf7ITopBiXtoSNs03MQTyl%2F2GJ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:29.7200158","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:13:11.793Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:25.388Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A07Z&sr=b&sp=r&sig=8LO5S6f1n8vBTdhV34L64p6xQDKjAy7%2Fm%2FVoM5vDlHU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:07.5129673","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:50.234Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:03.389Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,9 +472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:29 GMT
+      - Mon, 09 Oct 2023 19:20:07 GMT
       mise-correlation-id:
-      - 5bdac6db-2dbd-46a9-828a-85a1f47715cf
+      - beb40476-4c5b-419f-b6c0-076c9972ac25
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:35.8868534Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:35.8868534Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:14.8313783Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:14.8313783Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:30 GMT
+      - Mon, 09 Oct 2023 19:20:08 GMT
       etag:
-      - '"920131b3-0000-0100-0000-652426750000"'
+      - '"5600672d-0000-0100-0000-652452350000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A31Z&sr=b&sp=r&sig=MV0rD5mTi6%2Bn5jEEWW69obmYfQeI0dlUGXY8mq0t9PM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:31.9240423","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:13:11.793Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:25.388Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A09Z&sr=b&sp=r&sig=nfssOjVsvA0A3YkFbbbc9onsF7sdIb4uXXJovHJpCtg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:09.9705497","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:50.234Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:03.389Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1593'
+      - '1591'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:31 GMT
+      - Mon, 09 Oct 2023 19:20:10 GMT
       mise-correlation-id:
-      - 6c79fe1a-5f5a-49d1-9a48-7e828a744bd2
+      - c6a1271b-4bb4-4b2b-a310-121cbcacd7ca
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:35.8868534Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:35.8868534Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:14.8313783Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:14.8313783Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:33 GMT
+      - Mon, 09 Oct 2023 19:20:11 GMT
       etag:
-      - '"920131b3-0000-0100-0000-652426750000"'
+      - '"5600672d-0000-0100-0000-652452350000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:13:34 GMT
+      - Mon, 09 Oct 2023 19:20:13 GMT
       mise-correlation-id:
-      - b72ef6d0-e2ce-49bc-a7b5-09424f78247e
+      - bd44c9c2-d2d2-4ac1-94a4-b2d8ddbdb259
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A35Z&sr=b&sp=r&sig=X0MleczDwtpHPK6nDGm%2BErspO%2B8NYiuFbP2G8kScAJY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:35.1388043","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A35Z&sr=b&sp=r&sig=pZjBeVbIpxwx3yopwrmVufgtIO2dGz3%2FA6kAyIbKxnc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:35.1386853","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A35Z&sr=b&sp=r&sig=QkRS4TI90gaxkPCBfe4tWQ34wMxSPWsTIi1quYvtkdA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:35.1388308","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A13Z&sr=b&sp=r&sig=ty9fyavUEwuTvoVdiW5Al25s1p8pddpPXatmaki4KL0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:13.9059997","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A13Z&sr=b&sp=r&sig=2ZCzQzHrqo%2Fnj3bMuIBJl4ajnGosM%2BjgKhTBTivDFxw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:13.9057771","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A13Z&sr=b&sp=r&sig=buLfDSpkabFxW975wxlKTaAZTZ3pCVB9KyP1uGVRsD0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:13.9060215","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:13.827Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3164'
+      - '3162'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:13:35 GMT
+      - Mon, 09 Oct 2023 19:20:14 GMT
       location:
-      - https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+      - https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 810f3cf3-67bb-4b5f-92f4-6c7924a829aa
+      - 9de9750b-a5e8-410b-a7fc-561603586e90
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,334 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A35Z&sr=b&sp=r&sig=6WJnbsoynHFu9vs63H1ER5kqh8%2BucpKQuqYC59tlkr8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:35.6204889","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A35Z&sr=b&sp=r&sig=tt6pCqQKCaHVOHFCh1cCYLwTBTT3gweUtIgPik31Yd8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:35.620394","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A35Z&sr=b&sp=r&sig=vEq7Xig%2BlUvTP2syAbQ7tRO8U4nb%2BsVy0L9%2F1aJko64%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:35.620509","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.504Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3209'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:35 GMT
-      mise-correlation-id:
-      - b76657ae-21ff-4a53-8241-7bc5bd742b04
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A40Z&sr=b&sp=r&sig=QOfL%2Ba1jSQIso1zITtSqCkf%2Bo48CfyqaOy9T%2BNKr3kY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:40.9198483","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A40Z&sr=b&sp=r&sig=2X%2BplKTC8QfGMYwlH0oOBZslD8pvyo8uNy%2FGjAdrAbE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:40.9197789","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A40Z&sr=b&sp=r&sig=xsgksO%2FGfegIToyhoNcQWx5yWCn%2BtKxkngInE3SKcU8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:40.9198649","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3219'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:40 GMT
-      mise-correlation-id:
-      - 03a58ebc-0964-4995-9e86-588c1da29c59
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A46Z&sr=b&sp=r&sig=qKXrLWJ89EKSH1otm%2Bj3%2F6vprebLs3%2BLizL6K3SCHAM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:46.1992667","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A46Z&sr=b&sp=r&sig=DcVSendJQdOPsuS8KahHQCIMRIvVxdNKx%2BXlXcVNmG4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:46.1991742","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A46Z&sr=b&sp=r&sig=stL09%2F4Jnhr5ljnxSJi8C70r4blmCuZjncQ1jJgFvWU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:46.1992879","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3215'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:46 GMT
-      mise-correlation-id:
-      - 900b9d61-0b83-49e4-995a-c6a948efac7b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A52Z&sr=b&sp=r&sig=lvc6gzFGK0JW5fe%2FgMmB8cSTcpDx%2BeoG1sWNbM4q1Oc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:52.4697055","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A52Z&sr=b&sp=r&sig=XNbpvYaUwiC6XvejpCmpEXWR6PNY4mTi617Tp%2FLJViE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:52.4696357","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A52Z&sr=b&sp=r&sig=zcBFbgLF2aqx3LaaU%2FxpHOeqS8abL%2Bmly8XPX1kA6Lw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:52.4697232","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3215'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:52 GMT
-      mise-correlation-id:
-      - 24ce588d-a1c3-4067-84a7-11bc6eb758d5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A58Z&sr=b&sp=r&sig=gt%2BWgdwm%2FrnsSAZc5tWm%2BAMaoKSEWaXSQupJ6qRI4yQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:58.1500688","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A58Z&sr=b&sp=r&sig=Cqb33kranoAd8Bb%2B52QS889r3RG%2BJrnThq22kWnEN9A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:58.1499686","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A58Z&sr=b&sp=r&sig=Pr4bkxO6IoaGjL6xn2pNAkFtNLJFbbicUs7vV6mNsvY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:58.1500936","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3215'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:13:58 GMT
-      mise-correlation-id:
-      - d25830cc-b9f1-4816-9b56-a06a192f862f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A03Z&sr=b&sp=r&sig=GUeCXrnNNAI0Kim6HLdcf0lIlIAge3k2A17K5x7D2bA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:03.5655425","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A03Z&sr=b&sp=r&sig=ibJJddSeyUdfiWivjfHkBhNcuQMnqlu2T%2Ff%2BpymHdXk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:03.5654745","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A03Z&sr=b&sp=r&sig=8UGPwXEx1RcBMRBtRAt1ZGrJ2gd9qUlNijwHF%2B2We7Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:03.5655576","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3211'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:03 GMT
-      mise-correlation-id:
-      - 7d0cf34d-050e-4bef-94d8-aa0e4abbc460
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A08Z&sr=b&sp=r&sig=%2B5ZyGeu11HvEjWuHsqVHx2t9On955s70DVm2R4Lw6oI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:08.8459567","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A08Z&sr=b&sp=r&sig=CwomC9twIlM5J9%2B95vJiTQalPdzkJcj8mMu%2FUP9yyW4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:08.8458544","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A08Z&sr=b&sp=r&sig=DVJTJxccx8W6rwv4Rg%2FL%2FpfoOcgSesi%2FvKRwGUDje54%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:08.845983","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3216'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:08 GMT
-      mise-correlation-id:
-      - 3a216e77-88ff-4725-a14b-c6c6849b3b51
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A14Z&sr=b&sp=r&sig=KJ9LmBM3EBVO9vb0Mz4QIaUUH9qPAMJBQ0ibo5X3wmA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:14.1280046","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A14Z&sr=b&sp=r&sig=R2Tequlb26mqnF0AwuMUnXBlpvdwfv4EvB5Z42nHrKM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:14.1279357","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A14Z&sr=b&sp=r&sig=plYtvCWdRrd3y7oUo5C6bKbFKDKDSg3%2BdZph5to0QZM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:14.1280201","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3207'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:14 GMT
-      mise-correlation-id:
-      - d4b64e77-53a1-4614-a2ee-53948f1261a5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A19Z&sr=b&sp=r&sig=LGhMjr7Pwt6%2B7sVnd2yZMLSHDG1XMEyvqaE4dtCO9OE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:19.4120382","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A19Z&sr=b&sp=r&sig=RhUn7BKicf28OHheXHTcDlqHeW4WSaHguH4bvaENDrw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:19.4119728","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A19Z&sr=b&sp=r&sig=%2F90Kn0o8hRwC2234iHw4urvcjIVAcq7ehADLWUJmgkQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:19.4120536","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3209'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:19 GMT
-      mise-correlation-id:
-      - 10cb0e32-3501-45e4-abb0-d73c83f20f28
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A25Z&sr=b&sp=r&sig=02%2BR7CgmtlCsqqY0DSCVpnuGEV0dLobNN36VuHfFZGo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:25.3565917","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A25Z&sr=b&sp=r&sig=W1qWPMPm8BqvJCIXNsHQBgUuh1plgAp3LiNCsd7meSI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:25.3564563","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A25Z&sr=b&sp=r&sig=x50Ja6WrKyUl%2BkLdj9K2Ox%2F1WcPZneqCeFYQc%2BVgvX8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:25.3566076","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONED","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:25.344Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=UT2q6wqTTCxWKEptunrN1wLb2f6%2BPLgSE%2Fty5z%2BBc6w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:14.34162","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=u45CxvU5zvwTa1bdR9br2ytz%2FNk23f%2BscVLP59EUi28%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:14.341551","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=4yLHCbP2mqPbOFspXEirW0EIwCaKPAb2Eyq%2FlG3Wieg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:14.3416361","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.233Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1038,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:14:25 GMT
+      - Mon, 09 Oct 2023 19:20:14 GMT
       mise-correlation-id:
-      - fab10f97-fd7f-45e5-9bd7-99415feb52aa
+      - 637b233d-bb26-41bf-ae70-66997f965965
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,442 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A30Z&sr=b&sp=r&sig=43%2B2FWEifw%2FbcCrlhPDZFBEUHdwpG9UYSZVQ%2BPM932g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:30.631639","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A30Z&sr=b&sp=r&sig=3M7Hqs1hfltGXnrnCL1ah%2Fy6JkhcTtnZasGOb%2BtLmCA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:30.6315712","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A30Z&sr=b&sp=r&sig=ean2DktuLKjmwEIZ8lVccyeXXd89Jf2XaR3rCrbTuEI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:30.6316536","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3211'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:30 GMT
-      mise-correlation-id:
-      - 061515aa-c34d-422d-ae3c-53e497a67f5c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A35Z&sr=b&sp=r&sig=tz5i5EG6MKKAHymzsa41lvmA5yFva9gr9flGSWYk2f4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:35.8984783","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A35Z&sr=b&sp=r&sig=rBuAPBYJnlAu%2F85yfctBtNi01lh8gKhT1YP0s8RE%2BA0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:35.8983964","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A35Z&sr=b&sp=r&sig=ka%2BmV4DB4klci%2FL%2F1hcNw1c0%2FUOOILIjWSnPCg%2FQnZI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:35.8984934","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3216'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:35 GMT
-      mise-correlation-id:
-      - 74d5aaef-0772-4196-bedb-9ed35453dad0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A41Z&sr=b&sp=r&sig=2zuPNne6k1bJ9VGcSfl6XOp1UYhahu1LF7Klo7Yx0vM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:41.1839124","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A41Z&sr=b&sp=r&sig=2DOkmuUtFBkMyHbez7nc%2FH2ZhgmNYTgrotkeS1Y5y%2BU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:41.1838321","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A41Z&sr=b&sp=r&sig=R3eIdTwdrdOSBkOqWr%2FWVdmdGmvpfwPFNdSCzESV45s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:41.1839275","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3208'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:41 GMT
-      mise-correlation-id:
-      - 7cbc74dc-eb0a-406f-8675-12d6b719723a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A46Z&sr=b&sp=r&sig=EMdDqSk3oYUfua1d9DUBGIhU6ulhTLXsuX0M2uW9qh0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:46.4909181","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A46Z&sr=b&sp=r&sig=XdBPY8%2FuLvHbuXTBeTIAVpAG7EFeNPC6aNq9TYJFicU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:46.4908291","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A46Z&sr=b&sp=r&sig=v2uanEaUnxWC3pk9mPUrzZrutNoy1zKlYBK4htXTCaA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:46.4909341","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:46 GMT
-      mise-correlation-id:
-      - e960bfaa-444e-4c77-85f4-a37c102ed3dd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A51Z&sr=b&sp=r&sig=YDZmdizCGTHK2krFcBEByWS97hI98YgaaQGBkgkF%2FS8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:51.761958","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A51Z&sr=b&sp=r&sig=bsCGKUujiRAuIbe1Ezx725LMsazQicH0I4kO%2BGbEzHI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:51.7618735","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A51Z&sr=b&sp=r&sig=4Hs4S2aEAp%2Fv4KoDOlw6bT%2BOb4XjlG2wh9FyY78EPzw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:51.7619799","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3209'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:51 GMT
-      mise-correlation-id:
-      - d469562e-6928-44ff-ad3d-7372d69b5459
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A57Z&sr=b&sp=r&sig=bwvWBAh2vWYqH%2BYmgliHevg4qY3TnbRVP9KJNE97TEk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:57.0404536","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A57Z&sr=b&sp=r&sig=aQ1sU7Y0rIg%2Beae0zyZ7JGhecIdchGcTYYuQsXNgK%2FM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:57.0403763","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A57Z&sr=b&sp=r&sig=dl%2BUb%2Bw39Cil%2F9L%2BHLtyzhr8pEt0zfeWURuaECg%2BTz0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:57.0404778","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3218'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:14:57 GMT
-      mise-correlation-id:
-      - e04f9d80-f91d-473c-a75f-c2760c9e0809
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A02Z&sr=b&sp=r&sig=nN%2F37EUr4Bif612COtosfnaPIhZNSWec%2F3MhHZ7rDic%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:02.5809662","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A02Z&sr=b&sp=r&sig=FCWimL0rM1xS1fRDMJWh4av26DFvzU7JtirK4i8rzBY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:02.5808966","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A02Z&sr=b&sp=r&sig=wEeRHUvS0FVdAgTZpy7i6JcQ4pAQhlvQ3YJVIsazcMo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:02.5809816","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:02 GMT
-      mise-correlation-id:
-      - 04666514-8dc7-4a56-982c-ff0551b6439f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A07Z&sr=b&sp=r&sig=KPOMTyMjV2gmJ7%2Bd7maiomMska%2B2gIqwO%2FdVRHPsJG8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:07.857227","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A07Z&sr=b&sp=r&sig=ICsJ5o%2BaJK06rQJAIs4Gu2vqKnx1QQ2E%2BVkuI5DgeUc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:07.8571226","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A07Z&sr=b&sp=r&sig=eWkmu2tnevWf8EYbF7wLy8hOy5qFn9TXF2NsqgqWPYg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:07.8572538","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3211'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:07 GMT
-      mise-correlation-id:
-      - 9725cdba-c2da-41a2-ac24-855ead5d449c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A13Z&sr=b&sp=r&sig=Tr6hsOF9N5c5izM813jr22GiwbRy4unY%2Bh%2FxHet%2B0nY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:13.175442","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A13Z&sr=b&sp=r&sig=4rfWZ5NV%2B3y0sGp%2Bx7B59NW%2FPqH%2Fps8h2gNysT%2Bzd9Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:13.175355","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A13Z&sr=b&sp=r&sig=nE0fsQn2lr3%2BDZoPaKvNyOj%2ByeT%2BgXf02XUIKvsDAkQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:13.1754658","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3222'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:13 GMT
-      mise-correlation-id:
-      - 28df76d7-4358-4d5d-b144-42914ba0bcec
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A18Z&sr=b&sp=r&sig=GHdD7AGoeDWTxPP8eAb%2F1uo6cRi%2FwX8eFPqB%2FR14oAo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:18.4489479","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A18Z&sr=b&sp=r&sig=zPqEufJkX1NM7VNq%2FcX0sAhldf2gEoBDMlTfJTzW2Ys%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:18.4488684","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A18Z&sr=b&sp=r&sig=h7%2BZe7Iz%2FWM6W2lufShhYnwF5yeFxwGqOcF11Wo%2Flq0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:18.4489625","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3216'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:18 GMT
-      mise-correlation-id:
-      - b95b5f5f-8e01-44b7-8021-38b3be23685f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A23Z&sr=b&sp=r&sig=HJiauWXdRQ89eie0%2F1hhcpD5mqePJJPNnHZQds9epQ0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:23.7398782","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A23Z&sr=b&sp=r&sig=MY8cfq08WpkDhMSn7cNa6YyKq2KxHTrbJMyR1yV94pY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:23.7397713","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A23Z&sr=b&sp=r&sig=ASjWFBMF9EtnjL%2FatRsJAYeNic2dFhNP37ozL5jWpUg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:23.7399048","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:23 GMT
-      mise-correlation-id:
-      - 699e8498-566f-4641-b3e9-ee4deb1678c1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A29Z&sr=b&sp=r&sig=e92D58lGkT%2FNe704jcUaipbU7mPT13F6RJrrZUbTB9M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:29.0211481","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A29Z&sr=b&sp=r&sig=sHV%2BZiQBzp2E6ukztAl9pRz2M9oIPwDEawDNCniUlEM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:29.0210732","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A29Z&sr=b&sp=r&sig=D1p3fT%2FChZp3kPRkQjkIA%2F1BWIHIAjhk0DyN7hF04%2Bg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:29.0211643","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3212'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:29 GMT
-      mise-correlation-id:
-      - 8b3d5b75-ae64-4706-814e-2ed327a3015e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A34Z&sr=b&sp=r&sig=D6iZSPROSVr%2BQMXsFIOprZAM%2FiO%2FRnyZ7Fg%2BCPS2sik%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:34.2942766","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A34Z&sr=b&sp=r&sig=qzN%2BpjJ%2F9SCwRY%2Bw2do8wZGVn1qqHPEBwf4azP25dD0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:34.2942016","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A34Z&sr=b&sp=r&sig=VK5uCSxVjYT5TCAvhhajIdtbRgbnpMr1r%2BTVJ77GOqQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:34.294295","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A19Z&sr=b&sp=r&sig=On%2F6fb25N4hYcUFu4RF4PkMO6CHtV%2Fyc0C1fOdikCOk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:19.8067721","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A19Z&sr=b&sp=r&sig=95z6BBW7%2FvhsBxUicTYIP%2B7ZWqf%2FwoMSzNneNysuwGw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:19.8066948","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A19Z&sr=b&sp=r&sig=ClNRwbBfO%2FXF0lZt6xctDNfZWnDg9PjcdRHb7O9J8rk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:19.8067866","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.497Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1506,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:34 GMT
+      - Mon, 09 Oct 2023 19:20:19 GMT
       mise-correlation-id:
-      - 78261338-c473-46ec-8c7a-294d62933fca
+      - 6f4672a4-9abd-4c2c-a645-68179c161f2c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1528,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A39Z&sr=b&sp=r&sig=OI8WNnyt%2FMPsDjUFNNEbJLSU5qBKkZ5B05XMoZkGfo8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:39.576845","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A39Z&sr=b&sp=r&sig=LCNe%2BeZ%2FwzZAhZIMjSZGgUD9%2F%2FEa2WiWXFjiNJJVVAY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:39.5767594","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A39Z&sr=b&sp=r&sig=XDtdBpesCizB%2FWn3FSDiv2TSQJexyC0H4CduCU3yYbU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:39.5768637","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A25Z&sr=b&sp=r&sig=cVGj9SJOeTcRzazv6YO8by2FWG0DHuR62aCbfjhRBrY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:25.4322267","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A25Z&sr=b&sp=r&sig=n0uEf8fQ6xiYcGZhU9uyDEswfxb6MZ0d2feX2yeMP74%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:25.4321536","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A25Z&sr=b&sp=r&sig=7vqHoR7vorMjrp6noDLRMwx4%2B%2FePnc%2FlT9dcLgbKhSE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:25.4322493","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.497Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3213'
+      - '3211'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:39 GMT
+      - Mon, 09 Oct 2023 19:20:25 GMT
       mise-correlation-id:
-      - 49545059-b877-44d9-bf8f-f9cc2d44e424
+      - 5772f641-4eea-4a63-ae97-8029ecaeb69d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A44Z&sr=b&sp=r&sig=Koz01%2FBaVKvZwSkWnbk0ZYqxg%2F6k1GR8q3Y%2FQpEbw1Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:44.8594008","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A44Z&sr=b&sp=r&sig=K9prLEo5sdpGOHhTteGA8W7sDx%2Bz657LowxrEAE%2FecE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:44.8593055","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A44Z&sr=b&sp=r&sig=cTdTOr4mXCvcAFaOlq%2FCYZeXRUvvl5apLPFj%2FxcwDzY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:44.8594246","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A30Z&sr=b&sp=r&sig=P1VAwCt3s0XZFrMl7PmLgaHxv21owk3GEoO85T8QQok%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:30.7657524","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A30Z&sr=b&sp=r&sig=dcru6U89cDa6ezuVA7Z2hYjf37bQ7Yq4jovEVSb9R00%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:30.7656496","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A30Z&sr=b&sp=r&sig=3bgSt8FBNmZhSgmLgWCY8fwsjDCFzZJzorvs2SWms5I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:30.7657727","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.497Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3216'
+      - '3205'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:15:44 GMT
+      - Mon, 09 Oct 2023 19:20:30 GMT
       mise-correlation-id:
-      - 014c9f21-6069-4ef8-a4e5-682f7765ba62
+      - d411a2a9-a196-4c6a-ac3b-71e00edac304
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,154 +844,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A50Z&sr=b&sp=r&sig=z3T7gFQJNwPsy6ZU2XumxqqpIe8RO%2FoR7ScFn83nMYc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:50.1354519","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A50Z&sr=b&sp=r&sig=tX0kH8UBjxvDewfgjSSa1gvKZPqzMz5AueTyFWCVd7U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:50.1353821","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A50Z&sr=b&sp=r&sig=FXttiQx%2Fygqdp1KD4R3eMSLVhsdkVUueER8SbdkgRzw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:50.1354686","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:50 GMT
-      mise-correlation-id:
-      - 60097231-f244-4271-a8ed-ac72dd22fa68
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A55Z&sr=b&sp=r&sig=H1JXTbcLgFxdXcQ%2F2eNXYxtkRfvhaCyzLvS%2FcnGqgrU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:55.4161484","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A55Z&sr=b&sp=r&sig=8aU4hveImUxPdFKfPHOIyVngA9NqG1qxXMMkYjM80Kg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:55.4160519","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A55Z&sr=b&sp=r&sig=s0rjSI1HjVgLLslmbICjpVuGb3mCkJcrejateUyRVyA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:55.4161728","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:15:55 GMT
-      mise-correlation-id:
-      - fd9b3bbd-9886-4020-88b1-8c4aa489983d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A00Z&sr=b&sp=r&sig=LeyUpY5fGNtMwsrG%2BF3Zxe2nXE8rZBGDWxUYy7dyAco%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:00.6955296","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A00Z&sr=b&sp=r&sig=IUoR6MCU68V9QBAPSpbz6BV3kn0Gx0GM%2FPG7oYyDw58%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:00.6954534","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A00Z&sr=b&sp=r&sig=9tuVep9wjdxK5HszVIo55zt0WqGoXHTVfjv3B0cV4lw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:00.6955441","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:16:00 GMT
-      mise-correlation-id:
-      - 3bc29e7c-007c-4356-b2a3-68694eae7dda
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A05Z&sr=b&sp=r&sig=AlIAQvk8%2FVOxD%2Bdjs7LAsCeZz2juYgZz1lnKGn%2FmGGQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:05.9686954","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A05Z&sr=b&sp=r&sig=Rk6xgsJ8uXtrBERc83SqLxp2JZ0Nf97ADNKLkr3QUF0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:05.9686289","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A05Z&sr=b&sp=r&sig=Sj69VYUFE35YN6dfmqKIYdzYDxnOkV4Tyn2JJibLdek%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:05.9687447","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3208'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:16:05 GMT
-      mise-correlation-id:
-      - 594fe8bb-81c0-41be-91b7-9a4c4e1c5a30
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A12Z&sr=b&sp=r&sig=5dxGPeiIK1xM%2FXDqCKZSHhW95Ij2lI6WXyijB7gUfNc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:12.1888677","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A12Z&sr=b&sp=r&sig=1T4qj%2BsJ2WnlwgT8JYE9vxYnO%2FwehMGP8rR%2Fv9B1SeY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:12.1887981","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A12Z&sr=b&sp=r&sig=UxZogR5nlhQ1A7AQRZHzAzByGZ7fhjuaoavh9KT8XSs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:12.188884","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A36Z&sr=b&sp=r&sig=pSUCXpgUtDoPZW4IG0gVkNn9wAgaxoo%2BwXVJ3SUkON0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:36.0549074","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A36Z&sr=b&sp=r&sig=LyS7nfliINir22gsgUBbIQZ9144Cs8KgsaPF2i6J2Z0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:36.0548325","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A36Z&sr=b&sp=r&sig=tzPpcXvkLRh1sGezf6i4kagSCYYtu1mgtCKw0Ta0A%2BU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:36.0549234","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.497Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +858,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:12 GMT
+      - Mon, 09 Oct 2023 19:20:36 GMT
       mise-correlation-id:
-      - d86d0c04-265b-4093-9299-ff6c561467bf
+      - 52e94e1e-ccdf-431c-851e-3d7c8a694617
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,10 +880,406 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A17Z&sr=b&sp=r&sig=vPcnU5CAdfzJUiG018Mxj%2FN8bUUCtPm%2BYXeXQNKtNRg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:17.8465971","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A17Z&sr=b&sp=r&sig=qQZyLCZ6jROp5z%2F%2Bp6nVQXCrA2c148lGkHG59wEAvUY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:17.8465125","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A17Z&sr=b&sp=r&sig=ye1GlDH1T6DOX6RX8ZTw6KPbFl3LSkyMIHIS03GSe10%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:17.8466123","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A42Z&sr=b&sp=r&sig=j9zEZwAmJsAzQcWY2xP5357ci6MpRMbi3dM%2FaFvsGvQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:42.5382804","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A42Z&sr=b&sp=r&sig=6l5xTaWj4l2VcqdeVl94XYWNIJpQkIWeevFUxkXfJkg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:42.5382035","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A42Z&sr=b&sp=r&sig=rf62Y%2BITEV0tSol9wa5IzgcgN6SjRoc0o81S2D2KKQo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:42.538294","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.497Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:42 GMT
+      mise-correlation-id:
+      - f296a26f-d8a9-4485-8eb1-3ffe21c72b8a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A47Z&sr=b&sp=r&sig=mIPW8ZTG5r%2BV0No0jShZkraZVBLsXe8s8pam2LIZ21I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:47.8221214","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A47Z&sr=b&sp=r&sig=718WLAz11tGl8qaVprTS22Xjk8OX2%2FTexMHte9qBvBg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:47.8220392","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A47Z&sr=b&sp=r&sig=%2BOAepjfnC4XYDbV7Abz%2FCzkf78BrPyHTqAF%2BD%2FpPD6c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:47.8221416","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.497Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3217'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:47 GMT
+      mise-correlation-id:
+      - 9cc1b53b-15e3-4039-84b2-5c0152b29eca
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A53Z&sr=b&sp=r&sig=ZDh3pkWw3j%2BPdJP5D6I3yCXlfdKNwYgx8YO8S9AhRdA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:53.3008865","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A53Z&sr=b&sp=r&sig=52DcPKXX0gDf75vm4vZiwonAg64nRpgI64S0SGi6ALE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:53.3008191","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A53Z&sr=b&sp=r&sig=yjSf2mirnIhvWktSUWeZ1kF96D7kiX7129LhIjzFFz8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:53.3009022","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.497Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3207'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:53 GMT
+      mise-correlation-id:
+      - d1bbf77f-74cf-4c1b-96f2-74737a8eade0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A58Z&sr=b&sp=r&sig=uEJdXdmAgNGPaHq7A%2BppnaezRMAvLD5vXGofWJS1lvI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:58.6267141","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A58Z&sr=b&sp=r&sig=DAi5%2FcSflZ02CadWLU7UljhEqpbKqrw8WZD0T2gl4pU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:58.6266211","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A58Z&sr=b&sp=r&sig=GX%2Fn%2BGlyGnKadUnsmZqkaBpbPJyoYp4%2BzcAKP8ggqVU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:58.6267349","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:58.227Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3214'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:20:58 GMT
+      mise-correlation-id:
+      - 056d8142-d9ea-49b7-a26f-3f347a30c1c1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A03Z&sr=b&sp=r&sig=tg10nWqwYhwV2cznUOFu2TkGbN9pA8zGsl3AJVdssdk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:03.9446115","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A03Z&sr=b&sp=r&sig=nPLInz345Kg3fXOSnFfKDwB2FixsodEnoWvjqHRozkc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:03.9445232","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A03Z&sr=b&sp=r&sig=dnuktAdPUzJOt5GD9Dkb8z4QPPzC%2FIVu0IsQpa4GhvQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:03.9446254","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:03 GMT
+      mise-correlation-id:
+      - dd28ad5b-cb54-4aa3-81cc-2cc80e3f8586
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A09Z&sr=b&sp=r&sig=sxoIlbbIRclC%2Bby5sDj2v%2Fk4todps936KjCv6PUh594%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:09.2615224","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A09Z&sr=b&sp=r&sig=TRdm0F8QD%2FQ6cOSXMoAgbFriEylTt6sI%2BeydLlxsnDE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:09.261448","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A09Z&sr=b&sp=r&sig=ypUD6fPK%2B7zDw%2B4EBL1WAN%2BwwwfkEgap4KsJqF4xToE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:09.2615383","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3215'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:09 GMT
+      mise-correlation-id:
+      - fc7ceded-8935-4577-a959-e6e41d2000b5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A14Z&sr=b&sp=r&sig=Y81Da7ukkgYiV%2FZyfTYoh57VZBi4VpQiyhznp%2FqUOJk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:14.6343252","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A14Z&sr=b&sp=r&sig=uVbh8OmrUyQqxS79a1%2BaiC00m9%2BoL4hAMtfPKgTzlHQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:14.6342536","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A14Z&sr=b&sp=r&sig=eZkr%2BGg7hqy29nOrtA6WcTDClDfZ4HVlOBdk0R7G8fA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:14.634339","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3211'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:14 GMT
+      mise-correlation-id:
+      - c1b1cf35-4c53-458b-849e-f3f0b96f92ce
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A19Z&sr=b&sp=r&sig=Q%2FH6qGBjeLxbUs7%2FU8Az2Afh1AFPzET8I5VMuo3op5k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:19.9543912","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A19Z&sr=b&sp=r&sig=odVKQOTT1i3wkVazQexBOIt0z9ginYXb4MospDoz%2Bms%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:19.9542869","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A19Z&sr=b&sp=r&sig=70zJ%2BQ4zLisRC%2BumLKDfW3I7NEhwyCAuHvfrjpsXkro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:19.954414","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3211'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:19 GMT
+      mise-correlation-id:
+      - 34a2057e-1485-4919-8824-9ce68ab9543a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A25Z&sr=b&sp=r&sig=wwMTGbozI%2BStBa43aa%2BwZGvCN7Y66j9WGzYEpD2cV5M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:25.3315114","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A25Z&sr=b&sp=r&sig=%2B2CQy5IS12wVAxITu7jjIff%2FjjEkynZLl5Xm30cFjL8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:25.3314199","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A25Z&sr=b&sp=r&sig=74qsDVDwtDLmo4V9WZI%2FfCAB7ngmiLtJuO4w5%2Fi8d4s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:25.3315318","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3214'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:25 GMT
+      mise-correlation-id:
+      - 75221234-7c53-43fb-86a2-521e3507d61c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A30Z&sr=b&sp=r&sig=ZFHSyP%2FE%2BOyxBhxyRU4WkA2zNfUvE0Rbrt0gYhXlT%2Fs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:30.6502513","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A30Z&sr=b&sp=r&sig=9fqw5WZoccX7HNwYTFmymX%2B5Ud22JZe7yhQkr43LuzQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:30.6501952","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A30Z&sr=b&sp=r&sig=ZYMpWymyDwDAAt6tuyCTjCQNBom14LE%2F6bL4Rm%2FOe0o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:30.650266","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3213'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:30 GMT
+      mise-correlation-id:
+      - f6294554-5923-40b1-b29e-13caf81ef423
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A35Z&sr=b&sp=r&sig=8kxpEJY%2BqQrDvzeUdKeOUi1I59CiGTuPKo626QsqmrY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:35.9301042","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A35Z&sr=b&sp=r&sig=C3HAq1yNG%2FXCoFWP5bSGvgKzFOn2wZ3hkxnyvZ8SxGo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:35.9300042","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A35Z&sr=b&sp=r&sig=sOEvBEklyjMGZypqCBr5z%2FUv6IY%2BdxDDaxlzZ%2FnFRrU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:35.9301256","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3212'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:35 GMT
+      mise-correlation-id:
+      - daad48cd-8092-4af3-a7a7-ed6f2661dbbb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A41Z&sr=b&sp=r&sig=d1kORKS%2BLIC4FE5UieFP0xZgGwjo%2BY5ql2yEsUp8Auw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:41.8637831","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A41Z&sr=b&sp=r&sig=3w4et6oLE0e6btXVKU2r4RnFZxhu02OJMDGFkGIMFtQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:41.8637149","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A41Z&sr=b&sp=r&sig=%2Bn1opU3gP1Yi3j9VwEBu%2BIxz5QyFlSXYvxXnRT67WxA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:41.8637969","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1794,9 +1290,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:17 GMT
+      - Mon, 09 Oct 2023 19:21:41 GMT
       mise-correlation-id:
-      - bdb6a2a3-aaf5-4d0a-9fe8-071cab9494a6
+      - 1a853e18-b53b-4bff-a5dd-c03e5d87eb3b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1816,24 +1312,492 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A23Z&sr=b&sp=r&sig=VNbKlWlDbGF1iwz5pLu1m7I%2BvkgLmbF4Fjk6ydwPqRs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:23.1346956","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A23Z&sr=b&sp=r&sig=4GKGOoY6qnSvAk75NbK4FNMzM9MDPmSXBb5kOaMPkB4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:23.1345984","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A23Z&sr=b&sp=r&sig=ScZ5DhlNrCGoFocHLofbx6rRpd7sFYufii1Fit3zgwQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:23.1347182","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-09T16:13:35.504Z","endDateTime":"2023-10-09T16:16:19.773Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:19.847Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A47Z&sr=b&sp=r&sig=pmwEgVswjoFijAGszC7NuwAmRxd1NZqbQ8zZKz%2FK2HA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:47.1314328","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A47Z&sr=b&sp=r&sig=QLi%2B0jSdbqe3rS1r92v98JkpE1t1S2RX6GY%2FRhC1X5k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:47.1313618","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A47Z&sr=b&sp=r&sig=KHXbbIwT5ohk9fOUNORfhmjwPZZaSy%2B8Ks3KDvsjS5o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:47.1314468","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3339'
+      - '3210'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:23 GMT
+      - Mon, 09 Oct 2023 19:21:47 GMT
       mise-correlation-id:
-      - 7651c445-edfc-444c-a2d7-4563bc6d9b8e
+      - 34b2fcd7-aacc-4d5c-9f0a-1d5cb337def5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A52Z&sr=b&sp=r&sig=b0J2bPqm7jFh1lLZxbDtkjoCUEe%2B2ugiZNj5iA1xtn8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:52.4023155","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A52Z&sr=b&sp=r&sig=9Q4MJrjhUBiWBzoMKRQ3mZ0CLTyZhfpHTnXwur1tTQA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:52.402245","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A52Z&sr=b&sp=r&sig=CBmm3Dign9kPx%2Fis%2BtHwFVtVWoo06Ux1kWT7w6ufPhc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:52.4023294","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3207'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:52 GMT
+      mise-correlation-id:
+      - 870c007b-2d1b-4ce3-a94b-3c1b11e10f54
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A57Z&sr=b&sp=r&sig=6XTqLqzFOpuzsAlGwsGjGC8AP80ap7Ej4BmCR5b7WJE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:57.6626819","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A57Z&sr=b&sp=r&sig=qsMIhShHTvBrwTr8jJra6QXxIvFzmkDf4HMwWIDlI%2Fc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:57.6626027","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A57Z&sr=b&sp=r&sig=mbNwQwkOrFP5i9mNi9rQ%2FCf6DL4Mc7%2FyM0EFYa8kBog%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:57.6626979","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:21:57 GMT
+      mise-correlation-id:
+      - 9f779277-1f17-4206-8cbf-1dc71505dbb2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A02Z&sr=b&sp=r&sig=d3dXdzBrjuf7I9zeDiapawPIuVRtOYCHyuS2vkmNZpw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:02.9260636","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A02Z&sr=b&sp=r&sig=XjNWahGa1uomAQo7wg7EuKqkLmEbOWBI6W2B3eIwR9A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:02.9259845","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A02Z&sr=b&sp=r&sig=U69V2J1uGUHCxOpASytRrn5qFbJOWZGxq6TAUs8%2BYeQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:02.9260781","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:02 GMT
+      mise-correlation-id:
+      - 86009931-45e8-4993-8642-5d544bfbe72a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A08Z&sr=b&sp=r&sig=O%2B8nHscd2OePNEY7cVIseVh5k4n2yT0VvP1g7js%2B3DU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:08.2300665","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A08Z&sr=b&sp=r&sig=fPbd573QUrJZGeOjKwFh9G7Ir8b3IbAn2tteo1GLbB4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:08.2299677","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A08Z&sr=b&sp=r&sig=zkHSAGXv0Haj35JmcLU4LafS7ZJSzDzWmErcaDorsQ4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:08.2300833","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:08 GMT
+      mise-correlation-id:
+      - 78921d25-f373-4ffe-8aad-0b9fd5d2733a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A13Z&sr=b&sp=r&sig=jdD9yPUSeduihBsS67zwL7lV%2BCj7xOHxWm5Dzt3Gya4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:13.4849274","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A13Z&sr=b&sp=r&sig=9LRsJXvZ3x7kLso4dmlU9J5AK5CvcF6C4KZwURDx0yY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:13.4848309","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A13Z&sr=b&sp=r&sig=CIwHVCZ0yoWM%2FuLUdKO5e6OV95JCVBD%2F4Ihr%2Fz3Z9Oc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:13.4849488","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:13 GMT
+      mise-correlation-id:
+      - 1ac13706-4403-4c35-a7b4-5f4329ff696f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A18Z&sr=b&sp=r&sig=4C5MilagrG0Qv%2F4c%2FN8823tj9w2KI1KsWG9e3NzXQKo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:18.7458112","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A18Z&sr=b&sp=r&sig=1zKy4iEIlsgDGzAxeO9og1lmDxVm9mRypevkj5WHgAY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:18.7457141","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A18Z&sr=b&sp=r&sig=jRJLxwYgxPrsgnm56TmSWARdP2GkICS6Hd8NlmI98l8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:18.7458319","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:18 GMT
+      mise-correlation-id:
+      - c604e453-e073-4d84-8137-497560f340b1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A24Z&sr=b&sp=r&sig=mDow8vgjiIOUJ%2BOU0W8VweT8IPCm8pPtOWj3%2FUdioj4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:24.0317999","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A24Z&sr=b&sp=r&sig=8PGnqbczg6qEqUqIM5tvf9ZSwYSEPNFm7E%2FwHpYPSb4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:24.0317224","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A24Z&sr=b&sp=r&sig=EV3%2BXbHnQ4kGIjgkgNQQv1C1RehhBAhQOteiEnUbeME%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:24.0318238","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:24 GMT
+      mise-correlation-id:
+      - 28be7d1d-e323-4ebe-8ba7-a83f490b910f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A29Z&sr=b&sp=r&sig=k%2FWO3sJ24ChatqEITOJH%2BOwYs1ScpgqyZDbcuXbJv%2FI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:29.4057663","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A29Z&sr=b&sp=r&sig=ax6lj46PvpoU8REMFcnL0JtvJAuR0P7T3ld0oTp5ZfQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:29.4056668","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A29Z&sr=b&sp=r&sig=NxL%2FuOOKnvkAF00ci8Gf%2FfDT0yAhVdntU8HgOf%2BYGVY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:29.4057914","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3214'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:29 GMT
+      mise-correlation-id:
+      - 7b5414f8-f3f0-4b58-8aa8-5e648319ed71
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A34Z&sr=b&sp=r&sig=5UxpQGIwaQd0BH71w3qkctR3Tyggpu6g%2B4vHpuuJ0As%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:34.6635815","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A34Z&sr=b&sp=r&sig=8XbhvzIG9nCDfVjbVbg9ei1yCOQK%2B2s410%2BL%2Fn0N9xY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:34.6635086","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A34Z&sr=b&sp=r&sig=lhTC9TokgJzutz1XdJxo3imtkaIeTGxUWWHBMHY6reQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:34.6635998","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:34 GMT
+      mise-correlation-id:
+      - e55f3095-20d6-419e-8e38-8c24968a4fae
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A40Z&sr=b&sp=r&sig=Zt4UTLjB3OVA%2B0Now%2F0LylMNqxdMSGVRtTEMH%2F6c6Ok%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:40.1118651","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A40Z&sr=b&sp=r&sig=LihFjeM69JYhUBgl6Mn%2BL1gePSE7cxKH9y8mF2fLr4M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:40.1117984","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A40Z&sr=b&sp=r&sig=VTH44rrFgLg7ZAEyfaaNRftGWb%2Bei%2B%2BtCXdP7GJIMhM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:40.111881","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3215'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:40 GMT
+      mise-correlation-id:
+      - 12046a72-cafa-4220-a6d8-c45d20cfead2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A45Z&sr=b&sp=r&sig=XBBuiaa2xoja8NI8voDnVLyCNjxfJ4wm12%2FB8CC%2B6Xw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:45.5262774","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A45Z&sr=b&sp=r&sig=N5TxNoMcxZRbP4tnOmlf9f8Kv9208zs0i9%2FUNYUZG1E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:45.5261869","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A45Z&sr=b&sp=r&sig=GQ3tZZGVOyaGfMd1uCmbCoI4PhKO6twQxwbs54HwzXM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:45.5263013","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:45 GMT
+      mise-correlation-id:
+      - c8e3f28c-2b98-4115-a30f-3ecd40e50d59
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A50Z&sr=b&sp=r&sig=HQ8Z0Q7Mqx3IACjQb7mtC8S8Nq0r1%2FnugNPTTb83Dl0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:50.8490246","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A50Z&sr=b&sp=r&sig=fJCjw%2B839YFx1IPyv3jPRl2fA5z4MK9auv5dhWBkBlY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:50.8489033","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A50Z&sr=b&sp=r&sig=hEOGnwRImMX0Vs2hYbwsrJekaFW3X%2FMHV0Cbl%2FDJfEw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:50.8490515","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:50 GMT
+      mise-correlation-id:
+      - 0fe330f8-2787-422f-abcc-3e710c91e756
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A56Z&sr=b&sp=r&sig=nAu%2F6ir%2BXv8sMrKcFZR0MdptxTwfbDWgo534M1yUVWM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:56.171329","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A56Z&sr=b&sp=r&sig=2Ty%2Bv%2FTkaLQUWhCQwOItbtWMjZODHCmiraRlmpKusz8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:56.1712522","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A56Z&sr=b&sp=r&sig=USQ7ayb7h6LBX9pe%2F6r%2B1PNlhNKlbIDnEbvQ31inFqc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:56.1713439","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-09T19:20:14.233Z","endDateTime":"2023-10-09T19:22:53.378Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:53.476Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3348'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:22:56 GMT
+      mise-correlation-id:
+      - 8bd1c5ad-a75a-4f0c-9599-df7f5d1205fb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1856,7 +1820,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:35.8868534Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:35.8868534Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:14.8313783Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:14.8313783Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1865,9 +1829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:24 GMT
+      - Mon, 09 Oct 2023 19:22:57 GMT
       etag:
-      - '"920131b3-0000-0100-0000-652426750000"'
+      - '"5600672d-0000-0100-0000-652452350000"'
       expires:
       - '-1'
       pragma:
@@ -1897,24 +1861,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=download-test-case&api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=download-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A25Z&sr=b&sp=r&sig=h5rTRH%2BKqvEOKk4zt%2F6toiF4o5KEOSw30lgraAmv5gE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:25.2948774","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A25Z&sr=b&sp=r&sig=59nJUQC%2FabUx9UnKVbJSEYackNub2loYM6XQx068qgY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:25.2947878","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A25Z&sr=b&sp=r&sig=bKJ7vs97v%2F83zOe1SezAQhE4p9W85c%2BA02CgShJ8tC4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:25.2948944","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-09T16:13:35.504Z","endDateTime":"2023-10-09T16:16:19.773Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:19.847Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A58Z&sr=b&sp=r&sig=%2FQovHTF8nMQjA2Qc8qKff%2Bm5AItpJBS660OWd5DYq38%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:58.5659109","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A58Z&sr=b&sp=r&sig=H%2FU%2FI3%2BGdGulIc8Mb8x3Ex2DQCGQDkZzRGiH0wPG72o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:58.5658393","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A58Z&sr=b&sp=r&sig=bNNjkT20KdmrA1O61uNVtVXUdz%2BujwbQfrkkZe1PcfM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:58.5659255","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-09T19:20:14.233Z","endDateTime":"2023-10-09T19:22:53.378Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:57.625Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3359'
+      - '3361'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:25 GMT
+      - Mon, 09 Oct 2023 19:22:58 GMT
       mise-correlation-id:
-      - 84475b05-98f3-4761-ac33-020b9a112b4c
+      - 3337ed07-6692-4121-b622-63200583e9f5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1937,7 +1901,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:35.8868534Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:35.8868534Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:14.8313783Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:14.8313783Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1946,9 +1910,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:26 GMT
+      - Mon, 09 Oct 2023 19:22:59 GMT
       etag:
-      - '"920131b3-0000-0100-0000-652426750000"'
+      - '"5600672d-0000-0100-0000-652452350000"'
       expires:
       - '-1'
       pragma:
@@ -1978,415 +1942,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A27Z&sr=b&sp=r&sig=mcg1YwYsI8vXk3oXHiKl80ZFCJnaNM8otp0RfeEs0r8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:27.679744","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A27Z&sr=b&sp=r&sig=vcFrt51ckonLHNGdGtB1W6ZW5rbNpcpyyHs%2BxqZWWNs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:27.6796597","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A27Z&sr=b&sp=r&sig=P9z%2BINbrF6Nis2FLWG01xIMOG1zholXPUCPalJJsbxI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:27.6797653","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-09T16:13:35.504Z","endDateTime":"2023-10-09T16:16:19.773Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:19.847Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3340'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:16:27 GMT
-      mise-correlation-id:
-      - 7df35f8c-e3d4-4dfd-9c84-1f9922da2acb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A27Z&sr=b&sp=r&sig=mcg1YwYsI8vXk3oXHiKl80ZFCJnaNM8otp0RfeEs0r8%3D
-  response:
-    body:
-      string: "displayName: CLI-Test\ntestPlan: sample-JMX-file.jmx\ndescription:
-        Test created from az load test command\nengineInstances: 1\ntestId: download-test-case\nsplitAllCSVs:
-        False\nfailureCriteria:\n- avg(requests_per_sec) > 78\n- percentage(error)
-        > 50\n- GetCustomerDetails: avg(latency) > 200\nenv:\n- name: rps\n  value:
-        1\n- name: duration_in_sec\n  value: 1\n"
-    headers:
-      accept-ranges:
-      - bytes
-      content-length:
-      - '345'
-      content-md5:
-      - YBcWc67Cm9gXA2Vwhu5fxg==
-      content-type:
-      - application/octet-stream
-      date:
-      - Mon, 09 Oct 2023 16:16:28 GMT
-      etag:
-      - '"0x8DBC8E2B04555D0"'
-      last-modified:
-      - Mon, 09 Oct 2023 16:13:34 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-blob-type:
-      - BlockBlob
-      x-ms-creation-time:
-      - Mon, 09 Oct 2023 16:13:34 GMT
-      x-ms-lease-state:
-      - available
-      x-ms-lease-status:
-      - unlocked
-      x-ms-meta-filename:
-      - Y29uZmlnLnlhbWw=
-      x-ms-meta-filetype:
-      - ADDITIONAL_ARTIFACTS
-      x-ms-meta-isencoded:
-      - 'true'
-      x-ms-server-encrypted:
-      - 'true'
-      x-ms-version:
-      - '2021-10-04'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A27Z&sr=b&sp=r&sig=vcFrt51ckonLHNGdGtB1W6ZW5rbNpcpyyHs%2BxqZWWNs%3D
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
-        properties=\"5.0\" jmeter=\"5.5\">\r\n  <hashTree>\r\n    <TestPlan guiclass=\"TestPlanGui\"
-        testclass=\"TestPlan\" testname=\"Azure Load Testing\" enabled=\"true\">\r\n
-        \     <stringProp name=\"TestPlan.comments\"></stringProp>\r\n      <boolProp
-        name=\"TestPlan.functional_mode\">false</boolProp>\r\n      <boolProp name=\"TestPlan.tearDown_on_shutdown\">true</boolProp>\r\n
-        \     <boolProp name=\"TestPlan.serialize_threadgroups\">false</boolProp>\r\n
-        \     <elementProp name=\"TestPlan.user_defined_variables\" elementType=\"Arguments\"
-        guiclass=\"ArgumentsPanel\" testclass=\"Arguments\" testname=\"User Defined
-        Variables\" enabled=\"true\">\r\n        <collectionProp name=\"Arguments.arguments\"/>\r\n
-        \     </elementProp>\r\n      <stringProp name=\"TestPlan.user_define_classpath\"></stringProp>\r\n
-        \   </TestPlan>\r\n    <hashTree>\r\n      <Arguments guiclass=\"ArgumentsPanel\"
-        testclass=\"Arguments\" testname=\"User Defined Variables\" enabled=\"true\">\r\n
-        \       <collectionProp name=\"Arguments.arguments\">\r\n          <elementProp
-        name=\"duration_in_sec\" elementType=\"Argument\">\r\n            <stringProp
-        name=\"Argument.name\">duration_in_sec</stringProp>\r\n            <stringProp
-        name=\"Argument.value\">${__groovy( System.getenv(&quot;duration_in_sec&quot;)
-        ?: &quot;10&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
-        \         </elementProp>\r\n          <elementProp name=\"rps\" elementType=\"Argument\">\r\n
-        \           <stringProp name=\"Argument.name\">rps</stringProp>\r\n            <stringProp
-        name=\"Argument.value\">${__groovy( System.getenv(&quot;rps&quot;) ?: &quot;1&quot;
-        )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
-        \         </elementProp>\r\n          <elementProp name=\"domain\" elementType=\"Argument\">\r\n
-        \           <stringProp name=\"Argument.name\">domain</stringProp>\r\n            <stringProp
-        name=\"Argument.value\">${__groovy( System.getenv(&quot;domain&quot;) ?: &quot;example.com&quot;
-        )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
-        \         </elementProp>\r\n          <elementProp name=\"protocol\" elementType=\"Argument\">\r\n
-        \           <stringProp name=\"Argument.name\">protocol</stringProp>\r\n            <stringProp
-        name=\"Argument.value\">${__groovy( System.getenv(&quot;protocol&quot;) ?:
-        &quot;https&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
-        \         </elementProp>\r\n          <elementProp name=\"url_path\" elementType=\"Argument\">\r\n
-        \           <stringProp name=\"Argument.name\">url_path</stringProp>\r\n            <stringProp
-        name=\"Argument.value\">${__groovy( System.getenv(&quot;url_path&quot;) ?:
-        &quot;/&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
-        \         </elementProp>\r\n        </collectionProp>\r\n      </Arguments>\r\n
-        \     <hashTree/>\r\n      <OpenModelThreadGroup guiclass=\"OpenModelThreadGroupGui\"
-        testclass=\"OpenModelThreadGroup\" testname=\"Open Model Thread Group\" enabled=\"true\">\r\n
-        \       <elementProp name=\"ThreadGroup.main_controller\" elementType=\"OpenModelThreadGroupController\"/>\r\n
-        \       <stringProp name=\"ThreadGroup.on_sample_error\">continue</stringProp>\r\n
-        \       <stringProp name=\"OpenModelThreadGroup.schedule\">rate(${rps}/sec)
-        random_arrivals(${duration_in_sec} sec)</stringProp>\r\n        <stringProp
-        name=\"OpenModelThreadGroup.random_seed\"></stringProp>\r\n      </OpenModelThreadGroup>\r\n
-        \     <hashTree>\r\n        <HTTPSamplerProxy guiclass=\"HttpTestSampleGui\"
-        testclass=\"HTTPSamplerProxy\" testname=\"HTTP Request\" enabled=\"true\">\r\n
-        \         <elementProp name=\"HTTPsampler.Arguments\" elementType=\"Arguments\"
-        guiclass=\"HTTPArgumentsPanel\" testclass=\"Arguments\" testname=\"User Defined
-        Variables\" enabled=\"true\">\r\n            <collectionProp name=\"Arguments.arguments\"/>\r\n
-        \         </elementProp>\r\n          <stringProp name=\"HTTPSampler.domain\">${domain}</stringProp>\r\n
-        \         <stringProp name=\"HTTPSampler.port\"></stringProp>\r\n          <stringProp
-        name=\"HTTPSampler.protocol\">${protocol}</stringProp>\r\n          <stringProp
-        name=\"HTTPSampler.contentEncoding\"></stringProp>\r\n          <stringProp
-        name=\"HTTPSampler.path\">${url_path}</stringProp>\r\n          <stringProp
-        name=\"HTTPSampler.method\">GET</stringProp>\r\n          <boolProp name=\"HTTPSampler.follow_redirects\">true</boolProp>\r\n
-        \         <boolProp name=\"HTTPSampler.auto_redirects\">false</boolProp>\r\n
-        \         <boolProp name=\"HTTPSampler.use_keepalive\">true</boolProp>\r\n
-        \         <boolProp name=\"HTTPSampler.DO_MULTIPART_POST\">false</boolProp>\r\n
-        \         <stringProp name=\"HTTPSampler.embedded_url_re\"></stringProp>\r\n
-        \         <stringProp name=\"HTTPSampler.connect_timeout\"></stringProp>\r\n
-        \         <stringProp name=\"HTTPSampler.response_timeout\"></stringProp>\r\n
-        \       </HTTPSamplerProxy>\r\n        <hashTree/>\r\n      </hashTree>\r\n
-        \   </hashTree>\r\n  </hashTree>\r\n</jmeterTestPlan>\r\n"
-    headers:
-      accept-ranges:
-      - bytes
-      content-length:
-      - '4870'
-      content-md5:
-      - xGA4QxS45K0eB2EZNBGk8w==
-      content-type:
-      - application/octet-stream
-      date:
-      - Mon, 09 Oct 2023 16:16:28 GMT
-      etag:
-      - '"0x8DBC8E2A360FE86"'
-      last-modified:
-      - Mon, 09 Oct 2023 16:13:13 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-blob-type:
-      - BlockBlob
-      x-ms-creation-time:
-      - Mon, 09 Oct 2023 16:13:13 GMT
-      x-ms-lease-state:
-      - available
-      x-ms-lease-status:
-      - unlocked
-      x-ms-meta-filename:
-      - c2FtcGxlLUpNWC1maWxlLmpteA==
-      x-ms-meta-filetype:
-      - JMX_FILE
-      x-ms-meta-isencoded:
-      - 'true'
-      x-ms-server-encrypted:
-      - 'true'
-      x-ms-version:
-      - '2021-10-04'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A27Z&sr=b&sp=r&sig=P9z%2BINbrF6Nis2FLWG01xIMOG1zholXPUCPalJJsbxI%3D
-  response:
-    body:
-      string: !!binary |
-        UEsDBC0AAAAIALGBSVcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
-        AAAAAAFZAab+ZGlzcGxheU5hbWU6IENMSS1UZXN0CnRlc3RQbGFuOiBzYW1wbGUtSk1YLWZpbGUu
-        am14CmRlc2NyaXB0aW9uOiBUZXN0IGNyZWF0ZWQgZnJvbSBheiBsb2FkIHRlc3QgY29tbWFuZApl
-        bmdpbmVJbnN0YW5jZXM6IDEKdGVzdElkOiBkb3dubG9hZC10ZXN0LWNhc2UKc3BsaXRBbGxDU1Zz
-        OiBGYWxzZQpmYWlsdXJlQ3JpdGVyaWE6Ci0gYXZnKHJlcXVlc3RzX3Blcl9zZWMpID4gNzgKLSBw
-        ZXJjZW50YWdlKGVycm9yKSA+IDUwCi0gR2V0Q3VzdG9tZXJEZXRhaWxzOiBhdmcobGF0ZW5jeSkg
-        PiAyMDAKZW52OgotIG5hbWU6IHJwcwogIHZhbHVlOiAxCi0gbmFtZTogZHVyYXRpb25faW5fc2Vj
-        CiAgdmFsdWU6IDEKUEsDBC0AAAAIALGBSVfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
-        LmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAAQYT+ew8P3htbCB2ZXJzaW9uPSIxLjAiIGVuY29kaW5n
-        PSJVVEYtOCI/Pg0KPGptZXRlclRlc3RQbGFuIHZlcnNpb249IjEuMiIgcHJvcGVydGllcz0iNS4w
-        IiBqbWV0ZXI9IjUuNSI+DQogIDxoYXNoVHJlZT4NCiAgICA8VGVzdFBsYW4gZ3VpY2xhc3M9IlRl
-        c3RQbGFuR3VpIiB0ZXN0Y2xhc3M9IlRlc3RQbGFuIiB0ZXN0bmFtZT0iQXp1cmUgTG9hZCBUZXN0
-        aW5nIiBlbmFibGVkPSJ0cnVlIj4NCiAgICAgIDxzdHJpbmdQcm9wIG5hbWU9IlRlc3RQbGFuLmNv
-        bW1lbnRzIj48L3N0cmluZ1Byb3A+DQogICAgICA8Ym9vbFByb3AgbmFtZT0iVGVzdFBsYW4uZnVu
-        Y3Rpb25hbF9tb2RlIj5mYWxzZTwvYm9vbFByb3A+DQogICAgICA8Ym9vbFByb3AgbmFtZT0iVGVz
-        dFBsYW4udGVhckRvd25fb25fc2h1dGRvd24iPnRydWU8L2Jvb2xQcm9wPg0KICAgICAgPGJvb2xQ
-        cm9wIG5hbWU9IlRlc3RQbGFuLnNlcmlhbGl6ZV90aHJlYWRncm91cHMiPmZhbHNlPC9ib29sUHJv
-        cD4NCiAgICAgIDxlbGVtZW50UHJvcCBuYW1lPSJUZXN0UGxhbi51c2VyX2RlZmluZWRfdmFyaWFi
-        bGVzIiBlbGVtZW50VHlwZT0iQXJndW1lbnRzIiBndWljbGFzcz0iQXJndW1lbnRzUGFuZWwiIHRl
-        c3RjbGFzcz0iQXJndW1lbnRzIiB0ZXN0bmFtZT0iVXNlciBEZWZpbmVkIFZhcmlhYmxlcyIgZW5h
-        YmxlZD0idHJ1ZSI+DQogICAgICAgIDxjb2xsZWN0aW9uUHJvcCBuYW1lPSJBcmd1bWVudHMuYXJn
-        dW1lbnRzIi8+DQogICAgICA8L2VsZW1lbnRQcm9wPg0KICAgICAgPHN0cmluZ1Byb3AgbmFtZT0i
-        VGVzdFBsYW4udXNlcl9kZWZpbmVfY2xhc3NwYXRoIj48L3N0cmluZ1Byb3A+DQogICAgPC9UZXN0
-        UGxhbj4NCiAgICA8aGFzaFRyZWU+DQogICAgICA8QXJndW1lbnRzIGd1aWNsYXNzPSJBcmd1bWVu
-        dHNQYW5lbCIgdGVzdGNsYXNzPSJBcmd1bWVudHMiIHRlc3RuYW1lPSJVc2VyIERlZmluZWQgVmFy
-        aWFibGVzIiBlbmFibGVkPSJ0cnVlIj4NCiAgICAgICAgPGNvbGxlY3Rpb25Qcm9wIG5hbWU9IkFy
-        Z3VtZW50cy5hcmd1bWVudHMiPg0KICAgICAgICAgIDxlbGVtZW50UHJvcCBuYW1lPSJkdXJhdGlv
-        bl9pbl9zZWMiIGVsZW1lbnRUeXBlPSJBcmd1bWVudCI+DQogICAgICAgICAgICA8c3RyaW5nUHJv
-        cCBuYW1lPSJBcmd1bWVudC5uYW1lIj5kdXJhdGlvbl9pbl9zZWM8L3N0cmluZ1Byb3A+DQogICAg
-        ICAgICAgICA8c3RyaW5nUHJvcCBuYW1lPSJBcmd1bWVudC52YWx1ZSI+JHtfX2dyb292eSggU3lz
-        dGVtLmdldGVudigmcXVvdDtkdXJhdGlvbl9pbl9zZWMmcXVvdDspID86ICZxdW90OzEwJnF1b3Q7
-        ICl9PC9zdHJpbmdQcm9wPg0KICAgICAgICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iQXJndW1lbnQu
-        bWV0YWRhdGEiPj08L3N0cmluZ1Byb3A+DQogICAgICAgICAgPC9lbGVtZW50UHJvcD4NCiAgICAg
-        ICAgICA8ZWxlbWVudFByb3AgbmFtZT0icnBzIiBlbGVtZW50VHlwZT0iQXJndW1lbnQiPg0KICAg
-        ICAgICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iQXJndW1lbnQubmFtZSI+cnBzPC9zdHJpbmdQcm9w
-        Pg0KICAgICAgICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iQXJndW1lbnQudmFsdWUiPiR7X19ncm9v
-        dnkoIFN5c3RlbS5nZXRlbnYoJnF1b3Q7cnBzJnF1b3Q7KSA/OiAmcXVvdDsxJnF1b3Q7ICl9PC9z
-        dHJpbmdQcm9wPg0KICAgICAgICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iQXJndW1lbnQubWV0YWRh
-        dGEiPj08L3N0cmluZ1Byb3A+DQogICAgICAgICAgPC9lbGVtZW50UHJvcD4NCiAgICAgICAgICA8
-        ZWxlbWVudFByb3AgbmFtZT0iZG9tYWluIiBlbGVtZW50VHlwZT0iQXJndW1lbnQiPg0KICAgICAg
-        ICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iQXJndW1lbnQubmFtZSI+ZG9tYWluPC9zdHJpbmdQcm9w
-        Pg0KICAgICAgICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iQXJndW1lbnQudmFsdWUiPiR7X19ncm9v
-        dnkoIFN5c3RlbS5nZXRlbnYoJnF1b3Q7ZG9tYWluJnF1b3Q7KSA/OiAmcXVvdDtleGFtcGxlLmNv
-        bSZxdW90OyApfTwvc3RyaW5nUHJvcD4NCiAgICAgICAgICAgIDxzdHJpbmdQcm9wIG5hbWU9IkFy
-        Z3VtZW50Lm1ldGFkYXRhIj49PC9zdHJpbmdQcm9wPg0KICAgICAgICAgIDwvZWxlbWVudFByb3A+
-        DQogICAgICAgICAgPGVsZW1lbnRQcm9wIG5hbWU9InByb3RvY29sIiBlbGVtZW50VHlwZT0iQXJn
-        dW1lbnQiPg0KICAgICAgICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iQXJndW1lbnQubmFtZSI+cHJv
-        dG9jb2w8L3N0cmluZ1Byb3A+DQogICAgICAgICAgICA8c3RyaW5nUHJvcCBuYW1lPSJBcmd1bWVu
-        dC52YWx1ZSI+JHtfX2dyb292eSggU3lzdGVtLmdldGVudigmcXVvdDtwcm90b2NvbCZxdW90Oykg
-        PzogJnF1b3Q7aHR0cHMmcXVvdDsgKX08L3N0cmluZ1Byb3A+DQogICAgICAgICAgICA8c3RyaW5n
-        UHJvcCBuYW1lPSJBcmd1bWVudC5tZXRhZGF0YSI+PTwvc3RyaW5nUHJvcD4NCiAgICAgICAgICA8
-        L2VsZW1lbnRQcm9wPg0KICAgICAgICAgIDxlbGVtZW50UHJvcCBuYW1lPSJ1cmxfcGF0aCIgZWxl
-        bWVudFR5cGU9IkFyZ3VtZW50Ij4NCiAgICAgICAgICAgIDxzdHJpbmdQcm9wIG5hbWU9IkFyZ3Vt
-        ZW50Lm5hbWUiPnVybF9wYXRoPC9zdHJpbmdQcm9wPg0KICAgICAgICAgICAgPHN0cmluZ1Byb3Ag
-        bmFtZT0iQXJndW1lbnQudmFsdWUiPiR7X19ncm9vdnkoIFN5c3RlbS5nZXRlbnYoJnF1b3Q7dXJs
-        X3BhdGgmcXVvdDspID86ICZxdW90Oy8mcXVvdDsgKX08L3N0cmluZ1Byb3A+DQogICAgICAgICAg
-        ICA8c3RyaW5nUHJvcCBuYW1lPSJBcmd1bWVudC5tZXRhZGF0YSI+PTwvc3RyaW5nUHJvcD4NCiAg
-        ICAgICAgICA8L2VsZW1lbnRQcm9wPg0KICAgICAgICA8L2NvbGxlY3Rpb25Qcm9wPg0KICAgICAg
-        PC9Bcmd1bWVudHM+DQogICAgICA8aGFzaFRyZWUvPg0KICAgICAgPE9wZW5Nb2RlbFRocmVhZEdy
-        b3VwIGd1aWNsYXNzPSJPcGVuTW9kZWxUaHJlYWRHcm91cEd1aSIgdGVzdGNsYXNzPSJPcGVuTW9k
-        ZWxUaHJlYWRHcm91cCIgdGVzdG5hbWU9Ik9wZW4gTW9kZWwgVGhyZWFkIEdyb3VwIiBlbmFibGVk
-        PSJ0cnVlIj4NCiAgICAgICAgPGVsZW1lbnRQcm9wIG5hbWU9IlRocmVhZEdyb3VwLm1haW5fY29u
-        dHJvbGxlciIgZWxlbWVudFR5cGU9Ik9wZW5Nb2RlbFRocmVhZEdyb3VwQ29udHJvbGxlciIvPg0K
-        ICAgICAgICA8c3RyaW5nUHJvcCBuYW1lPSJUaHJlYWRHcm91cC5vbl9zYW1wbGVfZXJyb3IiPmNv
-        bnRpbnVlPC9zdHJpbmdQcm9wPg0KICAgICAgICA8c3RyaW5nUHJvcCBuYW1lPSJPcGVuTW9kZWxU
-        aHJlYWRHcm91cC5zY2hlZHVsZSI+cmF0ZSgke3Jwc30vc2VjKSByYW5kb21fYXJyaXZhbHMoJHtk
-        dXJhdGlvbl9pbl9zZWN9IHNlYyk8L3N0cmluZ1Byb3A+DQogICAgICAgIDxzdHJpbmdQcm9wIG5h
-        bWU9Ik9wZW5Nb2RlbFRocmVhZEdyb3VwLnJhbmRvbV9zZWVkIj48L3N0cmluZ1Byb3A+DQogICAg
-        ICA8L09wZW5Nb2RlbFRocmVhZEdyb3VwPg0KICAgICAgPGhhc2hUcmVlPg0KICAgICAgICA8SFRU
-        UFNhbXBsZXJQcm94eSBndWljbGFzcz0iSHR0cFRlc3RTYW1wbGVHdWkiIHRlc3RjbGFzcz0iSFRU
-        UFNhbXBsZXJQcm94eSIgdGVzdG5hbWU9IkhUVFAgUmVxdWVzdCIgZW5hYmxlZD0idHJ1ZSI+DQog
-        ICAgICAgICAgPGVsZW1lbnRQcm9wIG5hbWU9IkhUVFBzYW1wbGVyLkFyZ3VtZW50cyIgZWxlbWVu
-        dFR5cGU9IkFyZ3VtZW50cyIgZ3VpY2xhc3M9IkhUVFBBcmd1bWVudHNQYW5lbCIgdGVzdGNsYXNz
-        PSJBcmd1bWVudHMiIHRlc3RuYW1lPSJVc2VyIERlZmluZWQgVmFyaWFibGVzIiBlbmFibGVkPSJ0
-        cnVlIj4NCiAgICAgICAgICAgIDxjb2xsZWN0aW9uUHJvcCBuYW1lPSJBcmd1bWVudHMuYXJndW1l
-        bnRzIi8+DQogICAgICAgICAgPC9lbGVtZW50UHJvcD4NCiAgICAgICAgICA8c3RyaW5nUHJvcCBu
-        YW1lPSJIVFRQU2FtcGxlci5kb21haW4iPiR7ZG9tYWlufTwvc3RyaW5nUHJvcD4NCiAgICAgICAg
-        ICA8c3RyaW5nUHJvcCBuYW1lPSJIVFRQU2FtcGxlci5wb3J0Ij48L3N0cmluZ1Byb3A+DQogICAg
-        ICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iSFRUUFNhbXBsZXIucHJvdG9jb2wiPiR7cHJvdG9jb2x9
-        PC9zdHJpbmdQcm9wPg0KICAgICAgICAgIDxzdHJpbmdQcm9wIG5hbWU9IkhUVFBTYW1wbGVyLmNv
-        bnRlbnRFbmNvZGluZyI+PC9zdHJpbmdQcm9wPg0KICAgICAgICAgIDxzdHJpbmdQcm9wIG5hbWU9
-        IkhUVFBTYW1wbGVyLnBhdGgiPiR7dXJsX3BhdGh9PC9zdHJpbmdQcm9wPg0KICAgICAgICAgIDxz
-        dHJpbmdQcm9wIG5hbWU9IkhUVFBTYW1wbGVyLm1ldGhvZCI+R0VUPC9zdHJpbmdQcm9wPg0KICAg
-        ICAgICAgIDxib29sUHJvcCBuYW1lPSJIVFRQU2FtcGxlci5mb2xsb3dfcmVkaXJlY3RzIj50cnVl
-        PC9ib29sUHJvcD4NCiAgICAgICAgICA8Ym9vbFByb3AgbmFtZT0iSFRUUFNhbXBsZXIuYXV0b19y
-        ZWRpcmVjdHMiPmZhbHNlPC9ib29sUHJvcD4NCiAgICAgICAgICA8Ym9vbFByb3AgbmFtZT0iSFRU
-        UFNhbXBsZXIudXNlX2tlZXBhbGl2ZSI+dHJ1ZTwvYm9vbFByb3A+DQogICAgICAgICAgPGJvb2xQ
-        cm9wIG5hbWU9IkhUVFBTYW1wbGVyLkRPX01VTFRJUEFSVF9QT1NUIj5mYWxzZTwvYm9vbFByb3A+
-        DQogICAgICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iSFRUUFNhbXBsZXIuZW1iZWRkZWRfdXJsX3Jl
-        Ij48L3N0cmluZ1Byb3A+DQogICAgICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iSFRUUFNhbXBsZXIu
-        Y29ubmVjdF90aW1lb3V0Ij48L3N0cmluZ1Byb3A+DQogICAgICAgICAgPHN0cmluZ1Byb3AgbmFt
-        ZT0iSFRUUFNhbXBsZXIucmVzcG9uc2VfdGltZW91dCI+PC9zdHJpbmdQcm9wPg0KICAgICAgICA8
-        L0hUVFBTYW1wbGVyUHJveHk+DQogICAgICAgIDxoYXNoVHJlZS8+DQogICAgICA8L2hhc2hUcmVl
-        Pg0KICAgIDwvaGFzaFRyZWU+DQogIDwvaGFzaFRyZWU+DQo8L2ptZXRlclRlc3RQbGFuPg0KUEsB
-        AjMALQAAAAgAsYFJVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
-        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACACxgUlX8Zv7b///////////EwAUAAAAAAAAAAAA
-        AACbAQAAc2FtcGxlLUpNWC1maWxlLmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAUEsFBgAAAAACAAIA
-        ogAAAOsUAAAAAA==
-    headers:
-      accept-ranges:
-      - bytes
-      content-length:
-      - '5539'
-      content-md5:
-      - 2pplCcA4STo7VjXO6zs8qA==
-      content-type:
-      - application/octet-stream
-      date:
-      - Mon, 09 Oct 2023 16:16:30 GMT
-      etag:
-      - '"0x8DBC8E2B04E7C2D"'
-      last-modified:
-      - Mon, 09 Oct 2023 16:13:34 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-blob-type:
-      - BlockBlob
-      x-ms-creation-time:
-      - Mon, 09 Oct 2023 16:13:34 GMT
-      x-ms-lease-state:
-      - available
-      x-ms-lease-status:
-      - unlocked
-      x-ms-meta-filename:
-      - aW5wdXRhcnRpZmFjdHMuemlw
-      x-ms-meta-filetype:
-      - ADDITIONAL_ARTIFACTS
-      x-ms-meta-isencoded:
-      - 'true'
-      x-ms-server-encrypted:
-      - 'true'
-      x-ms-version:
-      - '2021-10-04'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:35.8868534Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:35.8868534Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:16:31 GMT
-      etag:
-      - '"920131b3-0000-0100-0000-652426750000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A32Z&sr=b&sp=r&sig=qRX9At7Ul%2BqUDw5njQNm6jz6IlKD1glrC%2FKVOoOFkDU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:32.9354302","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A32Z&sr=b&sp=r&sig=dvPnJUV2S95FMpbWIpCVokuriAYl8YnN2m4PCGgh%2FYk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:32.9353571","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A32Z&sr=b&sp=r&sig=Pd2dEk4v181u6AM1bZ%2FZhBQPObbo3Fb%2FMcN9Nx6ppDg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:32.9354468","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-09T16:13:35.504Z","endDateTime":"2023-10-09T16:16:19.773Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:19.847Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A00Z&sr=b&sp=r&sig=O72bktlStFE%2FW%2FvCEGSOYJvgixlj%2BOhetTnn6JsQw78%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:00.5892982","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A00Z&sr=b&sp=r&sig=DKRvMiov%2F3FeoJf1SMHnn4wGyhq8uqsYgt5wKZOO6Bc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:00.5892316","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A00Z&sr=b&sp=r&sig=gYh%2BxqvpeBZwyzo8DGZF4SHu6zFurA4Lfmw7rZVRJbk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:00.5893135","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-09T19:20:14.233Z","endDateTime":"2023-10-09T19:22:53.378Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:57.625Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2397,9 +1957,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:32 GMT
+      - Mon, 09 Oct 2023 19:23:00 GMT
       mise-correlation-id:
-      - ecad8337-db93-4bfe-a443-e458341ad080
+      - 080a1193-9387-46f6-b5e7-31ee5f7ef1fd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2419,7 +1979,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A32Z&sr=b&sp=r&sig=qRX9At7Ul%2BqUDw5njQNm6jz6IlKD1glrC%2FKVOoOFkDU%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A00Z&sr=b&sp=r&sig=O72bktlStFE%2FW%2FvCEGSOYJvgixlj%2BOhetTnn6JsQw78%3D
   response:
     body:
       string: "displayName: CLI-Test\ntestPlan: sample-JMX-file.jmx\ndescription:
@@ -2437,17 +1997,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Mon, 09 Oct 2023 16:16:33 GMT
+      - Mon, 09 Oct 2023 19:23:00 GMT
       etag:
-      - '"0x8DBC8E2B04555D0"'
+      - '"0x8DBC8FCC3421802"'
       last-modified:
-      - Mon, 09 Oct 2023 16:13:34 GMT
+      - Mon, 09 Oct 2023 19:20:13 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 09 Oct 2023 16:13:34 GMT
+      - Mon, 09 Oct 2023 19:20:13 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2477,7 +2037,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A32Z&sr=b&sp=r&sig=dvPnJUV2S95FMpbWIpCVokuriAYl8YnN2m4PCGgh%2FYk%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A00Z&sr=b&sp=r&sig=DKRvMiov%2F3FeoJf1SMHnn4wGyhq8uqsYgt5wKZOO6Bc%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -2550,17 +2110,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Mon, 09 Oct 2023 16:16:34 GMT
+      - Mon, 09 Oct 2023 19:23:01 GMT
       etag:
-      - '"0x8DBC8E2A360FE86"'
+      - '"0x8DBC8FCB5B5C487"'
       last-modified:
-      - Mon, 09 Oct 2023 16:13:13 GMT
+      - Mon, 09 Oct 2023 19:19:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 09 Oct 2023 16:13:13 GMT
+      - Mon, 09 Oct 2023 19:19:50 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2590,18 +2150,18 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A32Z&sr=b&sp=r&sig=Pd2dEk4v181u6AM1bZ%2FZhBQPObbo3Fb%2FMcN9Nx6ppDg%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A00Z&sr=b&sp=r&sig=gYh%2BxqvpeBZwyzo8DGZF4SHu6zFurA4Lfmw7rZVRJbk%3D
   response:
     body:
       string: !!binary |
-        UEsDBC0AAAAIALGBSVcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
+        UEsDBC0AAAAIAIaaSVcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
         AAAAAAFZAab+ZGlzcGxheU5hbWU6IENMSS1UZXN0CnRlc3RQbGFuOiBzYW1wbGUtSk1YLWZpbGUu
         am14CmRlc2NyaXB0aW9uOiBUZXN0IGNyZWF0ZWQgZnJvbSBheiBsb2FkIHRlc3QgY29tbWFuZApl
         bmdpbmVJbnN0YW5jZXM6IDEKdGVzdElkOiBkb3dubG9hZC10ZXN0LWNhc2UKc3BsaXRBbGxDU1Zz
         OiBGYWxzZQpmYWlsdXJlQ3JpdGVyaWE6Ci0gYXZnKHJlcXVlc3RzX3Blcl9zZWMpID4gNzgKLSBw
         ZXJjZW50YWdlKGVycm9yKSA+IDUwCi0gR2V0Q3VzdG9tZXJEZXRhaWxzOiBhdmcobGF0ZW5jeSkg
         PiAyMDAKZW52OgotIG5hbWU6IHJwcwogIHZhbHVlOiAxCi0gbmFtZTogZHVyYXRpb25faW5fc2Vj
-        CiAgdmFsdWU6IDEKUEsDBC0AAAAIALGBSVfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
+        CiAgdmFsdWU6IDEKUEsDBC0AAAAIAIaaSVfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
         LmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAAQYT+ew8P3htbCB2ZXJzaW9uPSIxLjAiIGVuY29kaW5n
         PSJVVEYtOCI/Pg0KPGptZXRlclRlc3RQbGFuIHZlcnNpb249IjEuMiIgcHJvcGVydGllcz0iNS4w
         IiBqbWV0ZXI9IjUuNSI+DQogIDxoYXNoVHJlZT4NCiAgICA8VGVzdFBsYW4gZ3VpY2xhc3M9IlRl
@@ -2688,8 +2248,8 @@ interactions:
         ZT0iSFRUUFNhbXBsZXIucmVzcG9uc2VfdGltZW91dCI+PC9zdHJpbmdQcm9wPg0KICAgICAgICA8
         L0hUVFBTYW1wbGVyUHJveHk+DQogICAgICAgIDxoYXNoVHJlZS8+DQogICAgICA8L2hhc2hUcmVl
         Pg0KICAgIDwvaGFzaFRyZWU+DQogIDwvaGFzaFRyZWU+DQo8L2ptZXRlclRlc3RQbGFuPg0KUEsB
-        AjMALQAAAAgAsYFJVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
-        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACACxgUlX8Zv7b///////////EwAUAAAAAAAAAAAA
+        AjMALQAAAAgAhppJVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
+        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACACGmklX8Zv7b///////////EwAUAAAAAAAAAAAA
         AACbAQAAc2FtcGxlLUpNWC1maWxlLmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAUEsFBgAAAAACAAIA
         ogAAAOsUAAAAAA==
     headers:
@@ -2698,21 +2258,21 @@ interactions:
       content-length:
       - '5539'
       content-md5:
-      - 2pplCcA4STo7VjXO6zs8qA==
+      - /awq7A5BsWf/8AZoYNnc1g==
       content-type:
       - application/octet-stream
       date:
-      - Mon, 09 Oct 2023 16:16:35 GMT
+      - Mon, 09 Oct 2023 19:23:03 GMT
       etag:
-      - '"0x8DBC8E2B04E7C2D"'
+      - '"0x8DBC8FCC34D8800"'
       last-modified:
-      - Mon, 09 Oct 2023 16:13:34 GMT
+      - Mon, 09 Oct 2023 19:20:13 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 09 Oct 2023 16:13:34 GMT
+      - Mon, 09 Oct 2023 19:20:13 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2723,6 +2283,522 @@ interactions:
       - ADDITIONAL_ARTIFACTS
       x-ms-meta-isencoded:
       - 'true'
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-10-04'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:14.8313783Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:14.8313783Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:23:04 GMT
+      etag:
+      - '"5600672d-0000-0100-0000-652452350000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=vx0pWqUvBREJlY2kOZXU%2BBcSUhH8ic%2B%2B6ndRVmKq7rY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:06.2363362","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=nmmKwh1jq2MfPijRGSpK2vKNr2wQVvFnV%2FsQZl9BNlc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:06.2362077","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=ROf2jcKzi75XmDsbLaGll97A0sM4EgrbHtzrYJr13Lo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:06.2363652","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/67833cff-7459-4889-83c0-804c8a8b3b8c_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=b0aLU7veKpn%2FFVrH%2BGTvXpeiG4SuZTpE5vksgGdvHBo%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:06.2364222","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/67833cff-7459-4889-83c0-804c8a8b3b8c_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=8jxhlW1rSTwzaRgI8ih3AMOH%2BdBgpHAKo%2FzT0ux%2Fvns%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:06.2364533","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-09T19:20:14.233Z","endDateTime":"2023-10-09T19:22:53.378Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:04.557Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '4514'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:23:06 GMT
+      mise-correlation-id:
+      - 04bb6317-164b-49f6-99ba-990af0f5b3b2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=vx0pWqUvBREJlY2kOZXU%2BBcSUhH8ic%2B%2B6ndRVmKq7rY%3D
+  response:
+    body:
+      string: "displayName: CLI-Test\ntestPlan: sample-JMX-file.jmx\ndescription:
+        Test created from az load test command\nengineInstances: 1\ntestId: download-test-case\nsplitAllCSVs:
+        False\nfailureCriteria:\n- avg(requests_per_sec) > 78\n- percentage(error)
+        > 50\n- GetCustomerDetails: avg(latency) > 200\nenv:\n- name: rps\n  value:
+        1\n- name: duration_in_sec\n  value: 1\n"
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '345'
+      content-md5:
+      - YBcWc67Cm9gXA2Vwhu5fxg==
+      content-type:
+      - application/octet-stream
+      date:
+      - Mon, 09 Oct 2023 19:23:06 GMT
+      etag:
+      - '"0x8DBC8FCC3421802"'
+      last-modified:
+      - Mon, 09 Oct 2023 19:20:13 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Mon, 09 Oct 2023 19:20:13 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-meta-filename:
+      - Y29uZmlnLnlhbWw=
+      x-ms-meta-filetype:
+      - ADDITIONAL_ARTIFACTS
+      x-ms-meta-isencoded:
+      - 'true'
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-10-04'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=nmmKwh1jq2MfPijRGSpK2vKNr2wQVvFnV%2FsQZl9BNlc%3D
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
+        properties=\"5.0\" jmeter=\"5.5\">\r\n  <hashTree>\r\n    <TestPlan guiclass=\"TestPlanGui\"
+        testclass=\"TestPlan\" testname=\"Azure Load Testing\" enabled=\"true\">\r\n
+        \     <stringProp name=\"TestPlan.comments\"></stringProp>\r\n      <boolProp
+        name=\"TestPlan.functional_mode\">false</boolProp>\r\n      <boolProp name=\"TestPlan.tearDown_on_shutdown\">true</boolProp>\r\n
+        \     <boolProp name=\"TestPlan.serialize_threadgroups\">false</boolProp>\r\n
+        \     <elementProp name=\"TestPlan.user_defined_variables\" elementType=\"Arguments\"
+        guiclass=\"ArgumentsPanel\" testclass=\"Arguments\" testname=\"User Defined
+        Variables\" enabled=\"true\">\r\n        <collectionProp name=\"Arguments.arguments\"/>\r\n
+        \     </elementProp>\r\n      <stringProp name=\"TestPlan.user_define_classpath\"></stringProp>\r\n
+        \   </TestPlan>\r\n    <hashTree>\r\n      <Arguments guiclass=\"ArgumentsPanel\"
+        testclass=\"Arguments\" testname=\"User Defined Variables\" enabled=\"true\">\r\n
+        \       <collectionProp name=\"Arguments.arguments\">\r\n          <elementProp
+        name=\"duration_in_sec\" elementType=\"Argument\">\r\n            <stringProp
+        name=\"Argument.name\">duration_in_sec</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;duration_in_sec&quot;)
+        ?: &quot;10&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n          <elementProp name=\"rps\" elementType=\"Argument\">\r\n
+        \           <stringProp name=\"Argument.name\">rps</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;rps&quot;) ?: &quot;1&quot;
+        )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n          <elementProp name=\"domain\" elementType=\"Argument\">\r\n
+        \           <stringProp name=\"Argument.name\">domain</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;domain&quot;) ?: &quot;example.com&quot;
+        )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n          <elementProp name=\"protocol\" elementType=\"Argument\">\r\n
+        \           <stringProp name=\"Argument.name\">protocol</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;protocol&quot;) ?:
+        &quot;https&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n          <elementProp name=\"url_path\" elementType=\"Argument\">\r\n
+        \           <stringProp name=\"Argument.name\">url_path</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;url_path&quot;) ?:
+        &quot;/&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n        </collectionProp>\r\n      </Arguments>\r\n
+        \     <hashTree/>\r\n      <OpenModelThreadGroup guiclass=\"OpenModelThreadGroupGui\"
+        testclass=\"OpenModelThreadGroup\" testname=\"Open Model Thread Group\" enabled=\"true\">\r\n
+        \       <elementProp name=\"ThreadGroup.main_controller\" elementType=\"OpenModelThreadGroupController\"/>\r\n
+        \       <stringProp name=\"ThreadGroup.on_sample_error\">continue</stringProp>\r\n
+        \       <stringProp name=\"OpenModelThreadGroup.schedule\">rate(${rps}/sec)
+        random_arrivals(${duration_in_sec} sec)</stringProp>\r\n        <stringProp
+        name=\"OpenModelThreadGroup.random_seed\"></stringProp>\r\n      </OpenModelThreadGroup>\r\n
+        \     <hashTree>\r\n        <HTTPSamplerProxy guiclass=\"HttpTestSampleGui\"
+        testclass=\"HTTPSamplerProxy\" testname=\"HTTP Request\" enabled=\"true\">\r\n
+        \         <elementProp name=\"HTTPsampler.Arguments\" elementType=\"Arguments\"
+        guiclass=\"HTTPArgumentsPanel\" testclass=\"Arguments\" testname=\"User Defined
+        Variables\" enabled=\"true\">\r\n            <collectionProp name=\"Arguments.arguments\"/>\r\n
+        \         </elementProp>\r\n          <stringProp name=\"HTTPSampler.domain\">${domain}</stringProp>\r\n
+        \         <stringProp name=\"HTTPSampler.port\"></stringProp>\r\n          <stringProp
+        name=\"HTTPSampler.protocol\">${protocol}</stringProp>\r\n          <stringProp
+        name=\"HTTPSampler.contentEncoding\"></stringProp>\r\n          <stringProp
+        name=\"HTTPSampler.path\">${url_path}</stringProp>\r\n          <stringProp
+        name=\"HTTPSampler.method\">GET</stringProp>\r\n          <boolProp name=\"HTTPSampler.follow_redirects\">true</boolProp>\r\n
+        \         <boolProp name=\"HTTPSampler.auto_redirects\">false</boolProp>\r\n
+        \         <boolProp name=\"HTTPSampler.use_keepalive\">true</boolProp>\r\n
+        \         <boolProp name=\"HTTPSampler.DO_MULTIPART_POST\">false</boolProp>\r\n
+        \         <stringProp name=\"HTTPSampler.embedded_url_re\"></stringProp>\r\n
+        \         <stringProp name=\"HTTPSampler.connect_timeout\"></stringProp>\r\n
+        \         <stringProp name=\"HTTPSampler.response_timeout\"></stringProp>\r\n
+        \       </HTTPSamplerProxy>\r\n        <hashTree/>\r\n      </hashTree>\r\n
+        \   </hashTree>\r\n  </hashTree>\r\n</jmeterTestPlan>\r\n"
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '4870'
+      content-md5:
+      - xGA4QxS45K0eB2EZNBGk8w==
+      content-type:
+      - application/octet-stream
+      date:
+      - Mon, 09 Oct 2023 19:23:08 GMT
+      etag:
+      - '"0x8DBC8FCB5B5C487"'
+      last-modified:
+      - Mon, 09 Oct 2023 19:19:50 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Mon, 09 Oct 2023 19:19:50 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-meta-filename:
+      - c2FtcGxlLUpNWC1maWxlLmpteA==
+      x-ms-meta-filetype:
+      - JMX_FILE
+      x-ms-meta-isencoded:
+      - 'true'
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-10-04'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=ROf2jcKzi75XmDsbLaGll97A0sM4EgrbHtzrYJr13Lo%3D
+  response:
+    body:
+      string: !!binary |
+        UEsDBC0AAAAIAIaaSVcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
+        AAAAAAFZAab+ZGlzcGxheU5hbWU6IENMSS1UZXN0CnRlc3RQbGFuOiBzYW1wbGUtSk1YLWZpbGUu
+        am14CmRlc2NyaXB0aW9uOiBUZXN0IGNyZWF0ZWQgZnJvbSBheiBsb2FkIHRlc3QgY29tbWFuZApl
+        bmdpbmVJbnN0YW5jZXM6IDEKdGVzdElkOiBkb3dubG9hZC10ZXN0LWNhc2UKc3BsaXRBbGxDU1Zz
+        OiBGYWxzZQpmYWlsdXJlQ3JpdGVyaWE6Ci0gYXZnKHJlcXVlc3RzX3Blcl9zZWMpID4gNzgKLSBw
+        ZXJjZW50YWdlKGVycm9yKSA+IDUwCi0gR2V0Q3VzdG9tZXJEZXRhaWxzOiBhdmcobGF0ZW5jeSkg
+        PiAyMDAKZW52OgotIG5hbWU6IHJwcwogIHZhbHVlOiAxCi0gbmFtZTogZHVyYXRpb25faW5fc2Vj
+        CiAgdmFsdWU6IDEKUEsDBC0AAAAIAIaaSVfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
+        LmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAAQYT+ew8P3htbCB2ZXJzaW9uPSIxLjAiIGVuY29kaW5n
+        PSJVVEYtOCI/Pg0KPGptZXRlclRlc3RQbGFuIHZlcnNpb249IjEuMiIgcHJvcGVydGllcz0iNS4w
+        IiBqbWV0ZXI9IjUuNSI+DQogIDxoYXNoVHJlZT4NCiAgICA8VGVzdFBsYW4gZ3VpY2xhc3M9IlRl
+        c3RQbGFuR3VpIiB0ZXN0Y2xhc3M9IlRlc3RQbGFuIiB0ZXN0bmFtZT0iQXp1cmUgTG9hZCBUZXN0
+        aW5nIiBlbmFibGVkPSJ0cnVlIj4NCiAgICAgIDxzdHJpbmdQcm9wIG5hbWU9IlRlc3RQbGFuLmNv
+        bW1lbnRzIj48L3N0cmluZ1Byb3A+DQogICAgICA8Ym9vbFByb3AgbmFtZT0iVGVzdFBsYW4uZnVu
+        Y3Rpb25hbF9tb2RlIj5mYWxzZTwvYm9vbFByb3A+DQogICAgICA8Ym9vbFByb3AgbmFtZT0iVGVz
+        dFBsYW4udGVhckRvd25fb25fc2h1dGRvd24iPnRydWU8L2Jvb2xQcm9wPg0KICAgICAgPGJvb2xQ
+        cm9wIG5hbWU9IlRlc3RQbGFuLnNlcmlhbGl6ZV90aHJlYWRncm91cHMiPmZhbHNlPC9ib29sUHJv
+        cD4NCiAgICAgIDxlbGVtZW50UHJvcCBuYW1lPSJUZXN0UGxhbi51c2VyX2RlZmluZWRfdmFyaWFi
+        bGVzIiBlbGVtZW50VHlwZT0iQXJndW1lbnRzIiBndWljbGFzcz0iQXJndW1lbnRzUGFuZWwiIHRl
+        c3RjbGFzcz0iQXJndW1lbnRzIiB0ZXN0bmFtZT0iVXNlciBEZWZpbmVkIFZhcmlhYmxlcyIgZW5h
+        YmxlZD0idHJ1ZSI+DQogICAgICAgIDxjb2xsZWN0aW9uUHJvcCBuYW1lPSJBcmd1bWVudHMuYXJn
+        dW1lbnRzIi8+DQogICAgICA8L2VsZW1lbnRQcm9wPg0KICAgICAgPHN0cmluZ1Byb3AgbmFtZT0i
+        VGVzdFBsYW4udXNlcl9kZWZpbmVfY2xhc3NwYXRoIj48L3N0cmluZ1Byb3A+DQogICAgPC9UZXN0
+        UGxhbj4NCiAgICA8aGFzaFRyZWU+DQogICAgICA8QXJndW1lbnRzIGd1aWNsYXNzPSJBcmd1bWVu
+        dHNQYW5lbCIgdGVzdGNsYXNzPSJBcmd1bWVudHMiIHRlc3RuYW1lPSJVc2VyIERlZmluZWQgVmFy
+        aWFibGVzIiBlbmFibGVkPSJ0cnVlIj4NCiAgICAgICAgPGNvbGxlY3Rpb25Qcm9wIG5hbWU9IkFy
+        Z3VtZW50cy5hcmd1bWVudHMiPg0KICAgICAgICAgIDxlbGVtZW50UHJvcCBuYW1lPSJkdXJhdGlv
+        bl9pbl9zZWMiIGVsZW1lbnRUeXBlPSJBcmd1bWVudCI+DQogICAgICAgICAgICA8c3RyaW5nUHJv
+        cCBuYW1lPSJBcmd1bWVudC5uYW1lIj5kdXJhdGlvbl9pbl9zZWM8L3N0cmluZ1Byb3A+DQogICAg
+        ICAgICAgICA8c3RyaW5nUHJvcCBuYW1lPSJBcmd1bWVudC52YWx1ZSI+JHtfX2dyb292eSggU3lz
+        dGVtLmdldGVudigmcXVvdDtkdXJhdGlvbl9pbl9zZWMmcXVvdDspID86ICZxdW90OzEwJnF1b3Q7
+        ICl9PC9zdHJpbmdQcm9wPg0KICAgICAgICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iQXJndW1lbnQu
+        bWV0YWRhdGEiPj08L3N0cmluZ1Byb3A+DQogICAgICAgICAgPC9lbGVtZW50UHJvcD4NCiAgICAg
+        ICAgICA8ZWxlbWVudFByb3AgbmFtZT0icnBzIiBlbGVtZW50VHlwZT0iQXJndW1lbnQiPg0KICAg
+        ICAgICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iQXJndW1lbnQubmFtZSI+cnBzPC9zdHJpbmdQcm9w
+        Pg0KICAgICAgICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iQXJndW1lbnQudmFsdWUiPiR7X19ncm9v
+        dnkoIFN5c3RlbS5nZXRlbnYoJnF1b3Q7cnBzJnF1b3Q7KSA/OiAmcXVvdDsxJnF1b3Q7ICl9PC9z
+        dHJpbmdQcm9wPg0KICAgICAgICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iQXJndW1lbnQubWV0YWRh
+        dGEiPj08L3N0cmluZ1Byb3A+DQogICAgICAgICAgPC9lbGVtZW50UHJvcD4NCiAgICAgICAgICA8
+        ZWxlbWVudFByb3AgbmFtZT0iZG9tYWluIiBlbGVtZW50VHlwZT0iQXJndW1lbnQiPg0KICAgICAg
+        ICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iQXJndW1lbnQubmFtZSI+ZG9tYWluPC9zdHJpbmdQcm9w
+        Pg0KICAgICAgICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iQXJndW1lbnQudmFsdWUiPiR7X19ncm9v
+        dnkoIFN5c3RlbS5nZXRlbnYoJnF1b3Q7ZG9tYWluJnF1b3Q7KSA/OiAmcXVvdDtleGFtcGxlLmNv
+        bSZxdW90OyApfTwvc3RyaW5nUHJvcD4NCiAgICAgICAgICAgIDxzdHJpbmdQcm9wIG5hbWU9IkFy
+        Z3VtZW50Lm1ldGFkYXRhIj49PC9zdHJpbmdQcm9wPg0KICAgICAgICAgIDwvZWxlbWVudFByb3A+
+        DQogICAgICAgICAgPGVsZW1lbnRQcm9wIG5hbWU9InByb3RvY29sIiBlbGVtZW50VHlwZT0iQXJn
+        dW1lbnQiPg0KICAgICAgICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iQXJndW1lbnQubmFtZSI+cHJv
+        dG9jb2w8L3N0cmluZ1Byb3A+DQogICAgICAgICAgICA8c3RyaW5nUHJvcCBuYW1lPSJBcmd1bWVu
+        dC52YWx1ZSI+JHtfX2dyb292eSggU3lzdGVtLmdldGVudigmcXVvdDtwcm90b2NvbCZxdW90Oykg
+        PzogJnF1b3Q7aHR0cHMmcXVvdDsgKX08L3N0cmluZ1Byb3A+DQogICAgICAgICAgICA8c3RyaW5n
+        UHJvcCBuYW1lPSJBcmd1bWVudC5tZXRhZGF0YSI+PTwvc3RyaW5nUHJvcD4NCiAgICAgICAgICA8
+        L2VsZW1lbnRQcm9wPg0KICAgICAgICAgIDxlbGVtZW50UHJvcCBuYW1lPSJ1cmxfcGF0aCIgZWxl
+        bWVudFR5cGU9IkFyZ3VtZW50Ij4NCiAgICAgICAgICAgIDxzdHJpbmdQcm9wIG5hbWU9IkFyZ3Vt
+        ZW50Lm5hbWUiPnVybF9wYXRoPC9zdHJpbmdQcm9wPg0KICAgICAgICAgICAgPHN0cmluZ1Byb3Ag
+        bmFtZT0iQXJndW1lbnQudmFsdWUiPiR7X19ncm9vdnkoIFN5c3RlbS5nZXRlbnYoJnF1b3Q7dXJs
+        X3BhdGgmcXVvdDspID86ICZxdW90Oy8mcXVvdDsgKX08L3N0cmluZ1Byb3A+DQogICAgICAgICAg
+        ICA8c3RyaW5nUHJvcCBuYW1lPSJBcmd1bWVudC5tZXRhZGF0YSI+PTwvc3RyaW5nUHJvcD4NCiAg
+        ICAgICAgICA8L2VsZW1lbnRQcm9wPg0KICAgICAgICA8L2NvbGxlY3Rpb25Qcm9wPg0KICAgICAg
+        PC9Bcmd1bWVudHM+DQogICAgICA8aGFzaFRyZWUvPg0KICAgICAgPE9wZW5Nb2RlbFRocmVhZEdy
+        b3VwIGd1aWNsYXNzPSJPcGVuTW9kZWxUaHJlYWRHcm91cEd1aSIgdGVzdGNsYXNzPSJPcGVuTW9k
+        ZWxUaHJlYWRHcm91cCIgdGVzdG5hbWU9Ik9wZW4gTW9kZWwgVGhyZWFkIEdyb3VwIiBlbmFibGVk
+        PSJ0cnVlIj4NCiAgICAgICAgPGVsZW1lbnRQcm9wIG5hbWU9IlRocmVhZEdyb3VwLm1haW5fY29u
+        dHJvbGxlciIgZWxlbWVudFR5cGU9Ik9wZW5Nb2RlbFRocmVhZEdyb3VwQ29udHJvbGxlciIvPg0K
+        ICAgICAgICA8c3RyaW5nUHJvcCBuYW1lPSJUaHJlYWRHcm91cC5vbl9zYW1wbGVfZXJyb3IiPmNv
+        bnRpbnVlPC9zdHJpbmdQcm9wPg0KICAgICAgICA8c3RyaW5nUHJvcCBuYW1lPSJPcGVuTW9kZWxU
+        aHJlYWRHcm91cC5zY2hlZHVsZSI+cmF0ZSgke3Jwc30vc2VjKSByYW5kb21fYXJyaXZhbHMoJHtk
+        dXJhdGlvbl9pbl9zZWN9IHNlYyk8L3N0cmluZ1Byb3A+DQogICAgICAgIDxzdHJpbmdQcm9wIG5h
+        bWU9Ik9wZW5Nb2RlbFRocmVhZEdyb3VwLnJhbmRvbV9zZWVkIj48L3N0cmluZ1Byb3A+DQogICAg
+        ICA8L09wZW5Nb2RlbFRocmVhZEdyb3VwPg0KICAgICAgPGhhc2hUcmVlPg0KICAgICAgICA8SFRU
+        UFNhbXBsZXJQcm94eSBndWljbGFzcz0iSHR0cFRlc3RTYW1wbGVHdWkiIHRlc3RjbGFzcz0iSFRU
+        UFNhbXBsZXJQcm94eSIgdGVzdG5hbWU9IkhUVFAgUmVxdWVzdCIgZW5hYmxlZD0idHJ1ZSI+DQog
+        ICAgICAgICAgPGVsZW1lbnRQcm9wIG5hbWU9IkhUVFBzYW1wbGVyLkFyZ3VtZW50cyIgZWxlbWVu
+        dFR5cGU9IkFyZ3VtZW50cyIgZ3VpY2xhc3M9IkhUVFBBcmd1bWVudHNQYW5lbCIgdGVzdGNsYXNz
+        PSJBcmd1bWVudHMiIHRlc3RuYW1lPSJVc2VyIERlZmluZWQgVmFyaWFibGVzIiBlbmFibGVkPSJ0
+        cnVlIj4NCiAgICAgICAgICAgIDxjb2xsZWN0aW9uUHJvcCBuYW1lPSJBcmd1bWVudHMuYXJndW1l
+        bnRzIi8+DQogICAgICAgICAgPC9lbGVtZW50UHJvcD4NCiAgICAgICAgICA8c3RyaW5nUHJvcCBu
+        YW1lPSJIVFRQU2FtcGxlci5kb21haW4iPiR7ZG9tYWlufTwvc3RyaW5nUHJvcD4NCiAgICAgICAg
+        ICA8c3RyaW5nUHJvcCBuYW1lPSJIVFRQU2FtcGxlci5wb3J0Ij48L3N0cmluZ1Byb3A+DQogICAg
+        ICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iSFRUUFNhbXBsZXIucHJvdG9jb2wiPiR7cHJvdG9jb2x9
+        PC9zdHJpbmdQcm9wPg0KICAgICAgICAgIDxzdHJpbmdQcm9wIG5hbWU9IkhUVFBTYW1wbGVyLmNv
+        bnRlbnRFbmNvZGluZyI+PC9zdHJpbmdQcm9wPg0KICAgICAgICAgIDxzdHJpbmdQcm9wIG5hbWU9
+        IkhUVFBTYW1wbGVyLnBhdGgiPiR7dXJsX3BhdGh9PC9zdHJpbmdQcm9wPg0KICAgICAgICAgIDxz
+        dHJpbmdQcm9wIG5hbWU9IkhUVFBTYW1wbGVyLm1ldGhvZCI+R0VUPC9zdHJpbmdQcm9wPg0KICAg
+        ICAgICAgIDxib29sUHJvcCBuYW1lPSJIVFRQU2FtcGxlci5mb2xsb3dfcmVkaXJlY3RzIj50cnVl
+        PC9ib29sUHJvcD4NCiAgICAgICAgICA8Ym9vbFByb3AgbmFtZT0iSFRUUFNhbXBsZXIuYXV0b19y
+        ZWRpcmVjdHMiPmZhbHNlPC9ib29sUHJvcD4NCiAgICAgICAgICA8Ym9vbFByb3AgbmFtZT0iSFRU
+        UFNhbXBsZXIudXNlX2tlZXBhbGl2ZSI+dHJ1ZTwvYm9vbFByb3A+DQogICAgICAgICAgPGJvb2xQ
+        cm9wIG5hbWU9IkhUVFBTYW1wbGVyLkRPX01VTFRJUEFSVF9QT1NUIj5mYWxzZTwvYm9vbFByb3A+
+        DQogICAgICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iSFRUUFNhbXBsZXIuZW1iZWRkZWRfdXJsX3Jl
+        Ij48L3N0cmluZ1Byb3A+DQogICAgICAgICAgPHN0cmluZ1Byb3AgbmFtZT0iSFRUUFNhbXBsZXIu
+        Y29ubmVjdF90aW1lb3V0Ij48L3N0cmluZ1Byb3A+DQogICAgICAgICAgPHN0cmluZ1Byb3AgbmFt
+        ZT0iSFRUUFNhbXBsZXIucmVzcG9uc2VfdGltZW91dCI+PC9zdHJpbmdQcm9wPg0KICAgICAgICA8
+        L0hUVFBTYW1wbGVyUHJveHk+DQogICAgICAgIDxoYXNoVHJlZS8+DQogICAgICA8L2hhc2hUcmVl
+        Pg0KICAgIDwvaGFzaFRyZWU+DQogIDwvaGFzaFRyZWU+DQo8L2ptZXRlclRlc3RQbGFuPg0KUEsB
+        AjMALQAAAAgAhppJVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
+        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACACGmklX8Zv7b///////////EwAUAAAAAAAAAAAA
+        AACbAQAAc2FtcGxlLUpNWC1maWxlLmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAUEsFBgAAAAACAAIA
+        ogAAAOsUAAAAAA==
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '5539'
+      content-md5:
+      - /awq7A5BsWf/8AZoYNnc1g==
+      content-type:
+      - application/octet-stream
+      date:
+      - Mon, 09 Oct 2023 19:23:09 GMT
+      etag:
+      - '"0x8DBC8FCC34D8800"'
+      last-modified:
+      - Mon, 09 Oct 2023 19:20:13 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Mon, 09 Oct 2023 19:20:13 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-meta-filename:
+      - aW5wdXRhcnRpZmFjdHMuemlw
+      x-ms-meta-filetype:
+      - ADDITIONAL_ARTIFACTS
+      x-ms-meta-isencoded:
+      - 'true'
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-10-04'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/67833cff-7459-4889-83c0-804c8a8b3b8c_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=8jxhlW1rSTwzaRgI8ih3AMOH%2BdBgpHAKo%2FzT0ux%2Fvns%3D
+  response:
+    body:
+      string: !!binary |
+        UEsDBBQAAAAIAN2aSVdzPUjhVAEAAHADAAASABwAZW5naW5lMV93b3JrZXIubG9nVVQJAAMSUyRl
+        ElMkZXV4CwABBAAAAAAEAAAAAJ2SXWuDMBSG7/srzs1gG9XF2PoR2IXQFDbUQZX1WmzqUtSUJHXb
+        v59aRxmtIAshHE7yPie852CEbcNCBvLB8gm2CFrMHc+DbbCJQZiZeTBfI6aZJBCKImQNKwm8xOu3
+        Gb5SOnNsLc/KvFXmrfbQnlEQpiFXmtUdJaVJCkkabFK6AvpO4xQMkCxnvGG7m9AFHoGuecm2kref
+        u+A3Awlow2oNmimd6EzqMbY9wg5OWigtjhdyl4VsSPdgUGcyfHL9AUxKIUFmmoGPYN/GDlLmzaqO
+        5UyyicarqSZ5/jTn/yJPx1JkO14XcKi6JpulKGDf2nqzho+tf9TIRXUs2VgDfDxixcTm0no3Rrat
+        flCHKZZmcqqqTHLVkVQff8Mz9AsBrwEh0u82+divJwVBU5DhRcRrAj7Gtu1iZDvecuG6Sw+5EGVf
+        BIzrGw+olL/qe2QidPcw+wFQSwECHgMUAAAACADdmklXcz1I4VQBAABwAwAAEgAYAAAAAAABAAAA
+        pIEAAAAAZW5naW5lMV93b3JrZXIubG9nVVQFAAMSUyRldXgLAAEEAAAAAAQAAAAAUEsFBgAAAAAB
+        AAEAWAAAAKABAAAAAA==
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '526'
+      content-md5:
+      - wYZV5+6v3oqkXqbE3COecw==
+      content-type:
+      - application/octet-stream
+      date:
+      - Mon, 09 Oct 2023 19:23:09 GMT
+      etag:
+      - '"0x8DBC8FD25A21C15"'
+      last-modified:
+      - Mon, 09 Oct 2023 19:22:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Mon, 09 Oct 2023 19:22:58 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-10-04'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/67833cff-7459-4889-83c0-804c8a8b3b8c_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=b0aLU7veKpn%2FFVrH%2BGTvXpeiG4SuZTpE5vksgGdvHBo%3D
+  response:
+    body:
+      string: !!binary |
+        UEsDBBQAAAAIAN2aSVc8lqSAdQAAAKMAAAATABwAZW5naW5lMV9yZXN1bHRzLmNzdlVUCQADElMk
+        ZRJTJGV1eAsAAQQAAAAABAAAAAA9jjsOwkAQQ3vO4lOQCilQwHKAya4JkWY/2pkUuT1RJNI9y8+S
+        fcl8ueQGqjRjgspERae1WoxDTTzDnWYyE/7tlPSQTCRxCVsjbI1xr/GRRdd+qtPmNBiLXw+aewvH
+        2iCqf3w/R4ziLHHDLSnD/gpDLYXRLz9QSwECHgMUAAAACADdmklXPJakgHUAAACjAAAAEwAYAAAA
+        AAABAAAApIEAAAAAZW5naW5lMV9yZXN1bHRzLmNzdlVUBQADElMkZXV4CwABBAAAAAAEAAAAAFBL
+        BQYAAAAAAQABAFkAAADCAAAAAAA=
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '305'
+      content-md5:
+      - jZrSlcEMB1yRTsKrPGo7TQ==
+      content-type:
+      - application/octet-stream
+      date:
+      - Mon, 09 Oct 2023 19:23:10 GMT
+      etag:
+      - '"0x8DBC8FD25AC2CB7"'
+      last-modified:
+      - Mon, 09 Oct 2023 19:22:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Mon, 09 Oct 2023 19:22:58 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_download_files.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_download_files.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:14.8313783Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:14.8313783Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:22.0199528Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:22.0199528Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:48 GMT
+      - Fri, 13 Oct 2023 13:52:56 GMT
       etag:
-      - '"5600672d-0000-0100-0000-652452350000"'
+      - '"d80153fb-0000-0100-0000-65294b990000"'
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:19:49 GMT
+      - Fri, 13 Oct 2023 13:52:57 GMT
       mise-correlation-id:
-      - 5acbbda8-e603-4e70-b867-452866b9943d
+      - ad70a149-cab7-43c4-b04f-59472da587a0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"d8f1010f-4928-47da-8a65-e0587be59206": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "7efb4f19-9fef-4335-ad73-bd4361e600c3":
+      {"passFailMetrics": {"5ab853c8-30d1-4dfb-aef0-916256c71cd2": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "f648a763-1709-461c-8c58-cf9cd0161426":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "24d868b1-b8e0-4328-b1ef-3569f3e4267f": {"aggregate": "avg", "clientMetric":
+      "50"}, "ea858bcd-2d1d-458f-8f53-9aed3d809347": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -104,13 +104,13 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:50.234Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:19:50.234Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:58.342Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:58.342Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:50 GMT
+      - Fri, 13 Oct 2023 13:52:58 GMT
       location:
-      - https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+      - https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 6b390da1-e468-4b00-ad21-1beccdeae44b
+      - 8f565631-d031-4a40-af9b-b508612a4774
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -143,9 +143,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:50 GMT
+      - Fri, 13 Oct 2023 13:52:58 GMT
       mise-correlation-id:
-      - fdc220aa-5905-45cb-80b5-7b020ced21dd
+      - df382072-ea90-4e33-94a2-00fad7fb1245
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -273,27 +273,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A51Z&sr=b&sp=r&sig=jPDH7P%2FUfqZxrpDaxPocNC5%2Bp%2BEaAjp0ZJjaBgmXuUY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:51.0467837","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A59Z&sr=b&sp=r&sig=ZtTy45%2F5h0IiIXvmldnCuxcYjHPxs35LxrNNLosstqQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:59.1670467","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:51 GMT
+      - Fri, 13 Oct 2023 13:52:59 GMT
       location:
-      - https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - f4977216-0821-4f25-a916-444a56dbf095
+      - 2ce64733-dc7b-4a8c-a4f2-065aec47dfa6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -311,12 +311,120 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A51Z&sr=b&sp=r&sig=E8EnzQ4P1vOzjr3AgOi8wsFVAqKxUahXtTZqLnIovyE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:51.3157392","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A59Z&sr=b&sp=r&sig=C9GCzyQvnAH7TDU2hAl3qlywozyw7lToUpvrIV%2B3Tqo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:59.4572392","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:52:59 GMT
+      mise-correlation-id:
+      - b6405a80-8e23-4464-b433-2167007fe520
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A03%3A04Z&sr=b&sp=r&sig=8%2BD56AAAkE46pS4fhao9vf3COjCeiZY0CedXINYbI4c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:03:04.7100726","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:04 GMT
+      mise-correlation-id:
+      - a1b4644c-813e-4be9-8d10-cde6bd86c78b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A03%3A10Z&sr=b&sp=r&sig=D8Q6lNBFJtSSUr29gI%2B21k9Mqp6Vwo5%2BBzkgZEYF8r0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:03:10.0387289","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:10 GMT
+      mise-correlation-id:
+      - 432afb36-5a46-4f5a-ad50-c7852cc49e1c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A03%3A15Z&sr=b&sp=r&sig=mjGmkknCkE5BHo5abmlfFn9MoqH64aOiJGDD%2B1BhtUE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:03:15.3591202","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:51 GMT
+      - Fri, 13 Oct 2023 13:53:15 GMT
       mise-correlation-id:
-      - 8d6e8252-bc29-4cd6-a660-14b499545332
+      - 35a73915-3b0d-4a5d-8527-bfda6c68e0d3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -347,134 +455,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A56Z&sr=b&sp=r&sig=0K9L9SSMYixg6fkR4m%2FuTpU8ZkUNzgIBUWFdFoWEST4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:56.654193","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A15Z&sr=b&sp=r&sig=YcvBzlsN6Au0jiwMFfnSJ79CmIpxVcJyQ61m4AOkQ1E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:15.6823491","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:58.342Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:12.118Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '1579'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:56 GMT
+      - Fri, 13 Oct 2023 13:53:15 GMT
       mise-correlation-id:
-      - 37937733-8edf-42de-81dc-783e9744cd4e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A30%3A01Z&sr=b&sp=r&sig=TPXsTNlXHuGmyYBiBoejO1D9daNqPz7vxVBcNf0001k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:30:01.9795438","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:01 GMT
-      mise-correlation-id:
-      - 85224c09-59ca-4813-a317-21a00b90c465
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A30%3A07Z&sr=b&sp=r&sig=Jx16rGTi8fP9kCIiL4Xu3WueAILNezgvUqhL3r4qKOo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:30:07.2450597","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '547'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:07 GMT
-      mise-correlation-id:
-      - bdcd934f-d9d7-47fc-a2d6-15c85320b090
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A07Z&sr=b&sp=r&sig=8LO5S6f1n8vBTdhV34L64p6xQDKjAy7%2Fm%2FVoM5vDlHU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:07.5129673","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:50.234Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:03.389Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1583'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:07 GMT
-      mise-correlation-id:
-      - beb40476-4c5b-419f-b6c0-076c9972ac25
+      - af52b428-bccf-41b5-9465-bded65caf2fd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:14.8313783Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:14.8313783Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:22.0199528Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:22.0199528Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:08 GMT
+      - Fri, 13 Oct 2023 13:53:16 GMT
       etag:
-      - '"5600672d-0000-0100-0000-652452350000"'
+      - '"d80153fb-0000-0100-0000-65294b990000"'
       expires:
       - '-1'
       pragma:
@@ -536,26 +536,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A09Z&sr=b&sp=r&sig=nfssOjVsvA0A3YkFbbbc9onsF7sdIb4uXXJovHJpCtg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:09.9705497","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:19:50.234Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:03.389Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A17Z&sr=b&sp=r&sig=r2blfeze2jJ1hTeMjT0O3iXpniUlKxkzSsNI%2FCk8uxc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:17.9723061","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:52:58.342Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:12.118Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1591'
+      - '1593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:10 GMT
+      - Fri, 13 Oct 2023 13:53:18 GMT
       mise-correlation-id:
-      - c6a1271b-4bb4-4b2b-a310-121cbcacd7ca
+      - d280e19e-fd50-490d-832a-1de2aa4a1e26
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:14.8313783Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:14.8313783Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:22.0199528Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:22.0199528Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:11 GMT
+      - Fri, 13 Oct 2023 13:53:18 GMT
       etag:
-      - '"5600672d-0000-0100-0000-652452350000"'
+      - '"d80153fb-0000-0100-0000-65294b990000"'
       expires:
       - '-1'
       pragma:
@@ -617,9 +617,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:20:13 GMT
+      - Fri, 13 Oct 2023 13:53:19 GMT
       mise-correlation-id:
-      - bd44c9c2-d2d2-4ac1-94a4-b2d8ddbdb259
+      - 0dacdb0b-1e7d-4598-a3d7-b25c2564ec45
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -660,27 +660,27 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A13Z&sr=b&sp=r&sig=ty9fyavUEwuTvoVdiW5Al25s1p8pddpPXatmaki4KL0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:13.9059997","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A13Z&sr=b&sp=r&sig=2ZCzQzHrqo%2Fnj3bMuIBJl4ajnGosM%2BjgKhTBTivDFxw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:13.9057771","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A13Z&sr=b&sp=r&sig=buLfDSpkabFxW975wxlKTaAZTZ3pCVB9KyP1uGVRsD0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:13.9060215","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:13.827Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A20Z&sr=b&sp=r&sig=F0fThIJ%2BJpjIZ41Ge7fwB5dR7JdR9pN9Pq6KJBTNNHw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:20.5338605","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A20Z&sr=b&sp=r&sig=Z5PteR8OFR%2BIB477OWZGhTW6NRy%2FHCQ9kg2QOosCqRg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:20.5337778","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A20Z&sr=b&sp=r&sig=osEEunxQNQF60e04wiU6HyjRrtDroMHDdtUuUvtrhDw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:20.5338862","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:20.467Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3162'
+      - '3164'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:14 GMT
+      - Fri, 13 Oct 2023 13:53:20 GMT
       location:
-      - https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+      - https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 9de9750b-a5e8-410b-a7fc-561603586e90
+      - dd2e9de2-2714-4848-a5eb-569c1887525e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -698,25 +698,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=UT2q6wqTTCxWKEptunrN1wLb2f6%2BPLgSE%2Fty5z%2BBc6w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:14.34162","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=u45CxvU5zvwTa1bdR9br2ytz%2FNk23f%2BscVLP59EUi28%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:14.341551","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A14Z&sr=b&sp=r&sig=4yLHCbP2mqPbOFspXEirW0EIwCaKPAb2Eyq%2FlG3Wieg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:14.3416361","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.233Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A21Z&sr=b&sp=r&sig=OnTp3XL0IhmBT3xIJytM8Rf99f%2FSGU52REwLd5les40%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:21.0809734","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A21Z&sr=b&sp=r&sig=I84SUQTm0F47Mn3mhrioujgQsqpdUzie7y5YjUtRmy8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:21.080899","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A21Z&sr=b&sp=r&sig=2kLigLn0yVuPM69XjCJnIkXx0DrEFNp%2FxU%2FssE9fwTI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:21.0809872","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:20.467Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3212'
+      - '3163'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:14 GMT
+      - Fri, 13 Oct 2023 13:53:21 GMT
       mise-correlation-id:
-      - 637b233d-bb26-41bf-ae70-66997f965965
+      - d5fdb46f-e839-41b6-99a3-775d9f01f595
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -734,25 +734,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A19Z&sr=b&sp=r&sig=On%2F6fb25N4hYcUFu4RF4PkMO6CHtV%2Fyc0C1fOdikCOk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:19.8067721","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A19Z&sr=b&sp=r&sig=95z6BBW7%2FvhsBxUicTYIP%2B7ZWqf%2FwoMSzNneNysuwGw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:19.8066948","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A19Z&sr=b&sp=r&sig=ClNRwbBfO%2FXF0lZt6xctDNfZWnDg9PjcdRHb7O9J8rk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:19.8067866","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.497Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A26Z&sr=b&sp=r&sig=ErAWBSIax%2Fpigd1eFWrDff9zmb%2BcQnT%2FGjLoJegqgzw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:26.3609856","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A26Z&sr=b&sp=r&sig=Qh0%2BVwUG5ep%2FMVC%2F60NWz12vFkvVWwOYqxSyBOvoSPM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:26.3609151","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A26Z&sr=b&sp=r&sig=xcXaF%2FSl9uTtyafTPX%2BZ3QejuSzKbOZzzVxc%2B%2B%2BUz8I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:26.3610019","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:22.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3217'
+      - '3227'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:19 GMT
+      - Fri, 13 Oct 2023 13:53:26 GMT
       mise-correlation-id:
-      - 6f4672a4-9abd-4c2c-a645-68179c161f2c
+      - 2806a5ba-13fd-4819-bd42-be543e90bb31
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -770,12 +770,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A25Z&sr=b&sp=r&sig=cVGj9SJOeTcRzazv6YO8by2FWG0DHuR62aCbfjhRBrY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:25.4322267","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A25Z&sr=b&sp=r&sig=n0uEf8fQ6xiYcGZhU9uyDEswfxb6MZ0d2feX2yeMP74%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:25.4321536","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A25Z&sr=b&sp=r&sig=7vqHoR7vorMjrp6noDLRMwx4%2B%2FePnc%2FlT9dcLgbKhSE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:25.4322493","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.497Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A31Z&sr=b&sp=r&sig=yMf1HZVlNUo3BJk5QnWkTQ0GlUddkrtENgXQpKmuVeQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:31.6278517","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A31Z&sr=b&sp=r&sig=snG%2BSUMFaLdZFlf8nqt3HlVLdMZufK8ht7ZuYRU4Tco%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:31.6277784","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A31Z&sr=b&sp=r&sig=I7N71q4ZYGzMB4G%2BB%2FfUAde2A2nHRb341Cua4qGaZi4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:31.6278666","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:22.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -786,9 +786,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:25 GMT
+      - Fri, 13 Oct 2023 13:53:31 GMT
       mise-correlation-id:
-      - 5772f641-4eea-4a63-ae97-8029ecaeb69d
+      - 8472a47e-ae2c-4d91-88f4-55257bb95079
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -806,48 +806,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A30Z&sr=b&sp=r&sig=P1VAwCt3s0XZFrMl7PmLgaHxv21owk3GEoO85T8QQok%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:30.7657524","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A30Z&sr=b&sp=r&sig=dcru6U89cDa6ezuVA7Z2hYjf37bQ7Yq4jovEVSb9R00%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:30.7656496","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A30Z&sr=b&sp=r&sig=3bgSt8FBNmZhSgmLgWCY8fwsjDCFzZJzorvs2SWms5I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:30.7657727","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.497Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:30 GMT
-      mise-correlation-id:
-      - d411a2a9-a196-4c6a-ac3b-71e00edac304
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A36Z&sr=b&sp=r&sig=pSUCXpgUtDoPZW4IG0gVkNn9wAgaxoo%2BwXVJ3SUkON0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:36.0549074","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A36Z&sr=b&sp=r&sig=LyS7nfliINir22gsgUBbIQZ9144Cs8KgsaPF2i6J2Z0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:36.0548325","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A36Z&sr=b&sp=r&sig=tzPpcXvkLRh1sGezf6i4kagSCYYtu1mgtCKw0Ta0A%2BU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:36.0549234","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.497Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A36Z&sr=b&sp=r&sig=3SH1qS1gFrfC%2BdCLYVCA1SrGLB1o46d4JJMbFJpXdlg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:36.9274529","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A36Z&sr=b&sp=r&sig=PSuFeWdB6f5T2YqRBfBZIReY7HauxPDrS5Iin2aRet4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:36.9273778","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A36Z&sr=b&sp=r&sig=E6c4GsXgA6%2BZGnVJaAAEmx6P4MvIk9IqpAc9A4xNv4g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:36.9274676","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:22.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -858,9 +822,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:36 GMT
+      - Fri, 13 Oct 2023 13:53:36 GMT
       mise-correlation-id:
-      - 52e94e1e-ccdf-431c-851e-3d7c8a694617
+      - 16e96b1f-119f-4145-8691-fd1f750b84db
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -878,25 +842,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A42Z&sr=b&sp=r&sig=j9zEZwAmJsAzQcWY2xP5357ci6MpRMbi3dM%2FaFvsGvQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:42.5382804","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A42Z&sr=b&sp=r&sig=6l5xTaWj4l2VcqdeVl94XYWNIJpQkIWeevFUxkXfJkg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:42.5382035","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A42Z&sr=b&sp=r&sig=rf62Y%2BITEV0tSol9wa5IzgcgN6SjRoc0o81S2D2KKQo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:42.538294","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.497Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A42Z&sr=b&sp=r&sig=RMFRMh3ygpWoGFF7P4WvYb2obX8SE33vgXJS0WarVSE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:42.1829839","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A42Z&sr=b&sp=r&sig=DtzplhUoYUU2kTZYHaMIsHfShWvr24sNu7Wbe32dzhM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:42.182916","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A42Z&sr=b&sp=r&sig=YknB9M65S1IdqzC%2BknldLbtmNhCOYtDZRi%2F%2FtWg6ofQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:42.183","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:22.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3208'
+      - '3206'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:42 GMT
+      - Fri, 13 Oct 2023 13:53:42 GMT
       mise-correlation-id:
-      - f296a26f-d8a9-4485-8eb1-3ffe21c72b8a
+      - 294ec3c7-42a4-4eee-8040-9e881eb4f193
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -914,12 +878,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A47Z&sr=b&sp=r&sig=mIPW8ZTG5r%2BV0No0jShZkraZVBLsXe8s8pam2LIZ21I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:47.8221214","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A47Z&sr=b&sp=r&sig=718WLAz11tGl8qaVprTS22Xjk8OX2%2FTexMHte9qBvBg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:47.8220392","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A47Z&sr=b&sp=r&sig=%2BOAepjfnC4XYDbV7Abz%2FCzkf78BrPyHTqAF%2BD%2FpPD6c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:47.8221416","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.497Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A47Z&sr=b&sp=r&sig=amvF%2FQV2Xytk7A0%2FipNrQu8VJaAnD4K62G2WVuMcN80%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:47.5426739","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A47Z&sr=b&sp=r&sig=%2F95f6x%2BakJCIVBcZpqt7LV3qim0L8G6pqIjnTWvyT14%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:47.5425879","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A47Z&sr=b&sp=r&sig=RDYtlMKO0YG1VQSiLR8nmYzJia4Xy%2FzPgs%2BLUOpc30Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:47.5426884","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:22.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -930,9 +894,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:47 GMT
+      - Fri, 13 Oct 2023 13:53:47 GMT
       mise-correlation-id:
-      - 9cc1b53b-15e3-4039-84b2-5c0152b29eca
+      - 2e38e823-dfc3-4cd3-95b2-17a7563f6b29
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -950,12 +914,84 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A53Z&sr=b&sp=r&sig=ZDh3pkWw3j%2BPdJP5D6I3yCXlfdKNwYgx8YO8S9AhRdA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:53.3008865","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A53Z&sr=b&sp=r&sig=52DcPKXX0gDf75vm4vZiwonAg64nRpgI64S0SGi6ALE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:53.3008191","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A53Z&sr=b&sp=r&sig=yjSf2mirnIhvWktSUWeZ1kF96D7kiX7129LhIjzFFz8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:53.3009022","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:14.497Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A52Z&sr=b&sp=r&sig=K7aGSSK5Gom%2BxAGS9aoumNa%2BEtUD1au2DsQa%2FVwMChg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:52.804645","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A52Z&sr=b&sp=r&sig=%2FZK%2Bhg3dbbmxnIKsfqrzcyUwGcy7IVJpgoI8qc8MYzQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:52.8045474","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A52Z&sr=b&sp=r&sig=%2Bv8pVkkraJHkHQUOibpsy8zIENY20HnUd6CB8MwbHwM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:52.8046676","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:22.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3216'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:52 GMT
+      mise-correlation-id:
+      - 9b262b0a-be4a-48b5-ba2e-0654824fb55b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A58Z&sr=b&sp=r&sig=pUAGn5l9sPtPh4s36LGODKsp9BYjFrAo2XG8tJ2R%2Bm8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:58.0531103","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A58Z&sr=b&sp=r&sig=FMSJe1fVXg%2By0IGKVSztpwS2zQgTWL2mLldNQD696ak%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:53:58.0530429","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A53%3A58Z&sr=b&sp=r&sig=U0zMDOp34aEFaFlx%2F3gE5jwYI2hRYAeqINfBogctqEQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:53:58.0531249","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:22.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3211'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:53:58 GMT
+      mise-correlation-id:
+      - 06fd1ff5-e321-4ec6-9b4c-49acea54163f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A03Z&sr=b&sp=r&sig=JC%2FyeKM587dSLJJatJYJztTO9RqgvZzjUMPBYoqnB14%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:03.3127535","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A03Z&sr=b&sp=r&sig=GoueIXYfJ3meJr5PlZc4rgso6m7Cv2MUMlQ8Voyg4%2FA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:03.312685","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A03Z&sr=b&sp=r&sig=ALgNyPmZzy6LSct5F2aZyWTUWPYwUhyyeVNa2fkvYwA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:03.312767","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:53:22.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -966,9 +1002,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:20:53 GMT
+      - Fri, 13 Oct 2023 13:54:03 GMT
       mise-correlation-id:
-      - d1bbf77f-74cf-4c1b-96f2-74737a8eade0
+      - 63b65594-671e-415d-881f-7c55fe21fd07
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -986,48 +1022,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A58Z&sr=b&sp=r&sig=uEJdXdmAgNGPaHq7A%2BppnaezRMAvLD5vXGofWJS1lvI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:58.6267141","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A58Z&sr=b&sp=r&sig=DAi5%2FcSflZ02CadWLU7UljhEqpbKqrw8WZD0T2gl4pU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:20:58.6266211","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A20%3A58Z&sr=b&sp=r&sig=GX%2Fn%2BGlyGnKadUnsmZqkaBpbPJyoYp4%2BzcAKP8ggqVU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:20:58.6267349","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:20:58.227Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3214'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:20:58 GMT
-      mise-correlation-id:
-      - 056d8142-d9ea-49b7-a26f-3f347a30c1c1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A03Z&sr=b&sp=r&sig=tg10nWqwYhwV2cznUOFu2TkGbN9pA8zGsl3AJVdssdk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:03.9446115","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A03Z&sr=b&sp=r&sig=nPLInz345Kg3fXOSnFfKDwB2FixsodEnoWvjqHRozkc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:03.9445232","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A03Z&sr=b&sp=r&sig=dnuktAdPUzJOt5GD9Dkb8z4QPPzC%2FIVu0IsQpa4GhvQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:03.9446254","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A08Z&sr=b&sp=r&sig=ns4r8GYhLRn9wUVcTFZg4QcyPzHlbNShtajNAkDzups%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:08.6392613","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A08Z&sr=b&sp=r&sig=99Cfld6Wgm9fDvnJ09FTt4Xr6VUFJCDOYxoELBIKxOg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:08.6391905","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A08Z&sr=b&sp=r&sig=l7v2ucFboZL1WbuqB9zqxFGV%2FiVI5FEvbQL1mTqY6qE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:08.6392743","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1038,9 +1038,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:21:03 GMT
+      - Fri, 13 Oct 2023 13:54:08 GMT
       mise-correlation-id:
-      - dd28ad5b-cb54-4aa3-81cc-2cc80e3f8586
+      - 461e89d8-5854-4dc6-91c4-98a5bc8c7d59
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1058,25 +1058,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A09Z&sr=b&sp=r&sig=sxoIlbbIRclC%2Bby5sDj2v%2Fk4todps936KjCv6PUh594%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:09.2615224","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A09Z&sr=b&sp=r&sig=TRdm0F8QD%2FQ6cOSXMoAgbFriEylTt6sI%2BeydLlxsnDE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:09.261448","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A09Z&sr=b&sp=r&sig=ypUD6fPK%2B7zDw%2B4EBL1WAN%2BwwwfkEgap4KsJqF4xToE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:09.2615383","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A13Z&sr=b&sp=r&sig=pKUYy4qnAZnPmmWvdncwfm2kWbHJG7lidDoNgsJd314%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:13.8935262","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A13Z&sr=b&sp=r&sig=oqGelMg4o2i98i6AGHZNwV2xhAS1qPHEaY55WjANrIA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:13.8934393","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A13Z&sr=b&sp=r&sig=3yZLVLAMDc%2Fd1BmlX3u1AjwK6lIGNkGi8QbYy%2FjkvqQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:13.8935481","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3215'
+      - '3206'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:21:09 GMT
+      - Fri, 13 Oct 2023 13:54:13 GMT
       mise-correlation-id:
-      - fc7ceded-8935-4577-a959-e6e41d2000b5
+      - 6cd13030-8fef-4125-bfa0-960ab822c35e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1094,25 +1094,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A14Z&sr=b&sp=r&sig=Y81Da7ukkgYiV%2FZyfTYoh57VZBi4VpQiyhznp%2FqUOJk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:14.6343252","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A14Z&sr=b&sp=r&sig=uVbh8OmrUyQqxS79a1%2BaiC00m9%2BoL4hAMtfPKgTzlHQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:14.6342536","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A14Z&sr=b&sp=r&sig=eZkr%2BGg7hqy29nOrtA6WcTDClDfZ4HVlOBdk0R7G8fA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:14.634339","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A19Z&sr=b&sp=r&sig=bnetqtDbzv076GnLQC7cR5AostmbVteZbSvWm0fOYPA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:19.1781808","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A19Z&sr=b&sp=r&sig=dhcbE1PmtnAgwp6cAhaogXGM9gynLvMtLoPHMr46l5s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:19.1780954","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A19Z&sr=b&sp=r&sig=20v6ltBAb4EyLFG%2Bo0zMECaTsqXFnc309pQyyCw46sg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:19.1782016","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3211'
+      - '3204'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:21:14 GMT
+      - Fri, 13 Oct 2023 13:54:19 GMT
       mise-correlation-id:
-      - c1b1cf35-4c53-458b-849e-f3f0b96f92ce
+      - fd243e52-a5d0-43d2-9134-1da2f229159c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1130,25 +1130,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A19Z&sr=b&sp=r&sig=Q%2FH6qGBjeLxbUs7%2FU8Az2Afh1AFPzET8I5VMuo3op5k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:19.9543912","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A19Z&sr=b&sp=r&sig=odVKQOTT1i3wkVazQexBOIt0z9ginYXb4MospDoz%2Bms%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:19.9542869","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A19Z&sr=b&sp=r&sig=70zJ%2BQ4zLisRC%2BumLKDfW3I7NEhwyCAuHvfrjpsXkro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:19.954414","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A24Z&sr=b&sp=r&sig=R2rtS14Kw%2FYJ8a1Rp%2FBddqPMf7ZxdLW5JFflduNkouI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:24.4380739","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A24Z&sr=b&sp=r&sig=g%2Fh49llQhfmXAwZlCrWvWso1J3gOVh3xRl4fG38z%2FAE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:24.4380025","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A24Z&sr=b&sp=r&sig=phYl26DuB%2Bn874O%2Bzo45DeN%2Fqp5Hz%2FYvjBmaVWZGXko%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:24.4380874","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3211'
+      - '3218'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:21:19 GMT
+      - Fri, 13 Oct 2023 13:54:24 GMT
       mise-correlation-id:
-      - 34a2057e-1485-4919-8824-9ce68ab9543a
+      - e41a17c1-c1f9-4ae1-aa37-f629b56b3ff5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1166,25 +1166,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A25Z&sr=b&sp=r&sig=wwMTGbozI%2BStBa43aa%2BwZGvCN7Y66j9WGzYEpD2cV5M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:25.3315114","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A25Z&sr=b&sp=r&sig=%2B2CQy5IS12wVAxITu7jjIff%2FjjEkynZLl5Xm30cFjL8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:25.3314199","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A25Z&sr=b&sp=r&sig=74qsDVDwtDLmo4V9WZI%2FfCAB7ngmiLtJuO4w5%2Fi8d4s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:25.3315318","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A29Z&sr=b&sp=r&sig=Wzl9XGQM%2BLoAyOwIqqVvz7ImM56uwBrU34IKjp0pPQ0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:29.7099073","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A29Z&sr=b&sp=r&sig=tqAuK3XB2dgXtksH01Qq%2FGZ23bowFSWerMp0eGRDhR4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:29.7098394","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A29Z&sr=b&sp=r&sig=wAkxDVl1zmP9F55iNUk5gp1DrcDTlUkqC8pSobG0HbA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:29.7099221","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3214'
+      - '3206'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:21:25 GMT
+      - Fri, 13 Oct 2023 13:54:29 GMT
       mise-correlation-id:
-      - 75221234-7c53-43fb-86a2-521e3507d61c
+      - 36fa93db-6b69-466b-b1c0-1b10a6456f16
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1202,25 +1202,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A30Z&sr=b&sp=r&sig=ZFHSyP%2FE%2BOyxBhxyRU4WkA2zNfUvE0Rbrt0gYhXlT%2Fs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:30.6502513","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A30Z&sr=b&sp=r&sig=9fqw5WZoccX7HNwYTFmymX%2B5Ud22JZe7yhQkr43LuzQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:30.6501952","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A30Z&sr=b&sp=r&sig=ZYMpWymyDwDAAt6tuyCTjCQNBom14LE%2F6bL4Rm%2FOe0o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:30.650266","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A35Z&sr=b&sp=r&sig=VRJIjvt%2F9HRR4z3%2BWu8RFA%2BaKcmKNGfaFVCeWZVOxN8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:35.0562366","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A35Z&sr=b&sp=r&sig=lkWiav6xaV7WbsX%2FR4nEy5LZwCD48imkutkukqU2038%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:35.0561481","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A35Z&sr=b&sp=r&sig=as4j0SZA43rQ4xAYgp4o6urtfoJGHpYOJlIjoWlANW4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:35.0562513","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3213'
+      - '3210'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:21:30 GMT
+      - Fri, 13 Oct 2023 13:54:35 GMT
       mise-correlation-id:
-      - f6294554-5923-40b1-b29e-13caf81ef423
+      - 1ef25302-7e75-4376-8f44-1000a03c1e58
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1238,12 +1238,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A35Z&sr=b&sp=r&sig=8kxpEJY%2BqQrDvzeUdKeOUi1I59CiGTuPKo626QsqmrY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:35.9301042","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A35Z&sr=b&sp=r&sig=C3HAq1yNG%2FXCoFWP5bSGvgKzFOn2wZ3hkxnyvZ8SxGo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:35.9300042","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A35Z&sr=b&sp=r&sig=sOEvBEklyjMGZypqCBr5z%2FUv6IY%2BdxDDaxlzZ%2FnFRrU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:35.9301256","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A40Z&sr=b&sp=r&sig=bGGafou8iplS%2FLPJbj1UqQrUp4D9VE%2BubIqjnihwLw8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:40.3029999","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A40Z&sr=b&sp=r&sig=j4Xls4Uoj1zZcLdRPhHBKt1cvJKh%2BturO2%2BymweT%2FJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:40.3029316","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A40Z&sr=b&sp=r&sig=Y2OzDzDrJN1NOMH8uY6wa9A7t2TCwSLWmBegHhdBVEY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:40.3030145","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1254,9 +1254,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:21:35 GMT
+      - Fri, 13 Oct 2023 13:54:40 GMT
       mise-correlation-id:
-      - daad48cd-8092-4af3-a7a7-ed6f2661dbbb
+      - 0d1781a1-daad-4877-8d80-016fe1b20eb4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1274,156 +1274,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A41Z&sr=b&sp=r&sig=d1kORKS%2BLIC4FE5UieFP0xZgGwjo%2BY5ql2yEsUp8Auw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:41.8637831","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A41Z&sr=b&sp=r&sig=3w4et6oLE0e6btXVKU2r4RnFZxhu02OJMDGFkGIMFtQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:41.8637149","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A41Z&sr=b&sp=r&sig=%2Bn1opU3gP1Yi3j9VwEBu%2BIxz5QyFlSXYvxXnRT67WxA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:41.8637969","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3210'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:41 GMT
-      mise-correlation-id:
-      - 1a853e18-b53b-4bff-a5dd-c03e5d87eb3b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A47Z&sr=b&sp=r&sig=pmwEgVswjoFijAGszC7NuwAmRxd1NZqbQ8zZKz%2FK2HA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:47.1314328","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A47Z&sr=b&sp=r&sig=QLi%2B0jSdbqe3rS1r92v98JkpE1t1S2RX6GY%2FRhC1X5k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:47.1313618","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A47Z&sr=b&sp=r&sig=KHXbbIwT5ohk9fOUNORfhmjwPZZaSy%2B8Ks3KDvsjS5o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:47.1314468","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3210'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:47 GMT
-      mise-correlation-id:
-      - 34b2fcd7-aacc-4d5c-9f0a-1d5cb337def5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A52Z&sr=b&sp=r&sig=b0J2bPqm7jFh1lLZxbDtkjoCUEe%2B2ugiZNj5iA1xtn8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:52.4023155","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A52Z&sr=b&sp=r&sig=9Q4MJrjhUBiWBzoMKRQ3mZ0CLTyZhfpHTnXwur1tTQA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:52.402245","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A52Z&sr=b&sp=r&sig=CBmm3Dign9kPx%2Fis%2BtHwFVtVWoo06Ux1kWT7w6ufPhc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:52.4023294","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3207'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:52 GMT
-      mise-correlation-id:
-      - 870c007b-2d1b-4ce3-a94b-3c1b11e10f54
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A57Z&sr=b&sp=r&sig=6XTqLqzFOpuzsAlGwsGjGC8AP80ap7Ej4BmCR5b7WJE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:57.6626819","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A57Z&sr=b&sp=r&sig=qsMIhShHTvBrwTr8jJra6QXxIvFzmkDf4HMwWIDlI%2Fc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:21:57.6626027","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A21%3A57Z&sr=b&sp=r&sig=mbNwQwkOrFP5i9mNi9rQ%2FCf6DL4Mc7%2FyM0EFYa8kBog%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:21:57.6626979","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3208'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:21:57 GMT
-      mise-correlation-id:
-      - 9f779277-1f17-4206-8cbf-1dc71505dbb2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A02Z&sr=b&sp=r&sig=d3dXdzBrjuf7I9zeDiapawPIuVRtOYCHyuS2vkmNZpw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:02.9260636","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A02Z&sr=b&sp=r&sig=XjNWahGa1uomAQo7wg7EuKqkLmEbOWBI6W2B3eIwR9A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:02.9259845","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A02Z&sr=b&sp=r&sig=U69V2J1uGUHCxOpASytRrn5qFbJOWZGxq6TAUs8%2BYeQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:02.9260781","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A45Z&sr=b&sp=r&sig=SZDpjCyLYEurycEIygx4atTCbegUS4vIuJX7xtbiuLg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:45.5955496","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A45Z&sr=b&sp=r&sig=1Nk1nbZCxgjmG8%2FeNwwigK3jh5wDsCYN0rbF0r29R9k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:45.5954608","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A45Z&sr=b&sp=r&sig=E3bwq7zaCSXBuqIbHLgAruoCAJjePXo8zDeh4qGOFhM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:45.5955729","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1434,9 +1290,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:02 GMT
+      - Fri, 13 Oct 2023 13:54:45 GMT
       mise-correlation-id:
-      - 86009931-45e8-4993-8642-5d544bfbe72a
+      - 8fe28dd3-155e-4ed5-af27-2b12c176ba96
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1454,156 +1310,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A08Z&sr=b&sp=r&sig=O%2B8nHscd2OePNEY7cVIseVh5k4n2yT0VvP1g7js%2B3DU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:08.2300665","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A08Z&sr=b&sp=r&sig=fPbd573QUrJZGeOjKwFh9G7Ir8b3IbAn2tteo1GLbB4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:08.2299677","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A08Z&sr=b&sp=r&sig=zkHSAGXv0Haj35JmcLU4LafS7ZJSzDzWmErcaDorsQ4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:08.2300833","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:22:08 GMT
-      mise-correlation-id:
-      - 78921d25-f373-4ffe-8aad-0b9fd5d2733a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A13Z&sr=b&sp=r&sig=jdD9yPUSeduihBsS67zwL7lV%2BCj7xOHxWm5Dzt3Gya4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:13.4849274","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A13Z&sr=b&sp=r&sig=9LRsJXvZ3x7kLso4dmlU9J5AK5CvcF6C4KZwURDx0yY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:13.4848309","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A13Z&sr=b&sp=r&sig=CIwHVCZ0yoWM%2FuLUdKO5e6OV95JCVBD%2F4Ihr%2Fz3Z9Oc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:13.4849488","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3210'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:22:13 GMT
-      mise-correlation-id:
-      - 1ac13706-4403-4c35-a7b4-5f4329ff696f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A18Z&sr=b&sp=r&sig=4C5MilagrG0Qv%2F4c%2FN8823tj9w2KI1KsWG9e3NzXQKo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:18.7458112","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A18Z&sr=b&sp=r&sig=1zKy4iEIlsgDGzAxeO9og1lmDxVm9mRypevkj5WHgAY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:18.7457141","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A18Z&sr=b&sp=r&sig=jRJLxwYgxPrsgnm56TmSWARdP2GkICS6Hd8NlmI98l8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:18.7458319","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:22:18 GMT
-      mise-correlation-id:
-      - c604e453-e073-4d84-8137-497560f340b1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A24Z&sr=b&sp=r&sig=mDow8vgjiIOUJ%2BOU0W8VweT8IPCm8pPtOWj3%2FUdioj4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:24.0317999","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A24Z&sr=b&sp=r&sig=8PGnqbczg6qEqUqIM5tvf9ZSwYSEPNFm7E%2FwHpYPSb4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:24.0317224","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A24Z&sr=b&sp=r&sig=EV3%2BXbHnQ4kGIjgkgNQQv1C1RehhBAhQOteiEnUbeME%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:24.0318238","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3210'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:22:24 GMT
-      mise-correlation-id:
-      - 28be7d1d-e323-4ebe-8ba7-a83f490b910f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A29Z&sr=b&sp=r&sig=k%2FWO3sJ24ChatqEITOJH%2BOwYs1ScpgqyZDbcuXbJv%2FI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:29.4057663","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A29Z&sr=b&sp=r&sig=ax6lj46PvpoU8REMFcnL0JtvJAuR0P7T3ld0oTp5ZfQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:29.4056668","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A29Z&sr=b&sp=r&sig=NxL%2FuOOKnvkAF00ci8Gf%2FfDT0yAhVdntU8HgOf%2BYGVY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:29.4057914","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A50Z&sr=b&sp=r&sig=gVP8HJi7yWBZ8sBFlPTPQr8NTSXVfFi%2F%2FFFBuS%2BM0Fo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:50.8373273","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A50Z&sr=b&sp=r&sig=vR45rRuQ0iO%2Bgu0n5j7Y7nm95eeUFxzwa3n0HOQXyH8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:50.8372451","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A50Z&sr=b&sp=r&sig=R6mPshmptj0FBdLgttvqLwshus5EQ%2FCjfS%2BMXTff7Vk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:50.8373464","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1614,9 +1326,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:29 GMT
+      - Fri, 13 Oct 2023 13:54:50 GMT
       mise-correlation-id:
-      - 7b5414f8-f3f0-4b58-8aa8-5e648319ed71
+      - 6a305630-bf24-4d05-9bfe-50654eb0fe9f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1634,84 +1346,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A34Z&sr=b&sp=r&sig=5UxpQGIwaQd0BH71w3qkctR3Tyggpu6g%2B4vHpuuJ0As%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:34.6635815","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A34Z&sr=b&sp=r&sig=8XbhvzIG9nCDfVjbVbg9ei1yCOQK%2B2s410%2BL%2Fn0N9xY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:34.6635086","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A34Z&sr=b&sp=r&sig=lhTC9TokgJzutz1XdJxo3imtkaIeTGxUWWHBMHY6reQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:34.6635998","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3210'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:22:34 GMT
-      mise-correlation-id:
-      - e55f3095-20d6-419e-8e38-8c24968a4fae
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A40Z&sr=b&sp=r&sig=Zt4UTLjB3OVA%2B0Now%2F0LylMNqxdMSGVRtTEMH%2F6c6Ok%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:40.1118651","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A40Z&sr=b&sp=r&sig=LihFjeM69JYhUBgl6Mn%2BL1gePSE7cxKH9y8mF2fLr4M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:40.1117984","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A40Z&sr=b&sp=r&sig=VTH44rrFgLg7ZAEyfaaNRftGWb%2Bei%2B%2BtCXdP7GJIMhM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:40.111881","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3215'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:22:40 GMT
-      mise-correlation-id:
-      - 12046a72-cafa-4220-a6d8-c45d20cfead2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A45Z&sr=b&sp=r&sig=XBBuiaa2xoja8NI8voDnVLyCNjxfJ4wm12%2FB8CC%2B6Xw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:45.5262774","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A45Z&sr=b&sp=r&sig=N5TxNoMcxZRbP4tnOmlf9f8Kv9208zs0i9%2FUNYUZG1E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:45.5261869","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A45Z&sr=b&sp=r&sig=GQ3tZZGVOyaGfMd1uCmbCoI4PhKO6twQxwbs54HwzXM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:45.5263013","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A56Z&sr=b&sp=r&sig=HYOyRBYFbvyy29JggFNeyAa9TpE8CKILymZ6XiyCgEg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:56.1511038","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A56Z&sr=b&sp=r&sig=PGeR3D4DBVV1k1mBlsJgApqhmP4nVH%2FnuIVMO9nawec%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:54:56.1510284","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A54%3A56Z&sr=b&sp=r&sig=9IP8YR2wJD%2BLA99cILHK77koSxJvgoYe%2B4KkZ0JKVfg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:54:56.1511172","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1722,9 +1362,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:45 GMT
+      - Fri, 13 Oct 2023 13:54:56 GMT
       mise-correlation-id:
-      - c8e3f28c-2b98-4115-a30f-3ecd40e50d59
+      - 37e0304c-ed8a-4fd8-ab96-f63c66ef2601
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1742,12 +1382,264 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A50Z&sr=b&sp=r&sig=HQ8Z0Q7Mqx3IACjQb7mtC8S8Nq0r1%2FnugNPTTb83Dl0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:50.8490246","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A50Z&sr=b&sp=r&sig=fJCjw%2B839YFx1IPyv3jPRl2fA5z4MK9auv5dhWBkBlY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:50.8489033","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A50Z&sr=b&sp=r&sig=hEOGnwRImMX0Vs2hYbwsrJekaFW3X%2FMHV0Cbl%2FDJfEw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:50.8490515","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:20:14.233Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:21:03.414Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A01Z&sr=b&sp=r&sig=W84ap9E03pw0YZr4uAfI9Mng95JOm5IeQdyzx9PPETk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:01.4803431","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A01Z&sr=b&sp=r&sig=W%2B2bzTXl3HsSDzvPA3pzDHO%2FDNfPtJL3%2BL0xMNMmWWM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:01.4802008","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A01Z&sr=b&sp=r&sig=PieQGDoPfURC7zTkJ1ysubN1ZfNuY3ENmiFGIomcUeQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:01.4803661","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:01 GMT
+      mise-correlation-id:
+      - 7a5d5e88-6d40-4f9a-a11a-a9ebea2cfd00
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A06Z&sr=b&sp=r&sig=9Nj7Jiio%2B5PxTwH2XYejm%2FInO2MY%2BkTqWCOA%2FrY4SE4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:06.7501404","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A06Z&sr=b&sp=r&sig=4gL3bVWDlfp791elg89iDduGhb%2BKLG4pkF9iVClJgK0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:06.7500655","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A06Z&sr=b&sp=r&sig=l%2FZOxPCWwimGlUGvrjsqDiQC%2FRltWm6l1JHg7WMyUe8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:06.7501553","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3216'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:06 GMT
+      mise-correlation-id:
+      - a864e6c9-c4d0-47c2-b17f-0cf11e284215
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A12Z&sr=b&sp=r&sig=3MIdhGdio5ukmXWJ70Ba8nfm0WnVo8WQzWskwygR2bA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:12.0108747","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A12Z&sr=b&sp=r&sig=E11NI8jMgbuzCk%2BfRYwaZjzTdXDuQ6vi8AI0kXcneYo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:12.0107881","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A12Z&sr=b&sp=r&sig=mmFBO%2FZF1P2090tuoJM3i1ef8BkGWOGC09Ne3f4biro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:12.0108964","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:12 GMT
+      mise-correlation-id:
+      - 82b475a5-022e-41e0-b903-5422b7c75283
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A17Z&sr=b&sp=r&sig=m%2BkpXJRb%2FYAVUK5xF0PGiBVyAHBeT%2FrBzZ55QiDbDYY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:17.5924588","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A17Z&sr=b&sp=r&sig=07sq4NZeHre%2F%2B5dmEgnD22BIp7vm81497GphMlfvFAA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:17.5923792","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A17Z&sr=b&sp=r&sig=y1JcMrIv63Gx%2F4nu8NXoqZWKe5rv4ziI5YVEclUSHMw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:17.5924816","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3214'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:17 GMT
+      mise-correlation-id:
+      - 30201f53-c379-4bc8-af7a-57a81db88443
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A22Z&sr=b&sp=r&sig=SX17lRIoSv8AOGPkneMNpiuaNbzEwgfcLi2ymhpSlgM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:22.854803","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A22Z&sr=b&sp=r&sig=sk3OzkobVepC5dHma1P0k4E8kyDWd8GwpfRkclysG9o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:22.8547024","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A22Z&sr=b&sp=r&sig=83AOhGVZDxNEdQBun7X5DuC0ZMjaH7maQW%2BettU0eFM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:22.8548233","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:22 GMT
+      mise-correlation-id:
+      - 296e2bcb-ae7f-472e-a9cf-15172825dd92
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A28Z&sr=b&sp=r&sig=InPjcUy187Tz8my43b%2F3sLTrAo9e6I7U8ZhSxfNKt5M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:28.143778","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A28Z&sr=b&sp=r&sig=xKsrC3%2F20o%2Flb8PLLdvSMvVjLVqJPn7MENzEMGcN2PA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:28.1437073","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A28Z&sr=b&sp=r&sig=9%2B3%2FzL0FcuJ9QMRIK0W5kES6qsN%2BPRwFjhnPUichzX8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:28.1437919","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3213'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:28 GMT
+      mise-correlation-id:
+      - 31639580-518b-4265-ba8a-4fb5838bad46
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A33Z&sr=b&sp=r&sig=zLfcM6ddFj%2BTEA0hHrA%2BRiTsU8gDD7k0AfW%2B8DQOLZE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:33.410465","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A33Z&sr=b&sp=r&sig=duvuEpMImyaCBo97HWrD8A4M0%2Ft4c2DaQu9qkLAYgtc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:33.410371","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A33Z&sr=b&sp=r&sig=Tb%2FOegQUqCOYJSI8QcTbvdzu42Yyi%2FZSu4aicJlEOwA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:33.4104846","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3212'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:33 GMT
+      mise-correlation-id:
+      - ce3313dd-0d1b-4bb9-856b-bf865653a5c4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A38Z&sr=b&sp=r&sig=z18ziSzXEXlh9Zjbre4gPjlvdE7zW0XVmpBBieiTNGY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:38.6496375","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A38Z&sr=b&sp=r&sig=yQ9bVYx%2B9BYTy9XJ5Ma89VySCRDAAPSWV7lWUHjSZdo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:38.6495719","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A38Z&sr=b&sp=r&sig=s73EvekuucMibA%2FnGVmWTp9Oc%2FaJBvSkVVuj%2FTpxO7E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:38.6496511","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +1650,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:50 GMT
+      - Fri, 13 Oct 2023 13:55:38 GMT
       mise-correlation-id:
-      - 0fe330f8-2787-422f-abcc-3e710c91e756
+      - 9d0fe5fa-8111-42e0-8880-16169f2bd437
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1778,26 +1670,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A56Z&sr=b&sp=r&sig=nAu%2F6ir%2BXv8sMrKcFZR0MdptxTwfbDWgo534M1yUVWM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:56.171329","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A56Z&sr=b&sp=r&sig=2Ty%2Bv%2FTkaLQUWhCQwOItbtWMjZODHCmiraRlmpKusz8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:56.1712522","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A56Z&sr=b&sp=r&sig=USQ7ayb7h6LBX9pe%2F6r%2B1PNlhNKlbIDnEbvQ31inFqc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:56.1713439","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-09T19:20:14.233Z","endDateTime":"2023-10-09T19:22:53.378Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:53.476Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A44Z&sr=b&sp=r&sig=5bVid0rLzLbnAu5shgZmjH9yuP9tlSCMqwc7W%2FHSx2o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:44.00104","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A44Z&sr=b&sp=r&sig=SJeJG70doTl1Q3X1%2BeTwNm8FV4W%2FC6w1qjOVc5Ta7UA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:44.0009484","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A44Z&sr=b&sp=r&sig=wxMlDjW%2F3apEm7hB5FraMhzJFz49jRXAFg1VZ%2Fo9cY0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:44.001061","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3348'
+      - '3209'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:56 GMT
+      - Fri, 13 Oct 2023 13:55:43 GMT
       mise-correlation-id:
-      - 8bd1c5ad-a75a-4f0c-9599-df7f5d1205fb
+      - 4f2ddaf7-b4db-4d63-99e4-e6e403e3469f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1815,70 +1706,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:14.8313783Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:14.8313783Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:22:57 GMT
-      etag:
-      - '"5600672d-0000-0100-0000-652452350000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=download-test-case&api-version=2022-11-01
-  response:
-    body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A58Z&sr=b&sp=r&sig=%2FQovHTF8nMQjA2Qc8qKff%2Bm5AItpJBS660OWd5DYq38%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:58.5659109","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A58Z&sr=b&sp=r&sig=H%2FU%2FI3%2BGdGulIc8Mb8x3Ex2DQCGQDkZzRGiH0wPG72o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:22:58.5658393","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A22%3A58Z&sr=b&sp=r&sig=bNNjkT20KdmrA1O61uNVtVXUdz%2BujwbQfrkkZe1PcfM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:22:58.5659255","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-09T19:20:14.233Z","endDateTime":"2023-10-09T19:22:53.378Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:57.625Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A49Z&sr=b&sp=r&sig=N75VzgkfP4AsmjbfpT%2BfubZ13YeNyoWURk25F5tdRL0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:49.2531177","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A49Z&sr=b&sp=r&sig=oE7oMszZ1bUkddVdrSauRQsaIG47CJ8Brua0nIKd7nc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:49.2530288","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A49Z&sr=b&sp=r&sig=5RmqnGudituIiRe77VvDXDfBGbnfd%2BR9%2Fonis66cfzM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:49.2531369","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3361'
+      - '3208'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:58 GMT
+      - Fri, 13 Oct 2023 13:55:49 GMT
       mise-correlation-id:
-      - 3337ed07-6692-4121-b622-63200583e9f5
+      - a99e8f82-de78-467d-ac5f-e6c1fb2a989d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1896,37 +1742,29 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:14.8313783Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:14.8313783Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A54Z&sr=b&sp=r&sig=W1xXO8tYQLV1aupbE1EhhdA3cIMMoukNf2XENzvJp3Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:54.5030651","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A54Z&sr=b&sp=r&sig=g1VNZuxFDo0BiCl1u4KTYMkh%2FsOnmHFpEbRiOIaujKA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:54.5029975","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A54Z&sr=b&sp=r&sig=1zuadd1TkqzX1CXegxVds%2BXhcldI6DlmjCIt4zpNuJg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:54.5030787","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
-      cache-control:
-      - no-cache
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
       content-length:
-      - '690'
+      - '3206'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:59 GMT
-      etag:
-      - '"5600672d-0000-0100-0000-652452350000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
+      - Fri, 13 Oct 2023 13:55:54 GMT
+      mise-correlation-id:
+      - 613bcc88-f61d-49f9-b8b9-621baf3aa01a
       strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
+      - max-age=15724800; includeSubDomains
       x-content-type-options:
       - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
     status:
       code: 200
       message: OK
@@ -1940,13 +1778,49 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A00Z&sr=b&sp=r&sig=O72bktlStFE%2FW%2FvCEGSOYJvgixlj%2BOhetTnn6JsQw78%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:00.5892982","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A00Z&sr=b&sp=r&sig=DKRvMiov%2F3FeoJf1SMHnn4wGyhq8uqsYgt5wKZOO6Bc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:00.5892316","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A00Z&sr=b&sp=r&sig=gYh%2BxqvpeBZwyzo8DGZF4SHu6zFurA4Lfmw7rZVRJbk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:00.5893135","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-09T19:20:14.233Z","endDateTime":"2023-10-09T19:22:53.378Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:57.625Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A59Z&sr=b&sp=r&sig=f16%2FKY1QLF4YAp8wQAgkvo8LBTlLXrUDnE%2F3szBSCmM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:59.7383411","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A59Z&sr=b&sp=r&sig=VJjZir9HzzpPJKtqIJ6O2pyIbrNWYA1dCBCDU7hMdVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:55:59.7382483","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A55%3A59Z&sr=b&sp=r&sig=l6cEj%2FcGXt4EA%2Bu6Gf7YaS1iGlz5OfUFq3bCL55DHms%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:55:59.7383634","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:53:22.268Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:54:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:55:59 GMT
+      mise-correlation-id:
+      - 4eff34d5-c4c9-4ef4-a033-4f6338302efe
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A05Z&sr=b&sp=r&sig=9Sn%2B27Rb4jJE2P31Da6MhTfBLN4WWj6xF9Q%2FGtjg4aI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:05.0794583","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A05Z&sr=b&sp=r&sig=iL%2BSx%2BidXYwTQc%2FS5d7X5YlXrAyoEvUb3NkYMjyn9zY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:05.0793887","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A05Z&sr=b&sp=r&sig=dG6a2tSwlzdZCiWsUYNyuLDaK0o0oppUF4G8dQNKKfE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:05.0794734","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-13T13:53:22.268Z","endDateTime":"2023-10-13T13:55:59.836Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:03.566Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1957,9 +1831,171 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:00 GMT
+      - Fri, 13 Oct 2023 13:56:05 GMT
       mise-correlation-id:
-      - 080a1193-9387-46f6-b5e7-31ee5f7ef1fd
+      - 47619fb5-c8ae-43ef-bc72-cbb3cdb3c979
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:22.0199528Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:22.0199528Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:56:06 GMT
+      etag:
+      - '"d80153fb-0000-0100-0000-65294b990000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=download-test-case&api-version=2022-11-01
+  response:
+    body:
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A07Z&sr=b&sp=r&sig=gBlp0jA5FuwFlpVWU%2BqIrJLr9w7HYjj7Par%2FOsr1n54%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:07.4850663","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A07Z&sr=b&sp=r&sig=E923Q89Nr0LYW2SYwIIBdNZ3WtiQCqYKm8SEVyxA0M8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:07.4849976","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A07Z&sr=b&sp=r&sig=1f8wgGSEA3CZNVXmenutu69Vk59ybGB%2FAeKiOLo%2F4yY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:07.4850805","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-13T13:53:22.268Z","endDateTime":"2023-10-13T13:55:59.836Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:03.566Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3357'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:56:07 GMT
+      mise-correlation-id:
+      - 7907bb9f-1443-4fa6-9382-a0186ded7b95
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:22.0199528Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:22.0199528Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:56:09 GMT
+      etag:
+      - '"d80153fb-0000-0100-0000-65294b990000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A09Z&sr=b&sp=r&sig=bmOH5ov%2BuN5c6UV6IzXmbE%2FNWWB8xyj6ZfuAbcvVlFo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:09.7681172","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A09Z&sr=b&sp=r&sig=0McKWTkGz7DrwRAFZrVrhWZ8QiFANhrE%2FBUOlo8glME%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:09.7680275","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A09Z&sr=b&sp=r&sig=ZrcBLmMrdZSVwr7C8D%2FTRIAsEkGeRTtMFe%2FQ77u5z%2F0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:09.7681355","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-13T13:53:22.268Z","endDateTime":"2023-10-13T13:55:59.836Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:03.566Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3349'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:56:09 GMT
+      mise-correlation-id:
+      - b40533cf-aa57-4899-967c-ef39be1d606b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1977,9 +2013,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A00Z&sr=b&sp=r&sig=O72bktlStFE%2FW%2FvCEGSOYJvgixlj%2BOhetTnn6JsQw78%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A09Z&sr=b&sp=r&sig=bmOH5ov%2BuN5c6UV6IzXmbE%2FNWWB8xyj6ZfuAbcvVlFo%3D
   response:
     body:
       string: "displayName: CLI-Test\ntestPlan: sample-JMX-file.jmx\ndescription:
@@ -1997,17 +2033,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Mon, 09 Oct 2023 19:23:00 GMT
+      - Fri, 13 Oct 2023 13:56:10 GMT
       etag:
-      - '"0x8DBC8FCC3421802"'
+      - '"0x8DBCBF3C265AB54"'
       last-modified:
-      - Mon, 09 Oct 2023 19:20:13 GMT
+      - Fri, 13 Oct 2023 13:53:20 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 09 Oct 2023 19:20:13 GMT
+      - Fri, 13 Oct 2023 13:53:20 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2035,9 +2071,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A00Z&sr=b&sp=r&sig=DKRvMiov%2F3FeoJf1SMHnn4wGyhq8uqsYgt5wKZOO6Bc%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A09Z&sr=b&sp=r&sig=0McKWTkGz7DrwRAFZrVrhWZ8QiFANhrE%2FBUOlo8glME%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -2110,17 +2146,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Mon, 09 Oct 2023 19:23:01 GMT
+      - Fri, 13 Oct 2023 13:56:11 GMT
       etag:
-      - '"0x8DBC8FCB5B5C487"'
+      - '"0x8DBCBF3B5CD1C6D"'
       last-modified:
-      - Mon, 09 Oct 2023 19:19:50 GMT
+      - Fri, 13 Oct 2023 13:52:59 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 09 Oct 2023 19:19:50 GMT
+      - Fri, 13 Oct 2023 13:52:59 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2148,20 +2184,20 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A00Z&sr=b&sp=r&sig=gYh%2BxqvpeBZwyzo8DGZF4SHu6zFurA4Lfmw7rZVRJbk%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A09Z&sr=b&sp=r&sig=ZrcBLmMrdZSVwr7C8D%2FTRIAsEkGeRTtMFe%2FQ77u5z%2F0%3D
   response:
     body:
       string: !!binary |
-        UEsDBC0AAAAIAIaaSVcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
+        UEsDBC0AAAAIAKpuTVcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
         AAAAAAFZAab+ZGlzcGxheU5hbWU6IENMSS1UZXN0CnRlc3RQbGFuOiBzYW1wbGUtSk1YLWZpbGUu
         am14CmRlc2NyaXB0aW9uOiBUZXN0IGNyZWF0ZWQgZnJvbSBheiBsb2FkIHRlc3QgY29tbWFuZApl
         bmdpbmVJbnN0YW5jZXM6IDEKdGVzdElkOiBkb3dubG9hZC10ZXN0LWNhc2UKc3BsaXRBbGxDU1Zz
         OiBGYWxzZQpmYWlsdXJlQ3JpdGVyaWE6Ci0gYXZnKHJlcXVlc3RzX3Blcl9zZWMpID4gNzgKLSBw
         ZXJjZW50YWdlKGVycm9yKSA+IDUwCi0gR2V0Q3VzdG9tZXJEZXRhaWxzOiBhdmcobGF0ZW5jeSkg
         PiAyMDAKZW52OgotIG5hbWU6IHJwcwogIHZhbHVlOiAxCi0gbmFtZTogZHVyYXRpb25faW5fc2Vj
-        CiAgdmFsdWU6IDEKUEsDBC0AAAAIAIaaSVfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
+        CiAgdmFsdWU6IDEKUEsDBC0AAAAIAKpuTVfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
         LmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAAQYT+ew8P3htbCB2ZXJzaW9uPSIxLjAiIGVuY29kaW5n
         PSJVVEYtOCI/Pg0KPGptZXRlclRlc3RQbGFuIHZlcnNpb249IjEuMiIgcHJvcGVydGllcz0iNS4w
         IiBqbWV0ZXI9IjUuNSI+DQogIDxoYXNoVHJlZT4NCiAgICA8VGVzdFBsYW4gZ3VpY2xhc3M9IlRl
@@ -2248,8 +2284,8 @@ interactions:
         ZT0iSFRUUFNhbXBsZXIucmVzcG9uc2VfdGltZW91dCI+PC9zdHJpbmdQcm9wPg0KICAgICAgICA8
         L0hUVFBTYW1wbGVyUHJveHk+DQogICAgICAgIDxoYXNoVHJlZS8+DQogICAgICA8L2hhc2hUcmVl
         Pg0KICAgIDwvaGFzaFRyZWU+DQogIDwvaGFzaFRyZWU+DQo8L2ptZXRlclRlc3RQbGFuPg0KUEsB
-        AjMALQAAAAgAhppJVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
-        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACACGmklX8Zv7b///////////EwAUAAAAAAAAAAAA
+        AjMALQAAAAgAqm5NVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
+        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACACqbk1X8Zv7b///////////EwAUAAAAAAAAAAAA
         AACbAQAAc2FtcGxlLUpNWC1maWxlLmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAUEsFBgAAAAACAAIA
         ogAAAOsUAAAAAA==
     headers:
@@ -2258,21 +2294,21 @@ interactions:
       content-length:
       - '5539'
       content-md5:
-      - /awq7A5BsWf/8AZoYNnc1g==
+      - lIk+qyTiOFlIQ5Nx6AB2EQ==
       content-type:
       - application/octet-stream
       date:
-      - Mon, 09 Oct 2023 19:23:03 GMT
+      - Fri, 13 Oct 2023 13:56:12 GMT
       etag:
-      - '"0x8DBC8FCC34D8800"'
+      - '"0x8DBCBF3C26F6DD9"'
       last-modified:
-      - Mon, 09 Oct 2023 19:20:13 GMT
+      - Fri, 13 Oct 2023 13:53:20 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 09 Oct 2023 19:20:13 GMT
+      - Fri, 13 Oct 2023 13:53:20 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2305,7 +2341,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:19:14.8313783Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:19:14.8313783Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:52:22.0199528Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:52:22.0199528Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2314,9 +2350,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:04 GMT
+      - Fri, 13 Oct 2023 13:56:13 GMT
       etag:
-      - '"5600672d-0000-0100-0000-652452350000"'
+      - '"d80153fb-0000-0100-0000-65294b990000"'
       expires:
       - '-1'
       pragma:
@@ -2344,26 +2380,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6255c0b5-dffd-4c85-8c93-a00896eba58d.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://e48f26d8-f050-4844-90eb-fc3cf392d240.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d8f1010f-4928-47da-8a65-e0587be59206":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7efb4f19-9fef-4335-ad73-bd4361e600c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"24d868b1-b8e0-4328-b1ef-3569f3e4267f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=vx0pWqUvBREJlY2kOZXU%2BBcSUhH8ic%2B%2B6ndRVmKq7rY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:06.2363362","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=nmmKwh1jq2MfPijRGSpK2vKNr2wQVvFnV%2FsQZl9BNlc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:06.2362077","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=ROf2jcKzi75XmDsbLaGll97A0sM4EgrbHtzrYJr13Lo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:06.2363652","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/67833cff-7459-4889-83c0-804c8a8b3b8c_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=b0aLU7veKpn%2FFVrH%2BGTvXpeiG4SuZTpE5vksgGdvHBo%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:06.2364222","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/67833cff-7459-4889-83c0-804c8a8b3b8c_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=8jxhlW1rSTwzaRgI8ih3AMOH%2BdBgpHAKo%2FzT0ux%2Fvns%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:06.2364533","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-09T19:20:14.233Z","endDateTime":"2023-10-09T19:22:53.378Z","executedDateTime":"2023-10-09T19:20:13.544Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T19:20:13.827Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:04.557Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5ab853c8-30d1-4dfb-aef0-916256c71cd2":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f648a763-1709-461c-8c58-cf9cd0161426":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea858bcd-2d1d-458f-8f53-9aed3d809347":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=noS3%2BlbrqUyCLYp3DbvacakCEPa7j7MA9Pre5as1zsI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:14.6768475","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=%2FC1%2BMQZtL4rHE0kcYhQypiD6h5GyY7PZc8S5MG%2BHKl0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:14.6767653","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=mgn0w%2F6GPOiJ4wLXDoKKwghPAB44YXPSB7vfet06WHY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:14.6768643","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/bbbdcc9c-1b07-4579-8c59-8f95c248ad79_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=ta5BXpbXuwE5DaE85z1AYGuooIRx6uO0lfk9jaLrCzI%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:14.6768797","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/bbbdcc9c-1b07-4579-8c59-8f95c248ad79_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=IWgR9pHRYhAGsk9XDDX0E5V%2FBuDK%2FrEUNTXj2PmNk88%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:14.6768962","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-13T13:53:22.268Z","endDateTime":"2023-10-13T13:55:59.836Z","executedDateTime":"2023-10-13T13:53:20.147Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-13T13:53:20.467Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:10.12Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4514'
+      - '4509'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:06 GMT
+      - Fri, 13 Oct 2023 13:56:14 GMT
       mise-correlation-id:
-      - 04bb6317-164b-49f6-99ba-990af0f5b3b2
+      - 21c2e7fc-cd9e-44f5-a400-ef5b7da544f0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2381,9 +2417,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/b341a150-6833-4715-b2ce-bf34d869b466?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=vx0pWqUvBREJlY2kOZXU%2BBcSUhH8ic%2B%2B6ndRVmKq7rY%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/2ddab17f-5b5e-4915-a111-a60b833eba8f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=noS3%2BlbrqUyCLYp3DbvacakCEPa7j7MA9Pre5as1zsI%3D
   response:
     body:
       string: "displayName: CLI-Test\ntestPlan: sample-JMX-file.jmx\ndescription:
@@ -2401,17 +2437,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Mon, 09 Oct 2023 19:23:06 GMT
+      - Fri, 13 Oct 2023 13:56:15 GMT
       etag:
-      - '"0x8DBC8FCC3421802"'
+      - '"0x8DBCBF3C265AB54"'
       last-modified:
-      - Mon, 09 Oct 2023 19:20:13 GMT
+      - Fri, 13 Oct 2023 13:53:20 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 09 Oct 2023 19:20:13 GMT
+      - Fri, 13 Oct 2023 13:53:20 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2439,9 +2475,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/89e152d6-eda2-4c8f-8c8c-32411b73acae?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=nmmKwh1jq2MfPijRGSpK2vKNr2wQVvFnV%2FsQZl9BNlc%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/3f15ffdc-c476-4d03-a92e-decc87f2071a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=%2FC1%2BMQZtL4rHE0kcYhQypiD6h5GyY7PZc8S5MG%2BHKl0%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -2514,17 +2550,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Mon, 09 Oct 2023 19:23:08 GMT
+      - Fri, 13 Oct 2023 13:56:15 GMT
       etag:
-      - '"0x8DBC8FCB5B5C487"'
+      - '"0x8DBCBF3B5CD1C6D"'
       last-modified:
-      - Mon, 09 Oct 2023 19:19:50 GMT
+      - Fri, 13 Oct 2023 13:52:59 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 09 Oct 2023 19:19:50 GMT
+      - Fri, 13 Oct 2023 13:52:59 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2552,20 +2588,20 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/402b283e-fb54-45ca-af1d-244af2892c4a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=ROf2jcKzi75XmDsbLaGll97A0sM4EgrbHtzrYJr13Lo%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/a0ac125e-bf64-4b9b-884a-0f94e1311524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=mgn0w%2F6GPOiJ4wLXDoKKwghPAB44YXPSB7vfet06WHY%3D
   response:
     body:
       string: !!binary |
-        UEsDBC0AAAAIAIaaSVcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
+        UEsDBC0AAAAIAKpuTVcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
         AAAAAAFZAab+ZGlzcGxheU5hbWU6IENMSS1UZXN0CnRlc3RQbGFuOiBzYW1wbGUtSk1YLWZpbGUu
         am14CmRlc2NyaXB0aW9uOiBUZXN0IGNyZWF0ZWQgZnJvbSBheiBsb2FkIHRlc3QgY29tbWFuZApl
         bmdpbmVJbnN0YW5jZXM6IDEKdGVzdElkOiBkb3dubG9hZC10ZXN0LWNhc2UKc3BsaXRBbGxDU1Zz
         OiBGYWxzZQpmYWlsdXJlQ3JpdGVyaWE6Ci0gYXZnKHJlcXVlc3RzX3Blcl9zZWMpID4gNzgKLSBw
         ZXJjZW50YWdlKGVycm9yKSA+IDUwCi0gR2V0Q3VzdG9tZXJEZXRhaWxzOiBhdmcobGF0ZW5jeSkg
         PiAyMDAKZW52OgotIG5hbWU6IHJwcwogIHZhbHVlOiAxCi0gbmFtZTogZHVyYXRpb25faW5fc2Vj
-        CiAgdmFsdWU6IDEKUEsDBC0AAAAIAIaaSVfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
+        CiAgdmFsdWU6IDEKUEsDBC0AAAAIAKpuTVfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
         LmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAAQYT+ew8P3htbCB2ZXJzaW9uPSIxLjAiIGVuY29kaW5n
         PSJVVEYtOCI/Pg0KPGptZXRlclRlc3RQbGFuIHZlcnNpb249IjEuMiIgcHJvcGVydGllcz0iNS4w
         IiBqbWV0ZXI9IjUuNSI+DQogIDxoYXNoVHJlZT4NCiAgICA8VGVzdFBsYW4gZ3VpY2xhc3M9IlRl
@@ -2652,8 +2688,8 @@ interactions:
         ZT0iSFRUUFNhbXBsZXIucmVzcG9uc2VfdGltZW91dCI+PC9zdHJpbmdQcm9wPg0KICAgICAgICA8
         L0hUVFBTYW1wbGVyUHJveHk+DQogICAgICAgIDxoYXNoVHJlZS8+DQogICAgICA8L2hhc2hUcmVl
         Pg0KICAgIDwvaGFzaFRyZWU+DQogIDwvaGFzaFRyZWU+DQo8L2ptZXRlclRlc3RQbGFuPg0KUEsB
-        AjMALQAAAAgAhppJVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
-        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACACGmklX8Zv7b///////////EwAUAAAAAAAAAAAA
+        AjMALQAAAAgAqm5NVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
+        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACACqbk1X8Zv7b///////////EwAUAAAAAAAAAAAA
         AACbAQAAc2FtcGxlLUpNWC1maWxlLmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAUEsFBgAAAAACAAIA
         ogAAAOsUAAAAAA==
     headers:
@@ -2662,21 +2698,21 @@ interactions:
       content-length:
       - '5539'
       content-md5:
-      - /awq7A5BsWf/8AZoYNnc1g==
+      - lIk+qyTiOFlIQ5Nx6AB2EQ==
       content-type:
       - application/octet-stream
       date:
-      - Mon, 09 Oct 2023 19:23:09 GMT
+      - Fri, 13 Oct 2023 13:56:17 GMT
       etag:
-      - '"0x8DBC8FCC34D8800"'
+      - '"0x8DBCBF3C26F6DD9"'
       last-modified:
-      - Mon, 09 Oct 2023 19:20:13 GMT
+      - Fri, 13 Oct 2023 13:53:20 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 09 Oct 2023 19:20:13 GMT
+      - Fri, 13 Oct 2023 13:53:20 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2704,43 +2740,43 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/67833cff-7459-4889-83c0-804c8a8b3b8c_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=8jxhlW1rSTwzaRgI8ih3AMOH%2BdBgpHAKo%2FzT0ux%2Fvns%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/bbbdcc9c-1b07-4579-8c59-8f95c248ad79_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=IWgR9pHRYhAGsk9XDDX0E5V%2FBuDK%2FrEUNTXj2PmNk88%3D
   response:
     body:
       string: !!binary |
-        UEsDBBQAAAAIAN2aSVdzPUjhVAEAAHADAAASABwAZW5naW5lMV93b3JrZXIubG9nVVQJAAMSUyRl
-        ElMkZXV4CwABBAAAAAAEAAAAAJ2SXWuDMBSG7/srzs1gG9XF2PoR2IXQFDbUQZX1WmzqUtSUJHXb
-        v59aRxmtIAshHE7yPie852CEbcNCBvLB8gm2CFrMHc+DbbCJQZiZeTBfI6aZJBCKImQNKwm8xOu3
-        Gb5SOnNsLc/KvFXmrfbQnlEQpiFXmtUdJaVJCkkabFK6AvpO4xQMkCxnvGG7m9AFHoGuecm2kref
-        u+A3Awlow2oNmimd6EzqMbY9wg5OWigtjhdyl4VsSPdgUGcyfHL9AUxKIUFmmoGPYN/GDlLmzaqO
-        5UyyicarqSZ5/jTn/yJPx1JkO14XcKi6JpulKGDf2nqzho+tf9TIRXUs2VgDfDxixcTm0no3Rrat
-        flCHKZZmcqqqTHLVkVQff8Mz9AsBrwEh0u82+divJwVBU5DhRcRrAj7Gtu1iZDvecuG6Sw+5EGVf
-        BIzrGw+olL/qe2QidPcw+wFQSwECHgMUAAAACADdmklXcz1I4VQBAABwAwAAEgAYAAAAAAABAAAA
-        pIEAAAAAZW5naW5lMV93b3JrZXIubG9nVVQFAAMSUyRldXgLAAEEAAAAAAQAAAAAUEsFBgAAAAAB
-        AAEAWAAAAKABAAAAAA==
+        UEsDBBQAAAAIAAJvTVdBUfnWUAEAAHADAAASABwAZW5naW5lMV93b3JrZXIubG9nVVQJAAN0TCll
+        dEwpZXV4CwABBAAAAAAEAAAAAKWSUWuDMBDH3/sp7mWwjemisWoDexBqYUMdVFmfxaYuRU1JUrd9
+        +0XrKGwKpTtCOC75/+64OxvZ2LCQYWGwMJk7BPkPvuvCJlgnwM3c3JsvMVVUEIh4GdGWVgSek9Xr
+        zP6ttNCDhf2TstDKQmv3+o6DKIuYVLTpKFmYZpBmwToLlxC+hUkGBghaUNbS7SgU2+44dMUquhFM
+        F3fGrwcShC1tFCgqVapyoabYUwUHR8Wl4oczuYtCPoR7MMgTGT6YegcqBBcgckVhgWCnfRdJczSr
+        4+GL2hQmy0ub5C6cK5DHQ8XzLWtK2NfdkM2Kl7DTbR3N4VnXlF3w+lDRqQF41v+GGzbbKbKN+kUd
+        tliY6bGuc8FkR5K9/wVP0BsC1gBCpD86eN/bo4SgLcnwI2YNgYVtY6zJ2PXnjufNfeRBnH8SMP6+
+        +BAK8aO+RSZCN3ezb1BLAQIeAxQAAAAIAAJvTVdBUfnWUAEAAHADAAASABgAAAAAAAEAAACkgQAA
+        AABlbmdpbmUxX3dvcmtlci5sb2dVVAUAA3RMKWV1eAsAAQQAAAAABAAAAABQSwUGAAAAAAEAAQBY
+        AAAAnAEAAAAA
     headers:
       accept-ranges:
       - bytes
       content-length:
-      - '526'
+      - '522'
       content-md5:
-      - wYZV5+6v3oqkXqbE3COecw==
+      - GTEfychG/+tYQaiLiLbCpw==
       content-type:
       - application/octet-stream
       date:
-      - Mon, 09 Oct 2023 19:23:09 GMT
+      - Fri, 13 Oct 2023 13:56:18 GMT
       etag:
-      - '"0x8DBC8FD25A21C15"'
+      - '"0x8DBCBF4243BD94E"'
       last-modified:
-      - Mon, 09 Oct 2023 19:22:58 GMT
+      - Fri, 13 Oct 2023 13:56:04 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 09 Oct 2023 19:22:58 GMT
+      - Fri, 13 Oct 2023 13:56:04 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2762,17 +2798,17 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/0769789a-90b2-4e80-9515-e6bba1646585/67833cff-7459-4889-83c0-804c8a8b3b8c_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A06Z&sr=b&sp=r&sig=b0aLU7veKpn%2FFVrH%2BGTvXpeiG4SuZTpE5vksgGdvHBo%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/440480a4-1303-4f8c-b672-b64f6688b552/bbbdcc9c-1b07-4579-8c59-8f95c248ad79_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A14Z&sr=b&sp=r&sig=ta5BXpbXuwE5DaE85z1AYGuooIRx6uO0lfk9jaLrCzI%3D
   response:
     body:
       string: !!binary |
-        UEsDBBQAAAAIAN2aSVc8lqSAdQAAAKMAAAATABwAZW5naW5lMV9yZXN1bHRzLmNzdlVUCQADElMk
-        ZRJTJGV1eAsAAQQAAAAABAAAAAA9jjsOwkAQQ3vO4lOQCilQwHKAya4JkWY/2pkUuT1RJNI9y8+S
+        UEsDBBQAAAAIAAJvTVc8lqSAdQAAAKMAAAATABwAZW5naW5lMV9yZXN1bHRzLmNzdlVUCQADdEwp
+        ZXRMKWV1eAsAAQQAAAAABAAAAAA9jjsOwkAQQ3vO4lOQCilQwHKAya4JkWY/2pkUuT1RJNI9y8+S
         fcl8ueQGqjRjgspERae1WoxDTTzDnWYyE/7tlPSQTCRxCVsjbI1xr/GRRdd+qtPmNBiLXw+aewvH
-        2iCqf3w/R4ziLHHDLSnD/gpDLYXRLz9QSwECHgMUAAAACADdmklXPJakgHUAAACjAAAAEwAYAAAA
-        AAABAAAApIEAAAAAZW5naW5lMV9yZXN1bHRzLmNzdlVUBQADElMkZXV4CwABBAAAAAAEAAAAAFBL
+        2iCqf3w/R4ziLHHDLSnD/gpDLYXRLz9QSwECHgMUAAAACAACb01XPJakgHUAAACjAAAAEwAYAAAA
+        AAABAAAApIEAAAAAZW5naW5lMV9yZXN1bHRzLmNzdlVUBQADdEwpZXV4CwABBAAAAAAEAAAAAFBL
         BQYAAAAAAQABAFkAAADCAAAAAAA=
     headers:
       accept-ranges:
@@ -2780,21 +2816,21 @@ interactions:
       content-length:
       - '305'
       content-md5:
-      - jZrSlcEMB1yRTsKrPGo7TQ==
+      - IA+PP1cP6xnCvw3XNqHzCg==
       content-type:
       - application/octet-stream
       date:
-      - Mon, 09 Oct 2023 19:23:10 GMT
+      - Fri, 13 Oct 2023 13:56:19 GMT
       etag:
-      - '"0x8DBC8FD25AC2CB7"'
+      - '"0x8DBCBF4244574CD"'
       last-modified:
-      - Mon, 09 Oct 2023 19:22:58 GMT
+      - Fri, 13 Oct 2023 13:56:04 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 09 Oct 2023 19:22:58 GMT
+      - Fri, 13 Oct 2023 13:56:04 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_download_files.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_download_files.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:56.250488Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:56.250488Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:35.8868534Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:35.8868534Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:30 GMT
+      - Mon, 09 Oct 2023 16:13:09 GMT
       etag:
-      - '"1a0af5da-0000-0100-0000-64af09c20000"'
+      - '"920131b3-0000-0100-0000-652426750000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:15:32 GMT
+      - Mon, 09 Oct 2023 16:13:11 GMT
       mise-correlation-id:
-      - 177b0df1-942f-4790-8223-b2ec498b8740
+      - 71af1f94-832a-4255-9ff0-c4ce001a9767
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -85,12 +85,12 @@ interactions:
 - request:
     body: '{"displayName": "CLI-Test", "description": "Test created from az load test
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
-      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "loadTestConfiguration":
+      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"fa0cb900-b9d3-470f-8208-89d8f2868f3b": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "5b3c52f3-5d5e-4c19-9db2-54387156e6f0":
+      {"passFailMetrics": {"d449c773-04d1-4d1c-bc15-21f5cd7db421": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "bba2108c-0525-456d-a02b-d147b2abec99":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "a7594e54-9e42-4a61-8886-2be0f30b1594": {"aggregate": "avg", "clientMetric":
+      "50"}, "ff8146e9-6274-498e-be31-c18794d8a4f4": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -100,32 +100,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '768'
+      - '789'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:15:33.021Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:15:33.021Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:13:11.793Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:11.793Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1064'
+      - '1010'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:33 GMT
+      - Mon, 09 Oct 2023 16:13:11 GMT
       location:
-      - https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+      - https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 7d7ab792-1e79-4dbc-8d05-8554806a7eec
+      - b7d32614-fa73-4393-801f-72ae77995b79
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:33 GMT
+      - Mon, 09 Oct 2023 16:13:12 GMT
       mise-correlation-id:
-      - 5fd0b3fb-7eca-42c3-87c2-d703ac579d5e
+      - 17c11bf1-3bfc-4c1b-a1d3-02dd49054308
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A25%3A33Z&sr=b&sp=r&sig=0%2BPUnOrl6Uue1iG3TJHS%2Fs3gc7Ho%2F%2FNyzWEefGGPd7Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:25:33.9929687","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A13Z&sr=b&sp=r&sig=ll5x1c7p2meSPvhc1SlLZhZN7rgjkETuEBqGkI1%2FP2U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:13.3438032","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '557'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:33 GMT
+      - Mon, 09 Oct 2023 16:13:13 GMT
       location:
-      - https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - d5c169a7-7c74-44da-adb0-a14121fe45a3
+      - 4041b049-a163-46a0-b544-ef95dca13d30
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A25%3A34Z&sr=b&sp=r&sig=v3480Sc61cl3K%2FoSCCju9rdup1hrfwjaW9nTmXgVEcc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:25:34.309675","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A13Z&sr=b&sp=r&sig=hUpNkGGeXISSR0x%2BfM9Rd9Ir3rEGs8CklkwIM3MHPcg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:13.6061207","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:34 GMT
+      - Mon, 09 Oct 2023 16:13:13 GMT
       mise-correlation-id:
-      - 65457807-c5e3-4543-b625-d9eccfe3d1f0
+      - 2487eebf-b7a2-433e-a0fc-849c756d22cd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A25%3A39Z&sr=b&sp=r&sig=fd0u42LBvHzjIRpcBTgtdrze8sn4sgSLoQHGVYePhS8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:25:39.6009462","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A18Z&sr=b&sp=r&sig=8konLNDtBjXNoUsd9DmJ7%2BVD4QlEuh7zWsFEEvte9m8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:18.8893546","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:39 GMT
+      - Mon, 09 Oct 2023 16:13:18 GMT
       mise-correlation-id:
-      - b6481c16-95f0-4e73-b91c-1af7277a2d7d
+      - d4c48785-e16b-49c5-b79a-d005c238eec1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A25%3A44Z&sr=b&sp=r&sig=kVJ2bwtgfDHuhmXXcc8cXOJZ7F6j49ZErtzlDXOGxrM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:25:44.9406418","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A24Z&sr=b&sp=r&sig=t%2FyjgwGAfrtt2JI5ZQHYRpp4HZWv4%2FzzTWlku89u%2F0E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:24.1613117","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:44 GMT
+      - Mon, 09 Oct 2023 16:13:24 GMT
       mise-correlation-id:
-      - f8dd3ebf-5176-4b60-b3d2-71b82e00cd09
+      - 197049f7-318e-4b98-93a0-955eaced6a99
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A25%3A50Z&sr=b&sp=r&sig=qv%2F2e7cctws0Vf6OY5HBxGJBqKx856p6Y6jMlUk9uZA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:25:50.2185797","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A23%3A29Z&sr=b&sp=r&sig=leJQEHI%2BD59G%2BIxMMVKd1Vgd9Qmi4wOMS7t%2F4F6otNU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:23:29.4587981","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:50 GMT
+      - Mon, 09 Oct 2023 16:13:29 GMT
       mise-correlation-id:
-      - 3efc26ac-9ecd-478c-acf5-66548a54f84f
+      - 45c183ce-47ae-4932-b228-aee95529c2c4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A15%3A50Z&sr=b&sp=r&sig=FiM9ogMraGFqUhOxiN4IoidI0UjA2hi9TAdjhSrLHNE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:15:50.4861082","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:15:33.021Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:15:48.372Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A29Z&sr=b&sp=r&sig=O6zQcFFwQTONWj%2F7sf7ITopBiXtoSNs03MQTyl%2F2GJ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:29.7200158","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:13:11.793Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:25.388Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1633'
+      - '1583'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:50 GMT
+      - Mon, 09 Oct 2023 16:13:29 GMT
       mise-correlation-id:
-      - b1fc3fc6-5972-41d5-9d0c-5e0932981030
+      - 5bdac6db-2dbd-46a9-828a-85a1f47715cf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:56.250488Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:56.250488Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:35.8868534Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:35.8868534Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:51 GMT
+      - Mon, 09 Oct 2023 16:13:30 GMT
       etag:
-      - '"1a0af5da-0000-0100-0000-64af09c20000"'
+      - '"920131b3-0000-0100-0000-652426750000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A15%3A53Z&sr=b&sp=r&sig=ytYKru%2BkYPuKBYMJNG4Ch1h%2F8tv%2B29SqZI98LyINxTw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:15:53.2846572","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:15:33.021Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:15:48.372Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A31Z&sr=b&sp=r&sig=MV0rD5mTi6%2Bn5jEEWW69obmYfQeI0dlUGXY8mq0t9PM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:31.9240423","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:13:11.793Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:25.388Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1651'
+      - '1593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:53 GMT
+      - Mon, 09 Oct 2023 16:13:31 GMT
       mise-correlation-id:
-      - def9f90b-e8da-4e7f-8f0b-994fb32e1f52
+      - 6c79fe1a-5f5a-49d1-9a48-7e828a744bd2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:56.250488Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:56.250488Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:35.8868534Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:35.8868534Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:54 GMT
+      - Mon, 09 Oct 2023 16:13:33 GMT
       etag:
-      - '"1a0af5da-0000-0100-0000-64af09c20000"'
+      - '"920131b3-0000-0100-0000-652426750000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:15:55 GMT
+      - Mon, 09 Oct 2023 16:13:34 GMT
       mise-correlation-id:
-      - 2b4eb1d7-ea04-4ae9-8785-86aa00c38035
+      - b72ef6d0-e2ce-49bc-a7b5-09424f78247e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/a25cd97d-f0a2-4d7e-a0f0-ea882066d847?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A15%3A56Z&sr=b&sp=r&sig=zEVZmL4flR9f%2BYbRw6lUby7%2FuFZDi4GC0h4x6nWxHdc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:15:56.7009243","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A15%3A56Z&sr=b&sp=r&sig=xIAP9tGWtdGGm0PqD0N54bOZm7bs22rXfLdULw9ylr4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:15:56.7008191","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/95514c2f-704d-47c6-8bcc-bbf96e626535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A15%3A56Z&sr=b&sp=r&sig=1acnBlnbH0PJHn85%2FHIJfx2xPa1xfw0qRn1FqA4gXec%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:15:56.700951","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","testId":"download-test-case","status":"ACCEPTED","executedDateTime":"2023-07-12T20:15:56.518Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-07-12T20:15:57.142Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:15:57.142Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A35Z&sr=b&sp=r&sig=X0MleczDwtpHPK6nDGm%2BErspO%2B8NYiuFbP2G8kScAJY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:35.1388043","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A35Z&sr=b&sp=r&sig=pZjBeVbIpxwx3yopwrmVufgtIO2dGz3%2FA6kAyIbKxnc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:35.1386853","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A35Z&sr=b&sp=r&sig=QkRS4TI90gaxkPCBfe4tWQ34wMxSPWsTIi1quYvtkdA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:35.1388308","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3196'
+      - '3164'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:57 GMT
+      - Mon, 09 Oct 2023 16:13:35 GMT
       location:
-      - https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+      - https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - e2cdbea3-f150-4ebc-940e-95bd8a95b31a
+      - 810f3cf3-67bb-4b5f-92f4-6c7924a829aa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/a25cd97d-f0a2-4d7e-a0f0-ea882066d847?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A15%3A57Z&sr=b&sp=r&sig=skBY9VtDGIlwudCJEIY4LWfChQgWYyIBN4hS%2FxbZGM8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:15:57.4410577","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A15%3A57Z&sr=b&sp=r&sig=FP3NCUuDuARpFTVeL54kBptYAos%2BVOXNZ5wwjCzuF9M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:15:57.4409605","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/95514c2f-704d-47c6-8bcc-bbf96e626535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A15%3A57Z&sr=b&sp=r&sig=Nt5LB2h6TeMPXeWHcPAKbkKR1EVpwc%2FjtzjMLX7r6WI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:15:57.4410818","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","testId":"download-test-case","status":"NOTSTARTED","startDateTime":"2023-07-12T20:15:57.288Z","executedDateTime":"2023-07-12T20:15:56.518Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-07-12T20:15:57.142Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:15:57.288Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A35Z&sr=b&sp=r&sig=6WJnbsoynHFu9vs63H1ER5kqh8%2BucpKQuqYC59tlkr8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:35.6204889","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A35Z&sr=b&sp=r&sig=tt6pCqQKCaHVOHFCh1cCYLwTBTT3gweUtIgPik31Yd8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:35.620394","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A35Z&sr=b&sp=r&sig=vEq7Xig%2BlUvTP2syAbQ7tRO8U4nb%2BsVy0L9%2F1aJko64%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:35.620509","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.504Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3242'
+      - '3209'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:57 GMT
+      - Mon, 09 Oct 2023 16:13:35 GMT
       mise-correlation-id:
-      - f00a7b31-8c97-4737-8d87-97703850683b
+      - b76657ae-21ff-4a53-8241-7bc5bd742b04
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/a25cd97d-f0a2-4d7e-a0f0-ea882066d847?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A04Z&sr=b&sp=r&sig=0v3PPjga%2FLG2Hm6sbTSCgIw3naynT9Zehmho%2FEGRu7Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:04.2107261","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A04Z&sr=b&sp=r&sig=9GOdwkNk3T5LrsbuKoolyjktk%2F4y6XtqSFuGugznPXE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:04.210662","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/95514c2f-704d-47c6-8bcc-bbf96e626535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A04Z&sr=b&sp=r&sig=xe0oEh584pi%2FSn3N56dfh748IE7qwe%2B1oh3qHN8TdzQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:04.2107404","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:15:57.288Z","executedDateTime":"2023-07-12T20:15:56.518Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-07-12T20:15:57.142Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:15:57.491Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A40Z&sr=b&sp=r&sig=QOfL%2Ba1jSQIso1zITtSqCkf%2Bo48CfyqaOy9T%2BNKr3kY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:40.9198483","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A40Z&sr=b&sp=r&sig=2X%2BplKTC8QfGMYwlH0oOBZslD8pvyo8uNy%2FGjAdrAbE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:40.9197789","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A40Z&sr=b&sp=r&sig=xsgksO%2FGfegIToyhoNcQWx5yWCn%2BtKxkngInE3SKcU8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:40.9198649","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3247'
+      - '3219'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:04 GMT
+      - Mon, 09 Oct 2023 16:13:40 GMT
       mise-correlation-id:
-      - ed70861f-8698-4cb5-a4de-3707760c8f3c
+      - 03a58ebc-0964-4995-9e86-588c1da29c59
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/a25cd97d-f0a2-4d7e-a0f0-ea882066d847?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A09Z&sr=b&sp=r&sig=235k9dXK3Yd08xNZlBgD6pg8eJfmQvg%2FVjtANmouk0A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:09.5176017","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A09Z&sr=b&sp=r&sig=J7tVpZXZeTMmUmIE46M%2BsYtqi4AMd0r39Ll4uHuw4fc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:09.5175329","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/95514c2f-704d-47c6-8bcc-bbf96e626535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A09Z&sr=b&sp=r&sig=wL4Zjhim2y2iDEJ9xw3zlNsceM91KzCq06OJd9%2BN%2FgU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:09.5176161","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:15:57.288Z","executedDateTime":"2023-07-12T20:15:56.518Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-07-12T20:15:57.142Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:15:57.491Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A46Z&sr=b&sp=r&sig=qKXrLWJ89EKSH1otm%2Bj3%2F6vprebLs3%2BLizL6K3SCHAM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:46.1992667","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A46Z&sr=b&sp=r&sig=DcVSendJQdOPsuS8KahHQCIMRIvVxdNKx%2BXlXcVNmG4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:46.1991742","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A46Z&sr=b&sp=r&sig=stL09%2F4Jnhr5ljnxSJi8C70r4blmCuZjncQ1jJgFvWU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:46.1992879","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3246'
+      - '3215'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:09 GMT
+      - Mon, 09 Oct 2023 16:13:46 GMT
       mise-correlation-id:
-      - 30ac11bf-9907-41a7-ae8c-79a1ed905468
+      - 900b9d61-0b83-49e4-995a-c6a948efac7b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/a25cd97d-f0a2-4d7e-a0f0-ea882066d847?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A14Z&sr=b&sp=r&sig=a%2BPtorcNz0qCZ%2BqeUlu61OFLDH%2F0s1eyr4DVM7dnfcc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:14.8395835","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A14Z&sr=b&sp=r&sig=EL9YoBINF1Gk8q8wA8%2BtHbwHNdieT9TVmF6JN4PRtxs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:14.8395074","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/95514c2f-704d-47c6-8bcc-bbf96e626535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A14Z&sr=b&sp=r&sig=upRPTb8%2F%2F1HtO3gxAeU8j3yliEn8SF9hROO9qhZNmNA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:14.839598","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:15:57.288Z","executedDateTime":"2023-07-12T20:15:56.518Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-07-12T20:15:57.142Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:15:57.491Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A52Z&sr=b&sp=r&sig=lvc6gzFGK0JW5fe%2FgMmB8cSTcpDx%2BeoG1sWNbM4q1Oc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:52.4697055","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A52Z&sr=b&sp=r&sig=XNbpvYaUwiC6XvejpCmpEXWR6PNY4mTi617Tp%2FLJViE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:52.4696357","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A52Z&sr=b&sp=r&sig=zcBFbgLF2aqx3LaaU%2FxpHOeqS8abL%2Bmly8XPX1kA6Lw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:52.4697232","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3249'
+      - '3215'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:14 GMT
+      - Mon, 09 Oct 2023 16:13:52 GMT
       mise-correlation-id:
-      - 248e933f-f8b8-47ba-8401-c5c7d2c3c433
+      - 24ce588d-a1c3-4067-84a7-11bc6eb758d5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/a25cd97d-f0a2-4d7e-a0f0-ea882066d847?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A20Z&sr=b&sp=r&sig=FHPnh2jk9EHsUcKV911OdfZRfcsrZJWqPNYm%2FcXmzbA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:20.4501132","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A20Z&sr=b&sp=r&sig=h7ZbbqBr52fr6ZMGRd69uY8yeD2YdXRBAQvv1VBL71s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:20.4500477","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/95514c2f-704d-47c6-8bcc-bbf96e626535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A20Z&sr=b&sp=r&sig=9lEY7Gxv%2BzsM6OwsAykb3RV1cOQ%2BQnOwtSGYMXPLDws%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:20.4501274","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:15:57.288Z","executedDateTime":"2023-07-12T20:15:56.518Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-07-12T20:15:57.142Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:15:57.491Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A58Z&sr=b&sp=r&sig=gt%2BWgdwm%2FrnsSAZc5tWm%2BAMaoKSEWaXSQupJ6qRI4yQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:58.1500688","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A58Z&sr=b&sp=r&sig=Cqb33kranoAd8Bb%2B52QS889r3RG%2BJrnThq22kWnEN9A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:13:58.1499686","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A13%3A58Z&sr=b&sp=r&sig=Pr4bkxO6IoaGjL6xn2pNAkFtNLJFbbicUs7vV6mNsvY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:13:58.1500936","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3244'
+      - '3215'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:20 GMT
+      - Mon, 09 Oct 2023 16:13:58 GMT
       mise-correlation-id:
-      - af5c97f5-d01b-4b26-8840-9d14718904d8
+      - d25830cc-b9f1-4816-9b56-a06a192f862f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -880,23 +880,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/a25cd97d-f0a2-4d7e-a0f0-ea882066d847?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A25Z&sr=b&sp=r&sig=Z5QNsHIqrG%2BnZsMr1RVMnGfbjm2FiFSwD0gY2FRR8O0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:25.7979322","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A25Z&sr=b&sp=r&sig=Jr5ex6cM9UM7btEMRkSLc7tVJJoQsae%2BV3%2FBnsZcgb0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:25.7978635","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/95514c2f-704d-47c6-8bcc-bbf96e626535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A25Z&sr=b&sp=r&sig=K9dsDUYUwlDkBWTqRkoY6bhvxEbE%2BGOaWOTm4XAc7eg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:25.7979475","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:15:57.288Z","executedDateTime":"2023-07-12T20:15:56.518Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-07-12T20:15:57.142Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:15:57.491Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A03Z&sr=b&sp=r&sig=GUeCXrnNNAI0Kim6HLdcf0lIlIAge3k2A17K5x7D2bA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:03.5655425","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A03Z&sr=b&sp=r&sig=ibJJddSeyUdfiWivjfHkBhNcuQMnqlu2T%2Ff%2BpymHdXk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:03.5654745","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A03Z&sr=b&sp=r&sig=8UGPwXEx1RcBMRBtRAt1ZGrJ2gd9qUlNijwHF%2B2We7Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:03.5655576","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3246'
+      - '3211'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:25 GMT
+      - Mon, 09 Oct 2023 16:14:03 GMT
       mise-correlation-id:
-      - df78f3fb-6f77-41ac-ad64-4332551d41d8
+      - 7d0cf34d-050e-4bef-94d8-aa0e4abbc460
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -916,23 +916,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/a25cd97d-f0a2-4d7e-a0f0-ea882066d847?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A31Z&sr=b&sp=r&sig=IxTlgzqTx%2Bh%2BEqiJPzQQL8sgBXDjnJlCdzrmdq3Pg%2Bs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:31.1297937","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A31Z&sr=b&sp=r&sig=BajTS4O1iGmNnWZRY6ONYsEv%2Bk2tNAjHKiplgbYsIEg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:31.1296912","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/95514c2f-704d-47c6-8bcc-bbf96e626535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A31Z&sr=b&sp=r&sig=wNfro317x00EFY10L9KIMD7MGQCgvY7L%2BD0REkh3wH0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:31.129809","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:15:57.288Z","executedDateTime":"2023-07-12T20:15:56.518Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-07-12T20:15:57.142Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:15:57.491Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A08Z&sr=b&sp=r&sig=%2B5ZyGeu11HvEjWuHsqVHx2t9On955s70DVm2R4Lw6oI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:08.8459567","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A08Z&sr=b&sp=r&sig=CwomC9twIlM5J9%2B95vJiTQalPdzkJcj8mMu%2FUP9yyW4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:08.8458544","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A08Z&sr=b&sp=r&sig=DVJTJxccx8W6rwv4Rg%2FL%2FpfoOcgSesi%2FvKRwGUDje54%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:08.845983","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3247'
+      - '3216'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:31 GMT
+      - Mon, 09 Oct 2023 16:14:08 GMT
       mise-correlation-id:
-      - 677c04a0-4ae1-4d42-8ec7-fd752f2edad1
+      - 3a216e77-88ff-4725-a14b-c6c6849b3b51
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -952,23 +952,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/a25cd97d-f0a2-4d7e-a0f0-ea882066d847?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A36Z&sr=b&sp=r&sig=QrKPHHYRm%2FyeMEh4nMTl5SNHsBLk6LaLVTIeDxQDSik%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:36.4020968","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A36Z&sr=b&sp=r&sig=KMWNe6LdDjLD557Vu%2BBmKEyNYc7TuKdL%2FGf9fuq6Jx4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:36.4020296","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/95514c2f-704d-47c6-8bcc-bbf96e626535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A36Z&sr=b&sp=r&sig=BcqLR9w5rAB6S3QZMBN5XeP0sVKrnv%2B5vEg0d1oRJYU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:36.4021105","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:15:57.288Z","executedDateTime":"2023-07-12T20:15:56.518Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-07-12T20:15:57.142Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:15:57.491Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A14Z&sr=b&sp=r&sig=KJ9LmBM3EBVO9vb0Mz4QIaUUH9qPAMJBQ0ibo5X3wmA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:14.1280046","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A14Z&sr=b&sp=r&sig=R2Tequlb26mqnF0AwuMUnXBlpvdwfv4EvB5Z42nHrKM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:14.1279357","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A14Z&sr=b&sp=r&sig=plYtvCWdRrd3y7oUo5C6bKbFKDKDSg3%2BdZph5to0QZM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:14.1280201","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3246'
+      - '3207'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:36 GMT
+      - Mon, 09 Oct 2023 16:14:14 GMT
       mise-correlation-id:
-      - 7243d0cf-3ab0-481f-ba8a-6b6455a47354
+      - d4b64e77-53a1-4614-a2ee-53948f1261a5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -988,23 +988,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/a25cd97d-f0a2-4d7e-a0f0-ea882066d847?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A41Z&sr=b&sp=r&sig=AnlleXYrmEQXhmioCoQExiTGEEIwKLMaV0rnpMo31y4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:41.6787497","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A41Z&sr=b&sp=r&sig=hkIUfPcyQ7FMSEdSwCjfXHD3aPaGP0hC9NaSQacy4%2Fk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:41.6786738","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/95514c2f-704d-47c6-8bcc-bbf96e626535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A41Z&sr=b&sp=r&sig=T%2Fr76oZml%2FVYIJ2O1OhrFoIg0rQNbXRhgbvpQe5rRUA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:41.6787637","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","testId":"download-test-case","status":"CONFIGURING","startDateTime":"2023-07-12T20:15:57.288Z","executedDateTime":"2023-07-12T20:15:56.518Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-07-12T20:15:57.142Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:39.516Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A19Z&sr=b&sp=r&sig=LGhMjr7Pwt6%2B7sVnd2yZMLSHDG1XMEyvqaE4dtCO9OE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:19.4120382","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A19Z&sr=b&sp=r&sig=RhUn7BKicf28OHheXHTcDlqHeW4WSaHguH4bvaENDrw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:19.4119728","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A19Z&sr=b&sp=r&sig=%2F90Kn0o8hRwC2234iHw4urvcjIVAcq7ehADLWUJmgkQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:19.4120536","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:13:35.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3243'
+      - '3209'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:41 GMT
+      - Mon, 09 Oct 2023 16:14:19 GMT
       mise-correlation-id:
-      - 5cac2787-8602-413b-a182-71b1afd769b6
+      - 10cb0e32-3501-45e4-abb0-d73c83f20f28
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1024,23 +1024,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/a25cd97d-f0a2-4d7e-a0f0-ea882066d847?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A46Z&sr=b&sp=r&sig=BvercTcyhm7IAeOAXZBAlPYinOBXmpZd%2BZrzh6FSWvA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:46.9777752","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A46Z&sr=b&sp=r&sig=UL0EocXKtBZvCqN8a6Q1GrEDmk4qX4yJcJUR1Buvglw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:46.9776894","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/95514c2f-704d-47c6-8bcc-bbf96e626535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A46Z&sr=b&sp=r&sig=zIEUA2VmeZx9X3MxkXYCX41K4NrgWl9fXt5boX5xTbU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:46.9777898","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:15:57.288Z","executedDateTime":"2023-07-12T20:15:56.518Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-07-12T20:15:57.142Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:43.274Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A25Z&sr=b&sp=r&sig=02%2BR7CgmtlCsqqY0DSCVpnuGEV0dLobNN36VuHfFZGo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:25.3565917","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A25Z&sr=b&sp=r&sig=W1qWPMPm8BqvJCIXNsHQBgUuh1plgAp3LiNCsd7meSI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:25.3564563","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A25Z&sr=b&sp=r&sig=x50Ja6WrKyUl%2BkLdj9K2Ox%2F1WcPZneqCeFYQc%2BVgvX8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:25.3566076","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONED","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:25.344Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3237'
+      - '3212'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:46 GMT
+      - Mon, 09 Oct 2023 16:14:25 GMT
       mise-correlation-id:
-      - 35421b5f-980a-4a41-ba89-ae0e0621b141
+      - fab10f97-fd7f-45e5-9bd7-99415feb52aa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,23 +1060,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/a25cd97d-f0a2-4d7e-a0f0-ea882066d847?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A52Z&sr=b&sp=r&sig=nNzwxhvel390jyiQT3Z9HUG98ZK5RhjcV49hHswtk1c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:52.3851342","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A52Z&sr=b&sp=r&sig=EntlqXhkTzm3%2BIN8%2BIjPvQXOMia2XX7yvLPWCq33Gdg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:52.3850705","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/95514c2f-704d-47c6-8bcc-bbf96e626535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A52Z&sr=b&sp=r&sig=WSfRqCPo7FUvvKCBfZh1u9dfYDe2ebfPFzKblTH2yHA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:52.385149","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:15:57.288Z","executedDateTime":"2023-07-12T20:15:56.518Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-07-12T20:15:57.142Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:43.274Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A30Z&sr=b&sp=r&sig=43%2B2FWEifw%2FbcCrlhPDZFBEUHdwpG9UYSZVQ%2BPM932g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:30.631639","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A30Z&sr=b&sp=r&sig=3M7Hqs1hfltGXnrnCL1ah%2Fy6JkhcTtnZasGOb%2BtLmCA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:30.6315712","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A30Z&sr=b&sp=r&sig=ean2DktuLKjmwEIZ8lVccyeXXd89Jf2XaR3rCrbTuEI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:30.6316536","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3238'
+      - '3211'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:52 GMT
+      - Mon, 09 Oct 2023 16:14:30 GMT
       mise-correlation-id:
-      - 2129dbf5-7c18-470d-a898-5f47aa2e7c87
+      - 061515aa-c34d-422d-ae3c-53e497a67f5c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1096,24 +1096,744 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/a25cd97d-f0a2-4d7e-a0f0-ea882066d847?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A57Z&sr=b&sp=r&sig=49ltqXgqWSc1saGLPeVzg2uYepslfh%2BLkOs961%2BdSkg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:57.7524878","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A57Z&sr=b&sp=r&sig=9HcZQWcic%2FpNMUr067IDvGOXmWe0jAWDChtPATtx%2B3k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:57.7524109","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/95514c2f-704d-47c6-8bcc-bbf96e626535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A57Z&sr=b&sp=r&sig=QTWO4SPEhLXx55Ui3TaglxkNIuExbx3dyhTWdF9dzFs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:57.7525092","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-07-12T20:15:57.288Z","endDateTime":"2023-07-12T20:16:53.676Z","executedDateTime":"2023-07-12T20:15:56.518Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-07-12T20:15:57.142Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:57.693Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A35Z&sr=b&sp=r&sig=tz5i5EG6MKKAHymzsa41lvmA5yFva9gr9flGSWYk2f4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:35.8984783","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A35Z&sr=b&sp=r&sig=rBuAPBYJnlAu%2F85yfctBtNi01lh8gKhT1YP0s8RE%2BA0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:35.8983964","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A35Z&sr=b&sp=r&sig=ka%2BmV4DB4klci%2FL%2F1hcNw1c0%2FUOOILIjWSnPCg%2FQnZI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:35.8984934","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3378'
+      - '3216'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:57 GMT
+      - Mon, 09 Oct 2023 16:14:35 GMT
       mise-correlation-id:
-      - 72c3626b-dee8-4e07-9f85-4cd26ab37a78
+      - 74d5aaef-0772-4196-bedb-9ed35453dad0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A41Z&sr=b&sp=r&sig=2zuPNne6k1bJ9VGcSfl6XOp1UYhahu1LF7Klo7Yx0vM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:41.1839124","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A41Z&sr=b&sp=r&sig=2DOkmuUtFBkMyHbez7nc%2FH2ZhgmNYTgrotkeS1Y5y%2BU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:41.1838321","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A41Z&sr=b&sp=r&sig=R3eIdTwdrdOSBkOqWr%2FWVdmdGmvpfwPFNdSCzESV45s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:41.1839275","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:41 GMT
+      mise-correlation-id:
+      - 7cbc74dc-eb0a-406f-8675-12d6b719723a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A46Z&sr=b&sp=r&sig=EMdDqSk3oYUfua1d9DUBGIhU6ulhTLXsuX0M2uW9qh0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:46.4909181","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A46Z&sr=b&sp=r&sig=XdBPY8%2FuLvHbuXTBeTIAVpAG7EFeNPC6aNq9TYJFicU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:46.4908291","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A46Z&sr=b&sp=r&sig=v2uanEaUnxWC3pk9mPUrzZrutNoy1zKlYBK4htXTCaA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:46.4909341","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:46 GMT
+      mise-correlation-id:
+      - e960bfaa-444e-4c77-85f4-a37c102ed3dd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A51Z&sr=b&sp=r&sig=YDZmdizCGTHK2krFcBEByWS97hI98YgaaQGBkgkF%2FS8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:51.761958","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A51Z&sr=b&sp=r&sig=bsCGKUujiRAuIbe1Ezx725LMsazQicH0I4kO%2BGbEzHI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:51.7618735","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A51Z&sr=b&sp=r&sig=4Hs4S2aEAp%2Fv4KoDOlw6bT%2BOb4XjlG2wh9FyY78EPzw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:51.7619799","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3209'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:51 GMT
+      mise-correlation-id:
+      - d469562e-6928-44ff-ad3d-7372d69b5459
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A57Z&sr=b&sp=r&sig=bwvWBAh2vWYqH%2BYmgliHevg4qY3TnbRVP9KJNE97TEk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:57.0404536","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A57Z&sr=b&sp=r&sig=aQ1sU7Y0rIg%2Beae0zyZ7JGhecIdchGcTYYuQsXNgK%2FM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:14:57.0403763","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A14%3A57Z&sr=b&sp=r&sig=dl%2BUb%2Bw39Cil%2F9L%2BHLtyzhr8pEt0zfeWURuaECg%2BTz0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:14:57.0404778","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3218'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:14:57 GMT
+      mise-correlation-id:
+      - e04f9d80-f91d-473c-a75f-c2760c9e0809
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A02Z&sr=b&sp=r&sig=nN%2F37EUr4Bif612COtosfnaPIhZNSWec%2F3MhHZ7rDic%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:02.5809662","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A02Z&sr=b&sp=r&sig=FCWimL0rM1xS1fRDMJWh4av26DFvzU7JtirK4i8rzBY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:02.5808966","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A02Z&sr=b&sp=r&sig=wEeRHUvS0FVdAgTZpy7i6JcQ4pAQhlvQ3YJVIsazcMo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:02.5809816","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:02 GMT
+      mise-correlation-id:
+      - 04666514-8dc7-4a56-982c-ff0551b6439f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A07Z&sr=b&sp=r&sig=KPOMTyMjV2gmJ7%2Bd7maiomMska%2B2gIqwO%2FdVRHPsJG8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:07.857227","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A07Z&sr=b&sp=r&sig=ICsJ5o%2BaJK06rQJAIs4Gu2vqKnx1QQ2E%2BVkuI5DgeUc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:07.8571226","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A07Z&sr=b&sp=r&sig=eWkmu2tnevWf8EYbF7wLy8hOy5qFn9TXF2NsqgqWPYg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:07.8572538","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3211'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:07 GMT
+      mise-correlation-id:
+      - 9725cdba-c2da-41a2-ac24-855ead5d449c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A13Z&sr=b&sp=r&sig=Tr6hsOF9N5c5izM813jr22GiwbRy4unY%2Bh%2FxHet%2B0nY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:13.175442","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A13Z&sr=b&sp=r&sig=4rfWZ5NV%2B3y0sGp%2Bx7B59NW%2FPqH%2Fps8h2gNysT%2Bzd9Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:13.175355","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A13Z&sr=b&sp=r&sig=nE0fsQn2lr3%2BDZoPaKvNyOj%2ByeT%2BgXf02XUIKvsDAkQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:13.1754658","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3222'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:13 GMT
+      mise-correlation-id:
+      - 28df76d7-4358-4d5d-b144-42914ba0bcec
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A18Z&sr=b&sp=r&sig=GHdD7AGoeDWTxPP8eAb%2F1uo6cRi%2FwX8eFPqB%2FR14oAo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:18.4489479","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A18Z&sr=b&sp=r&sig=zPqEufJkX1NM7VNq%2FcX0sAhldf2gEoBDMlTfJTzW2Ys%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:18.4488684","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A18Z&sr=b&sp=r&sig=h7%2BZe7Iz%2FWM6W2lufShhYnwF5yeFxwGqOcF11Wo%2Flq0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:18.4489625","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3216'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:18 GMT
+      mise-correlation-id:
+      - b95b5f5f-8e01-44b7-8021-38b3be23685f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A23Z&sr=b&sp=r&sig=HJiauWXdRQ89eie0%2F1hhcpD5mqePJJPNnHZQds9epQ0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:23.7398782","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A23Z&sr=b&sp=r&sig=MY8cfq08WpkDhMSn7cNa6YyKq2KxHTrbJMyR1yV94pY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:23.7397713","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A23Z&sr=b&sp=r&sig=ASjWFBMF9EtnjL%2FatRsJAYeNic2dFhNP37ozL5jWpUg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:23.7399048","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:23 GMT
+      mise-correlation-id:
+      - 699e8498-566f-4641-b3e9-ee4deb1678c1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A29Z&sr=b&sp=r&sig=e92D58lGkT%2FNe704jcUaipbU7mPT13F6RJrrZUbTB9M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:29.0211481","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A29Z&sr=b&sp=r&sig=sHV%2BZiQBzp2E6ukztAl9pRz2M9oIPwDEawDNCniUlEM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:29.0210732","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A29Z&sr=b&sp=r&sig=D1p3fT%2FChZp3kPRkQjkIA%2F1BWIHIAjhk0DyN7hF04%2Bg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:29.0211643","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3212'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:29 GMT
+      mise-correlation-id:
+      - 8b3d5b75-ae64-4706-814e-2ed327a3015e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A34Z&sr=b&sp=r&sig=D6iZSPROSVr%2BQMXsFIOprZAM%2FiO%2FRnyZ7Fg%2BCPS2sik%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:34.2942766","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A34Z&sr=b&sp=r&sig=qzN%2BpjJ%2F9SCwRY%2Bw2do8wZGVn1qqHPEBwf4azP25dD0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:34.2942016","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A34Z&sr=b&sp=r&sig=VK5uCSxVjYT5TCAvhhajIdtbRgbnpMr1r%2BTVJ77GOqQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:34.294295","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3217'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:34 GMT
+      mise-correlation-id:
+      - 78261338-c473-46ec-8c7a-294d62933fca
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A39Z&sr=b&sp=r&sig=OI8WNnyt%2FMPsDjUFNNEbJLSU5qBKkZ5B05XMoZkGfo8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:39.576845","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A39Z&sr=b&sp=r&sig=LCNe%2BeZ%2FwzZAhZIMjSZGgUD9%2F%2FEa2WiWXFjiNJJVVAY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:39.5767594","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A39Z&sr=b&sp=r&sig=XDtdBpesCizB%2FWn3FSDiv2TSQJexyC0H4CduCU3yYbU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:39.5768637","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3213'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:39 GMT
+      mise-correlation-id:
+      - 49545059-b877-44d9-bf8f-f9cc2d44e424
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A44Z&sr=b&sp=r&sig=Koz01%2FBaVKvZwSkWnbk0ZYqxg%2F6k1GR8q3Y%2FQpEbw1Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:44.8594008","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A44Z&sr=b&sp=r&sig=K9prLEo5sdpGOHhTteGA8W7sDx%2Bz657LowxrEAE%2FecE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:44.8593055","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A44Z&sr=b&sp=r&sig=cTdTOr4mXCvcAFaOlq%2FCYZeXRUvvl5apLPFj%2FxcwDzY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:44.8594246","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3216'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:44 GMT
+      mise-correlation-id:
+      - 014c9f21-6069-4ef8-a4e5-682f7765ba62
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A50Z&sr=b&sp=r&sig=z3T7gFQJNwPsy6ZU2XumxqqpIe8RO%2FoR7ScFn83nMYc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:50.1354519","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A50Z&sr=b&sp=r&sig=tX0kH8UBjxvDewfgjSSa1gvKZPqzMz5AueTyFWCVd7U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:50.1353821","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A50Z&sr=b&sp=r&sig=FXttiQx%2Fygqdp1KD4R3eMSLVhsdkVUueER8SbdkgRzw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:50.1354686","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:50 GMT
+      mise-correlation-id:
+      - 60097231-f244-4271-a8ed-ac72dd22fa68
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A55Z&sr=b&sp=r&sig=H1JXTbcLgFxdXcQ%2F2eNXYxtkRfvhaCyzLvS%2FcnGqgrU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:55.4161484","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A55Z&sr=b&sp=r&sig=8aU4hveImUxPdFKfPHOIyVngA9NqG1qxXMMkYjM80Kg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:15:55.4160519","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A15%3A55Z&sr=b&sp=r&sig=s0rjSI1HjVgLLslmbICjpVuGb3mCkJcrejateUyRVyA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:15:55.4161728","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:15:55 GMT
+      mise-correlation-id:
+      - fd9b3bbd-9886-4020-88b1-8c4aa489983d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A00Z&sr=b&sp=r&sig=LeyUpY5fGNtMwsrG%2BF3Zxe2nXE8rZBGDWxUYy7dyAco%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:00.6955296","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A00Z&sr=b&sp=r&sig=IUoR6MCU68V9QBAPSpbz6BV3kn0Gx0GM%2FPG7oYyDw58%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:00.6954534","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A00Z&sr=b&sp=r&sig=9tuVep9wjdxK5HszVIo55zt0WqGoXHTVfjv3B0cV4lw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:00.6955441","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:16:00 GMT
+      mise-correlation-id:
+      - 3bc29e7c-007c-4356-b2a3-68694eae7dda
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A05Z&sr=b&sp=r&sig=AlIAQvk8%2FVOxD%2Bdjs7LAsCeZz2juYgZz1lnKGn%2FmGGQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:05.9686954","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A05Z&sr=b&sp=r&sig=Rk6xgsJ8uXtrBERc83SqLxp2JZ0Nf97ADNKLkr3QUF0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:05.9686289","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A05Z&sr=b&sp=r&sig=Sj69VYUFE35YN6dfmqKIYdzYDxnOkV4Tyn2JJibLdek%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:05.9687447","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:16:05 GMT
+      mise-correlation-id:
+      - 594fe8bb-81c0-41be-91b7-9a4c4e1c5a30
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A12Z&sr=b&sp=r&sig=5dxGPeiIK1xM%2FXDqCKZSHhW95Ij2lI6WXyijB7gUfNc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:12.1888677","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A12Z&sr=b&sp=r&sig=1T4qj%2BsJ2WnlwgT8JYE9vxYnO%2FwehMGP8rR%2Fv9B1SeY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:12.1887981","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A12Z&sr=b&sp=r&sig=UxZogR5nlhQ1A7AQRZHzAzByGZ7fhjuaoavh9KT8XSs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:12.188884","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3209'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:16:12 GMT
+      mise-correlation-id:
+      - d86d0c04-265b-4093-9299-ff6c561467bf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A17Z&sr=b&sp=r&sig=vPcnU5CAdfzJUiG018Mxj%2FN8bUUCtPm%2BYXeXQNKtNRg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:17.8465971","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A17Z&sr=b&sp=r&sig=qQZyLCZ6jROp5z%2F%2Bp6nVQXCrA2c148lGkHG59wEAvUY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:17.8465125","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A17Z&sr=b&sp=r&sig=ye1GlDH1T6DOX6RX8ZTw6KPbFl3LSkyMIHIS03GSe10%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:17.8466123","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:13:35.504Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:14:29.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:16:17 GMT
+      mise-correlation-id:
+      - bdb6a2a3-aaf5-4d0a-9fe8-071cab9494a6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A23Z&sr=b&sp=r&sig=VNbKlWlDbGF1iwz5pLu1m7I%2BvkgLmbF4Fjk6ydwPqRs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:23.1346956","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A23Z&sr=b&sp=r&sig=4GKGOoY6qnSvAk75NbK4FNMzM9MDPmSXBb5kOaMPkB4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:23.1345984","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A23Z&sr=b&sp=r&sig=ScZ5DhlNrCGoFocHLofbx6rRpd7sFYufii1Fit3zgwQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:23.1347182","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-09T16:13:35.504Z","endDateTime":"2023-10-09T16:16:19.773Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:19.847Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3339'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:16:23 GMT
+      mise-correlation-id:
+      - 7651c445-edfc-444c-a2d7-4563bc6d9b8e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1136,18 +1856,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:56.250488Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:56.250488Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:35.8868534Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:35.8868534Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:59 GMT
+      - Mon, 09 Oct 2023 16:16:24 GMT
       etag:
-      - '"1a0af5da-0000-0100-0000-64af09c20000"'
+      - '"920131b3-0000-0100-0000-652426750000"'
       expires:
       - '-1'
       pragma:
@@ -1177,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=download-test-case&api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=download-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/a25cd97d-f0a2-4d7e-a0f0-ea882066d847?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A00Z&sr=b&sp=r&sig=qcn4h%2BMzRbaroaUn2OKNJt5XfMTR1O%2BFWhZdAEvDaTE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:00.8257721","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A00Z&sr=b&sp=r&sig=3KgmOn%2BR5qHMjjcqEcNo%2FB70vIWhlO0a%2B2BH18EBttw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:00.8257068","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/95514c2f-704d-47c6-8bcc-bbf96e626535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A00Z&sr=b&sp=r&sig=QqRVgMly6w0MtrpFw3dE5TxiFCZURr8aXLGuGoZpj68%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:00.8257859","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-07-12T20:15:57.288Z","endDateTime":"2023-07-12T20:16:53.676Z","executedDateTime":"2023-07-12T20:15:56.518Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-07-12T20:15:57.142Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:58.034Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A25Z&sr=b&sp=r&sig=h5rTRH%2BKqvEOKk4zt%2F6toiF4o5KEOSw30lgraAmv5gE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:25.2948774","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A25Z&sr=b&sp=r&sig=59nJUQC%2FabUx9UnKVbJSEYackNub2loYM6XQx068qgY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:25.2947878","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A25Z&sr=b&sp=r&sig=bKJ7vs97v%2F83zOe1SezAQhE4p9W85c%2BA02CgShJ8tC4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:25.2948944","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-09T16:13:35.504Z","endDateTime":"2023-10-09T16:16:19.773Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:19.847Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3392'
+      - '3359'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:00 GMT
+      - Mon, 09 Oct 2023 16:16:25 GMT
       mise-correlation-id:
-      - ae857a7b-4ae9-4a86-a89a-b8a9c5f89da5
+      - 84475b05-98f3-4761-ac33-020b9a112b4c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1217,18 +1937,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:56.250488Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:56.250488Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:35.8868534Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:35.8868534Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:01 GMT
+      - Mon, 09 Oct 2023 16:16:26 GMT
       etag:
-      - '"1a0af5da-0000-0100-0000-64af09c20000"'
+      - '"920131b3-0000-0100-0000-652426750000"'
       expires:
       - '-1'
       pragma:
@@ -1258,24 +1978,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/a25cd97d-f0a2-4d7e-a0f0-ea882066d847?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A03Z&sr=b&sp=r&sig=R47q2cfjJOnNDUeWxKTqDaskZSRZopbwOd8d%2FduVFvQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:03.1990487","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A03Z&sr=b&sp=r&sig=%2BqafX0hfRCGcCGq4M6%2BmXUuq5QndCpYUoX7pPOzmwZg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:03.1989623","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/95514c2f-704d-47c6-8bcc-bbf96e626535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A03Z&sr=b&sp=r&sig=Pqof4QCMBs5p8GmxwnYgNKP83EZoOUweXtCdDpccVls%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:03.1990697","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-07-12T20:15:57.288Z","endDateTime":"2023-07-12T20:16:53.676Z","executedDateTime":"2023-07-12T20:15:56.518Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-07-12T20:15:57.142Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:58.034Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A27Z&sr=b&sp=r&sig=mcg1YwYsI8vXk3oXHiKl80ZFCJnaNM8otp0RfeEs0r8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:27.679744","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A27Z&sr=b&sp=r&sig=vcFrt51ckonLHNGdGtB1W6ZW5rbNpcpyyHs%2BxqZWWNs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:27.6796597","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A27Z&sr=b&sp=r&sig=P9z%2BINbrF6Nis2FLWG01xIMOG1zholXPUCPalJJsbxI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:27.6797653","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-09T16:13:35.504Z","endDateTime":"2023-10-09T16:16:19.773Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:19.847Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3376'
+      - '3340'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:03 GMT
+      - Mon, 09 Oct 2023 16:16:27 GMT
       mise-correlation-id:
-      - af311e16-547f-41cb-bf75-0ffb216afb89
+      - 7df35f8c-e3d4-4dfd-9c84-1f9922da2acb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1295,14 +2015,14 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/a25cd97d-f0a2-4d7e-a0f0-ea882066d847?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A03Z&sr=b&sp=r&sig=R47q2cfjJOnNDUeWxKTqDaskZSRZopbwOd8d%2FduVFvQ%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A27Z&sr=b&sp=r&sig=mcg1YwYsI8vXk3oXHiKl80ZFCJnaNM8otp0RfeEs0r8%3D
   response:
     body:
-      string: "displayName: CLI-Test\ntestPlan: sample-JMX-file.jmx\ndescription:\
-        \ Test created from az load test command\nengineInstances: 1\ntestId: download-test-case\n\
-        splitAllCSVs: False\nfailureCriteria:\n- avg(requests_per_sec) > 78\n- percentage(error)\
-        \ > 50\n- GetCustomerDetails: avg(latency) > 200\nenv:\n- name: rps\n  value:\
-        \ 1\n- name: duration_in_sec\n  value: 1\n"
+      string: "displayName: CLI-Test\ntestPlan: sample-JMX-file.jmx\ndescription:
+        Test created from az load test command\nengineInstances: 1\ntestId: download-test-case\nsplitAllCSVs:
+        False\nfailureCriteria:\n- avg(requests_per_sec) > 78\n- percentage(error)
+        > 50\n- GetCustomerDetails: avg(latency) > 200\nenv:\n- name: rps\n  value:
+        1\n- name: duration_in_sec\n  value: 1\n"
     headers:
       accept-ranges:
       - bytes
@@ -1313,23 +2033,25 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 12 Jul 2023 20:17:04 GMT
+      - Mon, 09 Oct 2023 16:16:28 GMT
       etag:
-      - '"0x8DB8314CD0B9FEA"'
+      - '"0x8DBC8E2B04555D0"'
       last-modified:
-      - Wed, 12 Jul 2023 20:15:56 GMT
+      - Mon, 09 Oct 2023 16:13:34 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 12 Jul 2023 20:15:56 GMT
+      - Mon, 09 Oct 2023 16:13:34 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-meta-filename:
       - Y29uZmlnLnlhbWw=
+      x-ms-meta-filetype:
+      - ADDITIONAL_ARTIFACTS
       x-ms-meta-isencoded:
       - 'true'
       x-ms-server-encrypted:
@@ -1351,75 +2073,69 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A03Z&sr=b&sp=r&sig=%2BqafX0hfRCGcCGq4M6%2BmXUuq5QndCpYUoX7pPOzmwZg%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A27Z&sr=b&sp=r&sig=vcFrt51ckonLHNGdGtB1W6ZW5rbNpcpyyHs%2BxqZWWNs%3D
   response:
     body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"\
-        1.2\" properties=\"5.0\" jmeter=\"5.5\">\r\n  <hashTree>\r\n    <TestPlan\
-        \ guiclass=\"TestPlanGui\" testclass=\"TestPlan\" testname=\"Azure Load Testing\"\
-        \ enabled=\"true\">\r\n      <stringProp name=\"TestPlan.comments\"></stringProp>\r\
-        \n      <boolProp name=\"TestPlan.functional_mode\">false</boolProp>\r\n \
-        \     <boolProp name=\"TestPlan.tearDown_on_shutdown\">true</boolProp>\r\n\
-        \      <boolProp name=\"TestPlan.serialize_threadgroups\">false</boolProp>\r\
-        \n      <elementProp name=\"TestPlan.user_defined_variables\" elementType=\"\
-        Arguments\" guiclass=\"ArgumentsPanel\" testclass=\"Arguments\" testname=\"\
-        User Defined Variables\" enabled=\"true\">\r\n        <collectionProp name=\"\
-        Arguments.arguments\"/>\r\n      </elementProp>\r\n      <stringProp name=\"\
-        TestPlan.user_define_classpath\"></stringProp>\r\n    </TestPlan>\r\n    <hashTree>\r\
-        \n      <Arguments guiclass=\"ArgumentsPanel\" testclass=\"Arguments\" testname=\"\
-        User Defined Variables\" enabled=\"true\">\r\n        <collectionProp name=\"\
-        Arguments.arguments\">\r\n          <elementProp name=\"duration_in_sec\"\
-        \ elementType=\"Argument\">\r\n            <stringProp name=\"Argument.name\"\
-        >duration_in_sec</stringProp>\r\n            <stringProp name=\"Argument.value\"\
-        >${__groovy( System.getenv(&quot;duration_in_sec&quot;) ?: &quot;10&quot;\
-        \ )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\
-        \n          </elementProp>\r\n          <elementProp name=\"rps\" elementType=\"\
-        Argument\">\r\n            <stringProp name=\"Argument.name\">rps</stringProp>\r\
-        \n            <stringProp name=\"Argument.value\">${__groovy( System.getenv(&quot;rps&quot;)\
-        \ ?: &quot;1&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\"\
-        >=</stringProp>\r\n          </elementProp>\r\n          <elementProp name=\"\
-        domain\" elementType=\"Argument\">\r\n            <stringProp name=\"Argument.name\"\
-        >domain</stringProp>\r\n            <stringProp name=\"Argument.value\">${__groovy(\
-        \ System.getenv(&quot;domain&quot;) ?: &quot;example.com&quot; )}</stringProp>\r\
-        \n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n  \
-        \        </elementProp>\r\n          <elementProp name=\"protocol\" elementType=\"\
-        Argument\">\r\n            <stringProp name=\"Argument.name\">protocol</stringProp>\r\
-        \n            <stringProp name=\"Argument.value\">${__groovy( System.getenv(&quot;protocol&quot;)\
-        \ ?: &quot;https&quot; )}</stringProp>\r\n            <stringProp name=\"\
-        Argument.metadata\">=</stringProp>\r\n          </elementProp>\r\n       \
-        \   <elementProp name=\"url_path\" elementType=\"Argument\">\r\n         \
-        \   <stringProp name=\"Argument.name\">url_path</stringProp>\r\n         \
-        \   <stringProp name=\"Argument.value\">${__groovy( System.getenv(&quot;url_path&quot;)\
-        \ ?: &quot;/&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\"\
-        >=</stringProp>\r\n          </elementProp>\r\n        </collectionProp>\r\
-        \n      </Arguments>\r\n      <hashTree/>\r\n      <OpenModelThreadGroup guiclass=\"\
-        OpenModelThreadGroupGui\" testclass=\"OpenModelThreadGroup\" testname=\"Open\
-        \ Model Thread Group\" enabled=\"true\">\r\n        <elementProp name=\"ThreadGroup.main_controller\"\
-        \ elementType=\"OpenModelThreadGroupController\"/>\r\n        <stringProp\
-        \ name=\"ThreadGroup.on_sample_error\">continue</stringProp>\r\n        <stringProp\
-        \ name=\"OpenModelThreadGroup.schedule\">rate(${rps}/sec) random_arrivals(${duration_in_sec}\
-        \ sec)</stringProp>\r\n        <stringProp name=\"OpenModelThreadGroup.random_seed\"\
-        ></stringProp>\r\n      </OpenModelThreadGroup>\r\n      <hashTree>\r\n  \
-        \      <HTTPSamplerProxy guiclass=\"HttpTestSampleGui\" testclass=\"HTTPSamplerProxy\"\
-        \ testname=\"HTTP Request\" enabled=\"true\">\r\n          <elementProp name=\"\
-        HTTPsampler.Arguments\" elementType=\"Arguments\" guiclass=\"HTTPArgumentsPanel\"\
-        \ testclass=\"Arguments\" testname=\"User Defined Variables\" enabled=\"true\"\
-        >\r\n            <collectionProp name=\"Arguments.arguments\"/>\r\n      \
-        \    </elementProp>\r\n          <stringProp name=\"HTTPSampler.domain\">${domain}</stringProp>\r\
-        \n          <stringProp name=\"HTTPSampler.port\"></stringProp>\r\n      \
-        \    <stringProp name=\"HTTPSampler.protocol\">${protocol}</stringProp>\r\n\
-        \          <stringProp name=\"HTTPSampler.contentEncoding\"></stringProp>\r\
-        \n          <stringProp name=\"HTTPSampler.path\">${url_path}</stringProp>\r\
-        \n          <stringProp name=\"HTTPSampler.method\">GET</stringProp>\r\n \
-        \         <boolProp name=\"HTTPSampler.follow_redirects\">true</boolProp>\r\
-        \n          <boolProp name=\"HTTPSampler.auto_redirects\">false</boolProp>\r\
-        \n          <boolProp name=\"HTTPSampler.use_keepalive\">true</boolProp>\r\
-        \n          <boolProp name=\"HTTPSampler.DO_MULTIPART_POST\">false</boolProp>\r\
-        \n          <stringProp name=\"HTTPSampler.embedded_url_re\"></stringProp>\r\
-        \n          <stringProp name=\"HTTPSampler.connect_timeout\"></stringProp>\r\
-        \n          <stringProp name=\"HTTPSampler.response_timeout\"></stringProp>\r\
-        \n        </HTTPSamplerProxy>\r\n        <hashTree/>\r\n      </hashTree>\r\
-        \n    </hashTree>\r\n  </hashTree>\r\n</jmeterTestPlan>\r\n"
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
+        properties=\"5.0\" jmeter=\"5.5\">\r\n  <hashTree>\r\n    <TestPlan guiclass=\"TestPlanGui\"
+        testclass=\"TestPlan\" testname=\"Azure Load Testing\" enabled=\"true\">\r\n
+        \     <stringProp name=\"TestPlan.comments\"></stringProp>\r\n      <boolProp
+        name=\"TestPlan.functional_mode\">false</boolProp>\r\n      <boolProp name=\"TestPlan.tearDown_on_shutdown\">true</boolProp>\r\n
+        \     <boolProp name=\"TestPlan.serialize_threadgroups\">false</boolProp>\r\n
+        \     <elementProp name=\"TestPlan.user_defined_variables\" elementType=\"Arguments\"
+        guiclass=\"ArgumentsPanel\" testclass=\"Arguments\" testname=\"User Defined
+        Variables\" enabled=\"true\">\r\n        <collectionProp name=\"Arguments.arguments\"/>\r\n
+        \     </elementProp>\r\n      <stringProp name=\"TestPlan.user_define_classpath\"></stringProp>\r\n
+        \   </TestPlan>\r\n    <hashTree>\r\n      <Arguments guiclass=\"ArgumentsPanel\"
+        testclass=\"Arguments\" testname=\"User Defined Variables\" enabled=\"true\">\r\n
+        \       <collectionProp name=\"Arguments.arguments\">\r\n          <elementProp
+        name=\"duration_in_sec\" elementType=\"Argument\">\r\n            <stringProp
+        name=\"Argument.name\">duration_in_sec</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;duration_in_sec&quot;)
+        ?: &quot;10&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n          <elementProp name=\"rps\" elementType=\"Argument\">\r\n
+        \           <stringProp name=\"Argument.name\">rps</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;rps&quot;) ?: &quot;1&quot;
+        )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n          <elementProp name=\"domain\" elementType=\"Argument\">\r\n
+        \           <stringProp name=\"Argument.name\">domain</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;domain&quot;) ?: &quot;example.com&quot;
+        )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n          <elementProp name=\"protocol\" elementType=\"Argument\">\r\n
+        \           <stringProp name=\"Argument.name\">protocol</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;protocol&quot;) ?:
+        &quot;https&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n          <elementProp name=\"url_path\" elementType=\"Argument\">\r\n
+        \           <stringProp name=\"Argument.name\">url_path</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;url_path&quot;) ?:
+        &quot;/&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n        </collectionProp>\r\n      </Arguments>\r\n
+        \     <hashTree/>\r\n      <OpenModelThreadGroup guiclass=\"OpenModelThreadGroupGui\"
+        testclass=\"OpenModelThreadGroup\" testname=\"Open Model Thread Group\" enabled=\"true\">\r\n
+        \       <elementProp name=\"ThreadGroup.main_controller\" elementType=\"OpenModelThreadGroupController\"/>\r\n
+        \       <stringProp name=\"ThreadGroup.on_sample_error\">continue</stringProp>\r\n
+        \       <stringProp name=\"OpenModelThreadGroup.schedule\">rate(${rps}/sec)
+        random_arrivals(${duration_in_sec} sec)</stringProp>\r\n        <stringProp
+        name=\"OpenModelThreadGroup.random_seed\"></stringProp>\r\n      </OpenModelThreadGroup>\r\n
+        \     <hashTree>\r\n        <HTTPSamplerProxy guiclass=\"HttpTestSampleGui\"
+        testclass=\"HTTPSamplerProxy\" testname=\"HTTP Request\" enabled=\"true\">\r\n
+        \         <elementProp name=\"HTTPsampler.Arguments\" elementType=\"Arguments\"
+        guiclass=\"HTTPArgumentsPanel\" testclass=\"Arguments\" testname=\"User Defined
+        Variables\" enabled=\"true\">\r\n            <collectionProp name=\"Arguments.arguments\"/>\r\n
+        \         </elementProp>\r\n          <stringProp name=\"HTTPSampler.domain\">${domain}</stringProp>\r\n
+        \         <stringProp name=\"HTTPSampler.port\"></stringProp>\r\n          <stringProp
+        name=\"HTTPSampler.protocol\">${protocol}</stringProp>\r\n          <stringProp
+        name=\"HTTPSampler.contentEncoding\"></stringProp>\r\n          <stringProp
+        name=\"HTTPSampler.path\">${url_path}</stringProp>\r\n          <stringProp
+        name=\"HTTPSampler.method\">GET</stringProp>\r\n          <boolProp name=\"HTTPSampler.follow_redirects\">true</boolProp>\r\n
+        \         <boolProp name=\"HTTPSampler.auto_redirects\">false</boolProp>\r\n
+        \         <boolProp name=\"HTTPSampler.use_keepalive\">true</boolProp>\r\n
+        \         <boolProp name=\"HTTPSampler.DO_MULTIPART_POST\">false</boolProp>\r\n
+        \         <stringProp name=\"HTTPSampler.embedded_url_re\"></stringProp>\r\n
+        \         <stringProp name=\"HTTPSampler.connect_timeout\"></stringProp>\r\n
+        \         <stringProp name=\"HTTPSampler.response_timeout\"></stringProp>\r\n
+        \       </HTTPSamplerProxy>\r\n        <hashTree/>\r\n      </hashTree>\r\n
+        \   </hashTree>\r\n  </hashTree>\r\n</jmeterTestPlan>\r\n"
     headers:
       accept-ranges:
       - bytes
@@ -1430,23 +2146,25 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 12 Jul 2023 20:17:05 GMT
+      - Mon, 09 Oct 2023 16:16:28 GMT
       etag:
-      - '"0x8DB8314BF766C5B"'
+      - '"0x8DBC8E2A360FE86"'
       last-modified:
-      - Wed, 12 Jul 2023 20:15:33 GMT
+      - Mon, 09 Oct 2023 16:13:13 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 12 Jul 2023 20:15:33 GMT
+      - Mon, 09 Oct 2023 16:13:13 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-meta-filename:
       - c2FtcGxlLUpNWC1maWxlLmpteA==
+      x-ms-meta-filetype:
+      - JMX_FILE
       x-ms-meta-isencoded:
       - 'true'
       x-ms-server-encrypted:
@@ -1468,18 +2186,18 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/95514c2f-704d-47c6-8bcc-bbf96e626535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A03Z&sr=b&sp=r&sig=Pqof4QCMBs5p8GmxwnYgNKP83EZoOUweXtCdDpccVls%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A27Z&sr=b&sp=r&sig=P9z%2BINbrF6Nis2FLWG01xIMOG1zholXPUCPalJJsbxI%3D
   response:
     body:
       string: !!binary |
-        UEsDBC0AAAAIAPyh7FYUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
+        UEsDBC0AAAAIALGBSVcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
         AAAAAAFZAab+ZGlzcGxheU5hbWU6IENMSS1UZXN0CnRlc3RQbGFuOiBzYW1wbGUtSk1YLWZpbGUu
         am14CmRlc2NyaXB0aW9uOiBUZXN0IGNyZWF0ZWQgZnJvbSBheiBsb2FkIHRlc3QgY29tbWFuZApl
         bmdpbmVJbnN0YW5jZXM6IDEKdGVzdElkOiBkb3dubG9hZC10ZXN0LWNhc2UKc3BsaXRBbGxDU1Zz
         OiBGYWxzZQpmYWlsdXJlQ3JpdGVyaWE6Ci0gYXZnKHJlcXVlc3RzX3Blcl9zZWMpID4gNzgKLSBw
         ZXJjZW50YWdlKGVycm9yKSA+IDUwCi0gR2V0Q3VzdG9tZXJEZXRhaWxzOiBhdmcobGF0ZW5jeSkg
         PiAyMDAKZW52OgotIG5hbWU6IHJwcwogIHZhbHVlOiAxCi0gbmFtZTogZHVyYXRpb25faW5fc2Vj
-        CiAgdmFsdWU6IDEKUEsDBC0AAAAIAPyh7Fbxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
+        CiAgdmFsdWU6IDEKUEsDBC0AAAAIALGBSVfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
         LmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAAQYT+ew8P3htbCB2ZXJzaW9uPSIxLjAiIGVuY29kaW5n
         PSJVVEYtOCI/Pg0KPGptZXRlclRlc3RQbGFuIHZlcnNpb249IjEuMiIgcHJvcGVydGllcz0iNS4w
         IiBqbWV0ZXI9IjUuNSI+DQogIDxoYXNoVHJlZT4NCiAgICA8VGVzdFBsYW4gZ3VpY2xhc3M9IlRl
@@ -1566,8 +2284,8 @@ interactions:
         ZT0iSFRUUFNhbXBsZXIucmVzcG9uc2VfdGltZW91dCI+PC9zdHJpbmdQcm9wPg0KICAgICAgICA8
         L0hUVFBTYW1wbGVyUHJveHk+DQogICAgICAgIDxoYXNoVHJlZS8+DQogICAgICA8L2hhc2hUcmVl
         Pg0KICAgIDwvaGFzaFRyZWU+DQogIDwvaGFzaFRyZWU+DQo8L2ptZXRlclRlc3RQbGFuPg0KUEsB
-        AjMALQAAAAgA/KHsVhQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
-        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACAD8oexW8Zv7b///////////EwAUAAAAAAAAAAAA
+        AjMALQAAAAgAsYFJVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
+        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACACxgUlX8Zv7b///////////EwAUAAAAAAAAAAAA
         AACbAQAAc2FtcGxlLUpNWC1maWxlLmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAUEsFBgAAAAACAAIA
         ogAAAOsUAAAAAA==
     headers:
@@ -1576,27 +2294,29 @@ interactions:
       content-length:
       - '5539'
       content-md5:
-      - ftfe7zjelI1uysqYbQMaaw==
+      - 2pplCcA4STo7VjXO6zs8qA==
       content-type:
       - application/octet-stream
       date:
-      - Wed, 12 Jul 2023 20:17:06 GMT
+      - Mon, 09 Oct 2023 16:16:30 GMT
       etag:
-      - '"0x8DB8314CD15F490"'
+      - '"0x8DBC8E2B04E7C2D"'
       last-modified:
-      - Wed, 12 Jul 2023 20:15:56 GMT
+      - Mon, 09 Oct 2023 16:13:34 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 12 Jul 2023 20:15:56 GMT
+      - Mon, 09 Oct 2023 16:13:34 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-meta-filename:
       - aW5wdXRhcnRpZmFjdHMuemlw
+      x-ms-meta-filetype:
+      - ADDITIONAL_ARTIFACTS
       x-ms-meta-isencoded:
       - 'true'
       x-ms-server-encrypted:
@@ -1621,18 +2341,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:56.250488Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:56.250488Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:12:35.8868534Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:12:35.8868534Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:10 GMT
+      - Mon, 09 Oct 2023 16:16:31 GMT
       etag:
-      - '"1a0af5da-0000-0100-0000-64af09c20000"'
+      - '"920131b3-0000-0100-0000-652426750000"'
       expires:
       - '-1'
       pragma:
@@ -1662,24 +2382,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://78b2c95d-9b47-4006-b9a4-b8259d1c48d4.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://08bf86a4-18d8-475f-97cf-7f5ae48acdb3.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"fa0cb900-b9d3-470f-8208-89d8f2868f3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"5b3c52f3-5d5e-4c19-9db2-54387156e6f0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a7594e54-9e42-4a61-8886-2be0f30b1594":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/a25cd97d-f0a2-4d7e-a0f0-ea882066d847?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A13Z&sr=b&sp=r&sig=NY6tx%2BkBXjM2poCxnkS6xHs8Nol%2FkNW5I0aQs1vJvRk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:13.3873571","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A13Z&sr=b&sp=r&sig=qIZNt0IDzUDejmbBxxi7AfHhWjyoq8PnzNr%2B4uRXWGY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:13.3872918","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/95514c2f-704d-47c6-8bcc-bbf96e626535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A13Z&sr=b&sp=r&sig=dYE0oOgOSGqvA2CKTdgxNqd16OGfzLGPcHAjB9802Ds%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:13.3873715","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/f00b874e-28d4-4e21-a5f0-1192151c72d0_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A13Z&sr=b&sp=r&sig=sS7h1DRqZ5AZ1QuXXS9A8m2vo2%2Birj7cxXnSpSYcD%2Fk%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:13.3873841","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/f00b874e-28d4-4e21-a5f0-1192151c72d0_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A13Z&sr=b&sp=r&sig=VMCSZc0CictJnwkUpmRZ6BXDhjtS2CfEvPYcdaiP7D0%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:13.3873976","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-07-12T20:15:57.288Z","endDateTime":"2023-07-12T20:16:53.676Z","executedDateTime":"2023-07-12T20:15:56.518Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-07-12T20:15:57.142Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:17:04.878Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d449c773-04d1-4d1c-bc15-21f5cd7db421":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bba2108c-0525-456d-a02b-d147b2abec99":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ff8146e9-6274-498e-be31-c18794d8a4f4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A32Z&sr=b&sp=r&sig=qRX9At7Ul%2BqUDw5njQNm6jz6IlKD1glrC%2FKVOoOFkDU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:32.9354302","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A32Z&sr=b&sp=r&sig=dvPnJUV2S95FMpbWIpCVokuriAYl8YnN2m4PCGgh%2FYk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:32.9353571","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A32Z&sr=b&sp=r&sig=Pd2dEk4v181u6AM1bZ%2FZhBQPObbo3Fb%2FMcN9Nx6ppDg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:32.9354468","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-09T16:13:35.504Z","endDateTime":"2023-10-09T16:16:19.773Z","executedDateTime":"2023-10-09T16:13:34.786Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-09T16:13:35.056Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:19.847Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4539'
+      - '3347'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:13 GMT
+      - Mon, 09 Oct 2023 16:16:32 GMT
       mise-correlation-id:
-      - 4f60d89c-a060-4d58-9d80-b975e8f29095
+      - ecad8337-db93-4bfe-a443-e458341ad080
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1699,14 +2419,14 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/a25cd97d-f0a2-4d7e-a0f0-ea882066d847?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A13Z&sr=b&sp=r&sig=NY6tx%2BkBXjM2poCxnkS6xHs8Nol%2FkNW5I0aQs1vJvRk%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/dd99c7c7-2fcd-4917-be22-423a2092c01a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A32Z&sr=b&sp=r&sig=qRX9At7Ul%2BqUDw5njQNm6jz6IlKD1glrC%2FKVOoOFkDU%3D
   response:
     body:
-      string: "displayName: CLI-Test\ntestPlan: sample-JMX-file.jmx\ndescription:\
-        \ Test created from az load test command\nengineInstances: 1\ntestId: download-test-case\n\
-        splitAllCSVs: False\nfailureCriteria:\n- avg(requests_per_sec) > 78\n- percentage(error)\
-        \ > 50\n- GetCustomerDetails: avg(latency) > 200\nenv:\n- name: rps\n  value:\
-        \ 1\n- name: duration_in_sec\n  value: 1\n"
+      string: "displayName: CLI-Test\ntestPlan: sample-JMX-file.jmx\ndescription:
+        Test created from az load test command\nengineInstances: 1\ntestId: download-test-case\nsplitAllCSVs:
+        False\nfailureCriteria:\n- avg(requests_per_sec) > 78\n- percentage(error)
+        > 50\n- GetCustomerDetails: avg(latency) > 200\nenv:\n- name: rps\n  value:
+        1\n- name: duration_in_sec\n  value: 1\n"
     headers:
       accept-ranges:
       - bytes
@@ -1717,23 +2437,25 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 12 Jul 2023 20:17:13 GMT
+      - Mon, 09 Oct 2023 16:16:33 GMT
       etag:
-      - '"0x8DB8314CD0B9FEA"'
+      - '"0x8DBC8E2B04555D0"'
       last-modified:
-      - Wed, 12 Jul 2023 20:15:56 GMT
+      - Mon, 09 Oct 2023 16:13:34 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 12 Jul 2023 20:15:56 GMT
+      - Mon, 09 Oct 2023 16:13:34 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-meta-filename:
       - Y29uZmlnLnlhbWw=
+      x-ms-meta-filetype:
+      - ADDITIONAL_ARTIFACTS
       x-ms-meta-isencoded:
       - 'true'
       x-ms-server-encrypted:
@@ -1755,75 +2477,69 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/bc56fb3e-b08e-4757-b2d0-49ac2c7d7fdb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A13Z&sr=b&sp=r&sig=qIZNt0IDzUDejmbBxxi7AfHhWjyoq8PnzNr%2B4uRXWGY%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f191912a-462b-45a8-965e-452915ce37d7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A32Z&sr=b&sp=r&sig=dvPnJUV2S95FMpbWIpCVokuriAYl8YnN2m4PCGgh%2FYk%3D
   response:
     body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"\
-        1.2\" properties=\"5.0\" jmeter=\"5.5\">\r\n  <hashTree>\r\n    <TestPlan\
-        \ guiclass=\"TestPlanGui\" testclass=\"TestPlan\" testname=\"Azure Load Testing\"\
-        \ enabled=\"true\">\r\n      <stringProp name=\"TestPlan.comments\"></stringProp>\r\
-        \n      <boolProp name=\"TestPlan.functional_mode\">false</boolProp>\r\n \
-        \     <boolProp name=\"TestPlan.tearDown_on_shutdown\">true</boolProp>\r\n\
-        \      <boolProp name=\"TestPlan.serialize_threadgroups\">false</boolProp>\r\
-        \n      <elementProp name=\"TestPlan.user_defined_variables\" elementType=\"\
-        Arguments\" guiclass=\"ArgumentsPanel\" testclass=\"Arguments\" testname=\"\
-        User Defined Variables\" enabled=\"true\">\r\n        <collectionProp name=\"\
-        Arguments.arguments\"/>\r\n      </elementProp>\r\n      <stringProp name=\"\
-        TestPlan.user_define_classpath\"></stringProp>\r\n    </TestPlan>\r\n    <hashTree>\r\
-        \n      <Arguments guiclass=\"ArgumentsPanel\" testclass=\"Arguments\" testname=\"\
-        User Defined Variables\" enabled=\"true\">\r\n        <collectionProp name=\"\
-        Arguments.arguments\">\r\n          <elementProp name=\"duration_in_sec\"\
-        \ elementType=\"Argument\">\r\n            <stringProp name=\"Argument.name\"\
-        >duration_in_sec</stringProp>\r\n            <stringProp name=\"Argument.value\"\
-        >${__groovy( System.getenv(&quot;duration_in_sec&quot;) ?: &quot;10&quot;\
-        \ )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\
-        \n          </elementProp>\r\n          <elementProp name=\"rps\" elementType=\"\
-        Argument\">\r\n            <stringProp name=\"Argument.name\">rps</stringProp>\r\
-        \n            <stringProp name=\"Argument.value\">${__groovy( System.getenv(&quot;rps&quot;)\
-        \ ?: &quot;1&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\"\
-        >=</stringProp>\r\n          </elementProp>\r\n          <elementProp name=\"\
-        domain\" elementType=\"Argument\">\r\n            <stringProp name=\"Argument.name\"\
-        >domain</stringProp>\r\n            <stringProp name=\"Argument.value\">${__groovy(\
-        \ System.getenv(&quot;domain&quot;) ?: &quot;example.com&quot; )}</stringProp>\r\
-        \n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n  \
-        \        </elementProp>\r\n          <elementProp name=\"protocol\" elementType=\"\
-        Argument\">\r\n            <stringProp name=\"Argument.name\">protocol</stringProp>\r\
-        \n            <stringProp name=\"Argument.value\">${__groovy( System.getenv(&quot;protocol&quot;)\
-        \ ?: &quot;https&quot; )}</stringProp>\r\n            <stringProp name=\"\
-        Argument.metadata\">=</stringProp>\r\n          </elementProp>\r\n       \
-        \   <elementProp name=\"url_path\" elementType=\"Argument\">\r\n         \
-        \   <stringProp name=\"Argument.name\">url_path</stringProp>\r\n         \
-        \   <stringProp name=\"Argument.value\">${__groovy( System.getenv(&quot;url_path&quot;)\
-        \ ?: &quot;/&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\"\
-        >=</stringProp>\r\n          </elementProp>\r\n        </collectionProp>\r\
-        \n      </Arguments>\r\n      <hashTree/>\r\n      <OpenModelThreadGroup guiclass=\"\
-        OpenModelThreadGroupGui\" testclass=\"OpenModelThreadGroup\" testname=\"Open\
-        \ Model Thread Group\" enabled=\"true\">\r\n        <elementProp name=\"ThreadGroup.main_controller\"\
-        \ elementType=\"OpenModelThreadGroupController\"/>\r\n        <stringProp\
-        \ name=\"ThreadGroup.on_sample_error\">continue</stringProp>\r\n        <stringProp\
-        \ name=\"OpenModelThreadGroup.schedule\">rate(${rps}/sec) random_arrivals(${duration_in_sec}\
-        \ sec)</stringProp>\r\n        <stringProp name=\"OpenModelThreadGroup.random_seed\"\
-        ></stringProp>\r\n      </OpenModelThreadGroup>\r\n      <hashTree>\r\n  \
-        \      <HTTPSamplerProxy guiclass=\"HttpTestSampleGui\" testclass=\"HTTPSamplerProxy\"\
-        \ testname=\"HTTP Request\" enabled=\"true\">\r\n          <elementProp name=\"\
-        HTTPsampler.Arguments\" elementType=\"Arguments\" guiclass=\"HTTPArgumentsPanel\"\
-        \ testclass=\"Arguments\" testname=\"User Defined Variables\" enabled=\"true\"\
-        >\r\n            <collectionProp name=\"Arguments.arguments\"/>\r\n      \
-        \    </elementProp>\r\n          <stringProp name=\"HTTPSampler.domain\">${domain}</stringProp>\r\
-        \n          <stringProp name=\"HTTPSampler.port\"></stringProp>\r\n      \
-        \    <stringProp name=\"HTTPSampler.protocol\">${protocol}</stringProp>\r\n\
-        \          <stringProp name=\"HTTPSampler.contentEncoding\"></stringProp>\r\
-        \n          <stringProp name=\"HTTPSampler.path\">${url_path}</stringProp>\r\
-        \n          <stringProp name=\"HTTPSampler.method\">GET</stringProp>\r\n \
-        \         <boolProp name=\"HTTPSampler.follow_redirects\">true</boolProp>\r\
-        \n          <boolProp name=\"HTTPSampler.auto_redirects\">false</boolProp>\r\
-        \n          <boolProp name=\"HTTPSampler.use_keepalive\">true</boolProp>\r\
-        \n          <boolProp name=\"HTTPSampler.DO_MULTIPART_POST\">false</boolProp>\r\
-        \n          <stringProp name=\"HTTPSampler.embedded_url_re\"></stringProp>\r\
-        \n          <stringProp name=\"HTTPSampler.connect_timeout\"></stringProp>\r\
-        \n          <stringProp name=\"HTTPSampler.response_timeout\"></stringProp>\r\
-        \n        </HTTPSamplerProxy>\r\n        <hashTree/>\r\n      </hashTree>\r\
-        \n    </hashTree>\r\n  </hashTree>\r\n</jmeterTestPlan>\r\n"
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
+        properties=\"5.0\" jmeter=\"5.5\">\r\n  <hashTree>\r\n    <TestPlan guiclass=\"TestPlanGui\"
+        testclass=\"TestPlan\" testname=\"Azure Load Testing\" enabled=\"true\">\r\n
+        \     <stringProp name=\"TestPlan.comments\"></stringProp>\r\n      <boolProp
+        name=\"TestPlan.functional_mode\">false</boolProp>\r\n      <boolProp name=\"TestPlan.tearDown_on_shutdown\">true</boolProp>\r\n
+        \     <boolProp name=\"TestPlan.serialize_threadgroups\">false</boolProp>\r\n
+        \     <elementProp name=\"TestPlan.user_defined_variables\" elementType=\"Arguments\"
+        guiclass=\"ArgumentsPanel\" testclass=\"Arguments\" testname=\"User Defined
+        Variables\" enabled=\"true\">\r\n        <collectionProp name=\"Arguments.arguments\"/>\r\n
+        \     </elementProp>\r\n      <stringProp name=\"TestPlan.user_define_classpath\"></stringProp>\r\n
+        \   </TestPlan>\r\n    <hashTree>\r\n      <Arguments guiclass=\"ArgumentsPanel\"
+        testclass=\"Arguments\" testname=\"User Defined Variables\" enabled=\"true\">\r\n
+        \       <collectionProp name=\"Arguments.arguments\">\r\n          <elementProp
+        name=\"duration_in_sec\" elementType=\"Argument\">\r\n            <stringProp
+        name=\"Argument.name\">duration_in_sec</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;duration_in_sec&quot;)
+        ?: &quot;10&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n          <elementProp name=\"rps\" elementType=\"Argument\">\r\n
+        \           <stringProp name=\"Argument.name\">rps</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;rps&quot;) ?: &quot;1&quot;
+        )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n          <elementProp name=\"domain\" elementType=\"Argument\">\r\n
+        \           <stringProp name=\"Argument.name\">domain</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;domain&quot;) ?: &quot;example.com&quot;
+        )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n          <elementProp name=\"protocol\" elementType=\"Argument\">\r\n
+        \           <stringProp name=\"Argument.name\">protocol</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;protocol&quot;) ?:
+        &quot;https&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n          <elementProp name=\"url_path\" elementType=\"Argument\">\r\n
+        \           <stringProp name=\"Argument.name\">url_path</stringProp>\r\n            <stringProp
+        name=\"Argument.value\">${__groovy( System.getenv(&quot;url_path&quot;) ?:
+        &quot;/&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
+        \         </elementProp>\r\n        </collectionProp>\r\n      </Arguments>\r\n
+        \     <hashTree/>\r\n      <OpenModelThreadGroup guiclass=\"OpenModelThreadGroupGui\"
+        testclass=\"OpenModelThreadGroup\" testname=\"Open Model Thread Group\" enabled=\"true\">\r\n
+        \       <elementProp name=\"ThreadGroup.main_controller\" elementType=\"OpenModelThreadGroupController\"/>\r\n
+        \       <stringProp name=\"ThreadGroup.on_sample_error\">continue</stringProp>\r\n
+        \       <stringProp name=\"OpenModelThreadGroup.schedule\">rate(${rps}/sec)
+        random_arrivals(${duration_in_sec} sec)</stringProp>\r\n        <stringProp
+        name=\"OpenModelThreadGroup.random_seed\"></stringProp>\r\n      </OpenModelThreadGroup>\r\n
+        \     <hashTree>\r\n        <HTTPSamplerProxy guiclass=\"HttpTestSampleGui\"
+        testclass=\"HTTPSamplerProxy\" testname=\"HTTP Request\" enabled=\"true\">\r\n
+        \         <elementProp name=\"HTTPsampler.Arguments\" elementType=\"Arguments\"
+        guiclass=\"HTTPArgumentsPanel\" testclass=\"Arguments\" testname=\"User Defined
+        Variables\" enabled=\"true\">\r\n            <collectionProp name=\"Arguments.arguments\"/>\r\n
+        \         </elementProp>\r\n          <stringProp name=\"HTTPSampler.domain\">${domain}</stringProp>\r\n
+        \         <stringProp name=\"HTTPSampler.port\"></stringProp>\r\n          <stringProp
+        name=\"HTTPSampler.protocol\">${protocol}</stringProp>\r\n          <stringProp
+        name=\"HTTPSampler.contentEncoding\"></stringProp>\r\n          <stringProp
+        name=\"HTTPSampler.path\">${url_path}</stringProp>\r\n          <stringProp
+        name=\"HTTPSampler.method\">GET</stringProp>\r\n          <boolProp name=\"HTTPSampler.follow_redirects\">true</boolProp>\r\n
+        \         <boolProp name=\"HTTPSampler.auto_redirects\">false</boolProp>\r\n
+        \         <boolProp name=\"HTTPSampler.use_keepalive\">true</boolProp>\r\n
+        \         <boolProp name=\"HTTPSampler.DO_MULTIPART_POST\">false</boolProp>\r\n
+        \         <stringProp name=\"HTTPSampler.embedded_url_re\"></stringProp>\r\n
+        \         <stringProp name=\"HTTPSampler.connect_timeout\"></stringProp>\r\n
+        \         <stringProp name=\"HTTPSampler.response_timeout\"></stringProp>\r\n
+        \       </HTTPSamplerProxy>\r\n        <hashTree/>\r\n      </hashTree>\r\n
+        \   </hashTree>\r\n  </hashTree>\r\n</jmeterTestPlan>\r\n"
     headers:
       accept-ranges:
       - bytes
@@ -1834,23 +2550,25 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 12 Jul 2023 20:17:14 GMT
+      - Mon, 09 Oct 2023 16:16:34 GMT
       etag:
-      - '"0x8DB8314BF766C5B"'
+      - '"0x8DBC8E2A360FE86"'
       last-modified:
-      - Wed, 12 Jul 2023 20:15:33 GMT
+      - Mon, 09 Oct 2023 16:13:13 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 12 Jul 2023 20:15:33 GMT
+      - Mon, 09 Oct 2023 16:13:13 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-meta-filename:
       - c2FtcGxlLUpNWC1maWxlLmpteA==
+      x-ms-meta-filetype:
+      - JMX_FILE
       x-ms-meta-isencoded:
       - 'true'
       x-ms-server-encrypted:
@@ -1872,18 +2590,18 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/95514c2f-704d-47c6-8bcc-bbf96e626535?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A13Z&sr=b&sp=r&sig=dYE0oOgOSGqvA2CKTdgxNqd16OGfzLGPcHAjB9802Ds%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/2c4e3eda-2267-452e-bd91-bf46e623d3d8/f814a685-15a1-4302-b9f8-c57493f23d25?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A32Z&sr=b&sp=r&sig=Pd2dEk4v181u6AM1bZ%2FZhBQPObbo3Fb%2FMcN9Nx6ppDg%3D
   response:
     body:
       string: !!binary |
-        UEsDBC0AAAAIAPyh7FYUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
+        UEsDBC0AAAAIALGBSVcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
         AAAAAAFZAab+ZGlzcGxheU5hbWU6IENMSS1UZXN0CnRlc3RQbGFuOiBzYW1wbGUtSk1YLWZpbGUu
         am14CmRlc2NyaXB0aW9uOiBUZXN0IGNyZWF0ZWQgZnJvbSBheiBsb2FkIHRlc3QgY29tbWFuZApl
         bmdpbmVJbnN0YW5jZXM6IDEKdGVzdElkOiBkb3dubG9hZC10ZXN0LWNhc2UKc3BsaXRBbGxDU1Zz
         OiBGYWxzZQpmYWlsdXJlQ3JpdGVyaWE6Ci0gYXZnKHJlcXVlc3RzX3Blcl9zZWMpID4gNzgKLSBw
         ZXJjZW50YWdlKGVycm9yKSA+IDUwCi0gR2V0Q3VzdG9tZXJEZXRhaWxzOiBhdmcobGF0ZW5jeSkg
         PiAyMDAKZW52OgotIG5hbWU6IHJwcwogIHZhbHVlOiAxCi0gbmFtZTogZHVyYXRpb25faW5fc2Vj
-        CiAgdmFsdWU6IDEKUEsDBC0AAAAIAPyh7Fbxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
+        CiAgdmFsdWU6IDEKUEsDBC0AAAAIALGBSVfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
         LmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAAQYT+ew8P3htbCB2ZXJzaW9uPSIxLjAiIGVuY29kaW5n
         PSJVVEYtOCI/Pg0KPGptZXRlclRlc3RQbGFuIHZlcnNpb249IjEuMiIgcHJvcGVydGllcz0iNS4w
         IiBqbWV0ZXI9IjUuNSI+DQogIDxoYXNoVHJlZT4NCiAgICA8VGVzdFBsYW4gZ3VpY2xhc3M9IlRl
@@ -1970,8 +2688,8 @@ interactions:
         ZT0iSFRUUFNhbXBsZXIucmVzcG9uc2VfdGltZW91dCI+PC9zdHJpbmdQcm9wPg0KICAgICAgICA8
         L0hUVFBTYW1wbGVyUHJveHk+DQogICAgICAgIDxoYXNoVHJlZS8+DQogICAgICA8L2hhc2hUcmVl
         Pg0KICAgIDwvaGFzaFRyZWU+DQogIDwvaGFzaFRyZWU+DQo8L2ptZXRlclRlc3RQbGFuPg0KUEsB
-        AjMALQAAAAgA/KHsVhQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
-        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACAD8oexW8Zv7b///////////EwAUAAAAAAAAAAAA
+        AjMALQAAAAgAsYFJVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
+        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACACxgUlX8Zv7b///////////EwAUAAAAAAAAAAAA
         AACbAQAAc2FtcGxlLUpNWC1maWxlLmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAUEsFBgAAAAACAAIA
         ogAAAOsUAAAAAA==
     headers:
@@ -1980,139 +2698,31 @@ interactions:
       content-length:
       - '5539'
       content-md5:
-      - ftfe7zjelI1uysqYbQMaaw==
+      - 2pplCcA4STo7VjXO6zs8qA==
       content-type:
       - application/octet-stream
       date:
-      - Wed, 12 Jul 2023 20:17:16 GMT
+      - Mon, 09 Oct 2023 16:16:35 GMT
       etag:
-      - '"0x8DB8314CD15F490"'
+      - '"0x8DBC8E2B04E7C2D"'
       last-modified:
-      - Wed, 12 Jul 2023 20:15:56 GMT
+      - Mon, 09 Oct 2023 16:13:34 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 12 Jul 2023 20:15:56 GMT
+      - Mon, 09 Oct 2023 16:13:34 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-meta-filename:
       - aW5wdXRhcnRpZmFjdHMuemlw
+      x-ms-meta-filetype:
+      - ADDITIONAL_ARTIFACTS
       x-ms-meta-isencoded:
       - 'true'
-      x-ms-server-encrypted:
-      - 'true'
-      x-ms-version:
-      - '2021-10-04'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/f00b874e-28d4-4e21-a5f0-1192151c72d0_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A13Z&sr=b&sp=r&sig=VMCSZc0CictJnwkUpmRZ6BXDhjtS2CfEvPYcdaiP7D0%3D
-  response:
-    body:
-      string: !!binary |
-        UEsDBBQAAAAIAB2i7FZXJWMl7QAAABgCAAASABwAZW5naW5lMV93b3JrZXIubG9nVVQJAAM6Cq9k
-        OgqvZHV4CwABBAAAAAAEAAAAAJ3RwYrCMBAG4LtPMQ/QljTWqL0VjLBSu9CG9VzqWFO6jaRjff1N
-        V8HDVpC9hDDwfwn/cMbnPlv6IQfO4lDEUeRFoYBDkmdggjJogt0eCW0MqalTHLCN4SPbfs74n+TC
-        E4Ldk5VLVi7buHOfpCrVPWE3KkoWCgqV5EpuQH7JTIEPFivUAx4n0dXiBbrVLR6sdp978vlDAjlg
-        R0DYU0GlpRf2mofTdnIl05O5POVxCuVj/AtDf5fhpukMaK2xYEtCWDM4ubtgfTDxqvDYav5WTTLb
-        vFeS8MLlf8jrpTXlUXc1NN/jkoPW1HBytc5+AFBLAQIeAxQAAAAIAB2i7FZXJWMl7QAAABgCAAAS
-        ABgAAAAAAAEAAACkgQAAAABlbmdpbmUxX3dvcmtlci5sb2dVVAUAAzoKr2R1eAsAAQQAAAAABAAA
-        AABQSwUGAAAAAAEAAQBYAAAAOQEAAAAA
-    headers:
-      accept-ranges:
-      - bytes
-      content-length:
-      - '423'
-      content-md5:
-      - KWZC1TFfuPBN+AZEA0uM2Q==
-      content-type:
-      - application/octet-stream
-      date:
-      - Wed, 12 Jul 2023 20:17:19 GMT
-      etag:
-      - '"0x8DB8314F22AF7FB"'
-      last-modified:
-      - Wed, 12 Jul 2023 20:16:58 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-blob-type:
-      - BlockBlob
-      x-ms-creation-time:
-      - Wed, 12 Jul 2023 20:16:58 GMT
-      x-ms-lease-state:
-      - available
-      x-ms-lease-status:
-      - unlocked
-      x-ms-server-encrypted:
-      - 'true'
-      x-ms-version:
-      - '2021-10-04'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/dee0dbe8-8d7c-4778-9dd6-6e241c682e8e/f00b874e-28d4-4e21-a5f0-1192151c72d0_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A13Z&sr=b&sp=r&sig=sS7h1DRqZ5AZ1QuXXS9A8m2vo2%2Birj7cxXnSpSYcD%2Fk%3D
-  response:
-    body:
-      string: !!binary |
-        UEsDBBQAAAAIAB2i7FY8lqSAdQAAAKMAAAATABwAZW5naW5lMV9yZXN1bHRzLmNzdlVUCQADOgqv
-        ZDoKr2R1eAsAAQQAAAAABAAAAAA9jjsOwkAQQ3vO4lOQCilQwHKAya4JkWY/2pkUuT1RJNI9y8+S
-        fcl8ueQGqjRjgspERae1WoxDTTzDnWYyE/7tlPSQTCRxCVsjbI1xr/GRRdd+qtPmNBiLXw+aewvH
-        2iCqf3w/R4ziLHHDLSnD/gpDLYXRLz9QSwECHgMUAAAACAAdouxWPJakgHUAAACjAAAAEwAYAAAA
-        AAABAAAApIEAAAAAZW5naW5lMV9yZXN1bHRzLmNzdlVUBQADOgqvZHV4CwABBAAAAAAEAAAAAFBL
-        BQYAAAAAAQABAFkAAADCAAAAAAA=
-    headers:
-      accept-ranges:
-      - bytes
-      content-length:
-      - '305'
-      content-md5:
-      - 6rk0C7n9GV3L4q8hz5o58w==
-      content-type:
-      - application/octet-stream
-      date:
-      - Wed, 12 Jul 2023 20:17:20 GMT
-      etag:
-      - '"0x8DB8314F221B392"'
-      last-modified:
-      - Wed, 12 Jul 2023 20:16:58 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-blob-type:
-      - BlockBlob
-      x-ms-creation-time:
-      - Wed, 12 Jul 2023 20:16:58 GMT
-      x-ms-lease-state:
-      - available
-      x-ms-lease-status:
-      - unlocked
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_download_files.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_download_files.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:56.8808228Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:56.8808228Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:59.6197453Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:59.6197453Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:29 GMT
+      - Sun, 29 Oct 2023 22:22:34 GMT
       etag:
-      - '"d300dd3d-0000-0100-0000-6537b88a0000"'
+      - '"3c00f229-0000-0100-0000-653edb0a0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:29:31 GMT
+      - Sun, 29 Oct 2023 22:22:35 GMT
       mise-correlation-id:
-      - 46f20e1b-90b1-4c54-9f31-f3372b7d0144
+      - 1861d41f-d150-4b6b-b46e-e460acd32c06
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "9cde26e4-7d07-418a-9e51-249b880ea1d2":
+      {"passFailMetrics": {"b67ab143-afca-44bc-8ce9-7f41fe096879": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "244b313f-8b61-46a1-9311-e0205d00f16c":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "76c59287-ff07-4c68-b1c0-13f5de9950b6": {"aggregate": "avg", "clientMetric":
+      "50"}, "229243ef-e4e3-4ff0-8822-c9755465e287": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,26 +106,26 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:29:31.528Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:31.528Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:22:36.46Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:36.46Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1010'
+      - '1008'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:31 GMT
+      - Sun, 29 Oct 2023 22:22:36 GMT
       location:
-      - https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+      - https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 7baaa190-0230-4e72-94ed-e11175d319a8
+      - b4e8bebe-7620-4f63-ad1e-50159e8618bb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:31 GMT
+      - Sun, 29 Oct 2023 22:22:36 GMT
       mise-correlation-id:
-      - fa38b17d-86fa-4fef-b5ac-5276a79a9f17
+      - 06e069e7-dd45-4c9c-8cf1-be19a70d508f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A33Z&sr=b&sp=r&sig=tPLUKIVGFX99f4YGN2kBVLiwjHynTyK6mfq3zee2MZ8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:33.1582806","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A37Z&sr=b&sp=r&sig=tk%2Fs4o6u8nMl7DXK%2BVl921klDzgRPhIJp4wWgqEWRsE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:37.3113696","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:33 GMT
+      - Sun, 29 Oct 2023 22:22:37 GMT
       location:
-      - https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - ecdcd2ac-aadc-4198-8246-230811f9657b
+      - 3da9c7f6-f900-4f11-9b1a-95b77c08a39a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A33Z&sr=b&sp=r&sig=TGaGpmpR2gkMOfuzZWa8XVqWKvZo8mEBf7166m%2B%2FGb0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:33.4656428","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A37Z&sr=b&sp=r&sig=e3Ys2SJNI4LgqAkfvKx4Z1%2BXBwYe5sINFQ%2FIkj8wqVg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:37.6524629","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:33 GMT
+      - Sun, 29 Oct 2023 22:22:37 GMT
       mise-correlation-id:
-      - 93074567-cfe9-4aae-9b7b-ce33a8598121
+      - 14287a34-4f7e-4644-baf2-f57b4558236e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A38Z&sr=b&sp=r&sig=Fj2RDAX0L5vfe3Hqe%2FESxHqKSxc5xh6HjKt6rY2K9NA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:38.7545358","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A42Z&sr=b&sp=r&sig=l61lMOOtp%2FRCO%2F88GMifpyvXgG1DiHZBEpwhzFRklbw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:42.9612144","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:38 GMT
+      - Sun, 29 Oct 2023 22:22:42 GMT
       mise-correlation-id:
-      - fd7b1ab5-35ff-4802-bd4f-9b5da8fbd9f1
+      - 84f3d997-78ce-4488-9b1d-20c028ec7474
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A44Z&sr=b&sp=r&sig=DqQyG4fyWbLi9bBkv%2BHZxFz7kQstni6HBbDHhvvRWic%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:44.0922781","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A48Z&sr=b&sp=r&sig=fvOOs36uyQ%2F%2B25LYeTzRNlYJ8cukGT6KgwtErIfk9wg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:48.5610588","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:44 GMT
+      - Sun, 29 Oct 2023 22:22:48 GMT
       mise-correlation-id:
-      - 540f15a0-6904-46fc-a094-a7f5c33ab8b7
+      - 7264cb39-bfe6-47a8-a0af-a7e0a35584dd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A39%3A49Z&sr=b&sp=r&sig=cgSpEG%2FSn0Gwfq64986rKC2AZPlXkLu1QsnnDjERZJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:39:49.4231895","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A32%3A54Z&sr=b&sp=r&sig=AZvXSOcWMOMDQd8L6u3KBxqAWJaROUYw0hH9uhsDvrQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:32:54.0465242","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:49 GMT
+      - Sun, 29 Oct 2023 22:22:54 GMT
       mise-correlation-id:
-      - cc0184be-02d4-4f38-9b73-8cb270fc6fb2
+      - 75a2fcd7-f0f8-4839-a65d-adc6e7608873
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests/download-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A49Z&sr=b&sp=r&sig=1tusYDvku7sPrB4arhSMzVAnDsOPV7CnIHcMP%2BEW7gk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:49.6682579","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:29:31.528Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:47.495Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A54Z&sr=b&sp=r&sig=9GyeQmyswlKxH1x4p1xZ2MfDCaYtbejOsIt5yGytmd0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:54.2902352","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:22:36.46Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:49.36Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1581'
+      - '1577'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:49 GMT
+      - Sun, 29 Oct 2023 22:22:54 GMT
       mise-correlation-id:
-      - d962efd6-2ec8-479b-8ccf-190cd06b379a
+      - 03c463d3-955d-4616-9d1b-359cf1148058
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:56.8808228Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:56.8808228Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:59.6197453Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:59.6197453Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:51 GMT
+      - Sun, 29 Oct 2023 22:22:55 GMT
       etag:
-      - '"d300dd3d-0000-0100-0000-6537b88a0000"'
+      - '"3c00f229-0000-0100-0000-653edb0a0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A52Z&sr=b&sp=r&sig=%2BDFEqDemqPg8yIObjlwdSpsxCotKJTRmO7pjyqBdRSw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:52.7894904","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:29:31.528Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:47.495Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A22%3A57Z&sr=b&sp=r&sig=4bHE3OOzoIxbMp3dqKf7W4XTffC64sH9ZFZVAnJ3iC0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:22:57.0021623","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"download-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:22:36.46Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:22:49.36Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1593'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:52 GMT
+      - Sun, 29 Oct 2023 22:22:57 GMT
       mise-correlation-id:
-      - e58a7884-f482-481e-8965-8c03fa23931c
+      - ecbead00-f99b-46f4-b6f7-066d8c998f6e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:56.8808228Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:56.8808228Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:59.6197453Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:59.6197453Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:54 GMT
+      - Sun, 29 Oct 2023 22:22:57 GMT
       etag:
-      - '"d300dd3d-0000-0100-0000-6537b88a0000"'
+      - '"3c00f229-0000-0100-0000-653edb0a0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:29:55 GMT
+      - Sun, 29 Oct 2023 22:22:59 GMT
       mise-correlation-id:
-      - dc9efe7a-5052-4d89-9fb5-ff087499c394
+      - 46631057-5994-4e9e-bf6b-5a91a6732de1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A56Z&sr=b&sp=r&sig=1vNNYSsVESmRZnbIRIXS5u995otKiltGdhi1hZc%2FuAM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:56.109952","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A56Z&sr=b&sp=r&sig=UGqVWfhrgejsQh%2BkM%2F%2BERo8b8X9SXcJBoD4OtMEXr1g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:56.1097971","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A56Z&sr=b&sp=r&sig=yCxj0JXfKRc0MebYcMnHyulLwYLS7RFqOum2QwDtwmk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:56.1099791","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.037Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A00Z&sr=b&sp=r&sig=s9xCzX4l81BXJHW4azKrb69yhI%2BQRDsaVF%2Fpd3%2BybKA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:00.8804821","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A00Z&sr=b&sp=r&sig=epWmQrIz4c%2B%2FQAKsCPSM%2BCheumkLdoqczR%2BnnCPmXWg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:00.8803821","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A00Z&sr=b&sp=r&sig=SIhoxqrN0Il5RIl6E9nnRnzftXI6QShP05YFvFFyIbI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:00.8804982","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:00.789Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3165'
+      - '3172'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:56 GMT
+      - Sun, 29 Oct 2023 22:23:01 GMT
       location:
-      - https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+      - https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - b8e2b069-4433-42bc-82b7-11928122ccd8
+      - f3e8aed2-271f-4788-a148-665157bb9587
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A56Z&sr=b&sp=r&sig=PpV6H5VYsg3VVegZ0VbIsH%2B4OM96e9FOPepreuQOj3s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:56.5545797","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A56Z&sr=b&sp=r&sig=WjWvmvGg1HzypvjwwpQkt1crFjV7yqOX6P75w97LkDY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:29:56.5545069","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A29%3A56Z&sr=b&sp=r&sig=yMX4KhqYFTToBv25eLz%2B7TywxV330Nz%2B%2Fc1J214%2F9kw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:29:56.5545942","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.546Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A01Z&sr=b&sp=r&sig=QB0BiZJl3kgqI7pyCGsmEvLT3HZ%2BgeFTnKn3hV49xfI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:01.3997324","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A01Z&sr=b&sp=r&sig=Mrw0hGpaeKqC%2Fw8qtuVTN4pOhUvbJjh3%2B2zmbXv7L5Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:01.3996373","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A01Z&sr=b&sp=r&sig=cPKrD5ulBXyLwufxv3LjVJ8p2KDNqBdhgcfc40Umefg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:01.399753","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:00.789Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3215'
+      - '3163'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:29:56 GMT
+      - Sun, 29 Oct 2023 22:23:01 GMT
       mise-correlation-id:
-      - e2ebde3d-78d6-4c61-b382-243209fa178e
+      - 0c956524-5b47-4f4a-b468-54be9fff4508
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A01Z&sr=b&sp=r&sig=rdd2cuv2gnoBvhn8QLmsERPRhlE%2BVRwuuYyhE1v4ijM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:01.8454763","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A01Z&sr=b&sp=r&sig=WryXF%2FZE90WoOud%2FjvMTiNS9gls3A0gtvs8UCRD58CM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:01.8454064","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A01Z&sr=b&sp=r&sig=8fCCrcZ6xD%2F1K8QgjebsNYsXs4RMUl4f8wr%2FMBcG9cw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:01.8454912","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A06Z&sr=b&sp=r&sig=weXYPMA6wdVP3h5LCxONFlv%2Bc6mynd9272Eozzncw9w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:06.7325962","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A06Z&sr=b&sp=r&sig=mmc7TA9Lk%2BvfJ6wSl5jHAdUwKspdkUuGfSmo9HD3BF8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:06.7324902","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A06Z&sr=b&sp=r&sig=S%2B4tGgOe9531Y7QIz52Ic%2FcPLBRjqXUte2UnRk96rs0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:06.7326203","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:01.571Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3215'
+      - '3213'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:30:01 GMT
+      - Sun, 29 Oct 2023 22:23:06 GMT
       mise-correlation-id:
-      - 62592452-e9e1-4649-bbe1-0f901413581e
+      - 531db4d6-b6ba-43cf-98bc-bfefe5351ee9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,10 +772,190 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A07Z&sr=b&sp=r&sig=Ro5GeCArdrCzy0BikxLah%2B6651aSdD9NCg9g19RTJDU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:07.1498099","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A07Z&sr=b&sp=r&sig=dXBBJQLWiXauRbBdJC%2B9k8uFuSWcHLms6YfGAeyetCY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:07.1496447","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A07Z&sr=b&sp=r&sig=eMFMG%2FLVduk1tRx%2FlfV%2BuhOaQvh%2BqUkiOFJX7l84CQI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:07.1498294","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A12Z&sr=b&sp=r&sig=BXq5bHXF1dwlOGeVyR9E%2FUJxq%2BBgvGHreLbnbBEmnpg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:12.0490957","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A12Z&sr=b&sp=r&sig=Mp0m4qtROo7s18iTdL%2BkeKEoYrckPizQbEQj48aUGOE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:12.0490264","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A12Z&sr=b&sp=r&sig=r11LUetBVKrEqRjvMkyerf30KZx%2F1QJEIK90AjWkYho%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:12.0491096","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:01.571Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3213'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:12 GMT
+      mise-correlation-id:
+      - 91669978-9ef0-4e68-8800-5c61cfb329cc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A17Z&sr=b&sp=r&sig=e0KGc1D0Kw3%2BohBtgs9BEnHPhA%2BoaS03ypNO9fDCiYM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:17.3305051","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A17Z&sr=b&sp=r&sig=%2FUxRqa90bVjA1xx596dObN4TuF%2Bc72R7%2F5AW4bQ6OHs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:17.330413","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A17Z&sr=b&sp=r&sig=fd%2BU46BSHw3u%2FLb95h6APEtNImpQTgzmk2DzS%2BePOUY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:17.3305281","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:01.571Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:17 GMT
+      mise-correlation-id:
+      - 6ee6012d-a51f-42fb-ac0e-2dd5febc811c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A22Z&sr=b&sp=r&sig=BHzotRBj13nzYE1qEXQ1sNq%2B0VBjzaCdLQ%2FoyT7SzCY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:22.6014858","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A22Z&sr=b&sp=r&sig=%2BZDiyQ%2BeC7rgsOILKFsK1rjqfFlrRvvMipjafKe1bHQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:22.6014189","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A22Z&sr=b&sp=r&sig=lsJFm55jV1mdtXNc%2FP3K7kOHbojQzDqCRAY1nJhmGaw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:22.6015002","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:01.571Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3215'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:22 GMT
+      mise-correlation-id:
+      - ea0336ea-768e-4842-aa79-0ebd33c9cbd7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A27Z&sr=b&sp=r&sig=F0pM4XsFj%2BkAJE8YY%2BQk0vXB1%2BS4qeoGgo48D0CqpNo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:27.8924487","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A27Z&sr=b&sp=r&sig=dH7F3Ca%2FlIKG0BtWBPZUXSZIBRHwNQdwTjahtPRpruM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:27.8923741","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A27Z&sr=b&sp=r&sig=u0hi5E1Rfm6dHVa%2FQpagL8VDdt3SS%2BuNk%2F0XyszXdyM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:27.8924641","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:01.571Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:27 GMT
+      mise-correlation-id:
+      - 5d95279f-2f9f-4f93-af0b-400296d28306
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A33Z&sr=b&sp=r&sig=zGlLCCyinm9TUZMg4i9HD%2FgHBNjWSgXPZREc3D1dyfc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:33.1469654","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A33Z&sr=b&sp=r&sig=MtaNfC207mCP0NKw7ZimsfJ8mMJSAuRcSKd8VP9jhT8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:33.1468945","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A33Z&sr=b&sp=r&sig=E9Wg0SCe3kSx6s5z%2BzWQbtNv9Bwqr0%2Fx4wPCSV95AWE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:33.1469788","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:01.571Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3211'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:23:33 GMT
+      mise-correlation-id:
+      - 7c8e9dfc-dc14-49ff-80d1-8cdfbdde6f41
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A38Z&sr=b&sp=r&sig=c0B05J%2B7TLJMb5x4o0WAJW19FTVbup4%2FU5ahvFFdRqg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:38.3966503","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A38Z&sr=b&sp=r&sig=KSUjy%2F0SAD68YwetNLkby7F66FTwhJiXRQ%2BsjFQJO%2FU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:38.3965641","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A38Z&sr=b&sp=r&sig=gC241JEqkc%2F7XfEY7mS5nnNbMhe5soyuki2bxgrMTdY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:38.3966775","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:01.571Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -786,9 +966,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:30:07 GMT
+      - Sun, 29 Oct 2023 22:23:38 GMT
       mise-correlation-id:
-      - ebbc59b5-450b-4d84-a3f0-8b75a5d20ba5
+      - 639bd821-4ea8-466e-aa8e-7b61b8b76c08
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,10 +988,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A12Z&sr=b&sp=r&sig=tG628sPybP3TWpVXGYto4izskPfYJV%2BsbSg5VqiTQZI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:12.4824367","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A12Z&sr=b&sp=r&sig=mqa499RefFHjYmlEez93%2F1SCtxsWopf4F4X5OaZ4ZPI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:12.4822563","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A12Z&sr=b&sp=r&sig=bSs5Y3GFJfRcdSkouX1QauJh0bsTKgrZJI7zXPUHpvg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:12.4824647","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A43Z&sr=b&sp=r&sig=d1KSeB0tjoZFUQmjKpLiLX8HYNrzoNvwhznVoQlfujo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:43.6584117","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A43Z&sr=b&sp=r&sig=F7YNq2yVV2NP6adxxYsTjqRdg9hninhYEnjUEvjf9Io%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:43.6583383","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A43Z&sr=b&sp=r&sig=I2IvI%2FZvRdy2Wm9%2B9UnlLpxgoILLc9pMkke2mvz9KBc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:43.6584255","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:01.571Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -822,9 +1002,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:30:12 GMT
+      - Sun, 29 Oct 2023 22:23:43 GMT
       mise-correlation-id:
-      - a4e80270-4b4f-4368-b62d-67f97e063324
+      - f20299ff-c7b6-460b-9306-c080400a2826
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,586 +1024,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A17Z&sr=b&sp=r&sig=eqhn1WJ%2F9ehGm%2FdTAxsdEZ6uceb6eW5ctdMk0GCzhHQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:17.8313252","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A17Z&sr=b&sp=r&sig=n6M9cTb%2BEGIGrNJXan8JVmH08RhDCqIBQg6IId19ZiU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:17.8312343","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A17Z&sr=b&sp=r&sig=K2izR13WcweShruhwlUO5AIe7I4qPq3wUDuRZDfQTZg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:17.8313465","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3211'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:17 GMT
-      mise-correlation-id:
-      - 7d3d6bb1-ff36-40be-999c-9a204aca6433
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A23Z&sr=b&sp=r&sig=vi4ulbhcdje9ez2k4YHMluPkJ1RMzdvhpsU9pD4Ig%2FI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:23.1286527","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A23Z&sr=b&sp=r&sig=itIn7Q4Fj7DPLLCarEwP8RQDKjYjxmuXdsYfo6T8cRI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:23.1285712","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A23Z&sr=b&sp=r&sig=wkmpwHVGAByGIo9O6B5HMExPIV1Z6%2FVSq23WjFVvrnw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:23.1286677","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3209'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:23 GMT
-      mise-correlation-id:
-      - 9bd38ee1-892d-46d5-9799-6d0d5fa4f5ce
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A28Z&sr=b&sp=r&sig=oEFEk5J7OhYEuUYN%2BVpaiT1xKEceRkPHUj552Wmr0PQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:28.4261817","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A28Z&sr=b&sp=r&sig=FJrf8fsd3ugIS9VSIi61D70CXATFMjDCWqtgTA%2Fb2sI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:28.426088","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A28Z&sr=b&sp=r&sig=tw6X%2F%2FrhSzuolEHGnpiboO%2FtiAPpaMbG4v%2Bk3Ki84yg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:28.426197","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3215'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:28 GMT
-      mise-correlation-id:
-      - d40232aa-bb09-409f-9762-3c3650e7b12b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A33Z&sr=b&sp=r&sig=h2uvOeucEAHLdu%2BnUBfC4dGciI6uo4DIAmiE8Sq6nYM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:33.7303343","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A33Z&sr=b&sp=r&sig=DOjKGa6mTqLHHYMdEFdhvtCUoKpjli3ywetkFyZRzVM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:33.7302679","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A33Z&sr=b&sp=r&sig=l2ZrGy7Zb9KEcS9moTcydFolH6eX1JTddGxZ5dDJDaU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:33.7303486","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3207'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:33 GMT
-      mise-correlation-id:
-      - 48dbc54b-ad02-4ba6-8f94-9506319b37c5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A39Z&sr=b&sp=r&sig=tzbT7CVFey7Zemf8i12woZo8%2BCxZgQ%2FRNi%2FzBH8Ao5c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:39.0188307","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A39Z&sr=b&sp=r&sig=xjzm85sJwqHvypRCN3XuiEXzgdolTuJwILHpykkipf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:39.0187367","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A39Z&sr=b&sp=r&sig=8ZwL8Da58%2BecwHJh7tMnaHZ3tIqB4WgQLawZDcwb2bI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:39.0188526","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:29:56.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3213'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:39 GMT
-      mise-correlation-id:
-      - c65e6378-32af-4790-b6cf-275b765c892f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A44Z&sr=b&sp=r&sig=r6lx3kGOI2dM9Op2hrlISZHPp9rWhq%2F1Ep6zEz3yQUo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:44.2908999","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A44Z&sr=b&sp=r&sig=O5SjLAUuR%2BrNxhQm9JuIwhiFyZS05ubTZFPNCRq%2FqhE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:44.2907504","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A44Z&sr=b&sp=r&sig=8wowlaFOCzRja8YGvg%2FrQHPLmsSq9ov%2FWHAQtXRp3as%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:44.2909236","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"CONFIGURING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:39.586Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3214'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:44 GMT
-      mise-correlation-id:
-      - adebca25-910f-4a77-bfe6-37a23c7b36fc
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A49Z&sr=b&sp=r&sig=pOZZgnfKYJ8ruRKPVqFVqpqZ99Rh1NEGIgeZBWNELz4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:49.6143317","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A49Z&sr=b&sp=r&sig=oIynXqcYGlYxOJ7j%2BmL1rg38Y92ACe7zf01X7mfIvA4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:49.6142584","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A49Z&sr=b&sp=r&sig=%2FBXk%2FyKgitWYA4gQbb%2BXzkAogOOFhbRrxCsADwicmDg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:49.6143469","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3210'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:49 GMT
-      mise-correlation-id:
-      - c8c0c279-af3b-4940-af42-6c7f9a484f93
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A54Z&sr=b&sp=r&sig=Cgvu%2BxARwskp84j9INiKQWB%2BJHILZxYgTTS5%2FFyA1bo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:54.9568902","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A54Z&sr=b&sp=r&sig=d5og9ezdT957dPXdBlUsWPWpVnsEpGGGaStdb%2FI6j1o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:30:54.9568191","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A30%3A54Z&sr=b&sp=r&sig=ws5mc6zDgiWEuxpMmD8oO%2F3B4QjRYmbzOlWNTnP1dQ4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:30:54.9569043","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3212'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:30:54 GMT
-      mise-correlation-id:
-      - 6b44b238-eb80-4dc3-b90c-824ce2eb3d28
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A00Z&sr=b&sp=r&sig=%2FxcoFmLtrnmDDACpjbkOhsdNuEwBT8mBIKniG3HGXCo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:00.2884444","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A00Z&sr=b&sp=r&sig=1dwm47sSuZk3LG3oU3wf8J1Lh6UG533RTZEniTeu4EI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:00.2883625","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A00Z&sr=b&sp=r&sig=nhvy8jmtwL%2FlRJFonlEVK2KhCn3eW9LFB71unvvTP6w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:00.2884587","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:00 GMT
-      mise-correlation-id:
-      - 70e4e92e-0f12-4939-b264-984774330c48
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A05Z&sr=b&sp=r&sig=3CC4QdUj27OA1zR7RBOIh0mOvKds7G4%2BC2%2F0GAMBTIM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:05.624515","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A05Z&sr=b&sp=r&sig=6Jl%2BHH%2BnPZAaeX8qpCvdVzt4uQ00odC%2BT9mX8rHb3bg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:05.6244545","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A05Z&sr=b&sp=r&sig=ui4PxPYxS8PnkZGrdbGVmeG5q9jTHB3YNji34fz%2BRAM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:05.6245304","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3213'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:05 GMT
-      mise-correlation-id:
-      - a67b8764-eb3b-4ada-88e3-409a34fe4e3e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A10Z&sr=b&sp=r&sig=S2rIDWrHJmu%2BcfHVQYRjoKX3chup2YbtoPwuOftXtdI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:10.9470887","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A10Z&sr=b&sp=r&sig=GXL7Y7BzgP81YHrD6Not8O7GBkwr7zZXfMT8VQU0%2F0I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:10.947018","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A10Z&sr=b&sp=r&sig=3GmV9jxoDFtMUlMBydPxawm9vPU00ZyrSu0WacIquhA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:10.9471022","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:10 GMT
-      mise-correlation-id:
-      - 7dbb9dc7-5e16-41d2-b84c-be0d62c07cdc
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A16Z&sr=b&sp=r&sig=%2B02EF%2FAB9fFBelCDe4DIH4WcMiZH8vBcflX9m32itk8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:16.26238","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A16Z&sr=b&sp=r&sig=G8%2FwQLug7FrnYE2sn137%2BOt36iVRrtKX5mrfZMwqZhI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:16.262328","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A16Z&sr=b&sp=r&sig=VmHD%2B6uzBAdnWNHcJLYYCf%2FMh8aSO36mP0FA1W52lnk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:16.2623938","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3211'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:16 GMT
-      mise-correlation-id:
-      - 4d3f8dcc-c97b-437e-a193-ee1d0f35915a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A22Z&sr=b&sp=r&sig=RX9gi5dahobkgolFtKcaPqlfm5KAw%2FGe8vuzTnG%2Fq1o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:22.3930245","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A22Z&sr=b&sp=r&sig=OXKUDz2kEGorufnuBe4RDEiAM%2FdS66JXsHwUoA6DMig%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:22.3929138","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A22Z&sr=b&sp=r&sig=LJcF1AIgj%2BitRqdRXjWtyMGf0S0SauwOB%2F2q%2F2WpsFs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:22.3930524","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3214'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:22 GMT
-      mise-correlation-id:
-      - f9a89f93-3e59-4ff2-be22-d623dc89b0e2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A27Z&sr=b&sp=r&sig=7sU6U0z2PQ4DLbAgFjZnsoAvBYXqIdmlAcpDjPEb3OA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:27.7227954","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A27Z&sr=b&sp=r&sig=FtAFTKsa%2Bwac0ItctUnY0jKIIsQImnFLWWCaJpFsQJE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:27.7227244","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A27Z&sr=b&sp=r&sig=kAzNKxre55DMhinq0CHJ9P9HdeWDWMT4Xyl1OCFtWuY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:27.7228102","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:27 GMT
-      mise-correlation-id:
-      - bc89b2d7-4cf0-4fbe-8832-e5fb369909b0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A33Z&sr=b&sp=r&sig=2NwFLMR5Zj9H5cnrX2fUiWmp2HwPzm1M7ymcVQGMCZo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:33.0693615","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A33Z&sr=b&sp=r&sig=f%2BRkQgngSWRzWnLtARYlTYvLLi2UCN0Egk%2FeCeK9Mwo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:33.0692673","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A33Z&sr=b&sp=r&sig=osLZ4TU3RfqB8btfLc7X%2Fc4V64QjHL3MZZZW3k2ASa8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:33.0693841","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3208'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:33 GMT
-      mise-correlation-id:
-      - 69546933-47b0-4421-9faf-901bfe59197b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A38Z&sr=b&sp=r&sig=s5DqhJswAmWDV8H1Lr0agupgeZ5c9NJK6NzmIFlIUCE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:38.3476049","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A38Z&sr=b&sp=r&sig=DOA7hCWc29OXl7TCgrzWsslT2CRhEWQooQcDHfyl8CA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:38.347528","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A38Z&sr=b&sp=r&sig=VwB3f6LXBPBeNYS30wry%2B%2F3NlBCEJlMWVMsjKdgfplI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:38.3476193","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:38 GMT
-      mise-correlation-id:
-      - 71bc09dd-04bd-4052-b831-9a44189b6296
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A43Z&sr=b&sp=r&sig=ZNn6gMNWXdZhcRtmCoUHYI87ib%2FLDTI%2BizJjiZB%2FhJk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:43.7089864","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A43Z&sr=b&sp=r&sig=o2Qu5kfkIPcXwBpQFYaGfrx9Q04mbXM%2BAtQq4TuMTHY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:43.70891","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A43Z&sr=b&sp=r&sig=AGGFkv%2BOK50jz%2F%2F1RZoflYDEzXXmT1bPQgeKv%2B5Ur00%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:43.7090015","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A48Z&sr=b&sp=r&sig=WEUgnWCpEaWQB5ZT7OkCnJkB%2Bgnn%2Fxv%2BpLaxd8W7YCA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:48.9096776","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A48Z&sr=b&sp=r&sig=olMTHvMiKCJNmJX72NjIG4%2BYvxdwlsmw2rEmmiBiMkw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:48.9096106","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A48Z&sr=b&sp=r&sig=VkiohbmID6XJjYqpP%2BKvEKx9erz%2BDiDGNSuIJ7QICew%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:48.9096912","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"CONFIGURING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:47.901Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1434,9 +1038,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:43 GMT
+      - Sun, 29 Oct 2023 22:23:48 GMT
       mise-correlation-id:
-      - fc224f43-a008-4b6b-9e3f-f31232ff66b2
+      - 22e3b457-8b2c-4f99-a770-16419c32d555
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1456,46 +1060,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A49Z&sr=b&sp=r&sig=ybsegq2Jx8ENUulb3lqv0%2FS8PwPqcY7w%2BF3n1TEMndA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:49.0066526","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A49Z&sr=b&sp=r&sig=P9BhVEQ0Z9aQXfPhp5d40H5HZar9IeFKelOys86ffHo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:49.0065653","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A49Z&sr=b&sp=r&sig=UKDyGTfcGzys%2FAsK5zTSQaADoDMIu8hFCrqcnvxtbDE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:49.0066769","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3208'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:31:49 GMT
-      mise-correlation-id:
-      - 88234c62-c1ef-4c1a-9dba-957ddea2406e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A54Z&sr=b&sp=r&sig=s2dDtM9lH8aSy40Mc6X7xfgvDk14%2FzmCBHEJ1qKSqzM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:54.3650395","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A54Z&sr=b&sp=r&sig=5eARfDKr58m5CqdAT7jCMaFrbhzeQfaRx5Aq%2F8H%2BZ5o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:54.3649408","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A54Z&sr=b&sp=r&sig=6SRoeTgZRqgDhxF00x%2Fu3nmhL%2B4lntF89Hw6bduP%2F8M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:54.3650574","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A55Z&sr=b&sp=r&sig=1k2wWMd%2F4D%2Bjfnfz9JoDvroETbnzV0wCibjqr0pn0A4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:55.2695812","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A55Z&sr=b&sp=r&sig=NiqnDiT%2FbnVRnWfCq1vCj%2B4DDbf4Xevybgr2K9REams%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:23:55.2695029","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A23%3A55Z&sr=b&sp=r&sig=IZdzzK2p2txTj6%2F0ufDda8qaW%2BlCsf0dEqEtI3FZYhY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:23:55.2695968","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1506,9 +1074,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:54 GMT
+      - Sun, 29 Oct 2023 22:23:55 GMT
       mise-correlation-id:
-      - fce956b8-8923-4529-8ea3-5f3a524c390c
+      - acea92c3-47cf-4c44-96e9-0f358aa15ac4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1528,10 +1096,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A59Z&sr=b&sp=r&sig=zYUiRwmihu8TWY2%2FAte4DZR64%2BeD7WueFuNP37VSMSA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:59.6725329","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A59Z&sr=b&sp=r&sig=NqTOFLh6kqzZkrNxJeae9X5voxPVHDGTUud00ik67d4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:31:59.6724642","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A31%3A59Z&sr=b&sp=r&sig=FkRZtWjgINBVf0BVum23Gqd9up3tiuvLXVlT7nH9KnA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:31:59.6725465","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A00Z&sr=b&sp=r&sig=mrUbWfqsfD2zDkFrdiwcCuoiTTJACqQyvy4rhXiJxpU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:00.5211905","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A00Z&sr=b&sp=r&sig=pFshFWLf5jupbZ2Dh5mUnQnyMydz3O57hvkTHzmZCGY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:00.5211185","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A00Z&sr=b&sp=r&sig=%2BqqlF3P9SPHTgqblx9cA3EJyS%2FyWzxNqI71WkzvaKVo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:00.5212042","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1542,9 +1110,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:31:59 GMT
+      - Sun, 29 Oct 2023 22:24:00 GMT
       mise-correlation-id:
-      - 50b88ba8-064e-4772-9279-18949e47f794
+      - 25b08a1b-6e3c-4f27-83a4-52fb6820c65e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,23 +1132,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A05Z&sr=b&sp=r&sig=6waiHuh4%2FMao%2BJ%2BVAZgB19EvazO2mi1%2FRlbsLSY1W3w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:05.3529461","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A05Z&sr=b&sp=r&sig=s2fGefU7q744d0jGZada1s4yJ8Mdy4jeNbo9aitMtuY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:05.3528509","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A05Z&sr=b&sp=r&sig=4s7PJS9gVEQ1uM8PBRIdUSakyhDS6jggTlLarHBXgvo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:05.3529664","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A06Z&sr=b&sp=r&sig=NbLMOjzRBVzN4PwWbX9cAd4RfkGvlZ6%2BFgc%2BhDAigHY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:06.0698973","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A06Z&sr=b&sp=r&sig=zkxRwLX6FPlNu55REL%2FFRQnwGGbN%2Fg7tFm%2FGj7FkqYg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:06.0698214","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A06Z&sr=b&sp=r&sig=9X2HZaDww1zvJPIMtVzMUNo1BACtiVHSxoPjFMK6Jug%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:06.0699111","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3210'
+      - '3212'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:05 GMT
+      - Sun, 29 Oct 2023 22:24:06 GMT
       mise-correlation-id:
-      - 3a1f6a72-7d3c-427a-a891-4457ee5d5117
+      - 6ba6e0bb-97d3-4488-b0f9-2ac9892dea35
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,23 +1168,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A10Z&sr=b&sp=r&sig=Q7r3kEm%2BIGBCkdtxm6s5RZm%2FrRBsqgKWYnKor6hK5AI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:10.6343621","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A10Z&sr=b&sp=r&sig=pVBTBjZb0%2BV%2BuMqZb2bqLyaX599jJ%2F0HnIzxvG4z060%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:10.6342761","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A10Z&sr=b&sp=r&sig=tvDSiI2D8kT4Yxpp316XJihxAdMu%2FARkUh%2BdA68tiik%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:10.6343843","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A12Z&sr=b&sp=r&sig=KkP%2BNcZ3bITblRgsykK8BLNVDzXKiv1yS7UG5CFQwTA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:12.0406437","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A12Z&sr=b&sp=r&sig=6KCS%2FFnRkCSboELZFpFkRghk8xVmN%2B87mkFqBLZESto%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:12.0405818","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A12Z&sr=b&sp=r&sig=QXGr7ZTutSN5aBHLTf4vsWQQPYfNtubHr7a76GRfQNg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:12.0406592","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3216'
+      - '3208'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:10 GMT
+      - Sun, 29 Oct 2023 22:24:12 GMT
       mise-correlation-id:
-      - ffdca35a-33d2-44e8-9725-7039d824be67
+      - 99d4acf1-8e02-4209-8a84-e89fc39957da
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,23 +1204,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A15Z&sr=b&sp=r&sig=1lDrDHCiv7T%2FbFbA9iAhYdi9u9ddGwANyNV6%2FO6Y4UQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:15.8747606","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A15Z&sr=b&sp=r&sig=b93KT0pBoCcE2i%2BalkjS%2BZpR1wvfuI3mFSOvQT6WXDs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:15.874678","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A15Z&sr=b&sp=r&sig=WkDGzJZwFl%2B5R04esCvVrCaqPpOQ1uVRCS64xIlicTk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:15.8747765","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A17Z&sr=b&sp=r&sig=ksEoXJc8eDKx4mrHEdcJQv5SFdOo7KC%2FWYISiHCCmYE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:17.2783752","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A17Z&sr=b&sp=r&sig=mHy0gNmKqHp75kAnilREcFI5jF6X1gZM6rgqAziiigA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:17.2782767","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A17Z&sr=b&sp=r&sig=fwbWIFiRVUtoCG9RvCOlZ2to2gpYiVsIPTWu8lX%2FgY4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:17.2784015","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3211'
+      - '3206'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:15 GMT
+      - Sun, 29 Oct 2023 22:24:17 GMT
       mise-correlation-id:
-      - 9cd79991-d171-4d1d-a497-feb202571742
+      - ea9203fe-281c-492b-94a2-5db053f9c047
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,10 +1240,190 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A21Z&sr=b&sp=r&sig=jqbo9zwOcDQ4JltKl8wUera2pV35gO7eXxMlgsUoMKY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:21.1931854","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A21Z&sr=b&sp=r&sig=4bmKFArsHQwQSLFG3whjbINs2EgRxoyGPuHPQRsIYt0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:21.1931004","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A21Z&sr=b&sp=r&sig=zWUC0PnSuPq3rO4itScID10AOcogZrextC8Z%2FFYZUdQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:21.1932073","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A22Z&sr=b&sp=r&sig=Y7AEzKCXPwY0CDUReB5NO3OCrEEODNOuykL%2F%2FItd%2B50%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:22.6375228","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A22Z&sr=b&sp=r&sig=c0IvxkFJoNHMAD7iq0647KI9omF3uIRbMujIKoGZ6CY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:22.6373451","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A22Z&sr=b&sp=r&sig=YMU%2BAA%2FJjiAxhX3NBycwpcuD8H7HjOzOw%2Bygv5bYja8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:22.6375928","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3214'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:22 GMT
+      mise-correlation-id:
+      - d8b745c2-e648-4627-bd98-dd9f1bc1b9bc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A28Z&sr=b&sp=r&sig=4qnnkUgF7q2eFVQmFkJKENSNp7cB96aAFolnGTa%2BSIk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:28.1608884","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A28Z&sr=b&sp=r&sig=8C8hT2OMXoRb0fG%2FSncnH7UoXzOchs10aOxX2dX3530%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:28.1608178","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A28Z&sr=b&sp=r&sig=ALCD7yhkAaxPYVZ8HbTjHjYYDj3%2FSEt8Lem1RHlY1Gk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:28.1609029","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:28 GMT
+      mise-correlation-id:
+      - 22027699-90f7-4737-9195-1432632c3eca
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A33Z&sr=b&sp=r&sig=TvgNGitfxxx63TAeqPTQnkBl2wLlp3cOPmCDQaRuEiQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:33.402952","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A33Z&sr=b&sp=r&sig=%2FTo%2Ffj4W9u4xKdAaiY6Eiq4xjA8PPWP%2BICg%2BJ5qJMrI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:33.4028707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A33Z&sr=b&sp=r&sig=XR0NFuerFS4eqaWJfF6ZSdUoyVmkr%2BC9umyinBt%2BCEs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:33.402969","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3212'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:33 GMT
+      mise-correlation-id:
+      - 70c8fa40-e8b8-4f6c-8ec4-34216481851c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A38Z&sr=b&sp=r&sig=TVDI8OwW64p7aAvC47N7yg0q6wUPLe4emR3t4rnSknk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:38.6794765","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A38Z&sr=b&sp=r&sig=exX3KmdI34rO6DI0UrTK%2BiM3PoQqnHIz9YHrOF1PPrM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:38.6793747","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A38Z&sr=b&sp=r&sig=ieUTyW9HKkHSkU4KW14CCALMzLCj9B%2BQHhtMq9TUL7I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:38.6794993","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:38 GMT
+      mise-correlation-id:
+      - de3d6c9c-1bb8-4181-9a29-a2036f292a92
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A43Z&sr=b&sp=r&sig=qZ8OzkJQUYgYIXbgrrzmlukOInbNfyi6rGZoVLVxGe8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:43.9242291","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A43Z&sr=b&sp=r&sig=zDNiiSh22nc%2FoX3E0ryll21z5R0HzeJLPQSZK4tgIoc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:43.9241589","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A43Z&sr=b&sp=r&sig=f9kLNr6hYQ%2FVi9Smo995oaUPMrTaXOObkog5YV8uUCg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:43.9242434","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:43 GMT
+      mise-correlation-id:
+      - 7e2e80f1-f887-4990-ad41-607fcf662f64
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A49Z&sr=b&sp=r&sig=ZmG6iooRZbUMys2T4eh4skY%2FgDErQvNSm764jRMGsmY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:49.1769925","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A49Z&sr=b&sp=r&sig=jZEjyOkbmPt9Zh3Epp6adbxfncOd6qjZ6Kc62F5BYEY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:49.1769022","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A49Z&sr=b&sp=r&sig=Vaky4nX1pzsU0UNvHu84SM2U68WUJIuZ3Wvkt1Hov4k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:49.1770145","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1686,9 +1434,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:21 GMT
+      - Sun, 29 Oct 2023 22:24:49 GMT
       mise-correlation-id:
-      - 315bbb3d-571c-499b-996d-5df0edce94f0
+      - 8ed20d47-390c-4a40-8211-62534a82a5b6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,10 +1456,334 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A26Z&sr=b&sp=r&sig=x%2BcjWiTWt6j6o0yFMIG%2B3AXLdvqPm0ZXHEZrcwaN4nY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:26.4795647","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A26Z&sr=b&sp=r&sig=UCgey7fyIx74%2BPPJAsbA%2FLGdUiBbetDi1FF0cltThig%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:26.4794722","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A26Z&sr=b&sp=r&sig=4Di1%2BKR3T4KqI0acnBqHymsKgD5Hfk8E6Gih55uMt48%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:26.4795843","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A54Z&sr=b&sp=r&sig=DrjUmQpwMXqVxx%2F9d4jLU%2FA2iQekrrXxzXTaSJzApNk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:54.7075525","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A54Z&sr=b&sp=r&sig=XEOiGJV629kk%2Fa13ogal%2FxsyaAFRy6Q%2Bi6eUwo3731w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:24:54.7074648","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A24%3A54Z&sr=b&sp=r&sig=XR4WlAiV9UfTtJzIp0KvvJgzleZ%2BsDTsgyUC4fRi04o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:24:54.7075741","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3214'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:24:54 GMT
+      mise-correlation-id:
+      - 284de6c9-e6fc-49dc-9330-cae027a13cf8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A00Z&sr=b&sp=r&sig=gmuTfBKPsQ9TumJIK8ybWSgzrTSJYFhc3mKrxaTNwNI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:00.2823467","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A00Z&sr=b&sp=r&sig=Upib2PLO72fs%2BzhOELJWT8LdFQctf9wm0DDq6f5Bj50%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:00.2822782","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A00Z&sr=b&sp=r&sig=s2bMET6NUWS5BuDxmBucjJJDZoBYmZ%2BJNpDQ0NiOFfM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:00.2823613","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:25:00 GMT
+      mise-correlation-id:
+      - 8a344f27-10a2-47f7-bcbf-cca855c27e86
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A05Z&sr=b&sp=r&sig=GibAP67kDfeAnNoWs1MbVRm9N7XlMEDXydj6XOZOEu8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:05.6136792","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A05Z&sr=b&sp=r&sig=2WWXz%2BvH7h1I28g21YJpmlFBiJLIXREFqRG2l1RRUkg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:05.6136055","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A05Z&sr=b&sp=r&sig=Lt364%2BGqOLTgsiqOrD%2B9QF9OeR%2FYmkzM%2Bp86J8%2FjVUo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:05.6136939","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3214'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:25:05 GMT
+      mise-correlation-id:
+      - 9782eca0-b0f3-4149-a6c3-e5b38d577ae2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A10Z&sr=b&sp=r&sig=VRSY%2BBjM7oe5I7Q6DT5rlk%2ByL0jEaQeeB1ypqNHckTg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:10.9415153","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A10Z&sr=b&sp=r&sig=UIr90VMfa83OszyFmgyv7rBuY8bfU9uAK4hQgTthXjM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:10.9414161","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A10Z&sr=b&sp=r&sig=%2BtOju%2FmWnXsTCr3Bf1IFEa6tn0lvq5Jg%2B7lAaV5%2Bzfs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:10.9415439","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3214'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:25:10 GMT
+      mise-correlation-id:
+      - 99a96a87-0988-42fe-8c3f-7644e205afa6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A16Z&sr=b&sp=r&sig=6bsJfTlJCgYAilpv%2F5SfFQmQS2UYSQVH3e27x7SG3F8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:16.1980659","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A16Z&sr=b&sp=r&sig=QQGxqlQXeWrzvvpFuBNX%2BHek%2B1RJLSxXVQCmjrIZQYk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:16.1979965","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A16Z&sr=b&sp=r&sig=NdPxGEGFqZ%2F1Dx5St%2FFh1pIW59o7NSnlNNv1bSw7LA4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:16.19808","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:25:16 GMT
+      mise-correlation-id:
+      - 4003df36-d503-4e10-8f98-d25488533d8a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A21Z&sr=b&sp=r&sig=0S7opID8%2BiD2sFMO2up%2FsTZDiJLAfRSq1wD3IOGJMlo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:21.44894","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A21Z&sr=b&sp=r&sig=mM5MvJKahlH2QPwGc7lWwFAoXDyt4Iv7J2zAr%2BKLlUI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:21.4488557","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A21Z&sr=b&sp=r&sig=LPOxXyUQKXQNLql%2Fgu1IjrsobWr%2FY8micdiS8hJhuIA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:21.4489619","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:25:21 GMT
+      mise-correlation-id:
+      - 36847d83-1de0-49a2-bfb5-02df84f80be3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A26Z&sr=b&sp=r&sig=ckFYubz4aSseay9AqUDiqfTIqvhHtjA%2FZMJqApBLN2Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:26.7009334","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A26Z&sr=b&sp=r&sig=w4oiKIbxbK5AVBD0uyI27oZUiQq5Vp0W6psC55SDT0s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:26.7008671","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A26Z&sr=b&sp=r&sig=V6PD7rZZauAVWym01jdn5rtDa1pTVtf%2BzW%2BlAxsSKb4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:26.7009475","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:25:26 GMT
+      mise-correlation-id:
+      - 9a60abac-5d14-47e4-98c2-5d887516e708
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A31Z&sr=b&sp=r&sig=hRe33xv5OG87b8f6BFca8L4KOQ1rIW4%2FJ67R7su6%2F38%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:31.9464715","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A31Z&sr=b&sp=r&sig=eUs9UK2k0md1JszazfeQGIU0Hp%2BX7Sj64%2FqebLG7nuM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:31.9463905","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A31Z&sr=b&sp=r&sig=qVEaqUt%2BZIw5QmDvo%2Fl9BwHdvV3BZi1aDDis36AtA2w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:31.9464896","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3214'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:25:31 GMT
+      mise-correlation-id:
+      - e42e28a6-8ae0-469a-9fb3-0f69400fbcd4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A37Z&sr=b&sp=r&sig=QFEbbK4CkgT9XBSuQG09P3FIGzySOWQu0J88aM3kOKo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:37.2031335","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A37Z&sr=b&sp=r&sig=Bw07U%2B6iELNLlBEGUcreXT%2BgFwlzDY7roTtaKwJvdoI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:37.2030399","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A37Z&sr=b&sp=r&sig=jJwpFxMhb8aoTGRynG5%2BVUuhbKFJzpCHHf4dGjmvISs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:37.2031568","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:25:37 GMT
+      mise-correlation-id:
+      - f879f458-3afd-4c3c-b74d-938fd5b37534
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A42Z&sr=b&sp=r&sig=MLY9lDJzVy0xxM%2F5vN53TEfiO%2F6DvsMnc1MscLGUqz0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:42.4506754","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A42Z&sr=b&sp=r&sig=zx3Be9H%2BvGPVDN4MPRyrZGaCZaeuJS%2B9YgP30yHk3Dc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:42.4505932","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A42Z&sr=b&sp=r&sig=guaB0jLkv9Jn5%2FBrZA8qWIM7ma6y4VYK7ffyQII2h8g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:42.4506904","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:23:01.496Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:23:51.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1722,9 +1794,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:26 GMT
+      - Sun, 29 Oct 2023 22:25:42 GMT
       mise-correlation-id:
-      - f0909aad-bb63-4316-a215-21e4118ef790
+      - 7c899323-9933-4046-bc80-1bf74aea5a24
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,96 +1816,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A31Z&sr=b&sp=r&sig=%2BrSxyDh68b%2B9RR9OI1ZYvBdXfRH4hqOttSDt%2Bov%2F1WM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:31.7574517","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A31Z&sr=b&sp=r&sig=yWZIZHkngZ59sRiaJAHGfgCsfR4p11HoeZANZnM4VGE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:31.7573804","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A31Z&sr=b&sp=r&sig=qA62KSj5zU1o1cJMtutCFw3035zLldE4BuB%2F5useIMU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:31.7574662","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A47Z&sr=b&sp=r&sig=6VAFfzi76gMfV6e0NftBlBuaBHI%2FLzPCKb7qVKVz2Y8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:47.70348","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A47Z&sr=b&sp=r&sig=yyC6elxlygMvO1duBhw0scGLDCn8OaGmdSQs2VXtnkI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:47.7034012","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A47Z&sr=b&sp=r&sig=kjpQqtICkcjcFP2zZY8pcytvLusaG8k7ceuiZZ8d4b0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:47.7034939","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-29T22:23:01.496Z","endDateTime":"2023-10-29T22:25:45.508Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:45.612Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3212'
+      - '3337'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:31 GMT
+      - Sun, 29 Oct 2023 22:25:47 GMT
       mise-correlation-id:
-      - 8fbee0ae-4c68-4af1-9028-f6ddcba30b4c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A37Z&sr=b&sp=r&sig=DaaVFbQK%2FM42MD7VbAD66f6P8mKqkfKreN0oBpO4kig%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:37.0195067","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A37Z&sr=b&sp=r&sig=TiEF9XFqrb62pgenEmul%2F8viVllONMDyvm9bJHgGOWs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:37.0194199","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A37Z&sr=b&sp=r&sig=%2F563ACqKn9yhgvwMio4FDWMScgmUTWN%2BHLkGY%2BXd1fE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:37.0195218","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:29:56.407Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:30:45.403Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3212'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:32:37 GMT
-      mise-correlation-id:
-      - 5626e2a3-c5d3-43a9-b2da-c7413e030c28
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A42Z&sr=b&sp=r&sig=mjAKYHAe56KI4Wh0e60tfkMu7Av%2BiuAVdcGaqoqW7lg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:42.2742666","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A42Z&sr=b&sp=r&sig=X7Myw7mV3qLFYtYM9q%2FfYVFLsotDc5f4qor8eB5ZWno%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:42.2741495","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A42Z&sr=b&sp=r&sig=xiL8fJyYvaLNfWm4VdKaj6uPPm5nHciOS37IlKeAvPQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:42.274281","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-24T12:29:56.407Z","endDateTime":"2023-10-24T12:32:38.524Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:38.631Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3340'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:32:42 GMT
-      mise-correlation-id:
-      - 3582b256-9491-45b9-9505-63d34a3b7221
+      - 4ce90404-3bdf-4e8c-b23e-1b6bc37d2eb2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1856,18 +1856,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:56.8808228Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:56.8808228Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:59.6197453Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:59.6197453Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:42 GMT
+      - Sun, 29 Oct 2023 22:25:48 GMT
       etag:
-      - '"d300dd3d-0000-0100-0000-6537b88a0000"'
+      - '"3c00f229-0000-0100-0000-653edb0a0000"'
       expires:
       - '-1'
       pragma:
@@ -1897,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=download-test-case&api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=download-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A43Z&sr=b&sp=r&sig=vD5h75dryJbwEujvMIeWJEdbRhkb7LmkGd77VFBt%2BWs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:43.846732","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A43Z&sr=b&sp=r&sig=mHTiKBafKQFA5ALyMePf6jbWapBJA5ZDPe660WI2a7w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:43.8466642","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A43Z&sr=b&sp=r&sig=NANZH8sn5wQMV0iM%2BPs3S2Ny2INuzsvwnop2m9k4S9o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:43.8467485","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-24T12:29:56.407Z","endDateTime":"2023-10-24T12:32:38.524Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:38.631Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A49Z&sr=b&sp=r&sig=glw9sMHRSsNwf3OK6H%2F7MRgOJiWRCSYNMYDsaElo3js%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:49.9653674","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A49Z&sr=b&sp=r&sig=hZgg%2B6JWJkLQWcmE9Rk%2FmUqpmGsBBxWHA4JmcqtEkuc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:49.9652769","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A49Z&sr=b&sp=r&sig=KbUx3vH9Yi8Unc6hybstmpI%2Buut3dtXpYhRgfBNU%2B2I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:49.9653892","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-29T22:23:01.496Z","endDateTime":"2023-10-29T22:25:45.508Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:45.612Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3352'
+      - '3359'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:43 GMT
+      - Sun, 29 Oct 2023 22:25:49 GMT
       mise-correlation-id:
-      - 98a88529-5d92-4d5c-87ab-3de413e580d4
+      - 3042c853-1b1a-49fa-9b6b-9b3468611f85
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1937,18 +1937,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:56.8808228Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:56.8808228Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:59.6197453Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:59.6197453Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:45 GMT
+      - Sun, 29 Oct 2023 22:25:51 GMT
       etag:
-      - '"d300dd3d-0000-0100-0000-6537b88a0000"'
+      - '"3c00f229-0000-0100-0000-653edb0a0000"'
       expires:
       - '-1'
       pragma:
@@ -1978,24 +1978,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A46Z&sr=b&sp=r&sig=q07G%2BVVkWmE995oL%2BHQSiJouWFTxPyoQ3xevwpOFyBg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:46.5000856","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A46Z&sr=b&sp=r&sig=xvpAQBnziNA%2BjHAmkY6hRWDWa9Lf0%2FkUXijd18h3l%2Fw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:46.5000152","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A46Z&sr=b&sp=r&sig=JexKD0TKKw%2Fp14bHVq7v%2Fk1ixBc9lvGk39vKaiehtHg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:46.5000999","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-24T12:29:56.407Z","endDateTime":"2023-10-24T12:32:38.524Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:38.631Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A52Z&sr=b&sp=r&sig=O5SWc8ET%2BjA5nUNm%2FIgRyGrmSKbsOOzL1Yc%2B1L7BRRA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:52.2116037","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A52Z&sr=b&sp=r&sig=%2FGyOaY9creUfxpx88hfu7QYtLUxmODyFZbXSboIn%2BRo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:52.2115193","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A52Z&sr=b&sp=r&sig=tdEr8SZIqO3pwSD2cGNCG9lM01v3JOixW9rllEvQ1dI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:52.2116259","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-29T22:23:01.496Z","endDateTime":"2023-10-29T22:25:45.508Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:45.612Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3351'
+      - '3347'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:46 GMT
+      - Sun, 29 Oct 2023 22:25:52 GMT
       mise-correlation-id:
-      - 642e9673-927e-40a6-b040-39d7c729f6dc
+      - ab378685-edb1-43e6-ba21-356c5d83fba7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2015,7 +2015,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A46Z&sr=b&sp=r&sig=q07G%2BVVkWmE995oL%2BHQSiJouWFTxPyoQ3xevwpOFyBg%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A52Z&sr=b&sp=r&sig=O5SWc8ET%2BjA5nUNm%2FIgRyGrmSKbsOOzL1Yc%2B1L7BRRA%3D
   response:
     body:
       string: "displayName: CLI-Test\ntestPlan: sample-JMX-file.jmx\ndescription:
@@ -2033,17 +2033,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Tue, 24 Oct 2023 12:32:47 GMT
+      - Sun, 29 Oct 2023 22:25:54 GMT
       etag:
-      - '"0x8DBD48CEE1A9262"'
+      - '"0x8DBD8CD9BE2528F"'
       last-modified:
-      - Tue, 24 Oct 2023 12:29:55 GMT
+      - Sun, 29 Oct 2023 22:22:59 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Tue, 24 Oct 2023 12:29:55 GMT
+      - Sun, 29 Oct 2023 22:22:59 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2073,7 +2073,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A46Z&sr=b&sp=r&sig=xvpAQBnziNA%2BjHAmkY6hRWDWa9Lf0%2FkUXijd18h3l%2Fw%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A52Z&sr=b&sp=r&sig=%2FGyOaY9creUfxpx88hfu7QYtLUxmODyFZbXSboIn%2BRo%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -2146,17 +2146,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Tue, 24 Oct 2023 12:32:48 GMT
+      - Sun, 29 Oct 2023 22:25:55 GMT
       etag:
-      - '"0x8DBD48CE082C78B"'
+      - '"0x8DBD8CD8E60618F"'
       last-modified:
-      - Tue, 24 Oct 2023 12:29:33 GMT
+      - Sun, 29 Oct 2023 22:22:37 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Tue, 24 Oct 2023 12:29:33 GMT
+      - Sun, 29 Oct 2023 22:22:37 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2186,18 +2186,18 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A46Z&sr=b&sp=r&sig=JexKD0TKKw%2Fp14bHVq7v%2Fk1ixBc9lvGk39vKaiehtHg%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A52Z&sr=b&sp=r&sig=tdEr8SZIqO3pwSD2cGNCG9lM01v3JOixW9rllEvQ1dI%3D
   response:
     body:
       string: !!binary |
-        UEsDBC0AAAAIALtjWFcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
+        UEsDBC0AAAAIAN2yXVcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
         AAAAAAFZAab+ZGlzcGxheU5hbWU6IENMSS1UZXN0CnRlc3RQbGFuOiBzYW1wbGUtSk1YLWZpbGUu
         am14CmRlc2NyaXB0aW9uOiBUZXN0IGNyZWF0ZWQgZnJvbSBheiBsb2FkIHRlc3QgY29tbWFuZApl
         bmdpbmVJbnN0YW5jZXM6IDEKdGVzdElkOiBkb3dubG9hZC10ZXN0LWNhc2UKc3BsaXRBbGxDU1Zz
         OiBGYWxzZQpmYWlsdXJlQ3JpdGVyaWE6Ci0gYXZnKHJlcXVlc3RzX3Blcl9zZWMpID4gNzgKLSBw
         ZXJjZW50YWdlKGVycm9yKSA+IDUwCi0gR2V0Q3VzdG9tZXJEZXRhaWxzOiBhdmcobGF0ZW5jeSkg
         PiAyMDAKZW52OgotIG5hbWU6IHJwcwogIHZhbHVlOiAxCi0gbmFtZTogZHVyYXRpb25faW5fc2Vj
-        CiAgdmFsdWU6IDEKUEsDBC0AAAAIALtjWFfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
+        CiAgdmFsdWU6IDEKUEsDBC0AAAAIAN2yXVfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
         LmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAAQYT+ew8P3htbCB2ZXJzaW9uPSIxLjAiIGVuY29kaW5n
         PSJVVEYtOCI/Pg0KPGptZXRlclRlc3RQbGFuIHZlcnNpb249IjEuMiIgcHJvcGVydGllcz0iNS4w
         IiBqbWV0ZXI9IjUuNSI+DQogIDxoYXNoVHJlZT4NCiAgICA8VGVzdFBsYW4gZ3VpY2xhc3M9IlRl
@@ -2284,8 +2284,8 @@ interactions:
         ZT0iSFRUUFNhbXBsZXIucmVzcG9uc2VfdGltZW91dCI+PC9zdHJpbmdQcm9wPg0KICAgICAgICA8
         L0hUVFBTYW1wbGVyUHJveHk+DQogICAgICAgIDxoYXNoVHJlZS8+DQogICAgICA8L2hhc2hUcmVl
         Pg0KICAgIDwvaGFzaFRyZWU+DQogIDwvaGFzaFRyZWU+DQo8L2ptZXRlclRlc3RQbGFuPg0KUEsB
-        AjMALQAAAAgAu2NYVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
-        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACAC7Y1hX8Zv7b///////////EwAUAAAAAAAAAAAA
+        AjMALQAAAAgA3bJdVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
+        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACADdsl1X8Zv7b///////////EwAUAAAAAAAAAAAA
         AACbAQAAc2FtcGxlLUpNWC1maWxlLmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAUEsFBgAAAAACAAIA
         ogAAAOsUAAAAAA==
     headers:
@@ -2294,21 +2294,21 @@ interactions:
       content-length:
       - '5539'
       content-md5:
-      - QVvWLUBmRF+bvS5b8w+nrQ==
+      - 93fq3z4MPh6ygZI9IwDVUA==
       content-type:
       - application/octet-stream
       date:
-      - Tue, 24 Oct 2023 12:32:48 GMT
+      - Sun, 29 Oct 2023 22:25:55 GMT
       etag:
-      - '"0x8DBD48CEE234396"'
+      - '"0x8DBD8CD9C5AA52A"'
       last-modified:
-      - Tue, 24 Oct 2023 12:29:55 GMT
+      - Sun, 29 Oct 2023 22:23:00 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Tue, 24 Oct 2023 12:29:55 GMT
+      - Sun, 29 Oct 2023 22:23:00 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2341,18 +2341,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:28:56.8808228Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:28:56.8808228Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:21:59.6197453Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:21:59.6197453Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:50 GMT
+      - Sun, 29 Oct 2023 22:26:00 GMT
       etag:
-      - '"d300dd3d-0000-0100-0000-6537b88a0000"'
+      - '"3c00f229-0000-0100-0000-653edb0a0000"'
       expires:
       - '-1'
       pragma:
@@ -2382,11 +2382,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://7d33d962-f34b-43eb-a7ee-94fe0235b325.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
+    uri: https://0daa6401-068b-4ef5-acf9-004d81d93bdc.eastus.cnt-prod.loadtesting.azure.com/test-runs/download-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f4c73a30-3e9b-4ed8-aa27-99bfc8bd9a0f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9cde26e4-7d07-418a-9e51-249b880ea1d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"76c59287-ff07-4c68-b1c0-13f5de9950b6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A51Z&sr=b&sp=r&sig=Og5MgrV5rM%2FNC6Lsn3aSKlW38xicFHcLbE5J76zvO%2BA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:51.8233616","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A51Z&sr=b&sp=r&sig=X6j2y%2BduY9shp6e19IvCsVdzCwxQH%2BO3J3MWvoMVlqc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:32:51.8232766","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A51Z&sr=b&sp=r&sig=hX4GQ25yDzroicwLFAo79ZECZeAv0HhXMv1gohTqRbQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:32:51.8233774","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-24T12:29:56.407Z","endDateTime":"2023-10-24T12:32:38.524Z","executedDateTime":"2023-10-24T12:29:55.755Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-24T12:29:56.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:38.631Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b67ab143-afca-44bc-8ce9-7f41fe096879":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"244b313f-8b61-46a1-9311-e0205d00f16c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229243ef-e4e3-4ff0-8822-c9755465e287":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A02Z&sr=b&sp=r&sig=WNAsFe1Fbbr5Lr7QslNzqsUvTzTBo7jF8fd5%2F2CeQHo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:02.8168664","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A02Z&sr=b&sp=r&sig=VRpa6gQKXsswQ7TgoNIudZkNREfW3bRCzy%2F4m1nKt4k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:02.8167962","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A02Z&sr=b&sp=r&sig=0LuZco2I9NJ6G5C%2FGpN1fgDLD%2FMwDW20WmNHFooFkMc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:02.8168817","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"download-test-run-case","displayName":"download-test-run-case","testId":"download-test-case","status":"FAILED","startDateTime":"2023-10-29T22:23:01.496Z","endDateTime":"2023-10-29T22:25:45.508Z","executedDateTime":"2023-10-29T22:22:59.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/download-test-case/testRunId/download-test-run-case","createdDateTime":"2023-10-29T22:23:00.789Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:02.154Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2397,9 +2397,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:51 GMT
+      - Sun, 29 Oct 2023 22:26:02 GMT
       mise-correlation-id:
-      - 33910c52-80d2-4636-bd94-ddc5a0a31b19
+      - 5d181af1-2433-459c-92ae-883bc5b1dd30
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2419,7 +2419,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/3454b501-902e-4ec3-a42f-4d34e30bcf1d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A51Z&sr=b&sp=r&sig=Og5MgrV5rM%2FNC6Lsn3aSKlW38xicFHcLbE5J76zvO%2BA%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/bce2d3b8-7a1d-42ed-ba03-09a4989d6ee8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A02Z&sr=b&sp=r&sig=WNAsFe1Fbbr5Lr7QslNzqsUvTzTBo7jF8fd5%2F2CeQHo%3D
   response:
     body:
       string: "displayName: CLI-Test\ntestPlan: sample-JMX-file.jmx\ndescription:
@@ -2437,17 +2437,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Tue, 24 Oct 2023 12:32:52 GMT
+      - Sun, 29 Oct 2023 22:26:10 GMT
       etag:
-      - '"0x8DBD48CEE1A9262"'
+      - '"0x8DBD8CD9BE2528F"'
       last-modified:
-      - Tue, 24 Oct 2023 12:29:55 GMT
+      - Sun, 29 Oct 2023 22:22:59 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Tue, 24 Oct 2023 12:29:55 GMT
+      - Sun, 29 Oct 2023 22:22:59 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2477,7 +2477,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/fd36d18b-1075-4ce2-82f2-8ad76c5ae086?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A51Z&sr=b&sp=r&sig=X6j2y%2BduY9shp6e19IvCsVdzCwxQH%2BO3J3MWvoMVlqc%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/8ec217d5-ccb3-413a-99d4-718ed0c9cefc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A02Z&sr=b&sp=r&sig=VRpa6gQKXsswQ7TgoNIudZkNREfW3bRCzy%2F4m1nKt4k%3D
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
@@ -2550,17 +2550,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Tue, 24 Oct 2023 12:32:53 GMT
+      - Sun, 29 Oct 2023 22:26:11 GMT
       etag:
-      - '"0x8DBD48CE082C78B"'
+      - '"0x8DBD8CD8E60618F"'
       last-modified:
-      - Tue, 24 Oct 2023 12:29:33 GMT
+      - Sun, 29 Oct 2023 22:22:37 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Tue, 24 Oct 2023 12:29:33 GMT
+      - Sun, 29 Oct 2023 22:22:37 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -2590,18 +2590,18 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/77a7ea39-da08-423f-98ac-9434a33a2332/73180c64-5e53-40f8-a6c0-de82c73ee4d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A32%3A51Z&sr=b&sp=r&sig=hX4GQ25yDzroicwLFAo79ZECZeAv0HhXMv1gohTqRbQ%3D
+    uri: https://maltccstorageaccounteus.blob.core.windows.net/ce0cdd18-6a70-4c43-b582-8def9d103df7/ddb70e13-4d03-422a-ad0b-4cd2f6b472a0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A02Z&sr=b&sp=r&sig=0LuZco2I9NJ6G5C%2FGpN1fgDLD%2FMwDW20WmNHFooFkMc%3D
   response:
     body:
       string: !!binary |
-        UEsDBC0AAAAIALtjWFcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
+        UEsDBC0AAAAIAN2yXVcUBwCv//////////8LABQAY29uZmlnLnlhbWwBABAAWQEAAAAAAABeAQAA
         AAAAAAFZAab+ZGlzcGxheU5hbWU6IENMSS1UZXN0CnRlc3RQbGFuOiBzYW1wbGUtSk1YLWZpbGUu
         am14CmRlc2NyaXB0aW9uOiBUZXN0IGNyZWF0ZWQgZnJvbSBheiBsb2FkIHRlc3QgY29tbWFuZApl
         bmdpbmVJbnN0YW5jZXM6IDEKdGVzdElkOiBkb3dubG9hZC10ZXN0LWNhc2UKc3BsaXRBbGxDU1Zz
         OiBGYWxzZQpmYWlsdXJlQ3JpdGVyaWE6Ci0gYXZnKHJlcXVlc3RzX3Blcl9zZWMpID4gNzgKLSBw
         ZXJjZW50YWdlKGVycm9yKSA+IDUwCi0gR2V0Q3VzdG9tZXJEZXRhaWxzOiBhdmcobGF0ZW5jeSkg
         PiAyMDAKZW52OgotIG5hbWU6IHJwcwogIHZhbHVlOiAxCi0gbmFtZTogZHVyYXRpb25faW5fc2Vj
-        CiAgdmFsdWU6IDEKUEsDBC0AAAAIALtjWFfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
+        CiAgdmFsdWU6IDEKUEsDBC0AAAAIAN2yXVfxm/tv//////////8TABQAc2FtcGxlLUpNWC1maWxl
         LmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAAQYT+ew8P3htbCB2ZXJzaW9uPSIxLjAiIGVuY29kaW5n
         PSJVVEYtOCI/Pg0KPGptZXRlclRlc3RQbGFuIHZlcnNpb249IjEuMiIgcHJvcGVydGllcz0iNS4w
         IiBqbWV0ZXI9IjUuNSI+DQogIDxoYXNoVHJlZT4NCiAgICA8VGVzdFBsYW4gZ3VpY2xhc3M9IlRl
@@ -2688,8 +2688,8 @@ interactions:
         ZT0iSFRUUFNhbXBsZXIucmVzcG9uc2VfdGltZW91dCI+PC9zdHJpbmdQcm9wPg0KICAgICAgICA8
         L0hUVFBTYW1wbGVyUHJveHk+DQogICAgICAgIDxoYXNoVHJlZS8+DQogICAgICA8L2hhc2hUcmVl
         Pg0KICAgIDwvaGFzaFRyZWU+DQogIDwvaGFzaFRyZWU+DQo8L2ptZXRlclRlc3RQbGFuPg0KUEsB
-        AjMALQAAAAgAu2NYVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
-        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACAC7Y1hX8Zv7b///////////EwAUAAAAAAAAAAAA
+        AjMALQAAAAgA3bJdVxQHAK///////////wsAFAAAAAAAAAAAAAAAAAAAAGNvbmZpZy55YW1sAQAQ
+        AFkBAAAAAAAAXgEAAAAAAABQSwECMwAtAAAACADdsl1X8Zv7b///////////EwAUAAAAAAAAAAAA
         AACbAQAAc2FtcGxlLUpNWC1maWxlLmpteAEAEAAGEwAAAAAAAAsTAAAAAAAAUEsFBgAAAAACAAIA
         ogAAAOsUAAAAAA==
     headers:
@@ -2698,21 +2698,21 @@ interactions:
       content-length:
       - '5539'
       content-md5:
-      - QVvWLUBmRF+bvS5b8w+nrQ==
+      - 93fq3z4MPh6ygZI9IwDVUA==
       content-type:
       - application/octet-stream
       date:
-      - Tue, 24 Oct 2023 12:32:54 GMT
+      - Sun, 29 Oct 2023 22:26:12 GMT
       etag:
-      - '"0x8DBD48CEE234396"'
+      - '"0x8DBD8CD9C5AA52A"'
       last-modified:
-      - Tue, 24 Oct 2023 12:29:55 GMT
+      - Sun, 29 Oct 2023 22:23:00 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Tue, 24 Oct 2023 12:29:55 GMT
+      - Sun, 29 Oct 2023 22:23:00 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_list.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_list.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:12:55.4043087Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:12:55.4043087Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:15:49.7188431Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:15:49.7188431Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:30 GMT
+      - Mon, 09 Oct 2023 16:16:24 GMT
       etag:
-      - '"1a0a86c6-0000-0100-0000-64af094a0000"'
+      - '"920179d0-0000-0100-0000-652427380000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:13:32 GMT
+      - Mon, 09 Oct 2023 16:16:24 GMT
       mise-correlation-id:
-      - ec6a24b7-9cb6-45f9-bb78-2ee7eb73d916
+      - a2fe91e7-a4e8-4c56-b4c7-5858e94b3644
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -85,12 +85,12 @@ interactions:
 - request:
     body: '{"displayName": "CLI-Test", "description": "Test created from az load test
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
-      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "loadTestConfiguration":
+      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"36994fbe-cc9e-469a-afd6-2db000f89c30": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "ec6ca1d3-e877-4311-9b30-9c32c6b35abc":
+      {"passFailMetrics": {"26e5a276-6438-43d3-ba8f-444a3e943a00": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "e69e3b14-ea35-4cf4-8556-f44855504138":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "cc3d243b-8ca4-469b-9422-55d4b4fbd0bc": {"aggregate": "avg", "clientMetric":
+      "50"}, "7297c302-9c68-48e5-85d9-56d0c4c5f464": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -100,32 +100,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '768'
+      - '789'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"36994fbe-cc9e-469a-afd6-2db000f89c30":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"ec6ca1d3-e877-4311-9b30-9c32c6b35abc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"cc3d243b-8ca4-469b-9422-55d4b4fbd0bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:13:33.186Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:33.186Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:16:25.392Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:25.392Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1060'
+      - '1006'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:33 GMT
+      - Mon, 09 Oct 2023 16:16:25 GMT
       location:
-      - https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+      - https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 4c58c7ac-7385-4262-a061-2e8eb2cafdf7
+      - 03831b4c-118a-4eac-8fa2-79a37b59ceee
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:33 GMT
+      - Mon, 09 Oct 2023 16:16:26 GMT
       mise-correlation-id:
-      - 7cf7fc0a-36aa-43e9-8f6e-fe232f4b3df8
+      - c3bf4254-5da2-4ed4-8625-c1248b4ed5b0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A23%3A34Z&sr=b&sp=r&sig=JA%2ByV5MRqLUKsabj9TSvCn3wijaoUJ3lIYiQfn33W%2FI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:23:34.0043007","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A26%3A27Z&sr=b&sp=r&sig=rI59CCWhC%2BQpGEXZN0ATBPW1M3MtZ6UYZt1ZosbtIbM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:26:27.5688478","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:33 GMT
+      - Mon, 09 Oct 2023 16:16:27 GMT
       location:
-      - https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 7d913c37-a449-418f-98ae-2f196f1b9717
+      - 737fe9f6-c1f9-4b3d-8ffe-5678c7f0e3de
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A23%3A34Z&sr=b&sp=r&sig=W8b13CJrgMl6cnWNfTP64oTyEwr1VaH8yBgnqf8hID4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:23:34.2913274","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A26%3A27Z&sr=b&sp=r&sig=UQRD3Va0o49LjNIfSARyuvqhk2Aitp7jMFEZyxhWUYI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:26:27.8462875","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:34 GMT
+      - Mon, 09 Oct 2023 16:16:27 GMT
       mise-correlation-id:
-      - b916121f-c068-4ddd-be41-cea02b8140d2
+      - 1fa6078d-36c1-4031-8387-f5e40a3d63c2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A23%3A39Z&sr=b&sp=r&sig=ZQU6e1mjmicG6EtV2dSc7B%2FluboDyfFyYSydCVDa2xY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:23:39.5880515","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A26%3A33Z&sr=b&sp=r&sig=6IAouEvAdWT48Avtl5VgLjY5rNVSS%2BFPie%2Bm%2B3RiVps%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:26:33.1220761","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:39 GMT
+      - Mon, 09 Oct 2023 16:16:33 GMT
       mise-correlation-id:
-      - eaeb0261-37cb-4e7c-83ca-43baaa820fda
+      - 5732c5c8-db42-4a76-848a-1f0e606f6b10
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,10 +385,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A23%3A44Z&sr=b&sp=r&sig=zmqKYPl48bKUeMiyra7XS3LwhwClDNQH2pnBgQvsDkk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:23:44.9093076","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A26%3A38Z&sr=b&sp=r&sig=x7p76gkVQqlZq9tHbzICexFzFI7zuVepT6xyPxRIsv4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:26:38.4001651","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:44 GMT
+      - Mon, 09 Oct 2023 16:16:38 GMT
       mise-correlation-id:
-      - 7814dad0-b8fa-4a9d-b56b-023ff6d28038
+      - 8d595e7c-bb3b-4708-a65f-2c7077cc65db
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A23%3A50Z&sr=b&sp=r&sig=EZns5SHeFW%2Fm4zw4VlSutE6pTKF1A4%2BBkuUL0V%2B0LL4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:23:50.2331329","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A26%3A43Z&sr=b&sp=r&sig=mqFXYq51bx6E4TJQYLjJ%2FO3gx7S7k%2F%2F%2FPhB%2B4f0yNzE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:26:43.6623741","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '557'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:50 GMT
+      - Mon, 09 Oct 2023 16:16:43 GMT
       mise-correlation-id:
-      - 5dcf0051-a316-4890-a1c1-01adfecb2748
+      - 868ad63c-b22c-4bd2-9199-c9c85013b847
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"36994fbe-cc9e-469a-afd6-2db000f89c30":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"ec6ca1d3-e877-4311-9b30-9c32c6b35abc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"cc3d243b-8ca4-469b-9422-55d4b4fbd0bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A50Z&sr=b&sp=r&sig=0LCm4KtfFgEWvhSXuQAlDOuWBpmKh1wmVTxrFwK7fU0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:50.4992466","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:13:33.186Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:46.371Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A43Z&sr=b&sp=r&sig=GUYSWctVg%2BAFUa15PaGb%2FS65k3dQYZSgDgfCOenf4l0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:43.9236011","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:16:25.392Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:41.305Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1629'
+      - '1579'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:50 GMT
+      - Mon, 09 Oct 2023 16:16:43 GMT
       mise-correlation-id:
-      - 07fe09e2-0647-4ccc-8e37-82fa681a4844
+      - 98d31e0d-c4cc-401b-951a-dee94e93f1e2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:12:55.4043087Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:12:55.4043087Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:15:49.7188431Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:15:49.7188431Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:52 GMT
+      - Mon, 09 Oct 2023 16:16:45 GMT
       etag:
-      - '"1a0a86c6-0000-0100-0000-64af094a0000"'
+      - '"920179d0-0000-0100-0000-652427380000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"36994fbe-cc9e-469a-afd6-2db000f89c30":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"ec6ca1d3-e877-4311-9b30-9c32c6b35abc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"cc3d243b-8ca4-469b-9422-55d4b4fbd0bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A53Z&sr=b&sp=r&sig=YXjjUA5xQ9TnrTXwpue0OSEEIMDTFJTSFAfy7hAZ7lY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:53.0209134","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:13:33.186Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:46.371Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A46Z&sr=b&sp=r&sig=OG%2FX299R%2F%2BbGxqK8bl%2BLKjSpIOkL3jYHSo%2BPm5yE5hU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:46.1910827","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:16:25.392Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:41.305Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1641'
+      - '1597'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:53 GMT
+      - Mon, 09 Oct 2023 16:16:46 GMT
       mise-correlation-id:
-      - a220646e-7918-4b34-a002-924151bdef94
+      - 9902abbf-7247-45b6-b029-fd1a21bcd9d6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:12:55.4043087Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:12:55.4043087Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:15:49.7188431Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:15:49.7188431Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:53 GMT
+      - Mon, 09 Oct 2023 16:16:47 GMT
       etag:
-      - '"1a0a86c6-0000-0100-0000-64af094a0000"'
+      - '"920179d0-0000-0100-0000-652427380000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:13:55 GMT
+      - Mon, 09 Oct 2023 16:16:48 GMT
       mise-correlation-id:
-      - bdd67112-a077-465c-bd02-7c93cff58a5b
+      - 3d228ff8-88eb-448b-8202-7507537d88e1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"36994fbe-cc9e-469a-afd6-2db000f89c30":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"ec6ca1d3-e877-4311-9b30-9c32c6b35abc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"cc3d243b-8ca4-469b-9422-55d4b4fbd0bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/73ae80d0-ccd3-42be-8dcd-b58bda95b9fd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A56Z&sr=b&sp=r&sig=48tnltYTb5AY69DSculP9claWplrim8dOOwNwIE9f6Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:56.4213626","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A56Z&sr=b&sp=r&sig=Zhnl0aXvdShvL7%2BAdua4CaOjbOJ0%2FGc7qaxtHL%2FxWhU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:56.4212576","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/cf749943-aad7-41f5-91ce-9484eeae86d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A56Z&sr=b&sp=r&sig=g1g36PEhQbGYVVPcEfEwRZnjpVZf8fZbCnLo2xa7FE8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:56.4213907","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","testId":"list-test-case","status":"ACCEPTED","executedDateTime":"2023-07-12T20:13:56.266Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-07-12T20:13:56.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:56.772Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A49Z&sr=b&sp=r&sig=zg7jzXdqvxrLopQvk3GMd1dTpPSti2nl1%2FM2EiXvWlQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:49.3044632","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A49Z&sr=b&sp=r&sig=zg0u6nJOzmnRlz3cLXib1v7XrEtraHHjnFw8Jtd49eo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:49.3043329","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A49Z&sr=b&sp=r&sig=jzpRNcE4hjTWd9Is%2B0Vu%2FgdQEfvad%2FiEh1gSx8hmRG4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:49.304486","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.233Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3181'
+      - '3145'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:56 GMT
+      - Mon, 09 Oct 2023 16:16:49 GMT
       location:
-      - https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+      - https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 41aaff4f-1198-466a-a309-c2f147239c95
+      - 8df04030-910b-4845-99e6-5201703ddc35
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"36994fbe-cc9e-469a-afd6-2db000f89c30":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"ec6ca1d3-e877-4311-9b30-9c32c6b35abc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"cc3d243b-8ca4-469b-9422-55d4b4fbd0bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/73ae80d0-ccd3-42be-8dcd-b58bda95b9fd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A57Z&sr=b&sp=r&sig=xpJx1g8PQkG5mdZddl097e4mAIEX3UhlUnpElmSMGT8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:57.1191102","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A57Z&sr=b&sp=r&sig=Z8bwnKjBQiLYiNVUqvW1kc0txpn7WXbN02CbXQylpmk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:13:57.1190376","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/cf749943-aad7-41f5-91ce-9484eeae86d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A13%3A57Z&sr=b&sp=r&sig=UMLsQ18NKbiRYCnoli2iwZT2gT67dco4VmY2Gb7Uz4Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:13:57.1191238","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:56.937Z","executedDateTime":"2023-07-12T20:13:56.266Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-07-12T20:13:56.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:57.107Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A49Z&sr=b&sp=r&sig=%2BHgHouAG2pfh7uHRo4CIhoLZoe9nDI9Ue8j0fVnNwpM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:49.7640422","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A49Z&sr=b&sp=r&sig=%2F9rTMg3XDiiVsLxtv0WyVg%2FpGKmp999qqNT1fZzd17k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:49.7639723","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A49Z&sr=b&sp=r&sig=V9TVMxdiMBCt6y38XmNDtBY%2BGSN7eaTYfui%2FZu67auE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:49.76406","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.624Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3222'
+      - '3191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:13:57 GMT
+      - Mon, 09 Oct 2023 16:16:49 GMT
       mise-correlation-id:
-      - aa9e0831-943c-407e-b2d5-3328e124ecbf
+      - 7f0b51d8-337e-493e-bbc6-1f58808489a1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"36994fbe-cc9e-469a-afd6-2db000f89c30":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"ec6ca1d3-e877-4311-9b30-9c32c6b35abc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"cc3d243b-8ca4-469b-9422-55d4b4fbd0bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/73ae80d0-ccd3-42be-8dcd-b58bda95b9fd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A02Z&sr=b&sp=r&sig=vk0KQqM2YS6A0E14SWVM73u9gvjMgiwtOh67%2FFosjGg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:02.4251788","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A02Z&sr=b&sp=r&sig=ROGpSpA9np0afQtN9r7GLIrhDlO2lsf1aKTNWVBBwCQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:02.4250784","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/cf749943-aad7-41f5-91ce-9484eeae86d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A02Z&sr=b&sp=r&sig=AleqlQwVmx3pSSr6LBzgm32y3s69KuWHMVRtp7nXFVA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:02.4252068","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:56.937Z","executedDateTime":"2023-07-12T20:13:56.266Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-07-12T20:13:56.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:57.116Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A55Z&sr=b&sp=r&sig=PcA9SOuNkXU4n8EQrRZx%2Fjfdye4Ge7AYKcDbLfVKCxA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:55.0908643","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A55Z&sr=b&sp=r&sig=fpYRJowHtqwMRL6U2%2FmSmg2RE6X8qB4Y8zy0%2Bdt1rjo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:55.0907769","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A55Z&sr=b&sp=r&sig=b7o6vBrf9okFXp3%2FEhBxOr%2FyRkWK00sZ2Wn0jEmxz2g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:55.0908863","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3224'
+      - '3194'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:02 GMT
+      - Mon, 09 Oct 2023 16:16:55 GMT
       mise-correlation-id:
-      - e4b1dd5a-9c31-4bee-93bb-6effc4fdad69
+      - e23fcadd-23a8-4a37-a4ea-785e1f025897
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"36994fbe-cc9e-469a-afd6-2db000f89c30":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"ec6ca1d3-e877-4311-9b30-9c32c6b35abc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"cc3d243b-8ca4-469b-9422-55d4b4fbd0bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/73ae80d0-ccd3-42be-8dcd-b58bda95b9fd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A07Z&sr=b&sp=r&sig=eZxCn4ftI41%2Bx64zgF504zBArPZY6gU2bE%2BrjZDOpc4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:07.7212886","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A07Z&sr=b&sp=r&sig=1ycay6VQTBWmCI9h2GSdWCTsvID%2BYWmx46tmCBvo9RE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:07.7212037","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/cf749943-aad7-41f5-91ce-9484eeae86d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A07Z&sr=b&sp=r&sig=nEPzMBxinLjHQfS9cmqxZFVVTRVU7m2iwUpZV9CMcp4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:07.7213074","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:56.937Z","executedDateTime":"2023-07-12T20:13:56.266Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-07-12T20:13:56.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:57.116Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A00Z&sr=b&sp=r&sig=N9lVEaY3mTApgYiuFDHrTeM7J2A2VJobezxVHTUe4p4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:00.3695153","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A00Z&sr=b&sp=r&sig=mt%2FllvMVvTspTN9l%2FiORL1w2u%2Bqa55B7zVTthFrlDpk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:00.3694351","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A00Z&sr=b&sp=r&sig=hhYQssV3yKYclmZS5reflEzAHUHMo955NjD7xXl%2BGXs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:00.3695318","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3228'
+      - '3192'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:07 GMT
+      - Mon, 09 Oct 2023 16:17:00 GMT
       mise-correlation-id:
-      - 2cb85ed8-8ff5-4dc7-b6dc-28bf7c7aa305
+      - 170d9bc3-cfe7-48f8-ab2c-824b019bdc4c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"36994fbe-cc9e-469a-afd6-2db000f89c30":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"ec6ca1d3-e877-4311-9b30-9c32c6b35abc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"cc3d243b-8ca4-469b-9422-55d4b4fbd0bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/73ae80d0-ccd3-42be-8dcd-b58bda95b9fd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A14Z&sr=b&sp=r&sig=I5PV7YKi%2Fzp8vdbelXCl8B5I456VeDAaQbzsiHrKl3s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:14.3784568","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A14Z&sr=b&sp=r&sig=6gB9P4CN3mRrdHKEErkcfK9X647wEa4tQi%2FpAr8N7KE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:14.37839","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/cf749943-aad7-41f5-91ce-9484eeae86d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A14Z&sr=b&sp=r&sig=lLvd5003OkmFmPg5sC8M%2BHZUJBtMlzCtjpXUt280SME%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:14.3784711","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:56.937Z","executedDateTime":"2023-07-12T20:13:56.266Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-07-12T20:13:56.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:57.116Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A05Z&sr=b&sp=r&sig=VKDFlQwjpDYlDeQzQgF255kd7CjMee8k767UqiLoydA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:05.6453591","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A05Z&sr=b&sp=r&sig=iQ66H1nRGYcwBTppjFuwIAwNnGZ9CRVHq9bB3EjRjAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:05.6452715","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A05Z&sr=b&sp=r&sig=QtZorhOsJY3g5iy6KCSm%2B93hFQWoqB9wEvVC7%2FWL8iI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:05.6453832","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3226'
+      - '3188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:14 GMT
+      - Mon, 09 Oct 2023 16:17:05 GMT
       mise-correlation-id:
-      - e3ce1384-30cd-491a-b3fd-a32fac4cf307
+      - 84dbbd25-4d23-42c5-b4b0-816a1518b854
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"36994fbe-cc9e-469a-afd6-2db000f89c30":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"ec6ca1d3-e877-4311-9b30-9c32c6b35abc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"cc3d243b-8ca4-469b-9422-55d4b4fbd0bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/73ae80d0-ccd3-42be-8dcd-b58bda95b9fd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A19Z&sr=b&sp=r&sig=x1AS6W6lFJDJV5vb7rqRrd4vpk6agQjpvgJtxNotSFg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:19.6865247","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A19Z&sr=b&sp=r&sig=SJJyLG%2BWUAGdP02ULOQl%2B52uytMWt3xddvx9%2BBZa8Os%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:19.6864545","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/cf749943-aad7-41f5-91ce-9484eeae86d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A19Z&sr=b&sp=r&sig=dmOtKxqY0gaj2mxt4CLOeEGMWtaUvBEDRbzOTcZjF70%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:19.6865386","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:56.937Z","executedDateTime":"2023-07-12T20:13:56.266Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-07-12T20:13:56.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:57.116Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A10Z&sr=b&sp=r&sig=XTdVl0ccF9SzS%2FOZq2gUDCGVuwT3ZwVbaQdPWrT%2BRr8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:10.9255778","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A10Z&sr=b&sp=r&sig=ZlsqNzXIpn87bDlmpNVq2sIfsAV3B64vCVnJBTMjfR8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:10.925506","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A10Z&sr=b&sp=r&sig=FryLCNml5VZSRl22p%2F97I5xgyPwhiM5wV8lgiAwN90I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:10.9255944","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3228'
+      - '3189'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:19 GMT
+      - Mon, 09 Oct 2023 16:17:10 GMT
       mise-correlation-id:
-      - 217e251d-1b06-4aa5-b67b-1011c01ffc26
+      - 53171c0b-3b1d-4674-ad20-2b5bc1189131
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -880,23 +880,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"36994fbe-cc9e-469a-afd6-2db000f89c30":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"ec6ca1d3-e877-4311-9b30-9c32c6b35abc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"cc3d243b-8ca4-469b-9422-55d4b4fbd0bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/73ae80d0-ccd3-42be-8dcd-b58bda95b9fd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A24Z&sr=b&sp=r&sig=oIYoKtGWD4h9DquVVsH8TTttngG%2FTUQ%2BYNwgF2nm8ks%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:24.96159","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A24Z&sr=b&sp=r&sig=3f1SpW37QIHXrHOQKOlc%2Fk9iE5lWegHady1jQfxq%2Bd8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:24.9615212","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/cf749943-aad7-41f5-91ce-9484eeae86d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A24Z&sr=b&sp=r&sig=lP%2B8BySoAXTEoVKroyVPsfqduXu4Olubp6c3XzUXdw0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:24.9616046","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:56.937Z","executedDateTime":"2023-07-12T20:13:56.266Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-07-12T20:13:56.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:57.116Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A16Z&sr=b&sp=r&sig=gh%2F0nD5dWIjGfBSgYhhI%2F5Y%2BGnAQ%2BN%2BlyPY58ZCwo%2Fo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:16.1977155","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A16Z&sr=b&sp=r&sig=w85HSv5XgONKVQUbMO9BX%2BqJTG1uAIDAR53x23Gjnko%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:16.1976166","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A16Z&sr=b&sp=r&sig=xX4f%2BjctWWRuspSoNOA6rCaAgNb6mYkrhO0K7MOwK%2Fc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:16.1977435","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3230'
+      - '3202'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:24 GMT
+      - Mon, 09 Oct 2023 16:17:16 GMT
       mise-correlation-id:
-      - 3b335002-d129-4bbe-9fc3-73799a498b40
+      - c2d9866c-6d4b-45f9-85ed-da84ceea6c44
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -916,23 +916,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"36994fbe-cc9e-469a-afd6-2db000f89c30":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"ec6ca1d3-e877-4311-9b30-9c32c6b35abc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"cc3d243b-8ca4-469b-9422-55d4b4fbd0bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/73ae80d0-ccd3-42be-8dcd-b58bda95b9fd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A30Z&sr=b&sp=r&sig=U5YVmkLDViCJ22kUnZSR0Ckq1Yd0j9SscSUU%2FPPecOQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:30.2510588","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A30Z&sr=b&sp=r&sig=JRzbUB7d9%2FNNbYF9ZwnZcF5uIzgYqFHsQGp4qjrVNpY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:30.2509782","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/cf749943-aad7-41f5-91ce-9484eeae86d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A30Z&sr=b&sp=r&sig=R63y61DPeAq%2FKzAdyTc1tTclAkh0RQjH4Gs0RvGxiIc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:30.2510759","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:56.937Z","executedDateTime":"2023-07-12T20:13:56.266Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-07-12T20:13:56.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:57.116Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A21Z&sr=b&sp=r&sig=JVNuWL1%2BfdCUqfVp13ih3VuqBdXPVmBPvV1FvJHz6NQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:21.4934282","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A21Z&sr=b&sp=r&sig=rvLUm9ijnWJLyw4flo7ypXAQ6VeiYl7grG7zz52w3vA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:21.4933495","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A21Z&sr=b&sp=r&sig=AdB2O4OdNNqbOVQcx%2BnRtAVvPKQqBIOHmgu0QwOgB1A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:21.4934448","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3228'
+      - '3188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:30 GMT
+      - Mon, 09 Oct 2023 16:17:21 GMT
       mise-correlation-id:
-      - cafc506c-2402-4a86-8265-325b82b68a47
+      - c04bdd77-c171-47c2-9aae-c2bd79bb2b32
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -952,23 +952,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"36994fbe-cc9e-469a-afd6-2db000f89c30":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"ec6ca1d3-e877-4311-9b30-9c32c6b35abc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"cc3d243b-8ca4-469b-9422-55d4b4fbd0bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/73ae80d0-ccd3-42be-8dcd-b58bda95b9fd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A35Z&sr=b&sp=r&sig=XQD4mcmVZVFKbJ90%2FLjcc6YbE0cfUwbXUGgKbs0xOag%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:35.5695744","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A35Z&sr=b&sp=r&sig=PbYEVNz%2BUaEG3Yi%2FkuOIlSoXlJOSdp75gJFtsOE6DJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:35.5694759","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/cf749943-aad7-41f5-91ce-9484eeae86d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A35Z&sr=b&sp=r&sig=6RdtDKlWG%2Bb0eCgbTWQ%2BoTgp0re8P84zD1hnBQURnj8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:35.569602","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:13:56.937Z","executedDateTime":"2023-07-12T20:13:56.266Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-07-12T20:13:56.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:13:57.116Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A26Z&sr=b&sp=r&sig=nFNzNqA4FulpOlgNhV0pA2qJLb68zvGvVhJRUpBLijs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:26.8224182","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A26Z&sr=b&sp=r&sig=%2FrJ0VDYN1EDZz42o7wIaap2UMs9uOqWtenqcwnmJ2JI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:26.8223424","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A26Z&sr=b&sp=r&sig=VdTx7FySA8nEpb8pvoUv4dnqbqdjZICbVJIF3VzIP1M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:26.8224363","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3231'
+      - '3186'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:35 GMT
+      - Mon, 09 Oct 2023 16:17:26 GMT
       mise-correlation-id:
-      - 356bd187-f247-4dbc-a001-23deb973ed4b
+      - 51b6460c-d285-426d-9a5d-ce3854256a72
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -988,23 +988,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"36994fbe-cc9e-469a-afd6-2db000f89c30":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"ec6ca1d3-e877-4311-9b30-9c32c6b35abc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"cc3d243b-8ca4-469b-9422-55d4b4fbd0bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/73ae80d0-ccd3-42be-8dcd-b58bda95b9fd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A40Z&sr=b&sp=r&sig=6cWUQLKA0e6chXNEY89mwHX5HVvWo5OQUx%2F%2FFMvV9SM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:40.9508245","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A40Z&sr=b&sp=r&sig=fZv07hWJzBlx3V2xDK8f1HATydue7PGFpEsXVIpVmQg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:40.9507345","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/cf749943-aad7-41f5-91ce-9484eeae86d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A40Z&sr=b&sp=r&sig=DHCgb7zZlf4c2L19EKw%2BTWfqmieD55pBHv5cBXO55vQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:40.9508487","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","testId":"list-test-case","status":"CONFIGURING","startDateTime":"2023-07-12T20:13:56.937Z","executedDateTime":"2023-07-12T20:13:56.266Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-07-12T20:13:56.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:36.684Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A32Z&sr=b&sp=r&sig=38VkLZbUMgepymDvK20YSqY9kmbn9nMVUGEAqhNWsgM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:32.0919414","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A32Z&sr=b&sp=r&sig=0hqEGuBKsf8FWZxo00mdx04i%2FFn2FTUgjLs2nJzMObU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:32.0918623","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A32Z&sr=b&sp=r&sig=hlz1B2i5TUWb1jUyx%2Be86fK8aCreAuxtpVNz99gNIdE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:32.0919591","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3227'
+      - '3188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:40 GMT
+      - Mon, 09 Oct 2023 16:17:32 GMT
       mise-correlation-id:
-      - ca4a5e6f-4e8f-47cf-ad98-6b65a9791e96
+      - 9f0c6ec6-b3be-47f9-bada-411942fb1a4e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1024,23 +1024,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"36994fbe-cc9e-469a-afd6-2db000f89c30":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"ec6ca1d3-e877-4311-9b30-9c32c6b35abc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"cc3d243b-8ca4-469b-9422-55d4b4fbd0bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/73ae80d0-ccd3-42be-8dcd-b58bda95b9fd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A46Z&sr=b&sp=r&sig=2oPTxyf9tDyw4keNE4XYC%2FWJQDNYEww7ScfCyZ6rXzI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:46.2777558","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A46Z&sr=b&sp=r&sig=s5srMCecVQXK%2FHkIW%2F9mx7BJAYFKJVBs1LpW74blnVM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:46.2776594","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/cf749943-aad7-41f5-91ce-9484eeae86d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A46Z&sr=b&sp=r&sig=PvB5dD8k9g7Jp8je5phG8DkZ%2BBEP2DezjMCyOU0qVfE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:46.2777818","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:13:56.937Z","executedDateTime":"2023-07-12T20:13:56.266Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-07-12T20:13:56.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:41.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A37Z&sr=b&sp=r&sig=k0sQsF%2Fmkrpx2y0eqZdHbCMbEmpnsb41HzxuK80FZXg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:37.378173","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A37Z&sr=b&sp=r&sig=8ZzBULVBfjEuEmFLadlmjFYf5SdMtK0ZX%2FQV9tvv35w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:37.3780942","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A37Z&sr=b&sp=r&sig=q%2F%2BltUhN%2FWFozuQQjtN2BYJo1Nrra2X%2Fzu8Z9zQwoXQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:37.3781899","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3227'
+      - '3195'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:46 GMT
+      - Mon, 09 Oct 2023 16:17:37 GMT
       mise-correlation-id:
-      - c3cd6cd2-f32a-414b-b71e-60b6275eda52
+      - 443f8d5a-17f3-439d-b06f-dbad0305a701
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,24 +1060,780 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"36994fbe-cc9e-469a-afd6-2db000f89c30":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"ec6ca1d3-e877-4311-9b30-9c32c6b35abc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"cc3d243b-8ca4-469b-9422-55d4b4fbd0bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/73ae80d0-ccd3-42be-8dcd-b58bda95b9fd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A52Z&sr=b&sp=r&sig=zHytEEpQFIrMHQAJzNTjGLcVx7oRgjlLmvGv4IRD09Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:52.2685927","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A52Z&sr=b&sp=r&sig=Mcy5x7%2Bn24n8K%2BKTK67DAFMM2L0BNmC%2BarSkO9ap%2B90%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:52.2684867","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/cf749943-aad7-41f5-91ce-9484eeae86d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A52Z&sr=b&sp=r&sig=WGHrL3kc%2BHl2iB%2FKmK1k6A6TXd2YNs9Wv9hJ3AZYqxw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:52.2686128","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-07-12T20:13:56.937Z","endDateTime":"2023-07-12T20:14:51.747Z","executedDateTime":"2023-07-12T20:13:56.266Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-07-12T20:13:56.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:51.932Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A42Z&sr=b&sp=r&sig=oVPr6%2BafGm8hIYY%2Fx5ruB1rcTepTNANJCQxkxdReRLY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:42.6595145","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A42Z&sr=b&sp=r&sig=PPjo2Wb6vUNhlsViYIHfr%2FOtCTVnblNPVopw14FCH7E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:42.6594265","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A42Z&sr=b&sp=r&sig=zE1wSc9t3%2FLqzVGYooVvfxe2uFFPGItEmT6iUJHfD68%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:42.6595388","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:38.955Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3366'
+      - '3192'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:52 GMT
+      - Mon, 09 Oct 2023 16:17:42 GMT
       mise-correlation-id:
-      - e2257d7a-df64-4707-a00b-4a585e63d24d
+      - 87c1c913-65a9-4b23-a41a-455962074e0e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A47Z&sr=b&sp=r&sig=YNp8Vm0hGBEonNW1CsMG8DjtS8SNOXX3EnCYCvVhVBE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:47.9397693","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A47Z&sr=b&sp=r&sig=5T6yeudHjXOp3N3i3wtmXB%2BdOAJ5XGqV4WpDW5JR5Tg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:47.9396828","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A47Z&sr=b&sp=r&sig=Wr7kHx8dIc42AN%2BzIaoD0%2Begbplx9JhALP8lQP8Xoyc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:47.9397865","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:17:47 GMT
+      mise-correlation-id:
+      - 263e2710-a8b3-4813-92ff-71bcc445b3f9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A53Z&sr=b&sp=r&sig=3H26gtaYumqWQ7zDIpZJdjvu%2BA%2FQOmynsQl5Cbeq%2F6I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:53.214394","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A53Z&sr=b&sp=r&sig=u7cWBRQLGdNnQEGfgG7Bl7D7NEOauUyN1QrMgqxVO78%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:53.2143266","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A53Z&sr=b&sp=r&sig=jEAFbYsXywpZKLQ3xpy1hcW8btCY0iLe3KBk8RRFydA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:53.214409","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3185'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:17:53 GMT
+      mise-correlation-id:
+      - 383d2189-a078-40a8-9be8-d19e82617700
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A58Z&sr=b&sp=r&sig=8L03FQOmXWN%2B%2BZJ5IZAIFJKO78LqLgxUq88ZmkElhsU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:58.4921219","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A58Z&sr=b&sp=r&sig=6Iqu2wl8UWnmUEERVNVVwaWV590BPS%2FFXvYBRC68%2Bw4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:58.4920425","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A58Z&sr=b&sp=r&sig=PFe3zSaC9pNVwUjKL3aoCzKiGpiGaL1qmidBXiZL2ng%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:58.4921358","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:17:58 GMT
+      mise-correlation-id:
+      - 168194e1-0a97-4b72-bdc7-a644597c16a5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A03Z&sr=b&sp=r&sig=4tu7ZWY2p5Za2V1kvw0RE9hm3Nqqb69mXcesw7XpWvM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:03.7672617","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A03Z&sr=b&sp=r&sig=HlmrX%2BlTV38T5SFRUbynQPWuHNGuTTkTKDLF3%2BjfK7s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:03.7671849","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A03Z&sr=b&sp=r&sig=nXCY%2Bylf7wX6leMoUotU3BoLGdAjDIxIFYe01ayMdxU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:03.7672783","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:03 GMT
+      mise-correlation-id:
+      - 5d54dfca-2581-4f00-98c6-9d4f3c392571
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A09Z&sr=b&sp=r&sig=XAgmEzX7tMgJQ48U3qUEtSPJcyVaW0cSh3d7fqP9xlY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:09.0328756","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A09Z&sr=b&sp=r&sig=e6L5YOhjVXTCDxbpuGYUQ%2BZJLxTdhv8%2FG8mqUvaG%2Bf8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:09.0327857","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A09Z&sr=b&sp=r&sig=jtRcNcyhKjqqhiKhUEE5LSpXCkeEV%2BzEnmZfaQk6UF0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:09.0328959","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:09 GMT
+      mise-correlation-id:
+      - 6307f3c3-1954-4f98-8139-8e67c53c1bec
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A14Z&sr=b&sp=r&sig=JDkb%2FYGr%2Fhz4pPEOf9DyDJfyWl2LZxnubGVtFxNxOuI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:14.3013058","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A14Z&sr=b&sp=r&sig=GpavvQrefLGgylV1iuP2AHpIBvQuDuZYBQ8hLqkSWFM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:14.3012015","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A14Z&sr=b&sp=r&sig=mfE56A2J0NxMa6wyl4sD2f64wASb8Y%2FLvivXrbQDsu0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:14.3013329","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:14 GMT
+      mise-correlation-id:
+      - 716ee4ea-d8a3-4677-8410-e93331d2cc2b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A20Z&sr=b&sp=r&sig=xl6F80d3uf6sVHu15wavaH%2FL%2B25JHYLKO1ie2G9Ec6I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:20.2710152","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A20Z&sr=b&sp=r&sig=Tm1Ugoff4QlAhYjeN4SBQdNjgA5JoIHvIfFZ4T4fx5M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:20.270934","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A20Z&sr=b&sp=r&sig=2j0MwZ3sniXD7XpZQoi1pPhp6LmUzaThsfIzpSfYzGI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:20.2710297","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:20 GMT
+      mise-correlation-id:
+      - 4caf0b89-1897-4552-8b9d-ca91875922ee
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A25Z&sr=b&sp=r&sig=wh4oHcH5DfUh9DU6Br8LTBFtdZrx72clJW6QZwhU%2Bec%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:25.9081112","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A25Z&sr=b&sp=r&sig=3RkaJ9QyUHNmfr86IIMHyI9eSBlt%2B5ThSk3L3%2F%2BBoLk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:25.9080409","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A25Z&sr=b&sp=r&sig=cKHTUEHwY6tgf6BIwtMksVYzzH32qAAcpYG07UzVRE0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:25.9081264","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:25 GMT
+      mise-correlation-id:
+      - cf793f53-2ac6-4472-a31f-5ccf4020b7ff
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A31Z&sr=b&sp=r&sig=P0xmczkYxwIwuRkC1l29ZTM5djfKBDGC546at26IqG8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:31.2018596","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A31Z&sr=b&sp=r&sig=%2FDVNqOcGvq2wGk4GQQZ9JnVIJRj3bT65Ng2OYTW%2FpDE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:31.2017699","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A31Z&sr=b&sp=r&sig=uNcWAmB%2BQn2NvNr4KcTyQaM%2F6rWHD%2B6bK9FDSA4qNi8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:31.2018826","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:31 GMT
+      mise-correlation-id:
+      - f11d2b64-4054-4fe8-9ee1-fd310735cf92
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A36Z&sr=b&sp=r&sig=xCKDgXlbV94iKspdcVgLCZRqmNA%2BC0D4rOEMzwYRDCE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:36.4660506","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A36Z&sr=b&sp=r&sig=8ie%2Ffe%2FGmS2pSvWV5puBo%2FWS4R0rnylGwoH%2FerabLhw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:36.4659769","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A36Z&sr=b&sp=r&sig=OxFs%2BjN7iINkznHfxr9Phntu4yvOtDRKZSITEor2v7o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:36.4660663","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:36 GMT
+      mise-correlation-id:
+      - 2ad2bed6-5dc3-4beb-91ab-4bdd6044e318
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A41Z&sr=b&sp=r&sig=LEkq9Cwf6%2BDEfeUIF2PYiw7MRWiLDunykNCGMZ4VKIM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:41.7367843","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A41Z&sr=b&sp=r&sig=mf8MSpCCyb6yGSVzC03zkJxVd4qRr7d3uz5Srk1KZGA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:41.7366835","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A41Z&sr=b&sp=r&sig=nt8uQMiZiMRYVcENj%2BwdpNO8C7MRLTKPw%2FuU943Z3n4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:41.7368089","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:41 GMT
+      mise-correlation-id:
+      - b1d52c9d-3d89-4785-be55-3a8bccface23
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A47Z&sr=b&sp=r&sig=dM96MstZAcgq61ADPIktSP4ICp%2FIuZDO8Og1lXdqn0E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:47.0240559","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A47Z&sr=b&sp=r&sig=wzIa%2BhJZzSEV7tDDURKDGTwgQYyxQxEivQ2L%2BeZU3Rc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:47.0239879","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A47Z&sr=b&sp=r&sig=%2FWHoveke4PBAOUhzQ8TyIKGihhd7WvGcaExJS6g5Spk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:47.0240694","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:47 GMT
+      mise-correlation-id:
+      - b4d67e7b-81ae-4f2d-8ddd-8ad776372ad5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A52Z&sr=b&sp=r&sig=SMnaIClJ68r%2FaxshH2CvKZ4kGq8XtYNmH%2BH4kYrLrk8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:52.3007133","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A52Z&sr=b&sp=r&sig=7Dh5P033EepBJw5cIn6d%2Bn9c4adv457lmWZZ3qCLWvM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:52.3006407","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A52Z&sr=b&sp=r&sig=lHwI43ddI5bvwP7mt%2FXqnKVhlq7C51YkTAZggqlf7zk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:52.3007309","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:52 GMT
+      mise-correlation-id:
+      - a2a48625-c758-4f06-ba59-9d944559fec9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A58Z&sr=b&sp=r&sig=1e6hlCY95MWRc6pShMfnPWSH7%2Fs5cslchgj1EpZAzOs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:58.3793884","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A58Z&sr=b&sp=r&sig=FIYfZ9M2JqMxBoDxa%2FBVC7%2FofX6KeiJQ9OaGAsgUAY0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:58.3792934","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A58Z&sr=b&sp=r&sig=2KptcuxsUZ6izQeXyIe3j%2FzltWh4KQtCQLUvWwFj0LE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:58.3794069","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:58 GMT
+      mise-correlation-id:
+      - e5065ebd-dc51-475f-b2e8-fcb646b9830f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A03Z&sr=b&sp=r&sig=MeIZ4gOk1tOjOhONrd3Pc1vJzZ7Af3C443Lu09jrdyU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:03.6424991","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A03Z&sr=b&sp=r&sig=qXtAaz8VW1akJ%2FfewqAnS9%2FsAyr7TE3QSJkLkEuwzKI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:03.6424081","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A03Z&sr=b&sp=r&sig=AirTxD%2Fg%2Bi%2Bguaez8xvUivhEmE3Go1t9mL6qY0cx5ec%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:03.6425149","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:03 GMT
+      mise-correlation-id:
+      - dc21298a-b971-42ab-8692-b8563c1ab91f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A08Z&sr=b&sp=r&sig=RNFialESGVppTJnn9jaCWTM8msIeTHol31ryNII8tlA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:08.9332262","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A08Z&sr=b&sp=r&sig=As3nlv88me94kXDwCgLOsnXUXlmxF2KRQigDB7F%2F84M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:08.9331534","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A08Z&sr=b&sp=r&sig=Z1QdMtfPCMphMsot41MJTTPpRdaSkFz%2B0d0Kmk2%2Bkw4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:08.9332401","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:08 GMT
+      mise-correlation-id:
+      - 159c6183-d746-4096-b012-5ebc16393628
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A14Z&sr=b&sp=r&sig=Yvgv%2FvHkiOYW2ZInTLPeJvG10gQKRtTGd%2B0PX4I9JDY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:14.214443","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A14Z&sr=b&sp=r&sig=WuAZdcGeiCPQW3TRgBQjGVL7q0cxJjwLkUgmBs3c9Y0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:14.2143521","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A14Z&sr=b&sp=r&sig=XoZR4dytUz3R%2Fuyf%2FN78sXqiZ1WcAewmTgr9uRdjhrw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:14.2144742","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:14 GMT
+      mise-correlation-id:
+      - 25cdd740-cca4-4f5d-8f69-42b12f03bec4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A19Z&sr=b&sp=r&sig=xZnhgFn4FuqcT9kMslKQAIzw6GXy33bsMF%2BMNiXdMXY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:19.4746314","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A19Z&sr=b&sp=r&sig=lAHSb%2FSFJj%2FILvFWzdVT9VkIiVonmqT1mDWfKYFd13E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:19.4745572","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A19Z&sr=b&sp=r&sig=5S%2FzRZwMge1efe2ECN%2FwexnlNFAwYJwZyOKBODJUrWo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:19.4746477","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:19 GMT
+      mise-correlation-id:
+      - 45786eba-79e4-419f-a21f-734d1292bc6f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A24Z&sr=b&sp=r&sig=%2BPJ%2BU%2B3p0mDBhCS7TVbj1rgz%2FSkVFygNFGit5PgwCuE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:24.7594194","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A24Z&sr=b&sp=r&sig=2V%2FxZjmKEJduAMjAS6LyFCheWl%2ByRY35M627JnnWtww%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:24.7593495","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A24Z&sr=b&sp=r&sig=v6OS1CF9YDEZw64qjcAlfcI8HJ8uGpAQRCzpnUV%2BrTE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:24.759433","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:24 GMT
+      mise-correlation-id:
+      - df276bf6-b74c-4b6c-8531-32b64a56a4b5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A30Z&sr=b&sp=r&sig=JvQ0u5DHMzzFShQmuYcc%2F%2F07WivET7igIXpWxKPdRpg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:30.0303228","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A30Z&sr=b&sp=r&sig=k%2Fex1dVCd%2FKzOh6UrODKOcTvNB8u9Q1L%2FmUz9uyfQB0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:30.0302441","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A30Z&sr=b&sp=r&sig=jS0Wo%2Fdr7qSyug2dlbXuZuhYu5bYmhyBbIf2rDVpngI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:30.0303405","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:30 GMT
+      mise-correlation-id:
+      - 42d63aa2-059f-4698-b080-31b3ae0aa37b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A35Z&sr=b&sp=r&sig=%2BmZnDf7JDHfd8sWoJuUi6e4kBtc7N5Qf6v2habrVqgs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:35.3006356","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A35Z&sr=b&sp=r&sig=zIsUTNmGzNHw5eexY5hbLt7Xh3pabqBAJZnxBX%2FPIbE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:35.3005677","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A35Z&sr=b&sp=r&sig=jcP2SIJN0kIZ7A%2Bbeh%2FJMv%2BdHiXneEspVEC5bjOU368%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:35.3006504","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-09T16:16:49.624Z","endDateTime":"2023-10-09T16:19:33.998Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:34.173Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3327'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:35 GMT
+      mise-correlation-id:
+      - 9a5c04aa-3d8b-49b0-b8a7-5b0bf9e99922
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1100,7 +1856,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:12:55.4043087Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:12:55.4043087Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:15:49.7188431Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:15:49.7188431Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1109,9 +1865,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:53 GMT
+      - Mon, 09 Oct 2023 16:19:35 GMT
       etag:
-      - '"1a0a86c6-0000-0100-0000-64af094a0000"'
+      - '"920179d0-0000-0100-0000-652427380000"'
       expires:
       - '-1'
       pragma:
@@ -1141,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"36994fbe-cc9e-469a-afd6-2db000f89c30":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"ec6ca1d3-e877-4311-9b30-9c32c6b35abc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"cc3d243b-8ca4-469b-9422-55d4b4fbd0bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/73ae80d0-ccd3-42be-8dcd-b58bda95b9fd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A55Z&sr=b&sp=r&sig=Cs%2BpQguS34Oa42AcUJUfcbjCNPjRomfgalixD7IcT8I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:55.2858424","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A55Z&sr=b&sp=r&sig=2RuM91Jvq1sDYXFvTPxHvZtrrHdNEhH4wBWFeBl0FPc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:55.2857756","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/cf749943-aad7-41f5-91ce-9484eeae86d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A55Z&sr=b&sp=r&sig=fyA4Qlh87kvS97yahEHcssHQCMgpGvIOKopVybPIGUY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:55.2858567","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-07-12T20:13:56.937Z","endDateTime":"2023-07-12T20:14:51.747Z","executedDateTime":"2023-07-12T20:13:56.266Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-07-12T20:13:56.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:51.932Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A37Z&sr=b&sp=r&sig=OilTsvjuxXU6bnfF9QC6n7POgNVpMIGehEFjTtXvvbA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:37.5403037","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A37Z&sr=b&sp=r&sig=Deo6mYZacJyAY2cQ8Vd%2FUwLLO48sCZg3kPMynGXDZoU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:37.5402169","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A37Z&sr=b&sp=r&sig=EIC1YZ%2BhfT%2F9RCqjsfYtjZjXSexA3nx%2BvB63BxnB5cU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:37.5403207","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-09T16:16:49.624Z","endDateTime":"2023-10-09T16:19:33.998Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:34.173Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3368'
+      - '3337'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:55 GMT
+      - Mon, 09 Oct 2023 16:19:37 GMT
       mise-correlation-id:
-      - 9fac7297-64db-4001-a5b0-bc9835a3c40b
+      - ae789387-9d74-46e9-87a0-61b27d965aae
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1181,7 +1937,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:12:55.4043087Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:12:55.4043087Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:15:49.7188431Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:15:49.7188431Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1190,9 +1946,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:56 GMT
+      - Mon, 09 Oct 2023 16:19:38 GMT
       etag:
-      - '"1a0a86c6-0000-0100-0000-64af094a0000"'
+      - '"920179d0-0000-0100-0000-652427380000"'
       expires:
       - '-1'
       pragma:
@@ -1222,24 +1978,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d162b2f0-5766-445d-89f8-b98a4e1f7aa5.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
+    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"36994fbe-cc9e-469a-afd6-2db000f89c30":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"ec6ca1d3-e877-4311-9b30-9c32c6b35abc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"cc3d243b-8ca4-469b-9422-55d4b4fbd0bc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/73ae80d0-ccd3-42be-8dcd-b58bda95b9fd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A59Z&sr=b&sp=r&sig=DjC3FBqOciFLzYFyL5baakNzLTlTjvCIWsNhr60yVeY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:59.5952265","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/5eedd73b-8ea8-4bc5-818d-3cbb22c58313?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A59Z&sr=b&sp=r&sig=nN8lhKsLznsDreKfuKCX8EI7lxu6zNCoY4eHUWDjpmg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:14:59.5951618","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/76fae56c-ab9d-4bc1-872f-9c099f962221/cf749943-aad7-41f5-91ce-9484eeae86d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A14%3A59Z&sr=b&sp=r&sig=PKnHGMp56mWuaMgKdy6H5fWOv%2BP8TrItZgKNhTGdC14%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:14:59.5952414","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-07-12T20:13:56.937Z","endDateTime":"2023-07-12T20:14:51.747Z","executedDateTime":"2023-07-12T20:13:56.266Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-07-12T20:13:56.772Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:14:58.797Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A39Z&sr=b&sp=r&sig=C6bv2sQRDo7dLlPU5SBYnIYRI8oV91%2BmF0XwYwG29no%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:39.6894159","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A39Z&sr=b&sp=r&sig=csh5C9ZGbD9zOWEwMb627X1VsxgsATBMs3yJYZLFdio%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:39.6893469","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A39Z&sr=b&sp=r&sig=r2FzliAmg2XKrAOX8DHbCdTZMLp%2B6bsA0W%2FUeliCzh4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:39.6894303","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-09T16:16:49.624Z","endDateTime":"2023-10-09T16:19:33.998Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:34.173Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3368'
+      - '3335'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:14:59 GMT
+      - Mon, 09 Oct 2023 16:19:39 GMT
       mise-correlation-id:
-      - 275e23d5-ff5f-44d6-831d-33421b184922
+      - 5e49ef94-ce55-43ef-9799-66217c01b438
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_list.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_list.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:24:37.0997784Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:24:37.0997784Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:06.2312841Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:06.2312841Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:10 GMT
+      - Mon, 30 Oct 2023 07:25:42 GMT
       etag:
-      - '"3c00392e-0000-0100-0000-653edba70000"'
+      - '"3f00d570-0000-0100-0000-653f5a550000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:25:12 GMT
+      - Mon, 30 Oct 2023 07:25:43 GMT
       mise-correlation-id:
-      - 8f6ef86c-6967-4254-ba1b-e1de0b89ea9e
+      - f422bc8c-cbf2-48b4-a318-170c657589f9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"0d756310-bbee-4fa6-b9b7-c66f2b831884": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":
+      {"passFailMetrics": {"00c06f85-a17e-4ea1-bfe6-1c00fd22c066": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "6e65ffe0-d0d6-499b-860d-709524951ed0":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "9cb64308-d119-4505-b3dc-70abaf0ba6d3": {"aggregate": "avg", "clientMetric":
+      "50"}, "2aa14eef-9087-4dfa-b9a6-18ab9e823f0e": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:25:12.841Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:12.841Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:25:43.724Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:25:43.724Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:12 GMT
+      - Mon, 30 Oct 2023 07:25:43 GMT
       location:
-      - https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+      - https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 4185c11c-feba-4aae-abd5-1eceeacce0e2
+      - c6e121fb-9057-4db8-94b3-6b0fd3b214d0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:13 GMT
+      - Mon, 30 Oct 2023 07:25:44 GMT
       mise-correlation-id:
-      - ec5e5987-408c-453c-a983-fb7ddf01457f
+      - f1a59e78-f105-492f-ae64-9d3ceb1e895f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,10 +275,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A35%3A13Z&sr=b&sp=r&sig=PkaL2NKdnyy0be51%2Fw689ABWPsAJt%2B0ObXimG4UfzbI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:35:13.7966431","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A35%3A44Z&sr=b&sp=r&sig=P%2FxoLM5jncHdDXle8bg74wUPqPwR8uNJu%2FNwCWBKhC8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:35:44.5692199","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -289,11 +289,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:13 GMT
+      - Mon, 30 Oct 2023 07:25:44 GMT
       location:
-      - https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 45ddf34b-eec9-4752-a7a9-2d002e648277
+      - 95510b1e-37e7-4919-b110-2df006efaa80
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A35%3A14Z&sr=b&sp=r&sig=KANiYa3UbgkoN28O5AYfxaco%2BjwCl%2Frlfcd%2BHRwYmXg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:35:14.1173353","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A35%3A44Z&sr=b&sp=r&sig=6Qx40ba6cJHS3uJavRcOyp4X5%2BqHAgceZ7XfzYnHjiE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:35:44.851712","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:14 GMT
+      - Mon, 30 Oct 2023 07:25:44 GMT
       mise-correlation-id:
-      - 421401f2-a867-4d1f-8a9f-8815a0cbcacd
+      - 75abd61b-bdb4-47cb-bbff-aa39595ac5b3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A35%3A19Z&sr=b&sp=r&sig=XSHKf%2BrDCXQT3TKn5V3dInuEsF2iERxeRbVp%2Bo94SKE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:35:19.3618449","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A35%3A50Z&sr=b&sp=r&sig=wDXsRb3DC0dx3Pbrr8RLDApAVQbpNrjs60DSge7wQCE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:35:50.0863106","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:19 GMT
+      - Mon, 30 Oct 2023 07:25:50 GMT
       mise-correlation-id:
-      - 640097b3-78c3-4404-aa09-75849f21c4a6
+      - 5df9f035-ca81-4f9c-93a6-26099e927cd6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A35%3A24Z&sr=b&sp=r&sig=U%2BhZz42EmVLA7vJQ1wx%2FkzktjjDT%2Bduvg9vsjbDqSlE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:35:24.597229","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A35%3A55Z&sr=b&sp=r&sig=nOht8d6LD2Jy2RkGdkZ3OMFxfKcxtUL9MjovXt4bdcE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:35:55.3378651","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '554'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:24 GMT
+      - Mon, 30 Oct 2023 07:25:55 GMT
       mise-correlation-id:
-      - cf51ade1-4798-49af-b66d-8ec9d799dd59
+      - 099a90c8-0879-47d5-9dd1-ee53ae1e5972
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A35%3A29Z&sr=b&sp=r&sig=zZyp6MoHBf1CTiOphfQHKEKeKOS91MmrEpXlvEH70qo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:35:29.857089","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A36%3A00Z&sr=b&sp=r&sig=dzu29sc8ux%2F2GjHTGXNNEu3WlCBKFp1aPnkTzK50mhw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:36:00.598733","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '546'
+      - '548'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:29 GMT
+      - Mon, 30 Oct 2023 07:26:00 GMT
       mise-correlation-id:
-      - 325b6663-8b7e-4606-b2ae-e2d9744f7c94
+      - 6e2c5013-92be-4b2b-83e1-d573671da984
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,11 +457,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A30Z&sr=b&sp=r&sig=j97SLW6lLyh%2FmL5IKOOGeLqtSyN1HcurwkscEbLpKqg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:30.0933378","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:25:12.841Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:27.876Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A00Z&sr=b&sp=r&sig=FF3UbNOHjZQH3QxWog2jFkOti5QI5Z%2BbRZ9bBhGG6Oc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:00.9245825","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:25:43.724Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:25:57.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,9 +472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:30 GMT
+      - Mon, 30 Oct 2023 07:26:00 GMT
       mise-correlation-id:
-      - b6e8dbf4-80a3-4e13-9bfd-a44f21d74207
+      - 80979e42-886a-4e89-8781-8063cb9dbbb9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:24:37.0997784Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:24:37.0997784Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:06.2312841Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:06.2312841Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:30 GMT
+      - Mon, 30 Oct 2023 07:26:01 GMT
       etag:
-      - '"3c00392e-0000-0100-0000-653edba70000"'
+      - '"3f00d570-0000-0100-0000-653f5a550000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A33Z&sr=b&sp=r&sig=WSdc4YOvV7VPyEkJgANvw9cAzXETDyOw%2F0nskAXQsRY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:33.2739681","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:25:12.841Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:27.876Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A03Z&sr=b&sp=r&sig=3peDVtJKPPDdfabhISOgf1d6D29rWHBQM6%2F%2BGr9T8SU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:03.1670814","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:25:43.724Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:25:57.031Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1589'
+      - '1591'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:33 GMT
+      - Mon, 30 Oct 2023 07:26:03 GMT
       mise-correlation-id:
-      - 6403d92d-c558-47fc-8af1-eca50d44a08b
+      - 5419a435-c21b-40fc-bc0c-56c15caede24
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:24:37.0997784Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:24:37.0997784Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:06.2312841Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:06.2312841Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:33 GMT
+      - Mon, 30 Oct 2023 07:26:03 GMT
       etag:
-      - '"3c00392e-0000-0100-0000-653edba70000"'
+      - '"3f00d570-0000-0100-0000-653f5a550000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:25:34 GMT
+      - Mon, 30 Oct 2023 07:26:04 GMT
       mise-correlation-id:
-      - 67d98d0d-5921-4059-8c6b-f4362184daca
+      - bfebecd9-0d89-4474-8e74-bd71ad53db08
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A35Z&sr=b&sp=r&sig=erCHeGtost9NwikjTLYhi%2FEyijDQQCW7rUGJkjepP3M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:35.5508187","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A35Z&sr=b&sp=r&sig=MFr9vFxcASJxABb2Q1ta5CUZ1fJ6JIDA1rRnj%2BMC%2FS8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:35.550643","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A35Z&sr=b&sp=r&sig=K35aquONUAftx98H7Oh8E30beGi80SlSq4bHgXHDfok%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:35.550846","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:35.462Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A06Z&sr=b&sp=r&sig=lm1x4Q%2FkTxC27JnWGW2dTacC2jzeSN24x4RcCJeXNLU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:06.3290248","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A06Z&sr=b&sp=r&sig=GXAbz6uSkCwyfy55IVU3OPx5UiBJGmG9JGq9E59Qroc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:06.328905","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A06Z&sr=b&sp=r&sig=PWX5qFgfaM75Z5RXQA2QrgJ6ZGbU5EXMIh0mfyijNo8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:06.3290463","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"ACCEPTED","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:06.243Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3142'
+      - '3139'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:35 GMT
+      - Mon, 30 Oct 2023 07:26:06 GMT
       location:
-      - https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+      - https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 9792620f-f562-4683-9fd2-c59f4fb47149
+      - 7e732649-083e-4b63-8ed5-c34d68fdc3f2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A35Z&sr=b&sp=r&sig=qBVC%2F%2FF2FfNlSOK6tl2RhqD267kyDyAlDyLSt%2FKZQWY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:35.967319","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A35Z&sr=b&sp=r&sig=8%2FXxPdimx%2BtniW6rwqqUUWqWvnmu%2Bd%2B9G7330UUzZlo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:35.9672501","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A35Z&sr=b&sp=r&sig=gBOHiV3LGdsAJHchg%2BxKj9NbS8nFKbI6xm0zSX3pCRI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:35.9673343","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:35.462Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A06Z&sr=b&sp=r&sig=8TVp0Kb5ueJm%2B5DiOuMpmS0xpk%2FZ2USAPKWNv%2Fh7oRs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:06.7177069","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A06Z&sr=b&sp=r&sig=WGmWZlwePvW8Mey7TqHirZlbZYkOoj1aUh41HkatRYM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:06.7176098","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A06Z&sr=b&sp=r&sig=ZebhGQs7yNXNtwIsXgjIAFw64TgRgMVTWt4g0rfZNik%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:06.7177242","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"NOTSTARTED","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:06.635Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3153'
+      - '3189'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:35 GMT
+      - Mon, 30 Oct 2023 07:26:06 GMT
       mise-correlation-id:
-      - d4405ea5-61c8-41ec-b6e5-41729c0ecb99
+      - 433f8b9e-0485-48a2-9ff2-1d953001214b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A41Z&sr=b&sp=r&sig=6GyPtaDPiL9qbtmHAWafyPHF2s9A5M6KlOeINedW8iE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:41.2891657","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A41Z&sr=b&sp=r&sig=kXxqfOuMgq%2BqS7WMplfM8pZJ7xAucTMq6MVdMOJ2hmY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:41.2890762","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A41Z&sr=b&sp=r&sig=W%2FvFmXsQ4UtOeYQX1LKweY0XBj0ZHuTdogCAiZiupfw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:41.2891881","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:36.79Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A11Z&sr=b&sp=r&sig=In61KGu%2BMPklqA0o88y7Oo0FNZobI%2BwxCOrdLPyYRoI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:11.9611287","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A11Z&sr=b&sp=r&sig=KSai6BkVVbsDPVJDCbldrxOZCUQAMsntzjIPyqbYHr4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:11.9610269","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A11Z&sr=b&sp=r&sig=gY%2BKSPbAa7dM%2F4KeIT7a38tt2agMJW8WA30oDTD3EXk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:11.961156","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:06.857Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3188'
+      - '3192'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:41 GMT
+      - Mon, 30 Oct 2023 07:26:11 GMT
       mise-correlation-id:
-      - 26705dec-95d5-4671-91ec-403843d1ebec
+      - 975db5d2-b196-4017-96ec-139b160b3c6d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A46Z&sr=b&sp=r&sig=kWU9MVYTnRordJyICQUGUPXtSZ4EpGCwazjEWWVtuTk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:46.8145036","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A46Z&sr=b&sp=r&sig=sEl1Cketc1NTPw0FtxMtM5v9m2foccIFZyvch1uSdqU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:46.814412","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A46Z&sr=b&sp=r&sig=PNtw%2F%2FwWLjrHzuFNh3l9QTT16P1zDA%2F6zN8Bt%2F1%2FsbM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:46.8145288","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:36.79Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A17Z&sr=b&sp=r&sig=jCBEcnGg5bSTsBB070cyb22f3JzRjkFyFBf0MAMb7fc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:17.209302","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A17Z&sr=b&sp=r&sig=LVRDfTMX1IGf5xFXVVXzfLu%2BDuIruzMMapq1O8%2FelKE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:17.2092361","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A17Z&sr=b&sp=r&sig=ClndUDmF6qgoEchUPzDlLTx7jXZ3yyY1f0%2FZ3vowEfU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:17.2093172","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:06.857Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3193'
+      - '3190'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:46 GMT
+      - Mon, 30 Oct 2023 07:26:17 GMT
       mise-correlation-id:
-      - ccaf971c-ae11-4db8-9a7c-1ca1bba68916
+      - 9f988d32-8eca-4d4d-9726-7ee8539bb253
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A52Z&sr=b&sp=r&sig=21bPZTTN%2BC2c9KZlNaxyfi72ityqokO6CVy4GWscZ6Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:52.1335263","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A52Z&sr=b&sp=r&sig=GzHGhjLsLuzbqTXnppPh%2B%2FCimyaoXO3IewMXJY1%2F%2BUk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:52.1334288","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A52Z&sr=b&sp=r&sig=YGbKdBusqSwmAY4ocsRwT%2BOkZSnRYjEYf4y5M8dUa24%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:52.1341875","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:36.79Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A22Z&sr=b&sp=r&sig=waGocS6e4XKovhX0Yp2LnrRL7YpSUuHZST0BaK%2Ff9zk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:22.4840395","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A22Z&sr=b&sp=r&sig=4SPieAyK8kfdKF5Thvu%2B5MaiFbdVU3RTW%2BKyz3tR8xo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:22.4839543","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A22Z&sr=b&sp=r&sig=l%2B3mIhrk1wFiB66ZF%2Fx33smtJERTsgJuoGFKQOnFAR4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:22.4840865","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:06.857Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3196'
+      - '3195'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:52 GMT
+      - Mon, 30 Oct 2023 07:26:22 GMT
       mise-correlation-id:
-      - 791bbe6e-c2c5-4f3b-959a-4b47fd624038
+      - 4b790ad1-e8a5-4603-a6f5-db02925ebd2e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A58Z&sr=b&sp=r&sig=g9nlWE3KoN3xPnRyiLUvzUIR5VKJnoHWdtuN53gLxn8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:58.3462879","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A58Z&sr=b&sp=r&sig=i9KR0qCH88IdniQfZf2i0ctPuOkoqa9bBOJ1YKkj3%2BU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:58.3462213","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A58Z&sr=b&sp=r&sig=FqIUulWct1UmMdR0kH9bEDfkOApqUpmtnIOB%2BSCtV98%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:58.3463015","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:36.79Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A27Z&sr=b&sp=r&sig=DKwhuz8CMh4VtWrNIc48UInjPd8ZTQgqAi%2Fc5662DGY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:27.7380577","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A27Z&sr=b&sp=r&sig=Oq%2FPzv%2BJg6bx%2FpMcU2fDFyg3QuzRtSbh%2BrJ3VHcmwAI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:27.7379685","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A27Z&sr=b&sp=r&sig=XXdE3zS89OQXmjj%2BzqxkTGY4hZBWseOpW8HFzV0F6gg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:27.7380784","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:06.857Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3188'
+      - '3197'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:25:58 GMT
+      - Mon, 30 Oct 2023 07:26:27 GMT
       mise-correlation-id:
-      - 4f878781-23ac-4abf-8242-afe01bf1aa7d
+      - 6530d19e-764a-4086-89af-564d42725181
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -880,298 +880,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A03Z&sr=b&sp=r&sig=ApMAjCRKw52OCv1qiByl%2B0chj4zB8szcqBNcH%2BLhWXs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:03.7014866","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A03Z&sr=b&sp=r&sig=2l%2BGEoFcE6M4pQ%2BDDpQV5ROab9b0paYnjMJl7t1Wdoo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:03.7014041","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A03Z&sr=b&sp=r&sig=LVg6jfhxZy9DFaKFHwgAbuixiypGSH4V5KruR%2BakHzU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:03.7015081","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:36.79Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:26:03 GMT
-      mise-correlation-id:
-      - 0c1d6555-c581-426e-bcbd-4de0969c34aa
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A08Z&sr=b&sp=r&sig=L4uGueadQMfr1AV4J6kbBxpxP53p3A9gsX47rkeQc24%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:08.9479728","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A08Z&sr=b&sp=r&sig=HkkLYf8m3cVETA6Tv7XWZ5Wj4GBCkJ%2FApQk4ZYSydFw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:08.9478868","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A08Z&sr=b&sp=r&sig=dIO3dBEkfPjObTUDvbgdJB0PErNH2BsPzBtM4ikhUMQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:08.9479939","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:36.79Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:26:08 GMT
-      mise-correlation-id:
-      - d7bdeb98-c272-46b2-84aa-b84a4ef30ced
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A14Z&sr=b&sp=r&sig=bh68Sk49B8mW0ahVF%2Byy%2B8SXbD%2FH%2Ft77YhHNfp889QE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:14.2097943","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A14Z&sr=b&sp=r&sig=478MhMRN02voJ6TrJ9dbwSkeSOUV70%2FoIwdE4VwRRGA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:14.2097215","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A14Z&sr=b&sp=r&sig=%2BhlJSKacG3%2F0DXI%2BRZ%2Bek33x6uWcideMw7MgGG%2F79LQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:14.2098085","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:36.79Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:26:14 GMT
-      mise-correlation-id:
-      - 7e1367c8-d49f-44de-b9e1-04b30983c8ba
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A19Z&sr=b&sp=r&sig=enkhUeeyLJGpUdmjonpEHCtfipk%2BofVH89V2YXCEw48%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:19.5429132","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A19Z&sr=b&sp=r&sig=SFuYNcKGuxRj1ZK8FKOcRp47%2FG6DxL4RKgUI9L5u578%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:19.5428222","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A19Z&sr=b&sp=r&sig=t%2FZmA%2Bn5hNolRzm5Aq7Rf%2FqLTkUARXcmRcCUTRR6yn8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:19.5429353","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:36.79Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:26:19 GMT
-      mise-correlation-id:
-      - 7159f314-4ffc-48f7-9af7-fa4fc3906cda
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A24Z&sr=b&sp=r&sig=RbkNcFfhZGWEfPhFe1PR5t3zjB%2FxpMD5O9xWKv%2FB4HM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:24.8419997","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A24Z&sr=b&sp=r&sig=UcEwEJCltVd7FXfM%2B7wHp5jQsEoYDNE1Vem%2FZtxNz9U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:24.8419351","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A24Z&sr=b&sp=r&sig=56iqWh8T0quTrqcmLBov3hYGwUiLxLk%2FaTjxr0AnqoA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:24.842014","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"CONFIGURING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:21.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:26:24 GMT
-      mise-correlation-id:
-      - 7a473702-800f-47e3-8d7f-294bed7a9c5e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A30Z&sr=b&sp=r&sig=ArWy8zrmPXAUUvtXCGoZPVwNZdSi48gF2l7dMyH0YfQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:30.1558517","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A30Z&sr=b&sp=r&sig=KsHl4yVU8aEaeVju4kt6DquCuWnqlHpI%2FJqxScOk2Ow%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:30.1557728","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A30Z&sr=b&sp=r&sig=4%2B7UGklkoyANlMYHc%2B6AHUWRDJeObu4ZRYiEd4GPuSE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:30.1558666","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:26:30 GMT
-      mise-correlation-id:
-      - b33fbdc7-8aa2-432f-9b45-99ea0a51bcd5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A35Z&sr=b&sp=r&sig=v0bbld0R65KL3UnHWc38gXIC0O5oQcGNbP3CIuXJfbg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:35.5879953","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A35Z&sr=b&sp=r&sig=o%2FXlua%2F27r880nVkVCEaQp1zQoNVooRvg4SRHpA8sRE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:35.5879049","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A35Z&sr=b&sp=r&sig=BNaGo43uVUjN6Dlwr9bNbDb5LYolC3Z3hHgNxK%2BtxI0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:35.5880102","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:26:35 GMT
-      mise-correlation-id:
-      - e69baf63-1a10-475e-bb30-b049d6734ae7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A40Z&sr=b&sp=r&sig=z3pyZ6E7FOtEhxVVh9v%2Fu1GBUVGHq7P2%2BTlMD%2FrqpuU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:40.8516695","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A40Z&sr=b&sp=r&sig=QnhcMdAnWZ%2FHXsHt01c77aoJiE3OgYWhe8IxvVFdoQY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:40.8515836","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A40Z&sr=b&sp=r&sig=DBzf3uF2rSHhOadJuyfW6QR%2FEp%2FU5976kmFFz0kbHZ0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:40.8516916","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:26:40 GMT
-      mise-correlation-id:
-      - 61eb5d98-d748-44f7-a90f-f8b48eba29db
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A46Z&sr=b&sp=r&sig=sr%2BNRI8lZtEQXbmVbu4PVllfF1hux8HKoLV0vPJ5suU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:46.122287","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A46Z&sr=b&sp=r&sig=Dg%2Bfsvsw5zTJDvkDc26g0xiDOZaCBxKijUZsy%2FW09h4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:46.1221721","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A46Z&sr=b&sp=r&sig=LkxnhiclYvKndwgz0Kfw%2BT9H04AySt36uFRBiH0bu%2Fg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:46.1223109","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A33Z&sr=b&sp=r&sig=nw2WZlNo9SidWVy%2BAKfJcpZVsIsGq1Ho5Ehb9tDyNu4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:33.0655857","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A33Z&sr=b&sp=r&sig=1LFqGJWVunjrvvqstimedlpM3BiRHAanLtdoyBYHKGw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:33.0655141","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A33Z&sr=b&sp=r&sig=fGb%2F1de0cNyYyuErrRuzyiNXqljnbgdfvpBN9S5%2Bxbw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:33.0656002","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:06.857Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1182,9 +894,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:46 GMT
+      - Mon, 30 Oct 2023 07:26:33 GMT
       mise-correlation-id:
-      - 119fd8af-c42f-4f76-a45d-3e8eb3d4c8b5
+      - 1f3d0276-bb2a-4ebc-bd3f-cf52ae4612b8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1204,10 +916,262 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A51Z&sr=b&sp=r&sig=2G6wEuelO%2BkBflTuZ2aUfC%2BJloIVyt0I8qeplTeCK1I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:51.3771778","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A51Z&sr=b&sp=r&sig=ePQzbRbL1luyIeP%2BqGT10OZBviOYhUQeQ5orMxoOsO8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:51.3770822","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A51Z&sr=b&sp=r&sig=ErRPA6qkySiepKVO6ongcuHyymsJDYpXDmFoPvKkk28%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:51.3772021","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A38Z&sr=b&sp=r&sig=rIaNIR%2BtumMqwwUWxFmkHYsOdBagkv3rr2czseLaado%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:38.3663887","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A38Z&sr=b&sp=r&sig=0HfdP31103c4w19UWu2C%2FxmD3rrx93X%2BjjzIi5EEaB8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:38.3663001","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A38Z&sr=b&sp=r&sig=ptV%2F6FdUhyIclsM%2FFQJeaJwqhdwL%2Bn2MtzFRH9elnxM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:38.3664107","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:06.857Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:26:38 GMT
+      mise-correlation-id:
+      - e8778e0c-ab1e-427e-b4c1-3616811c4b97
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A43Z&sr=b&sp=r&sig=%2B0%2FrEEkWhYiTbu0vYq3lLCBztTr%2BzsabXtCotJApXS0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:43.6198085","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A43Z&sr=b&sp=r&sig=uLl7dXmCoe6Imdkai%2BwFKN%2BHvKlMYsPOLrucdpBMaNU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:43.6197407","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A43Z&sr=b&sp=r&sig=M9AMjVDN79294IXNJDVI64fzMXctv1SoC7iLJh%2BACQw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:43.6198221","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:06.857Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:26:43 GMT
+      mise-correlation-id:
+      - 05492195-6f08-428e-acc4-0b84bcd561e7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A48Z&sr=b&sp=r&sig=Jk4KsRq3ANN2uDak6p2YuYarErgE9Jiq9BZHoP2Xr2M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:48.9419397","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A48Z&sr=b&sp=r&sig=VGEj14GzZo6Z2B3dd6PmXFL26zFYMVsLqWRuE2eom%2Fc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:48.9418163","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A48Z&sr=b&sp=r&sig=xZmlN4PD%2FERq88btDBPTVK0bf2NQrlAjeCM%2FR5Hdzoo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:48.9419642","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:06.857Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:26:48 GMT
+      mise-correlation-id:
+      - a3c00f20-c556-4cff-87b0-22719f395e37
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A54Z&sr=b&sp=r&sig=OAF6LGN%2Fej%2BarIH8RKfbop1yMTMDWS8bwWAyxx37U0M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:54.1886696","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A54Z&sr=b&sp=r&sig=1vIuQZHweFkoCT1tyOh1M3yjJG4kj3oDk5%2FvUSpZzic%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:54.1885717","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A54Z&sr=b&sp=r&sig=MhThmM2ntATiV32ixxM%2BPTPofL%2FAffXCP%2FJoNzXfyQs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:54.18869","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:26:54 GMT
+      mise-correlation-id:
+      - 591831ad-eced-4d72-8fb3-d89c0b736dda
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A59Z&sr=b&sp=r&sig=CdyVNRHQb8GiJGcAvnkVuYjfzM12dHpCRpP8x%2BER5YQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:59.4379041","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A59Z&sr=b&sp=r&sig=TMRhhf2Lr0jZxhnh4fKzsowGC9Q%2BLxYer5dJNhON%2FI4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:59.4378014","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A59Z&sr=b&sp=r&sig=RIh438cg9Wt3KGEW3GK0tpqK5GiwFS2vMlakf%2BibiYc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:59.4379257","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:26:59 GMT
+      mise-correlation-id:
+      - 8f75c0ea-9d43-445e-a9d6-4643b8656335
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A04Z&sr=b&sp=r&sig=wApZb25sRkyWvETrAJhnxcG%2F4ReUoEyG3b7Via%2FrmXE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:04.6832532","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A04Z&sr=b&sp=r&sig=HKluf13B0Fxvg8W3z%2F4KS9brd63ArBvIejwSKqw%2BmA8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:04.6831867","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A04Z&sr=b&sp=r&sig=B3FlaJ0itS3L5dBeUTBaXbTZeoo39M3fB2gMQmclKWc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:04.6832672","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:27:04 GMT
+      mise-correlation-id:
+      - 08ce918e-2d53-4251-925d-5898ec15e9ff
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A09Z&sr=b&sp=r&sig=0Xw6cp2wAr9sRjY84Qn%2BOP4jOTdi%2FjwbMYQyKhp9D3Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:09.9230977","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A09Z&sr=b&sp=r&sig=HLpiEJhSsw0wlD%2FdSKNkIoklq6yot%2Fy4I0W88Pe703I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:09.9230298","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A09Z&sr=b&sp=r&sig=4NZiO9ZcqXwjS3XGDK8JWTwryt3rBZSuTdf8d2GHdc0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:09.9231125","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:27:09 GMT
+      mise-correlation-id:
+      - ff3c1f68-e3c0-4e40-bb48-b4e21a45c133
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A15Z&sr=b&sp=r&sig=siedOi2323PsZsXOaiiByu6vXkQb8eUATnKYQ8pgk58%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:15.1746493","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A15Z&sr=b&sp=r&sig=%2FMW5z6W0CPHcKddAYNAcLbUPT86CoR77uJ8As72YvRM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:15.1745531","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A15Z&sr=b&sp=r&sig=7EjBahlm5ofTM8mK2ueN%2FuXF78T%2FUMjggI6YAIBdqpA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:15.1746702","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1218,9 +1182,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:51 GMT
+      - Mon, 30 Oct 2023 07:27:15 GMT
       mise-correlation-id:
-      - a32174e4-90cb-4608-a6b3-34a53ce9f083
+      - 356adaa9-715a-439e-8cbe-781e9b32e01c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1240,46 +1204,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A56Z&sr=b&sp=r&sig=gVZCpVnocmhG23gNHov1FyunUp6ZxRUkrNcmKrUOWn0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:56.9495851","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A56Z&sr=b&sp=r&sig=CdirNnrp4rQXFpyPpqMBkimQbpxS9a%2BIzgZcjsPRrwk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:56.949519","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A56Z&sr=b&sp=r&sig=vdGOZR8QRY9SmURzMi1OFYYVFztSWiRmu4%2F1XsaJwno%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:56.9495986","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3185'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:26:56 GMT
-      mise-correlation-id:
-      - e74edaf7-689c-4fbb-937b-614131f3a7ce
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A02Z&sr=b&sp=r&sig=Osl35Nyyp6yrQA2najE3vcqKzvBseObTl1%2B78YqwwCE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:02.2046197","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A02Z&sr=b&sp=r&sig=ZN0RQpmVQMGfpjN7hQP3P3wE5pUE1CnoOhJMHSWBAVI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:02.2045365","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A02Z&sr=b&sp=r&sig=Ingo1VuwCU8zmnku2kiKSKl5xTx0MnZy%2FaCH%2FoOE9VI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:02.2046409","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A21Z&sr=b&sp=r&sig=pXXElhw34%2BJPO1s3EZN5xw5xLf8ra5s9ejI1WFfbYIw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:21.2872028","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A21Z&sr=b&sp=r&sig=9yFIJt0yIP2y4l%2BkgSH6diXfSm7T7lxl1E0CbocRJuk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:21.2871325","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A21Z&sr=b&sp=r&sig=7Iu72BqXJoApYhizF3gq3IzHrzR7%2Bt9t4q6K51Wfda4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:21.2872171","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1290,9 +1218,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:02 GMT
+      - Mon, 30 Oct 2023 07:27:21 GMT
       mise-correlation-id:
-      - 434dcedb-9de0-4ae4-ac3b-2b7886caa92e
+      - 119c4daf-d1c5-4a91-b909-0c396a49e90d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1312,10 +1240,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A07Z&sr=b&sp=r&sig=zBDF4tURHg3r1nqYZlqNNSGCWu7uA3luoBHgZOTaths%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:07.4857374","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A07Z&sr=b&sp=r&sig=hqDsrMkHV5ITpx8iafOZaf3DKVPAVFLJgpJ1cyfmlYE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:07.4856541","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A07Z&sr=b&sp=r&sig=F%2FNTRcovvAPf0l27U2vI5BkJC%2FUvw2xZ2PL2CRPlbMY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:07.4857595","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A26Z&sr=b&sp=r&sig=gxXRadf3EniwpE2mBkGnryru3yI4R%2BDdACKKCZZHHy8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:26.6136916","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A26Z&sr=b&sp=r&sig=3c9aupai5%2B49K8Yl83Fv6tafXsJG1X%2F2HYD1Q7viOao%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:26.6136304","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A26Z&sr=b&sp=r&sig=twfM8HUMwittC3bNnpw1UEBwWggqWq8hk4tfkZ5ChCU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:26.6137055","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:27:26 GMT
+      mise-correlation-id:
+      - 6b4e9a80-866a-4250-aece-1544d5dee6f7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A32Z&sr=b&sp=r&sig=48HycmEDLH1a3lN40C02nwuIG3GXS8yJvhuiVkI8zUo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:32.6400129","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A32Z&sr=b&sp=r&sig=dbjy9w6EKhPScry95hmekP7xjUIPKbM4X7j0qu0yOLo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:32.6399314","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A32Z&sr=b&sp=r&sig=QB6kigHscaW9IBaOj90XSzHImNfDGTSxMKOUJls4pOM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:32.640035","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3181'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:27:32 GMT
+      mise-correlation-id:
+      - d83d3c20-fd39-40f7-8f14-268bbbea747d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A37Z&sr=b&sp=r&sig=sv8u1L%2FLBJ4yu0FbodkvouhLGjOJ1MkSZMBw69k73JU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:37.9249252","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A37Z&sr=b&sp=r&sig=ZN%2FObVLEZiX5r4dkt8lfPWnB7UOtiaQnloDB6fUcHPs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:37.9248267","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A37Z&sr=b&sp=r&sig=MPtmjsK8rUZfN5qFCSL6XMvJmAsqAQechaOx9Su46Pg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:37.9249564","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1326,9 +1326,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:07 GMT
+      - Mon, 30 Oct 2023 07:27:37 GMT
       mise-correlation-id:
-      - c0cb7d81-4847-461b-8361-7604daf019b3
+      - 111b7a8e-cc59-46d4-9074-59eb368aeac6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1348,82 +1348,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A12Z&sr=b&sp=r&sig=Hq2lmzRcY%2BYwiCmH9R%2B%2FF7DMm7TWVt6Y6iZs6%2Bv0MX8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:12.7418392","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A12Z&sr=b&sp=r&sig=1%2B1z8GFIb3ygonlL91yjZWoKu7A7YFLx5p66g9tSASc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:12.7417707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A12Z&sr=b&sp=r&sig=WevgW6RR%2BtFOSarHgXgbzj80372MUdyeVLafDtcCBQ4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:12.7418537","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:12 GMT
-      mise-correlation-id:
-      - 6283d024-01aa-47e6-a724-04ae9f716769
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A18Z&sr=b&sp=r&sig=F7WZXkhpEiXjU6HwmrHbdTjabUB7T4Af8X%2Fh7NwCbYU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:18.3043193","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A18Z&sr=b&sp=r&sig=CKYNx0KiakaXRHHjwSI1erYEnb3VRyci48pyLxoMOxc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:18.3042273","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A18Z&sr=b&sp=r&sig=VBs15QSYVJTiLkUS4a1OBpNf1Xr5rg%2Bovum0GfTByAU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:18.3043449","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:18 GMT
-      mise-correlation-id:
-      - 60309a37-8bd1-4633-878b-c53a98c62798
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A23Z&sr=b&sp=r&sig=dumA4Fmmxzxxph75Zu%2FT5vrBuF%2BmeUscujiuYcm23Ro%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:23.5500872","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A23Z&sr=b&sp=r&sig=%2BazEFlvPxMpjAeRavhDONAOJrY27ZTZo1ytDy3A9hQ0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:23.5500013","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A23Z&sr=b&sp=r&sig=e3I1lVm%2Bbsu5co9Uubej9%2FiAnZ%2BSzQdkoFaWPKXhGQg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:23.550102","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A43Z&sr=b&sp=r&sig=sZL3lv7S7q5JvgL76J6Yv5kzUSeOv6ei%2Fte42iN9hXQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:43.1676561","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A43Z&sr=b&sp=r&sig=H5GL7QFHnFQ4FaC%2FZBI5ygkXkrV%2FtDnbjcbOhFo1RgI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:43.1675829","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A43Z&sr=b&sp=r&sig=alqNf%2B7eq8ME6Q%2BF19BmBJRiRr9tiDbCISGxjgv%2Brtw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:43.167672","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1434,9 +1362,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:23 GMT
+      - Mon, 30 Oct 2023 07:27:43 GMT
       mise-correlation-id:
-      - 90cdfdc1-6c4f-4ee4-af56-11b512039fb7
+      - e52954bb-2f7a-4c2f-980d-6a1bf65f8a34
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1456,46 +1384,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A28Z&sr=b&sp=r&sig=t78O7SEAd%2BuzTTck6rhsTrO4r%2BvZsiMBUYXzK%2FwLx%2FU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:28.7971174","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A28Z&sr=b&sp=r&sig=BOkkjiwhMHDdrBh3AJsUH9WV5YRl9IimJsRv%2FTD9mDk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:28.7970477","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A28Z&sr=b&sp=r&sig=yk2P3C4xM%2BEzmHs84KS5XPn4aI9K%2FIn9Xxz%2BvzO3afA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:28.7971315","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:28 GMT
-      mise-correlation-id:
-      - a283bdce-019b-41e7-9239-0cde34c7e9a0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A34Z&sr=b&sp=r&sig=wP0E7EfcCSolYQ%2BLMZV6X1lcHgYcJm2GhKEwsctpNw0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:34.0966936","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A34Z&sr=b&sp=r&sig=wMlchQfjekuQod6SWrhby%2FfVe3eyg60qRg%2FMBdRdiiU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:34.0966172","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A34Z&sr=b&sp=r&sig=Wke6Ke%2FUkwjp94JnnmKoj2wBdsk2jA%2F9fR6DyzYtKkI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:34.0967088","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A48Z&sr=b&sp=r&sig=M%2FnYMETE32BfZx6JjZt3vUyvONdQ9hiJ%2BurU4iF9%2BeU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:48.4273535","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A48Z&sr=b&sp=r&sig=L7lL6OXqobJmBklw9FlrSoNSuxiLC3uTZnBJi4%2FHTp4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:48.4272554","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A48Z&sr=b&sp=r&sig=hD1aHiiFg9IdYGHpssabStH9c%2FxCg6Ns5caanmtomNc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:48.4273751","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1506,9 +1398,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:34 GMT
+      - Mon, 30 Oct 2023 07:27:48 GMT
       mise-correlation-id:
-      - e93edf8c-f71c-462a-848a-a55cb92dd31b
+      - dbf24317-5e44-4d1c-b55f-ca2f4be244db
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1528,23 +1420,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A39Z&sr=b&sp=r&sig=u17L1YLlbeoy1iYWcR%2FkWPynXC9vvaZSLXnIB%2BRfq7c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:39.7249121","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A39Z&sr=b&sp=r&sig=zXVVm4Pb3uyL1x5a1vkpTAZjnj1fc30aw7x%2BEmtLrYE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:39.7248234","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A39Z&sr=b&sp=r&sig=Y%2FbBae3KuG9G%2BPpDc17v3oDDZCkTaA8ohhX2xlwm0%2Fo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:39.7249369","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A53Z&sr=b&sp=r&sig=cxG3diS0jVVMi31Sv6Nb%2FcATdGp%2FP5cLPnfCOgZEcUQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:53.6710631","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A53Z&sr=b&sp=r&sig=VZ4dHnk7faZfd9a4CKegVTL4ZhDXMJl4AYZyGM1elok%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:53.6709828","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A53Z&sr=b&sp=r&sig=ZKGcX3RMJYJ2gmm32eP9kLmq3f4zOZyiPVSZLE04BXQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:53.671077","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3194'
+      - '3185'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:39 GMT
+      - Mon, 30 Oct 2023 07:27:53 GMT
       mise-correlation-id:
-      - 836ff894-9382-43fc-bd7f-d16958a17bdd
+      - d8ea03bc-3f72-43b6-b1a6-5dcdfb359138
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,46 +1456,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A45Z&sr=b&sp=r&sig=r2p9etLKXR4KF2B7fVYQOUX0vZseEaadbqnoq%2FyjNJs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:45.0000286","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A44Z&sr=b&sp=r&sig=Imz4eFwxlb7DeTe7dZyFuB0at3cHZi7Sb06osdPw7vg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:44.9999209","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A45Z&sr=b&sp=r&sig=%2B%2BqDT2dV44yED9DBpj5ggyn%2BUzHU5MtLR%2FPzjHck5o4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:45.0000534","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:45 GMT
-      mise-correlation-id:
-      - bf7317a8-f436-477f-b18e-054510314f65
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A50Z&sr=b&sp=r&sig=hehalNGjHN4crfTjmrsJHCo5FM3EPIkqnW2oF3wDD10%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:50.8094357","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A50Z&sr=b&sp=r&sig=REJ4lCFNH8ci0Mpzwjxd21StyPXvd%2BHH6Bqi2s7xqC8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:50.8093683","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A50Z&sr=b&sp=r&sig=5g8Dha7VeiPcR306S%2BplOrfao6M123Q3D%2BnyTk0R0lY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:50.8094505","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A59Z&sr=b&sp=r&sig=pCF5FctG1LySqB0XeNTcRdiOydVeSO4TOzufddudT7U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:59.534003","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A59Z&sr=b&sp=r&sig=Dt7gMBkL3r0Vay1%2BBZqpSuu2JdnoBj%2FFHAM3fBqfr%2FM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:59.533937","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A59Z&sr=b&sp=r&sig=ZkVySrh3wru5VhldPE97Uml9JJ%2BjtGQVoUtWoZIZOSk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:59.5340175","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1614,9 +1470,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:50 GMT
+      - Mon, 30 Oct 2023 07:27:59 GMT
       mise-correlation-id:
-      - 059ec170-2bc1-4cca-bb91-b9518cd0c1d5
+      - a9085284-28de-4251-939d-4bbc3e9a5599
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,10 +1492,190 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A56Z&sr=b&sp=r&sig=pvdiCcUBoWRYwWAXL74mmjI0A1YFGin%2Fx8EQcNByn%2F0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:56.1225825","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A56Z&sr=b&sp=r&sig=3nYBKiBcr%2BTL8ClHHjkR5jnxL6uw%2BeKUKzvdsNo8SBI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:56.1225134","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A56Z&sr=b&sp=r&sig=GJkI7oFjSz4cd32sv3iLlKWAGHFbiTsH7gVTqXUHQBs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:56.1225967","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A04Z&sr=b&sp=r&sig=bgzONIEgTMSUQj%2FM%2Fthionlvp8cjlv51BVl8xoA3MIk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:04.8076299","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A04Z&sr=b&sp=r&sig=t0JvEK%2Ffv8GGT94AmwAEzmETJOa7tVnYHu2moSu5N0g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:04.8075328","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A04Z&sr=b&sp=r&sig=6eKn6Wc6hWCPsXZWj9bpZv6tZ%2B9T%2F5FLXKpk%2F3RHcds%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:04.8076519","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:04 GMT
+      mise-correlation-id:
+      - 4ef11d74-745d-47ad-addc-e5b51fa3090a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A10Z&sr=b&sp=r&sig=zwSVsed7wNuphwXaN0X8O%2BI8xXikJI30qcpO9WwgyWs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:10.050119","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A10Z&sr=b&sp=r&sig=W3MoCa3hJXBTu0jzsJOpgwQcTZBmFqc%2Fcr82fiZ398M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:10.0500407","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A10Z&sr=b&sp=r&sig=Tm1zDUye27wVfOLGgkMt5aSoZ7DRTpYUnY5brmZA7Gc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:10.0501337","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3185'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:10 GMT
+      mise-correlation-id:
+      - 272778db-03f3-4eae-9f98-d43f46ed2cf4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A15Z&sr=b&sp=r&sig=sw6Jpgvcm4TE%2FVLUrrnBy3u7s93kqD11uDK%2BuArNqqE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:15.3687128","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A15Z&sr=b&sp=r&sig=%2BgRpp0NL69Us5NepJK7tLdB2neItaBrJKS0nVX0dLWY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:15.368627","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A15Z&sr=b&sp=r&sig=E%2FTsCmFlK8WiUlnapPjcFzDL3HDItM2FSdjKBvseu0Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:15.3687352","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:15 GMT
+      mise-correlation-id:
+      - bda770e1-d9b7-49b4-9750-edc9d0b187cd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A20Z&sr=b&sp=r&sig=vTIwyL1AsP%2BArN7jMD0u8StT%2By3iwdyH0crRvq3eeHA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:20.6119149","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A20Z&sr=b&sp=r&sig=VvWlHf8u6dgOT0muJRps0OtFBUHgE1WTTzDiYURbdhk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:20.6118317","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A20Z&sr=b&sp=r&sig=z4VYPb5mZmZfN48WmOGnOWNUSix0W6Fn%2BlJwkxTAGiM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:20.6119363","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:20 GMT
+      mise-correlation-id:
+      - bd5d0f57-e7bb-4afa-b8bb-d8fca3137c33
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A25Z&sr=b&sp=r&sig=CaYCO8JeKsws1txalIL3MHFggpnwgGlFDGvRD395rkc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:25.922619","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A25Z&sr=b&sp=r&sig=sRDxPPSqZ8tpASOtJF2qvGZjKTyfAvydWa3wRNaqZI8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:25.9225506","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A25Z&sr=b&sp=r&sig=BOfjBhJQsKLN9pMR5di4%2Fdx95%2BVPecYiLper75lAqQo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:25.9226341","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3185'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:25 GMT
+      mise-correlation-id:
+      - db0759cf-c9df-45c0-876f-afd8e6513e24
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A31Z&sr=b&sp=r&sig=llqBIDKPFcUr3rBjgqucDUFAmGkq84YCk1fES8Zgx9c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:31.1770593","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A31Z&sr=b&sp=r&sig=dXexIS812Rq4crGrgvxvicC%2Fetlm3cDJET39i5my0hE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:31.1769653","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A31Z&sr=b&sp=r&sig=DtS%2Brr138yI1gmiw6Ojd9pOnkoAqs5JVi%2FiPNGzB%2BmY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:31.1770791","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1650,9 +1686,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:56 GMT
+      - Mon, 30 Oct 2023 07:28:31 GMT
       mise-correlation-id:
-      - 25bc3c43-f0b6-479b-a5e7-c738f507f617
+      - e5d52c13-487c-4570-a0df-81239036954a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,23 +1708,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A01Z&sr=b&sp=r&sig=72x2sc5P42EjkAZU2CvSUz71YfPZ%2F31PZnJ31rd%2BFMw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:01.4342166","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A01Z&sr=b&sp=r&sig=f0P5wfXw5Dzs8ThDaVBVjNuquQY%2F1PP4icGMrBEIOS0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:01.4341317","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A01Z&sr=b&sp=r&sig=RnztZXKlPgWHOiqTQEUpPWGQBIwfAqspyrnahOKgb%2Fo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:01.4342373","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A36Z&sr=b&sp=r&sig=B6TWpEKuQwLH%2BDQUMQ%2Bh%2BOXxofBTXv59zW3EDhp2LnI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:36.4164863","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A36Z&sr=b&sp=r&sig=Pfhot%2FJOO0dKQXZp5CR1MH5cm%2FyMy4xUwQZwiUjXaqQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:36.416392","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A36Z&sr=b&sp=r&sig=ub53VOLhfcPjFLIZoK7IP4PDBo3SGeHtevv1uThoECo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:36.4165087","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3190'
+      - '3191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:28:01 GMT
+      - Mon, 30 Oct 2023 07:28:36 GMT
       mise-correlation-id:
-      - b814714a-de23-4cf8-b374-d4175c7e68de
+      - 43ba4339-7c4b-4d60-a440-d2ca8524e40c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,23 +1744,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A06Z&sr=b&sp=r&sig=mzEWZcSQcSmZhDpGlicL%2FAlL%2FQJm0Pm8m6BYiy%2FKi4s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:06.7065209","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A06Z&sr=b&sp=r&sig=ppiW584wZ6t5YE%2F55mrlcus6RM2XQ7jZRy0bmdfV6%2Fc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:06.7064552","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A06Z&sr=b&sp=r&sig=vowkzg%2BRTe9HokQgKvlGOoKIMfDHbQh%2BHU2Tq%2FMlyX4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:06.7065357","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A41Z&sr=b&sp=r&sig=6ulc1EnYW%2Fk9uxas56JgENNa%2BurMNTKSru0wll6dgoY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:41.6699437","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A41Z&sr=b&sp=r&sig=3kE9%2B37HLyml2SR27uEfBRCIDjpHW0UGtTLpuXLAVQ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:41.6698813","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A41Z&sr=b&sp=r&sig=j2iijNi86%2BT8W59%2B6eoWv8%2F9GLi0m9Rw4aOzecIU5yY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:41.6699578","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:06.635Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.097Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3198'
+      - '3194'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:28:06 GMT
+      - Mon, 30 Oct 2023 07:28:41 GMT
       mise-correlation-id:
-      - 6e681dae-639f-451f-9e64-1588e74c801c
+      - f25fb22f-c311-453f-9028-5f3773c31406
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,96 +1780,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A12Z&sr=b&sp=r&sig=y09EeXqfMlqegbr8QjOXAWKMlHzjPUm%2FkELDLip31Gw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:12.0247886","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A12Z&sr=b&sp=r&sig=UmecqSZknzsaTRqmckc36XS4IMT7qzzaOJcNJwGICxM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:12.0247135","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A12Z&sr=b&sp=r&sig=XO4caqw7Hi%2FvM1pHMFdmyM6kMOSZnYHHaWjtzFCZsWs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:12.0248031","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A47Z&sr=b&sp=r&sig=oip84IfnQfAHMjEejK2USW8DBYz0sDDZxzk1ZfXsZJs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:47.005749","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A47Z&sr=b&sp=r&sig=xk%2FqQfOuTE4XIZWKekEnTIYRMyy8mY4I6jjYZDZ9XCI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:47.0056659","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A47Z&sr=b&sp=r&sig=WzXS0XoKN1BUcLWN%2BSAxFyHV0wYJ6dDqWbcX1aKQanA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:47.0057705","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-30T07:26:06.635Z","endDateTime":"2023-10-30T07:28:46.381Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:28:46.517Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3186'
+      - '3320'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:28:12 GMT
+      - Mon, 30 Oct 2023 07:28:47 GMT
       mise-correlation-id:
-      - f6dc7bf5-d02a-4959-86e2-d59d7d81353f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A17Z&sr=b&sp=r&sig=RT32JhOfE28bD%2Fy6Ab%2F%2FsLhIbcPh1KSbZSYzajk9q6o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:17.33432","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A17Z&sr=b&sp=r&sig=fZ%2FTfVu51t03nJ1LG%2FzREqTnloUX5CxzoltG98VlBig%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:17.3342507","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A17Z&sr=b&sp=r&sig=8IKeYWY1FTmfsGvyoYSNsE1YCYmiBo7cIvsng7Tov9Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:17.3343348","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:17 GMT
-      mise-correlation-id:
-      - 1e4ce3d4-24e5-4974-a8e6-42d6f4f0b43a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A22Z&sr=b&sp=r&sig=4gY4mMHTeFgDjdopv3RkwwA4VZFC0D%2BCXjg24klkVqE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:22.6738171","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A22Z&sr=b&sp=r&sig=IDQ80ykMwCU1hU5h7XI2wvbYQNnvs4lqqw1VEPl2ngQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:22.6737458","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A22Z&sr=b&sp=r&sig=Gj3eW3tZWeGwbYmSPGWF23twF95iZ1Y1YwA7Y5ghf5U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:22.6738321","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-29T22:25:36.568Z","endDateTime":"2023-10-29T22:28:18.865Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:18.969Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3319'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:22 GMT
-      mise-correlation-id:
-      - cee92943-18b3-489d-a7fa-c130d40f034a
+      - 52f31518-6e56-4d8a-aa97-494fb66e143a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1856,7 +1820,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:24:37.0997784Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:24:37.0997784Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:06.2312841Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:06.2312841Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1865,9 +1829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:28:23 GMT
+      - Mon, 30 Oct 2023 07:28:47 GMT
       etag:
-      - '"3c00392e-0000-0100-0000-653edba70000"'
+      - '"3f00d570-0000-0100-0000-653f5a550000"'
       expires:
       - '-1'
       pragma:
@@ -1897,92 +1861,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A24Z&sr=b&sp=r&sig=chp0%2BSvU4fb4NX469FBD%2BBms4aoWuflobErIrM%2FGYtk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:24.8065371","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A24Z&sr=b&sp=r&sig=rkP1A79sO%2F0v7M1PlYcc2BkwsJc8DHe2AwXHk4TOmgU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:24.806457","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A24Z&sr=b&sp=r&sig=gXZLgWrGuuflR91wDq90lHTITVGM%2FitcWQTusfybj2E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:24.806552","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-29T22:25:36.568Z","endDateTime":"2023-10-29T22:28:18.865Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:18.969Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3337'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:24 GMT
-      mise-correlation-id:
-      - 38cb9fb9-6b10-4427-8c88-da0b2f49f86c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:24:37.0997784Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:24:37.0997784Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '653'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:25 GMT
-      etag:
-      - '"3c00392e-0000-0100-0000-653edba70000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
-  response:
-    body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A26Z&sr=b&sp=r&sig=xsZuq7ye1oCvCA3H16B8kvX5sw8prsyM8MktivphKGY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:26.9363262","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A26Z&sr=b&sp=r&sig=L7Ru5U0VLOzGxyQih8bx9d9WOYdiOcgDMsBWe3qrMcU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:26.9362566","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A26Z&sr=b&sp=r&sig=%2F4uw1KTkdqcJ9qp5%2FEe6UkrGwzfuz4ExeySbUX4c2Kw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:26.9363407","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-29T22:25:36.568Z","endDateTime":"2023-10-29T22:28:18.865Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:18.969Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A49Z&sr=b&sp=r&sig=Xat%2BpNRBx93UknhG9mzvMmTRumcGoU6k52MDPibjTR8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:49.2746593","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A49Z&sr=b&sp=r&sig=2t8GSNsy94dtgd9bfpTvJdNPg9UFS5ucfhj6SQtKLLU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:49.2745777","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A49Z&sr=b&sp=r&sig=T715vGzfGulGBFnTxmxaVCDgSziS0d%2FK51CqRC5D9E4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:49.2746738","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-30T07:26:06.635Z","endDateTime":"2023-10-30T07:28:46.381Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:28:48.394Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1993,9 +1876,90 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:28:26 GMT
+      - Mon, 30 Oct 2023 07:28:49 GMT
       mise-correlation-id:
-      - f32a60b5-d3c3-4328-9f54-94e141a34390
+      - 46a20c3b-c048-420b-ade7-ee66f5be9c00
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:06.2312841Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:06.2312841Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '653'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:50 GMT
+      etag:
+      - '"3f00d570-0000-0100-0000-653f5a550000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c6faaa25-b19f-4d1b-add0-40adaaa91569.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
+  response:
+    body:
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"00c06f85-a17e-4ea1-bfe6-1c00fd22c066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6e65ffe0-d0d6-499b-860d-709524951ed0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2aa14eef-9087-4dfa-b9a6-18ab9e823f0e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/0bc4f75f-5801-4d20-a9b9-ff5771f1b235?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A51Z&sr=b&sp=r&sig=zmaFBIwxC%2FWecnKQyCyjYbLk9wEwn7LCyl7RQ%2BYZ7%2Bc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:51.3896675","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/b687b819-4261-4db1-afc3-d03d61456359?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A51Z&sr=b&sp=r&sig=Yju9glWqZNB%2FFgAfPui%2FRsIlD7FPwad04wzTaxQQCDM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:51.3895459","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c827f154-9b56-42a7-9fa0-82b45fa3ef51/a360d4c9-9ef2-4030-8e0d-19d926291c5f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A51Z&sr=b&sp=r&sig=lMJuIGljpFaKKAYHrXn77t2rSjmXAcYHOAqWiaZ0sQo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:51.3896861","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-30T07:26:06.635Z","endDateTime":"2023-10-30T07:28:46.381Z","executedDateTime":"2023-10-30T07:26:05.176Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-30T07:26:06.243Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:28:48.394Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3339'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:51 GMT
+      mise-correlation-id:
+      - 4ec90aa5-b7af-4ea0-b410-a3cc64035a7d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_list.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_list.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:11.5473273Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:11.5473273Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:08.7073742Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:08.7073742Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:44 GMT
+      - Wed, 18 Oct 2023 20:56:43 GMT
       etag:
-      - '"d901843a-0000-0100-0000-65294c7c0000"'
+      - '"75000769-0000-0100-0000-6530466a0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:56:45 GMT
+      - Wed, 18 Oct 2023 20:56:44 GMT
       mise-correlation-id:
-      - 6f9531af-543c-4e82-a7a4-ae15dfa79a5f
+      - 9c92b871-e793-4cf2-b878-80f78f7a9371
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"21dcff02-9053-48b3-8d3e-f94737c67bf0": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "feff087a-df0d-417a-9f30-5e85216ba2a7":
+      {"passFailMetrics": {"4edda639-cf21-4b33-bac0-f6606c8e634c": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "e37b96b6-c4df-47a3-bca3-04bbf740f4b6":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "ea26e3cf-d9ab-47d7-a700-f50560e0402d": {"aggregate": "avg", "clientMetric":
+      "50"}, "f43616cf-018e-4d5b-bd12-4e03babe3c81": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:56:46.091Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:46.091Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:45.054Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:45.054Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:46 GMT
+      - Wed, 18 Oct 2023 20:56:45 GMT
       location:
-      - https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+      - https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 090d5333-bb8b-4789-849a-198658069e30
+      - 60af2331-31f1-476f-8969-87ff2f2a7ff0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:46 GMT
+      - Wed, 18 Oct 2023 20:56:45 GMT
       mise-correlation-id:
-      - 41ffd95e-977c-4002-a6af-8bc60eba6f85
+      - f845da51-63e2-4763-995d-e5061230d180
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A06%3A46Z&sr=b&sp=r&sig=GVRAIYobCGjChrr1wA7ePkaRaVn%2FdC22sW%2B7MJcMJGY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:06:46.8584521","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A45Z&sr=b&sp=r&sig=EJIZzuZpmrV%2FmS6L5aIq6VYzl865RPDrl5rk7vdyve8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:45.9793901","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:46 GMT
+      - Wed, 18 Oct 2023 20:56:45 GMT
       location:
-      - https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 1b7c3c08-827b-426f-9045-04c364a45aaa
+      - f99b58c4-926c-46a0-b580-12e01489115d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A06%3A47Z&sr=b&sp=r&sig=qLqINYwPhJuDj%2F7CBuXYHahtPWzOUcaksiY2ARStYcQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:06:47.1422642","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A46Z&sr=b&sp=r&sig=1bd7Ehm26d%2F1HYi4Aa7FDI4Lux1lFWG8A%2BESyM1ikrY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:46.2449944","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:56:46 GMT
+      mise-correlation-id:
+      - 88cc226f-0bd5-4ae4-a44b-7df03357c2b9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A51Z&sr=b&sp=r&sig=%2FinGaiVDTdP9bHJ60Y66rZo%2BqGlKaMQ2%2FbeNBBtsb0I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:51.5149738","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '555'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:56:51 GMT
+      mise-correlation-id:
+      - 00b985ea-9478-4a37-909b-84e4197fabbb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A57Z&sr=b&sp=r&sig=iY0vCZo8vy%2BbHNMVgvCDGAfvpMCQtI0nQNoU0HKqfh0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:57.2184618","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:47 GMT
+      - Wed, 18 Oct 2023 20:56:57 GMT
       mise-correlation-id:
-      - 733ef210-c7a8-41d1-ade6-c16f06f1ed50
+      - ce3d3392-a987-43ae-87cc-5167ae48cc33
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A06%3A52Z&sr=b&sp=r&sig=zEd4dJoYkeMLLcCuI017CopnwA9ZtuIjb2WrwpV2tl4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:06:52.3970443","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A07%3A02Z&sr=b&sp=r&sig=x0aMxXXUNuEHqU6Ihj16OskIEDYRIl%2BBz%2FUZyqD9mdE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:07:02.4757284","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:52 GMT
+      - Wed, 18 Oct 2023 20:57:02 GMT
       mise-correlation-id:
-      - c7f2a359-6710-4254-8c0f-479bcbeffe85
+      - 63b3f93e-fdfc-4686-ac6b-4f86d31375fb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,83 +457,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A06%3A57Z&sr=b&sp=r&sig=39p%2FhpstyKLR%2BUIkPGz7SMNN8gJ2Xl7QgoK1ldruXQg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:06:57.649524","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '552'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:56:57 GMT
-      mise-correlation-id:
-      - a2f014c7-321f-41d5-805c-373b057632a9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A02Z&sr=b&sp=r&sig=TAVf7PrqNeJancr%2BV3ck3c5rBd4EEJ1CDdot6gWnoiE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:02.9081753","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:02 GMT
-      mise-correlation-id:
-      - 0bee71d0-88a2-48ba-b198-a94123f47fb0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A03Z&sr=b&sp=r&sig=2o1uM3AMneBas7jXGEWDiFkfFlNutd31ndCusiYvwNc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:03.1547694","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:56:46.091Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:59.771Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A02Z&sr=b&sp=r&sig=fhtcrfkQT9E9ptHOU0k6gwRdDyR9fMKWYjcB4CAQBxw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:02.7228758","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:45.054Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:58.036Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,9 +472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:03 GMT
+      - Wed, 18 Oct 2023 20:57:02 GMT
       mise-correlation-id:
-      - 744e1fa5-28c7-4be0-9aa4-8c5a96f99e8f
+      - 53922000-2266-48d6-9aea-dbebba5cc2b3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:11.5473273Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:11.5473273Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:08.7073742Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:08.7073742Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:03 GMT
+      - Wed, 18 Oct 2023 20:57:02 GMT
       etag:
-      - '"d901843a-0000-0100-0000-65294c7c0000"'
+      - '"75000769-0000-0100-0000-6530466a0000"'
       expires:
       - '-1'
       pragma:
@@ -538,11 +538,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A04Z&sr=b&sp=r&sig=IIVmQy0DYkp7HPCNZ%2BLlGpM7soJ0GrJyYTBwxuhgcAE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:04.9331926","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:56:46.091Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:59.771Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A04Z&sr=b&sp=r&sig=GPj88%2FCvbVekeRmH0UowNBah6FaauYJ0T8U6cQB9J10%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:04.4353328","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:45.054Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:58.036Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:04 GMT
+      - Wed, 18 Oct 2023 20:57:04 GMT
       mise-correlation-id:
-      - 6c67e95c-b53b-42bd-96b8-b09f1f273b2d
+      - 11c7a80c-cde3-44e0-82ef-34bf7cd19c2d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:11.5473273Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:11.5473273Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:08.7073742Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:08.7073742Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:06 GMT
+      - Wed, 18 Oct 2023 20:57:05 GMT
       etag:
-      - '"d901843a-0000-0100-0000-65294c7c0000"'
+      - '"75000769-0000-0100-0000-6530466a0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:57:07 GMT
+      - Wed, 18 Oct 2023 20:57:06 GMT
       mise-correlation-id:
-      - f7cc04fa-7e5e-498b-b27e-af48bf775300
+      - 31807d9c-e68b-47a0-8ad9-b5a83dbd955d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A09Z&sr=b&sp=r&sig=PnHhNle0lChl5wOVvBtUydn3x8HnPluJ7dg2Bgx%2BPMQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:09.0676441","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A09Z&sr=b&sp=r&sig=noNfaSj0qx5p%2B%2BPMP%2FF5TPGYx1o%2BwlWUF6ivtA5gU8E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:09.0675396","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A09Z&sr=b&sp=r&sig=mKA%2FiycRp5KRxdThCTOkh1%2FZPI8Svip250A3aatgtFM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:09.0676748","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:08.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A08Z&sr=b&sp=r&sig=QXAwqDZXp%2BL3LZmfOlhvLU%2Bx1lQH%2Fs7eQKH26JDfTs4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:08.1912547","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A08Z&sr=b&sp=r&sig=T52pxl3orSYse5VIjgI0NqWG6vbvjPsfaV4VNM1HYxM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:08.1911186","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A08Z&sr=b&sp=r&sig=%2FQaqWU2LGpQA9oSSaNGlpU2lwOFBJCHgLJQFggiCfm8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:08.1912813","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:08.11Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3152'
+      - '3144'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:09 GMT
+      - Wed, 18 Oct 2023 20:57:08 GMT
       location:
-      - https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+      - https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 43e58682-2f19-4c5e-bc5e-5266818354b8
+      - 360e7708-900e-4de3-9ad5-a316dd21b5e0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A09Z&sr=b&sp=r&sig=7c00diKPs4z3CQ%2BR9qiRsvdKb2V25N0zEyIvOaTamIM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:09.483822","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A09Z&sr=b&sp=r&sig=%2F81dTZmRNE4PF4fvO5ou1tM4B4inkqDY6BcBwRq9iYU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:09.4837527","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A09Z&sr=b&sp=r&sig=ozh1qxpcjklg%2BI2yE0oPswagbTDOXPdn2gJOrHPTFSo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:09.4838368","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"NOTSTARTED","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:09.366Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A08Z&sr=b&sp=r&sig=xphB7WlsSt86553BtteSFi0t7%2Fs%2B9ext91jAhoZ49xc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:08.5930187","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A08Z&sr=b&sp=r&sig=Mhn0QHP2HmBKSRRbTIKotKTVhO6%2FF6AiOJRnGrI%2FDzI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:08.5929438","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A08Z&sr=b&sp=r&sig=%2FKfhuAhJulVVE5pd7UJqopJTYtV%2FQkdWipSWHYPbhsU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:08.5930341","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"NOTSTARTED","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:08.48Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3188'
+      - '3192'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:09 GMT
+      - Wed, 18 Oct 2023 20:57:08 GMT
       mise-correlation-id:
-      - 2bc5ae9c-82ab-48c6-9873-153529b81699
+      - 08e8e37a-6ce9-4dc3-a319-144777ca7a29
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,190 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A14Z&sr=b&sp=r&sig=Ovh15FmDo%2FHZ1I%2BRBBptI1AO0yHz72Ov90sMFVceYlk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:14.732582","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A14Z&sr=b&sp=r&sig=Mn5cGvDFde3Gd2sKQPPvGRlJZRfbXzrmopuz2klyoMc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:14.7325013","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A14Z&sr=b&sp=r&sig=82YHHECUmRB1un%2BO19Z8vIIJ9Q88BnPiwZYo0v5MZxk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:14.7325995","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:09.476Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:14 GMT
-      mise-correlation-id:
-      - f64a8e1b-ece9-453b-9b17-8adcecb7a845
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A20Z&sr=b&sp=r&sig=B6l2UmTXdZ1kW26SApOt0bPF47oG5FGOAfzmXrwf3BA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:20.043117","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A20Z&sr=b&sp=r&sig=%2BNT8Qlhd2mw0W27rMt2W%2FtXyZcl4h5mt8707GTW4IyM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:20.043025","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A20Z&sr=b&sp=r&sig=3HQFJyoUz1tZmWpZNY6r38kjFOPRVkwegqdeXDZzzb0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:20.043139","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:09.476Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:20 GMT
-      mise-correlation-id:
-      - 1e4101a5-2b4c-4c7f-818f-f3a8da1c184b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A25Z&sr=b&sp=r&sig=%2FxfSGKJxv8k1G823Spvsdo5C0NCZGP%2FAHCFyr%2FWFBk0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:25.3192306","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A25Z&sr=b&sp=r&sig=ouyZquJOwkyEMpN3YYxHUtaBVROVIu7NCafEcZ16pgY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:25.3191514","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A25Z&sr=b&sp=r&sig=0FyajoBPTzs7uRLnGSVflBhQLHP3%2FlJiWgPzhSZM9mM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:25.3192507","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:09.476Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:25 GMT
-      mise-correlation-id:
-      - db74678c-c080-4e8b-ac12-87a2c5778ae5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A30Z&sr=b&sp=r&sig=orPm6P3lKtTqdBd0MH%2FLjyrgbXBdd0N%2Fyp8TQdSrY3Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:30.6404816","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A30Z&sr=b&sp=r&sig=p4jypik5oPdLYPZycJkABka7y4mk51gpoMDX2p2EpVM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:30.6404064","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A30Z&sr=b&sp=r&sig=i7StTgSzfaPSZVvi%2BOE39B2XdoHvu9jtJViIQv%2FBEuE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:30.6404956","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:09.476Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:30 GMT
-      mise-correlation-id:
-      - 83b39e89-8e9f-4827-85d3-ac2710da5e1e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A35Z&sr=b&sp=r&sig=D1hrylwo4u%2BACJTbwGEGLZ42lm9Ve1788lYSavCqZlc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:35.9504405","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A35Z&sr=b&sp=r&sig=OU1XI5GDH%2BY%2BWy2gRM2Czha0h6KK7SUJOE%2FRitmqZ40%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:35.9503537","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A35Z&sr=b&sp=r&sig=QxyNRqfS1dy9zz3fQRWcBGjSNsjyAza%2FB9V%2FL1Pl7%2BY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:35.9504638","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:09.476Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:35 GMT
-      mise-correlation-id:
-      - 7a64e116-6a9d-40ea-bfef-a6f232e7faba
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A41Z&sr=b&sp=r&sig=QaFXhJsx4lG32PQmkIFUAEGI2WYt7a0bMNMaHrTXnsI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:41.1987406","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A41Z&sr=b&sp=r&sig=oKNkcw2nLUf94XEvevLjMg%2FZN8Lqu9H9ypajRyuTmMo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:41.1986551","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A41Z&sr=b&sp=r&sig=25FYlDK8jYtubizcsFTcT9tHgxioQ9Dd4Hbc65VUA7E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:41.1987633","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:09.476Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A13Z&sr=b&sp=r&sig=%2BZRKcaULH8asDDXWD2eJFiNvNcwLtD7yBIhAhUMo6HY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:13.8772657","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A13Z&sr=b&sp=r&sig=6r0NpmiePJQkhDhox4op7NnrlYP73eKa8SC8mhg9QYo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:13.8771905","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A13Z&sr=b&sp=r&sig=pZkEjA1olzuJug0T2oGXM6Khbt%2Fa0hHU1PLXX9mittE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:13.8772804","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:08.692Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -930,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:41 GMT
+      - Wed, 18 Oct 2023 20:57:13 GMT
       mise-correlation-id:
-      - 0251250b-c540-4ecc-bebf-f0e923b62b01
+      - 73e8235c-abd8-4e7a-a691-b6e156df21d6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -952,118 +772,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A46Z&sr=b&sp=r&sig=%2Be%2Buo6awV7CeLnK1r%2FKH9UOVYBLGE%2FYHCQDaqFJQrMs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:46.4457268","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A46Z&sr=b&sp=r&sig=G7H0KuJYyilsBDnSpiQNf2fNpV%2BcjRbr9eAr3KNcKtA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:46.4456186","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A46Z&sr=b&sp=r&sig=Doo0ejMitvhHr9EURrtt47uV67rY31HVfUNb1XIToms%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:46.4457496","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:09.476Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3195'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:46 GMT
-      mise-correlation-id:
-      - 58eee598-8aa0-45e9-9f27-669a864698a7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A51Z&sr=b&sp=r&sig=oUpkWXwr%2BJrPMnBJiFiufuEMx1tNr6Rx4UIauV8JRqo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:51.6807884","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A51Z&sr=b&sp=r&sig=g4zn2BaYRG1fFkjIAk3qDTKjhs3NJmuvzDt79DfcqqM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:51.6807075","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A51Z&sr=b&sp=r&sig=8h3pAuSMB0o%2BPUa2KglCKYDUmrr8ssWWcfx9SlMIbYw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:51.6808097","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"CONFIGURING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:48.122Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:51 GMT
-      mise-correlation-id:
-      - 69b6dea1-0519-4d10-8ef3-5ddbfcf2dbc6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A56Z&sr=b&sp=r&sig=8nKTCarAQ9RNc7w2ra4%2BdRepnTUd7fyWCzy2eIqSVTo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:56.9461369","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A56Z&sr=b&sp=r&sig=jwRSm9AOcaRDyRLippgnrg3PDogEI%2FsmHW8oC8xxI3k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:56.9460718","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A56Z&sr=b&sp=r&sig=Aj3q1z3NBIAlG2TTSULA6jOj4dZ9UWFtmF3Wi2FjkdE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:56.94615","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3184'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:56 GMT
-      mise-correlation-id:
-      - cfad6195-a885-4444-991a-94f473b0b342
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A02Z&sr=b&sp=r&sig=XOW%2FSEzim67viW3EhsQsQb07MqaCwjG%2B8NK2FnYnb4Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:02.1938276","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A02Z&sr=b&sp=r&sig=al2xWxJ%2Fuv6%2BvjNG7BSJk2%2BYhW6NVKRhG%2B9zKhAz8Jw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:02.1937597","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A02Z&sr=b&sp=r&sig=FZkBXHI6guBE1dt7OIIg4z1hwVhFdJPJab%2BmJPB7LOg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:02.1938444","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A19Z&sr=b&sp=r&sig=Z8Ge9SBojlgsntPU2bILU%2FLvFBmoA2Z9VEAYLZurwLA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:19.1724835","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A19Z&sr=b&sp=r&sig=eeg%2ForgbirO7ty2SU%2BXi2Y73%2BQ6mtxq3Wg0wRGenOWI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:19.1723775","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A19Z&sr=b&sp=r&sig=zMZQ%2FOT1nSpY%2BkvbFlLoCyv%2FLpveZYfDwShBJdAoTL8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:19.172508","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:08.692Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1074,9 +786,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:58:02 GMT
+      - Wed, 18 Oct 2023 20:57:19 GMT
       mise-correlation-id:
-      - e38b0baa-00eb-488f-839d-39a3f5ffe03f
+      - cacf4f2d-7ec1-4484-ab84-0b48f35616ea
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1096,298 +808,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A07Z&sr=b&sp=r&sig=46xN85pebGTb2CUt5iXHFM8nHs4%2FazTMKyYTDF47VrM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:07.4899629","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A07Z&sr=b&sp=r&sig=WH4%2BuEJ39wnW%2Fb2JETdn7WgC50a%2B43uO0iHH%2FMgcHsY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:07.4898707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A07Z&sr=b&sp=r&sig=UogrZwJiWVgSZokZN12RSWbiJFy5j8M%2Bh4wqDZV722I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:07.4899787","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:07 GMT
-      mise-correlation-id:
-      - 7b595208-c1ed-4a02-970d-4fff2f14fe73
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A12Z&sr=b&sp=r&sig=dpX40k1Q05S9y1r%2FiuWXtGvXwbykKsWQw1hfFGVNLFU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:12.820822","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A12Z&sr=b&sp=r&sig=2zBx%2FwZ17CKuG30Uy5qM6xtzIkyHnEKjTXt%2BWFZgvEE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:12.820738","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A12Z&sr=b&sp=r&sig=8Q79sA7U83c1OteVzTbfOIFMg3l%2Fwi8V6vatxti%2BORM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:12.8208392","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:12 GMT
-      mise-correlation-id:
-      - 08c37549-b92b-4d8a-8708-37fa0328f588
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A18Z&sr=b&sp=r&sig=9rxd4G1Alaf5qozovOD1JI3Ve481LVw3kVAD1AIPM6w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:18.3062111","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A18Z&sr=b&sp=r&sig=IUO0cyjuL7xwvFqkdwQ5WqWE2QEd4of0nHXF0cXf2iM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:18.3061496","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A18Z&sr=b&sp=r&sig=vuJ%2FyiY3cuNEn%2FrAOkkU8fuYUYy8UrWJtR9HuQ84my8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:18.3062265","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:18 GMT
-      mise-correlation-id:
-      - db67735e-fdc9-485a-bffe-a6c880124707
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A24Z&sr=b&sp=r&sig=CInloO9587ZDJ%2Fn7KER5a%2F2odODviqhyZlQB0ukrYV4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:24.1611259","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A24Z&sr=b&sp=r&sig=u7wbc%2Bytjl9x1ca8aftOZJZwxMBbgA4HYkvCmTx5%2FGg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:24.1610608","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A24Z&sr=b&sp=r&sig=lRJa4%2B9swEI7VaPOWrB%2BY2Qlq6TIsOS7zMgqYQziPDE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:24.1611394","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:24 GMT
-      mise-correlation-id:
-      - 7a0d47fb-08a3-4013-af43-be93d542d230
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A29Z&sr=b&sp=r&sig=NiY5GxtvKJCWUJVZ0qy934dVblnfpLkiKylqw5%2FXso4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:29.4279056","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A29Z&sr=b&sp=r&sig=7GmNoNC0FK195FCK6%2Bc3FBco5WNUGU%2BETG2yuiOHjRI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:29.4278244","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A29Z&sr=b&sp=r&sig=TjYnfK8vK9JySZ6RUzxRw4GA5aRw9XoLEXDD27%2BYeEk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:29.4279253","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:29 GMT
-      mise-correlation-id:
-      - 7f1ea153-7402-4d5f-a115-9baff2329333
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A34Z&sr=b&sp=r&sig=N8ssdPa7VZNE6ZXYClywR6WWCUyC%2BshPhdnbUBxm0rY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:34.7653515","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A34Z&sr=b&sp=r&sig=NcgTWWz5AqkusuLU4qYx2SEND%2FT72TMC1mkdHNsKvCg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:34.765265","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A34Z&sr=b&sp=r&sig=lmEpdL2EcKm%2F%2FUD%2BJZv4FcZ%2FBWOTM3eT1YmGUqc3FkA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:34.7653738","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:34 GMT
-      mise-correlation-id:
-      - eb8185dd-37e5-45b8-a686-f9df28458462
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A40Z&sr=b&sp=r&sig=FJbCcQR4C66TzM82iRlbbRrDmNRSVPySXa0M1UuqVFQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:40.0801403","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A40Z&sr=b&sp=r&sig=qwhOsUJcoOp5vcJ7lOYyUe9oTxy6iGtsUqb%2BRy95ofU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:40.0800532","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A40Z&sr=b&sp=r&sig=M0B5DFke1JNj7c2g4PfhGpbxdGGAf345CbxNWvKPB4w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:40.0801558","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3184'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:40 GMT
-      mise-correlation-id:
-      - 7c8bf3d5-84d6-438b-a075-f12cc10095bb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A45Z&sr=b&sp=r&sig=gKVUINPswQbcC%2FNh2wKFGXFCE6PxrqwMOLoVxJzZdP8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:45.8489463","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A45Z&sr=b&sp=r&sig=oQ110Bklh3PBBobsfuByokQkpybV1tSXI%2FD9WJSIxzA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:45.8488779","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A45Z&sr=b&sp=r&sig=N9KscRCMmJpGTICu9BIR0ECH%2BJMczBZf79a7jnPPLO8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:45.8489612","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:45 GMT
-      mise-correlation-id:
-      - 6609dc65-395c-4e58-a248-a3fa13a7c300
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A51Z&sr=b&sp=r&sig=uNEZ1rw2Jsxuq2Eos1SLqe9isS%2BFMTiY5bRKj6M8HXM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:51.1594613","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A51Z&sr=b&sp=r&sig=LYKP85Jrns6Pa9%2Fjbh6T7dzBF6dGHa5Z22Jraxab%2BZQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:51.159345","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A51Z&sr=b&sp=r&sig=YZYep0g8zenDALbtcLdN3G1%2FMoaDJEVFZ2ptct3LJ48%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:51.1594851","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A24Z&sr=b&sp=r&sig=DPWZJc2JCr7C8wGTCiOYvvSYvA3KtAZyk1ro4I48i%2FY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:24.5033715","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A24Z&sr=b&sp=r&sig=x0Q0YtvjM5igndzigA6S4dN%2B7VH6ehouRZG2paTYLfA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:24.5032905","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A24Z&sr=b&sp=r&sig=KhMOY1r%2BQ52UVfqM3uwGEEJxBcWUpO38pA6BS5C3Z3Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:24.5033913","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:08.692Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1398,9 +822,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:58:51 GMT
+      - Wed, 18 Oct 2023 20:57:24 GMT
       mise-correlation-id:
-      - 6a1ede3a-cc0a-4999-a674-580407274394
+      - eaa6a07f-7592-45cc-82c0-cefa831374d6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1420,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A56Z&sr=b&sp=r&sig=H9yoBGBfn86CCnDnpq9IbgxHfs150SJjPnFw127Uzro%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:56.4155531","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A56Z&sr=b&sp=r&sig=zwrZSzS%2BqXahMw%2FhRfl%2BJ0NW2MaXhEExTOaBJoBZVzc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:56.4154755","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A56Z&sr=b&sp=r&sig=4%2BUezJ98YFTaDxqiWYYx6LCyKTKXmpuStG4FV%2FnjBp4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:56.4155683","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A29Z&sr=b&sp=r&sig=UuKJQkur8Kli3%2BMzYIFara1YVlrg3knipv1mHLnGADo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:29.7874138","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A29Z&sr=b&sp=r&sig=CvJNhcqQdGCaShaBuHWF3jdD4ak944nWOtePd3xaY5g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:29.7873366","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A29Z&sr=b&sp=r&sig=BBPu09fktXzBDTdtlTdLG%2F7CGJQPCitOGkUl4brOMmM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:29.7874289","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:08.692Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3192'
+      - '3187'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:58:56 GMT
+      - Wed, 18 Oct 2023 20:57:29 GMT
       mise-correlation-id:
-      - 3e9e0deb-7cb9-4d6d-a74e-ba163fce1944
+      - a28b68ca-0de3-4933-a049-2d4cafcd109b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1456,10 +880,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A01Z&sr=b&sp=r&sig=1BB%2FegsBLYM8hYdkvNZIxtwdNrS4GDmoiFbvV2vOBnc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:01.6603659","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A01Z&sr=b&sp=r&sig=EB2HoH9XlrQBwgqFDTlm31OYMFkJBN%2BMlonmKXiQL94%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:01.6602718","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A01Z&sr=b&sp=r&sig=4ciiP5w3nhtReE4FqDahEhvrr4q2sC48nTw%2BkDqQp6k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:01.6603822","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A35Z&sr=b&sp=r&sig=%2BwcEvmkrSHdg5VQqqPPYf6R13inB9G6zs8mb3y%2BHhNg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:35.0547362","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A35Z&sr=b&sp=r&sig=8fSUk1M4t9elLVGN2jrdjiGrcAiZPXYJA23ubP4ANrM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:35.0546337","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A35Z&sr=b&sp=r&sig=qdLQ8PaKZSNzZ6fnrJqqtWZ8z6C2ORRPgwwIesRegSs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:35.0547584","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:08.692Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:35 GMT
+      mise-correlation-id:
+      - fb8f4437-575b-46bc-8687-e4e69043bb33
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A40Z&sr=b&sp=r&sig=B9uNE0kM%2BSoERofdOSnf4UxoLIc7YLkjck%2Bi%2FjdmV4s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:40.3705442","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A40Z&sr=b&sp=r&sig=vp8HCuQOhb1q0hG0g7wJKZVX6bb%2FrHB%2FF0T2et%2BhxIs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:40.3704734","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A40Z&sr=b&sp=r&sig=sGjLuGlCXa%2Bz6OqjtuLWiaEKbbSA3EB2g93RN23UvLk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:40.3705592","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:08.692Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:40 GMT
+      mise-correlation-id:
+      - de47f646-c5f6-4e43-943f-265e9ea4d968
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A45Z&sr=b&sp=r&sig=pytUadNVGYrLZMUF5pU0w8Nw%2BliIK58s%2BS7Liysccng%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:45.6925087","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A45Z&sr=b&sp=r&sig=PIIu0ZrO5iwYqiazF7uYH4Xoe2r6sRUBf8GIhtenmN0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:45.6923914","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A45Z&sr=b&sp=r&sig=xqfz4MxTaOUdlsHQHKCPOylrZK6Q2TbwXb1cPz%2Fz5h4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:45.6925264","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:08.692Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:45 GMT
+      mise-correlation-id:
+      - de999f86-642e-47ff-b5a5-0fa1cd91ae24
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A51Z&sr=b&sp=r&sig=oiiF6R4LCsVzA2UWaVuuGXvxf1uEoPymtsIKFg7j8JQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:51.0348027","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A51Z&sr=b&sp=r&sig=juLPmuuqzuxUyl8vLmMITjc3BJofai%2F43IahTwN0jEM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:51.0347299","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A51Z&sr=b&sp=r&sig=C8hZ%2BpPyfRoNh5pjn9gvE7O2YkUAA1%2FuC4uai%2F5AfTk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:51.034817","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"CONFIGURING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:50.55Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1470,9 +1002,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:59:01 GMT
+      - Wed, 18 Oct 2023 20:57:51 GMT
       mise-correlation-id:
-      - 3bfa5f87-e067-4860-99a4-5d12ff6adb2b
+      - c906f367-d8b5-4498-85d5-ac6a8d7dfea8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1492,226 +1024,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A06Z&sr=b&sp=r&sig=FPP8gXQ%2FLKyM7ejjRDx%2BW19VR5aeNvzEizlit6VmeMc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:06.9229983","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A06Z&sr=b&sp=r&sig=ccGKJaYWQU34beQVrQykR0kp%2BA1er3NZ1ar2Yy8HaeE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:06.9228933","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A06Z&sr=b&sp=r&sig=4hmTbMoHSIzYGKQXfslO5U%2BxEOsJAgjs22wON4DT4s8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:06.9230234","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:06 GMT
-      mise-correlation-id:
-      - a7ecedf7-c8ee-48c9-b490-c24f7a766132
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A12Z&sr=b&sp=r&sig=jUn5RcjC7nBSQ341bhBrojZyupJHNcK1DgJ63G1m5Lg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:12.2464809","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A12Z&sr=b&sp=r&sig=oQezobBlZkmOWkpy37dU3nL%2FcoyRIBHYle8KlDFm%2BXY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:12.2463751","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A12Z&sr=b&sp=r&sig=MnwxXFw4Ln2lRpbUpj0J3IfjNC0Li2TaKN5aGP0okeI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:12.2465042","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:12 GMT
-      mise-correlation-id:
-      - fdd34ac5-352e-4cb4-95cf-859b787bfec8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A17Z&sr=b&sp=r&sig=ANH13hXXcNUcdWqagZsUS%2FzAuPf5D2js8kD1JKszZl8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:17.4914869","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A17Z&sr=b&sp=r&sig=mP1U%2BMqkqoloEtcZ%2BSS8OHi3gZHzuDCSgHSmopYO%2F%2BY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:17.4914157","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A17Z&sr=b&sp=r&sig=OqggfFdLzYWfsbjt0J7PapBgAmqk8yuGY%2BU5pyr92gk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:17.491502","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:17 GMT
-      mise-correlation-id:
-      - aa1b95e3-94c2-4ce2-82a6-756e4bba6bc3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A22Z&sr=b&sp=r&sig=JOwGQwEvo%2BCYkLAz0oPURtDxfDVweCpIl6aPSPAKBJ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:22.7279088","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A22Z&sr=b&sp=r&sig=B93bnT17RgXto8k9wPE01%2Fsyp9%2F2j4eazHKC7ZvkTVE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:22.7278208","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A22Z&sr=b&sp=r&sig=V5eGH82%2FoA5s52nuEuM4Fk6jSUmY%2BJrI4nPUAodL0vc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:22.7279245","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:22 GMT
-      mise-correlation-id:
-      - d8315664-84d1-47f3-a343-621ab63373fa
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A28Z&sr=b&sp=r&sig=pE95JKizlqv%2FlIMV3hThNvpPopzniI1JAE%2BJOLlWqSE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:28.0236106","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A28Z&sr=b&sp=r&sig=HLq7AwmcxYoM6ePMSgetKMbjt%2BWXPGQJ3U6fvGeo4ns%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:28.023523","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A28Z&sr=b&sp=r&sig=Mh%2FNMhBJQ%2FskbgEMUvOGbUvs8Tg25gB0X3CdJk%2Fot0g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:28.0236267","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:28 GMT
-      mise-correlation-id:
-      - 0f42c283-ff60-4157-9e90-505053335ece
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A33Z&sr=b&sp=r&sig=knpgWhdn1ya4igb%2F57LHABiyqyZPi38NuP6u6s0nKi4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:33.3506086","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A33Z&sr=b&sp=r&sig=c%2Brf%2Fmk5Asm9YGP7OnqmpwDsxynr1lcKMdnno28M39c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:33.3504997","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A33Z&sr=b&sp=r&sig=CvvrDZ5iBroUqFsAu3zaZBF1NsDxhl5LDsJcx%2FZDkwg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:33.3506348","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:33 GMT
-      mise-correlation-id:
-      - 2e471a3c-1c58-4022-b9ca-25a7cdc91574
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A38Z&sr=b&sp=r&sig=B3TTiE6U3kiNze%2BUYlKRxKm2KQKUTM4FavoaQo7fZP8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:38.6601903","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A38Z&sr=b&sp=r&sig=4ZczFfWIs0epo01RZ7wCb7faR91v5VgyYKY7mwKrYhw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:38.6601057","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A38Z&sr=b&sp=r&sig=CUAjAqicwXjoK6ummlC5GQ2vEYt06tQpDA06iZ3HRCE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:38.6602127","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A56Z&sr=b&sp=r&sig=JSDV4A2G6PIo6Zq0w%2FuivPh0l88lMyQo7nrA9Wn6XHM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:56.3553808","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A56Z&sr=b&sp=r&sig=FUWjpjgihjvD3nRMmxYZ5D9TP7nA7QDj0ylP3IwiSNg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:56.3553045","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A56Z&sr=b&sp=r&sig=dBLbjymZv44qts2Q2zSKJH1e12mnatTydAJxA%2BlIO4A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:56.3553948","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1722,9 +1038,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:59:38 GMT
+      - Wed, 18 Oct 2023 20:57:56 GMT
       mise-correlation-id:
-      - 344374ef-0ace-4f7a-b182-4f55ad02c4de
+      - 371baf9a-8a8f-452a-a158-216e8567e3c9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,10 +1060,370 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A43Z&sr=b&sp=r&sig=mOdndX2p%2BNlD%2BrLmhw9iwVQOuPNSd0A0CCp47v8bTi8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:43.9198317","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A43Z&sr=b&sp=r&sig=x099tmXPfx7YpsPe43CBoq5HwdmAJUcEdc2tWTDjX54%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:43.9197302","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A43Z&sr=b&sp=r&sig=JMKuWMiUmwpQy9SziQFjRoTXxMIzQIZNpbOMReGs11o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:43.9198577","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A01Z&sr=b&sp=r&sig=cp6LWbZRday8qoipzA5%2Faa5TKFze3FadXBr08ZtgcuY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:01.6862901","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A01Z&sr=b&sp=r&sig=58VTurLZkD0MyFfdXr%2BmhFPZI1qbQC8oVCsNIwgTpog%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:01.6862017","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A01Z&sr=b&sp=r&sig=ftAGo2QGOJsF92kCmzjL78PnoM0IJmwaXiwkvHOfRr4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:01.686313","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3183'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:01 GMT
+      mise-correlation-id:
+      - 416d3e9f-1bb1-468a-bc12-7a230e8ccb18
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A07Z&sr=b&sp=r&sig=92FYHkv8IL1KfDyh3pIsvfStn5gOxSdWxZikioJqj1g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:07.0137286","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A07Z&sr=b&sp=r&sig=3Eqkq0zLc%2BeeRS21WbuG8yyrbL7uRB81VOKWMGp0qE0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:07.0136418","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A07Z&sr=b&sp=r&sig=d89dKrsKeyzWLBUEo8URJdiHNEa8hlzCDH6Plh7MtPo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:07.013786","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3181'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:07 GMT
+      mise-correlation-id:
+      - d88a087e-d1c5-43eb-b4bd-f47a74825f69
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A12Z&sr=b&sp=r&sig=e202kvpnW5eLLgjYPafuKNVpN0IJV5n9FfrNWqUTt8k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:12.2838259","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A12Z&sr=b&sp=r&sig=jYI4aHV%2Bwp8Zg0WcY5xBeZksbTg%2BJxM4ufxXCyqCpkA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:12.2837353","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A12Z&sr=b&sp=r&sig=8doAKMyqpLBYZOE2YlELmXQRFzs3b9Y4Xux2OOyC2Cw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:12.2838472","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:12 GMT
+      mise-correlation-id:
+      - c6652d87-f636-4c42-9ddb-64798bdde30c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A17Z&sr=b&sp=r&sig=qYQOs6IpEK1hkUHyzEi9%2BKBv4doqbd98r8oJ73K2ths%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:17.5378547","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A17Z&sr=b&sp=r&sig=2dWZKNVYxdLbBLqc%2F8z4jaSZJzTr%2BGOSfjXGiIS4qDM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:17.5377821","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A17Z&sr=b&sp=r&sig=5YOkXkBFXYpnai3uCEnYSD%2FAK%2FcHgcp57OS6mj9Q5aU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:17.5378686","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:17 GMT
+      mise-correlation-id:
+      - 3721190b-a742-4403-9db3-e101dd7f962c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A22Z&sr=b&sp=r&sig=AaCOBGBJuy4Z2Vf7eKNroeNUxc1XUtGFyOUc3QJrdjI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:22.8043734","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A22Z&sr=b&sp=r&sig=imFxGUv7ORzkeW5PZTzQCEMa5vn8mraaEK6qro8YojA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:22.8042825","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A22Z&sr=b&sp=r&sig=vp%2B5qImo%2FB4uETvsJOxbpoO0KusIZ9ZaYtVCDGGrgTk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:22.8043866","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:22 GMT
+      mise-correlation-id:
+      - 1e1a493f-14cd-41cf-8d81-7bac4e7040a9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A28Z&sr=b&sp=r&sig=KtfIz1x1SXrNN6wjkRRyxRgUnP2mup3qTLp%2FzfD61uA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:28.0879569","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A28Z&sr=b&sp=r&sig=28ktbTtflsJd7Re%2F4oT%2F9aTlcANjYHLwzoSGczBGqWg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:28.0878767","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A28Z&sr=b&sp=r&sig=LYh5Afs98E5juCDYf6caAQx5imz3Cu8FHP%2FPDUIX%2BF8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:28.0879716","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:28 GMT
+      mise-correlation-id:
+      - 29bef93e-a3b3-474a-911f-2c9ab5785070
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A33Z&sr=b&sp=r&sig=v03%2FJ0zM16whCA9bLL61NQfwd0Vks8AdPeUeqQVPZvs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:33.4313923","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A33Z&sr=b&sp=r&sig=8EKLALdJ7TbW1NWyo9s70WFaYRI8sjrS5Mo8fRJMaCg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:33.4312815","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A33Z&sr=b&sp=r&sig=F%2FgTqllel%2BERNt9lDEelqZTtrmn5KuJS%2FexJrqH5k5I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:33.4314172","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:33 GMT
+      mise-correlation-id:
+      - a3ffc5c1-c406-4a1e-8650-214aabc8661b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A38Z&sr=b&sp=r&sig=k5YxcPzwjh9IkK20woCT%2BL3m6YNGaqaYPbVC0wp4gCM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:38.7319888","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A38Z&sr=b&sp=r&sig=BsJR5HwOU7BqJ%2FgURqeuNdsMPDyAoQtWT7y7R3ttcXs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:38.7319014","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A38Z&sr=b&sp=r&sig=l416%2FjqaQSUy6TzeMuUrIHpfz7Agw6XBd9hcEO%2FoK%2BQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:38.7320108","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:38 GMT
+      mise-correlation-id:
+      - e9da50cc-a9f2-42ba-a561-3bf9825f915d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A44Z&sr=b&sp=r&sig=aa1muKqRIMsirSYCWWuZihT4HZybH6Xy%2FpceBH0%2F27I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:44.0762897","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A44Z&sr=b&sp=r&sig=mYSRcU%2B3B1dPfx6fbPdMKei6Lmem5qSXPbjFbBTXSJM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:44.0761846","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A44Z&sr=b&sp=r&sig=oKUreASgE3UVntP%2FyvEVLJwLFB5q%2F5spppaTgWGExw0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:44.0763147","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:44 GMT
+      mise-correlation-id:
+      - 4680f9d9-118c-4022-a72d-3d213be5b159
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A49Z&sr=b&sp=r&sig=G%2FeFcjGkgJicrYrOToq3C1rsTCQ1ByjlrtFUVfeL170%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:49.4050347","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A49Z&sr=b&sp=r&sig=PxBkTuYrtTafDsP05rooF4Hz26lUMJck6SkuN9Lwsbg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:49.404946","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A49Z&sr=b&sp=r&sig=oNCbt5wxv9ueL8sGboUN%2BVxH7IF2buLU8hZwUylSqdQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:49.4050554","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3183'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:49 GMT
+      mise-correlation-id:
+      - 137955fa-c9b8-42f3-bce2-48d930f695c0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A54Z&sr=b&sp=r&sig=xuLUgCRBjG9Matxzts45GTy7o9yiSOoGvEM3YqmtLpg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:54.7320329","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A54Z&sr=b&sp=r&sig=mAQ15PHpgkGVgs20quHhgdcAkDvp9Aliy1CUO%2BTk8io%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:54.7319609","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A54Z&sr=b&sp=r&sig=odqs44u4RPgG6ZdjB0YdvzWBJ99ke7Rer1%2Fk%2BRcHfj4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:54.7320692","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +1434,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:59:43 GMT
+      - Wed, 18 Oct 2023 20:58:54 GMT
       mise-correlation-id:
-      - 5d003067-33a5-4ef4-adb3-a71e2636afdc
+      - 032f12ad-5db0-4263-80d3-1e376bdb12dc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,24 +1456,384 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A49Z&sr=b&sp=r&sig=nk9jIZAP%2Ba6XnW83KRc3Vn90qtQr8wehiu0ppLwTyPo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:49.1753245","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A49Z&sr=b&sp=r&sig=2dQ2h9fZ1iZ1h6%2BlttEG0UQyoGi7slRYNBKzoOE9h%2Bs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:49.1752349","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A49Z&sr=b&sp=r&sig=%2FLRiPaERVQRCWN7qeq7OR44%2BvO24E8NYmcXjSBsPy%2BE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:49.1753453","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-13T13:57:09.366Z","endDateTime":"2023-10-13T13:59:46.942Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:59:47.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A00Z&sr=b&sp=r&sig=J8IBguKHTSJDt9TRZOYHy1k2pdIescPdxyt%2B6aZgjB4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:00.0484489","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A00Z&sr=b&sp=r&sig=M%2BD6CHbsw0jX%2BzpCjnHNS7N1%2FkUL0KaXkfOr%2FOq0yvM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:00.0483549","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A00Z&sr=b&sp=r&sig=SDHbIYvYDr31ad3DxqcgajYtLV7oOez7IA%2BaBRiCjwY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:00.0484719","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3329'
+      - '3192'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:59:49 GMT
+      - Wed, 18 Oct 2023 20:59:00 GMT
       mise-correlation-id:
-      - 1ff69579-a194-4615-ad28-f676458bb3d7
+      - 62bfdeee-be93-4f15-82d8-a8dd0560b549
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A05Z&sr=b&sp=r&sig=xjK5KLjjrwX9%2Fwq4HYk2TdooZYWuHLof6DBEbpBsMwY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:05.3891673","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A05Z&sr=b&sp=r&sig=ItooIGtXstrFkwCttul14ghZ74EPWTWE8kjEiWyH0cs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:05.3890386","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A05Z&sr=b&sp=r&sig=EVRsjWDGRVj6K19Uzen%2BnKnVTRVR8rVaPD4P5H%2F6sEw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:05.3891889","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:05 GMT
+      mise-correlation-id:
+      - 593fd35f-3a68-4a94-b66d-4aaa6a601046
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A10Z&sr=b&sp=r&sig=DFDa1xWTTQjuf%2FsheaKy9DP954xuHJdQTlqM5wP7NEw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:10.6841512","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A10Z&sr=b&sp=r&sig=ESVO8PH6cjTDUEnlgXBigSCRbEoH9kwHB3diVRz8vi4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:10.6840751","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A10Z&sr=b&sp=r&sig=fiCqCByfhD7vH3V%2BKYYyfHVNdkh66ICZypxkAHrXB8s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:10.684165","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3183'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:10 GMT
+      mise-correlation-id:
+      - df5bc503-8af7-4385-8799-3a2af1d1edf1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A15Z&sr=b&sp=r&sig=rJVFbT6Deyi8RYsfrZkv8yuHWE1R53yhj%2F%2FQpQNemXs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:15.9510869","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A15Z&sr=b&sp=r&sig=H0r%2Ftdq9p0RNiHXT3%2Ft9zP79Jk%2BevZ3evdjhbQJ6jJM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:15.9509993","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A15Z&sr=b&sp=r&sig=yfSZAnP2JK6D9buYquS%2FSSE0Ze7l6O4LvG0Chsq6Avg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:15.9511082","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:15 GMT
+      mise-correlation-id:
+      - 131b6630-70aa-4212-b328-78a8bfe0c7a2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A21Z&sr=b&sp=r&sig=0t7nyvyY%2FO5qKaEMLrnpG9myRSKJPgIp%2FXiOrWZhpzE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:21.2484894","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A21Z&sr=b&sp=r&sig=8fGoIAR0o6X5AL%2B7Ekn7uVJrOgVBJCVQU%2BWZbV28Oyk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:21.2483938","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A21Z&sr=b&sp=r&sig=cm6Ia21E%2B%2FmYyXLKb1kh1ei7wVSTOkX8CsRKxpHVEBQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:21.2485101","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:21 GMT
+      mise-correlation-id:
+      - a4313d35-1415-4acb-b945-f225d7df04fd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A26Z&sr=b&sp=r&sig=%2FFaXqDBJTMgEq%2BbEJ1J1E1NKevCMqKH10dUs5nNA1Qg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:26.5724897","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A26Z&sr=b&sp=r&sig=02i9H8cuUhXac5%2FFZFXhAAfYMPpgjLOvIJoApHA5gac%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:26.572403","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A26Z&sr=b&sp=r&sig=B0lA3dB8iHdSwUyi71%2BAv3ImW5PS799pWg9fvY%2BLZ78%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:26.5725039","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:26 GMT
+      mise-correlation-id:
+      - 45f1cadd-d250-4398-b877-0c3bda4ee7c6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A31Z&sr=b&sp=r&sig=7o%2Fr8iJEbcSaM2EYXJ56cBJvBpv5IULRr57WJfnCzKQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:31.8981995","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A31Z&sr=b&sp=r&sig=565vCEMW%2Bhrq0PErHddaUJT0U2M23o4zihlZD3HT37c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:31.8981077","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A31Z&sr=b&sp=r&sig=qog9P1MkOQM%2FNQISMJk487wUI1ALjPdWY6I0%2BMz2B8c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:31.8982135","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:31 GMT
+      mise-correlation-id:
+      - 3e604e2a-f614-4ee9-b16f-155546a859a4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A37Z&sr=b&sp=r&sig=RwaSH%2ByX%2BYn1nnJm9AzE9EaeeKyS8Z6ObLcGzMz7OSs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:37.2031153","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A37Z&sr=b&sp=r&sig=yWb8akswDKaeXgQEUZxcGXytUwbJxCN%2Bo2HnOMSb5CA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:37.2030481","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A37Z&sr=b&sp=r&sig=jUhkFIbfhseGaCuo4qkFl9cK83tKBXNNUH772BRRu1g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:37.2031298","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:37 GMT
+      mise-correlation-id:
+      - 8a16da18-9b70-4f09-8223-405e0dd940fb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A42Z&sr=b&sp=r&sig=HDxOa%2Ftr8XoGPSdsOGKtAk8TdgDaeFBQGwNzL1GpD1w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:42.5346641","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A42Z&sr=b&sp=r&sig=CqAtPQpHM8V44mXUKHgLFVevli0kEjXZ%2BDmoquPfOV8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:42.53458","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A42Z&sr=b&sp=r&sig=654%2FzXAcVbtcoBnBx9dbxMqdZZxPemg1olZH2yfU7BE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:42.5346781","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:42 GMT
+      mise-correlation-id:
+      - 0da554ea-1d60-4238-b2f6-1404277b9eea
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A47Z&sr=b&sp=r&sig=V4f8MGdybIi%2FzFJmshUZIlEqiX3tQe6L1r6ZAEvaPRw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:47.7980693","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A47Z&sr=b&sp=r&sig=HKnOc0HgToQX6Jrilw%2BH2SwjSzrQU6i5AMfSNcwxxIE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:47.7979962","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A47Z&sr=b&sp=r&sig=OV%2FWAWPFP3pNPA6zed2ZV68y5Q3mplnPN6rk9OZdkbs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:47.7980833","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:47 GMT
+      mise-correlation-id:
+      - 5bcda248-cc01-4a86-9da0-a8fcae324dcb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A53Z&sr=b&sp=r&sig=XeshralMaEhPa08iJc9Cu3gwnfgBI6CKhg%2BLD%2F6RaYo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:53.0830478","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A53Z&sr=b&sp=r&sig=0f66Ujdk12RrDH1kewKCCNQOB6x1030q%2Fb1CuwC14Jw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:53.0829535","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A53Z&sr=b&sp=r&sig=MXgdakkJwHHBW3YhQFXxUaaaz%2FBz%2FMLe5uEKwFos4Hs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:53.0830726","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-18T20:57:08.48Z","endDateTime":"2023-10-18T20:59:48.846Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:48.941Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3325'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:53 GMT
+      mise-correlation-id:
+      - 91818177-d4c9-48a6-a4d2-b0a7898da4b0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,7 +1856,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:11.5473273Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:11.5473273Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:08.7073742Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:08.7073742Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1829,9 +1865,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:59:49 GMT
+      - Wed, 18 Oct 2023 20:59:53 GMT
       etag:
-      - '"d901843a-0000-0100-0000-65294c7c0000"'
+      - '"75000769-0000-0100-0000-6530466a0000"'
       expires:
       - '-1'
       pragma:
@@ -1861,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A51Z&sr=b&sp=r&sig=ESnrPocPflu2mwqNadYeEcxzRK5wn5eHSxmj0lvPx6A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:51.1324332","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A51Z&sr=b&sp=r&sig=XOXib3Llm9QIFZ%2FVqwrQNsmYsp5db2Mtq2HWMxTemLM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:51.132351","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A51Z&sr=b&sp=r&sig=Ko9%2FWYV46k03sSNQEx48Xpnf6EmnWXogq7s%2Fyd44G6M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:51.1324538","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-13T13:57:09.366Z","endDateTime":"2023-10-13T13:59:46.942Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:59:51.114Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A54Z&sr=b&sp=r&sig=pwhA3NDKuFNf%2FxhfErg%2FmsyfIbDsx4V0FpIvxnhKWf8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:54.7266226","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A54Z&sr=b&sp=r&sig=x3zFHhDL15WJEenbeWFDnjATGWoosPVyN3zkBOuiC4U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:54.7265478","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A54Z&sr=b&sp=r&sig=qtGzutLJfiadAPI%2B39A9ddiCthdJjdhIxS1ycJdpkpg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:54.7266376","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-18T20:57:08.48Z","endDateTime":"2023-10-18T20:59:48.846Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:48.941Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3334'
+      - '3333'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:59:51 GMT
+      - Wed, 18 Oct 2023 20:59:54 GMT
       mise-correlation-id:
-      - db70b77b-557b-4fe2-8333-2a662efd0c0f
+      - 977ae1a0-14b7-405a-8889-88a50660660a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1901,7 +1937,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:11.5473273Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:11.5473273Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:08.7073742Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:08.7073742Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1910,9 +1946,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:59:52 GMT
+      - Wed, 18 Oct 2023 20:59:55 GMT
       etag:
-      - '"d901843a-0000-0100-0000-65294c7c0000"'
+      - '"75000769-0000-0100-0000-6530466a0000"'
       expires:
       - '-1'
       pragma:
@@ -1942,24 +1978,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
+    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A53Z&sr=b&sp=r&sig=BUfVh1W0UJuIwkHSQLUD7XWie1YfwK7%2BuwOTe%2FPRksw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:53.1473781","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A53Z&sr=b&sp=r&sig=PUrwN5JEa6Yu4W2Sn3D9JKTLS0tzmj2fmvzoK6GYjAE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:53.1472512","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A53Z&sr=b&sp=r&sig=MgUeFnKgr1VNhbOtrR0sKbeLBc2xQIKRIgPWIF7Lw%2BI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:53.1474041","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-13T13:57:09.366Z","endDateTime":"2023-10-13T13:59:46.942Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:59:51.114Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A56Z&sr=b&sp=r&sig=dNwcmNs64a3EHa6bSp2XzBchjBzc0R7u4tXkKv%2BUb24%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:56.9765507","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A56Z&sr=b&sp=r&sig=OJcxy%2FP3YWBkxtn%2BWuzKdV5bT6rNVy4sOpy1Moak3mQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:56.9764682","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A56Z&sr=b&sp=r&sig=uN6I%2BxYjv592uwvK1mYcWFOtKHWCIJmOPSeBn3Q%2F1Ok%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:56.9765724","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-18T20:57:08.48Z","endDateTime":"2023-10-18T20:59:48.846Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:48.941Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3335'
+      - '3337'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:59:53 GMT
+      - Wed, 18 Oct 2023 20:59:56 GMT
       mise-correlation-id:
-      - 29901350-e809-4ce2-92a5-c9dd65dd66d9
+      - 7f401af7-257d-43cf-8f90-cdcf95bddea1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_list.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_list.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:08.7073742Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:08.7073742Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:16.3081565Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:16.3081565Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:43 GMT
+      - Tue, 24 Oct 2023 12:32:49 GMT
       etag:
-      - '"75000769-0000-0100-0000-6530466a0000"'
+      - '"d3003d48-0000-0100-0000-6537b9520000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:56:44 GMT
+      - Tue, 24 Oct 2023 12:32:51 GMT
       mise-correlation-id:
-      - 9c92b871-e793-4cf2-b878-80f78f7a9371
+      - 00d66296-865b-4e74-be93-f2b2d638e1a8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"4edda639-cf21-4b33-bac0-f6606c8e634c": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "e37b96b6-c4df-47a3-bca3-04bbf740f4b6":
+      {"passFailMetrics": {"8ea9774b-148e-4e8f-b05c-ee27257e0b92": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "e5edbeee-8871-48d6-8d74-cf802e7486ce":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "f43616cf-018e-4d5b-bd12-4e03babe3c81": {"aggregate": "avg", "clientMetric":
+      "50"}, "c2b6103f-53d9-4fd6-8c7c-02fb37130ec2": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:45.054Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:45.054Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:32:51.622Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:51.622Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:45 GMT
+      - Tue, 24 Oct 2023 12:32:51 GMT
       location:
-      - https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+      - https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 60af2331-31f1-476f-8969-87ff2f2a7ff0
+      - 10cddf94-49fd-4a71-a87d-3f2ad802e4be
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:45 GMT
+      - Tue, 24 Oct 2023 12:32:51 GMT
       mise-correlation-id:
-      - f845da51-63e2-4763-995d-e5061230d180
+      - fa6cbe2f-6a65-4d13-9a34-5a7ec71acad7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A45Z&sr=b&sp=r&sig=EJIZzuZpmrV%2FmS6L5aIq6VYzl865RPDrl5rk7vdyve8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:45.9793901","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A42%3A52Z&sr=b&sp=r&sig=bp0PFzgYTANTV%2BvZjXXO%2B0OdfkHDmLonoghsIsKWbVM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:42:52.5185419","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:45 GMT
+      - Tue, 24 Oct 2023 12:32:52 GMT
       location:
-      - https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - f99b58c4-926c-46a0-b580-12e01489115d
+      - 586894d2-3363-404a-b52b-9cc44396b5cd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A46Z&sr=b&sp=r&sig=1bd7Ehm26d%2F1HYi4Aa7FDI4Lux1lFWG8A%2BESyM1ikrY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:46.2449944","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:56:46 GMT
-      mise-correlation-id:
-      - 88cc226f-0bd5-4ae4-a44b-7df03357c2b9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A51Z&sr=b&sp=r&sig=%2FinGaiVDTdP9bHJ60Y66rZo%2BqGlKaMQ2%2FbeNBBtsb0I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:51.5149738","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:56:51 GMT
-      mise-correlation-id:
-      - 00b985ea-9478-4a37-909b-84e4197fabbb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A57Z&sr=b&sp=r&sig=iY0vCZo8vy%2BbHNMVgvCDGAfvpMCQtI0nQNoU0HKqfh0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:57.2184618","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A42%3A52Z&sr=b&sp=r&sig=82v0ugSg9YAcq3VjytcLxuE45C%2FNr14ng96IE22uMm8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:42:52.8647949","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:57 GMT
+      - Tue, 24 Oct 2023 12:32:52 GMT
       mise-correlation-id:
-      - ce3d3392-a987-43ae-87cc-5167ae48cc33
+      - 5d179109-5301-40ac-a5c3-6fd1e5841708
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A07%3A02Z&sr=b&sp=r&sig=x0aMxXXUNuEHqU6Ihj16OskIEDYRIl%2BBz%2FUZyqD9mdE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:07:02.4757284","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A42%3A58Z&sr=b&sp=r&sig=OQnJWvmLK1uHpR9XV23w8QxK3zeFjB3uHOzD4MNQ6Z8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:42:58.1260512","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:02 GMT
+      - Tue, 24 Oct 2023 12:32:58 GMT
       mise-correlation-id:
-      - 63b3f93e-fdfc-4686-ac6b-4f86d31375fb
+      - 8a0af756-80bf-474f-bb77-53575507e840
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +385,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A02Z&sr=b&sp=r&sig=fhtcrfkQT9E9ptHOU0k6gwRdDyR9fMKWYjcB4CAQBxw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:02.7228758","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:45.054Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:58.036Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A03Z&sr=b&sp=r&sig=7FGuSH5uG8I0xGWsqMO5gDwLnb185rxj4Qe38D7caRE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:03.384655","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1575'
+      - '548'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:02 GMT
+      - Tue, 24 Oct 2023 12:33:03 GMT
       mise-correlation-id:
-      - 53922000-2266-48d6-9aea-dbebba5cc2b3
+      - 8818d63a-2e11-40c4-bc11-87251eeb4f2a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A08Z&sr=b&sp=r&sig=xYEsvVC1evoDRioQ759JCJAc0zBzqGUbcPvQcdHQWqg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:08.6180547","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '547'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:33:08 GMT
+      mise-correlation-id:
+      - b7d11d8e-f589-4936-a9d1-e74cd3809f3e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A08Z&sr=b&sp=r&sig=s1W0hVQ7esrmLc9skwXt3fTGHuOWRs47XaT8xDp3T%2FA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:08.889675","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:32:51.622Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:04.722Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1576'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:33:08 GMT
+      mise-correlation-id:
+      - 96e6773b-0022-4620-ad9a-692b72985ee6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:08.7073742Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:08.7073742Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:16.3081565Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:16.3081565Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:02 GMT
+      - Tue, 24 Oct 2023 12:33:09 GMT
       etag:
-      - '"75000769-0000-0100-0000-6530466a0000"'
+      - '"d3003d48-0000-0100-0000-6537b9520000"'
       expires:
       - '-1'
       pragma:
@@ -538,11 +538,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A04Z&sr=b&sp=r&sig=GPj88%2FCvbVekeRmH0UowNBah6FaauYJ0T8U6cQB9J10%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:04.4353328","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:45.054Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:58.036Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A11Z&sr=b&sp=r&sig=XoZ78bmkcbn9aYa8PuFzGzQFd%2B0lxXu7pgwNaxqFIOg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:11.4625282","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:32:51.622Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:04.722Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:04 GMT
+      - Tue, 24 Oct 2023 12:33:11 GMT
       mise-correlation-id:
-      - 11c7a80c-cde3-44e0-82ef-34bf7cd19c2d
+      - 3ce42636-0c8f-40b0-9563-39a98d051558
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:08.7073742Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:08.7073742Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:16.3081565Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:16.3081565Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:05 GMT
+      - Tue, 24 Oct 2023 12:33:13 GMT
       etag:
-      - '"75000769-0000-0100-0000-6530466a0000"'
+      - '"d3003d48-0000-0100-0000-6537b9520000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:57:06 GMT
+      - Tue, 24 Oct 2023 12:33:13 GMT
       mise-correlation-id:
-      - 31807d9c-e68b-47a0-8ad9-b5a83dbd955d
+      - 554929e0-4cb5-4400-9896-707e3a9bec42
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A08Z&sr=b&sp=r&sig=QXAwqDZXp%2BL3LZmfOlhvLU%2Bx1lQH%2Fs7eQKH26JDfTs4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:08.1912547","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A08Z&sr=b&sp=r&sig=T52pxl3orSYse5VIjgI0NqWG6vbvjPsfaV4VNM1HYxM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:08.1911186","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A08Z&sr=b&sp=r&sig=%2FQaqWU2LGpQA9oSSaNGlpU2lwOFBJCHgLJQFggiCfm8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:08.1912813","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:08.11Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A16Z&sr=b&sp=r&sig=oiYjHVswS9ckZwDJ68%2FefLx07DrbOKKTv2xeBloZatY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:16.4328309","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A16Z&sr=b&sp=r&sig=3QPFPqWn2Ci7s6qq83xE5fATIKJWFbfVSILWxaSV4eM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:16.432699","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A16Z&sr=b&sp=r&sig=hrF5nMDGDPKo4U%2FUoPHMiydvLqNl4bh8nrVHGqMUnog%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:16.4328938","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:16.359Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3144'
+      - '3141'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:08 GMT
+      - Tue, 24 Oct 2023 12:33:16 GMT
       location:
-      - https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+      - https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 360e7708-900e-4de3-9ad5-a316dd21b5e0
+      - c4700b8b-ffc3-4813-a67c-75a2dc01fdc0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,10 +700,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A08Z&sr=b&sp=r&sig=xphB7WlsSt86553BtteSFi0t7%2Fs%2B9ext91jAhoZ49xc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:08.5930187","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A08Z&sr=b&sp=r&sig=Mhn0QHP2HmBKSRRbTIKotKTVhO6%2FF6AiOJRnGrI%2FDzI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:08.5929438","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A08Z&sr=b&sp=r&sig=%2FKfhuAhJulVVE5pd7UJqopJTYtV%2FQkdWipSWHYPbhsU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:08.5930341","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"NOTSTARTED","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:08.48Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A16Z&sr=b&sp=r&sig=NQV6pXOz61NLrPsBonggT%2FHqQ5mIOvd13rFh0afRpoU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:16.9885056","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A16Z&sr=b&sp=r&sig=aLL%2BWvD0Tt41haL9aMlWhAklnsipauJwz7q%2BDW7jrzE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:16.9884295","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A16Z&sr=b&sp=r&sig=cEzkpJ1phWOA9C4fIumxEpcZ%2BaDDmzWfY6bZIxMP0ZU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:16.9885194","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"NOTSTARTED","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:16.778Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:33:17 GMT
+      mise-correlation-id:
+      - a1d14e8f-7920-4617-9858-f3d56c567aa5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A22Z&sr=b&sp=r&sig=exzVqdxhgYGqfRQGpd4TjQMB40Oynjv%2B2ZOuQ8K73ec%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:22.6610266","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A22Z&sr=b&sp=r&sig=vlFkA0rqzAeD3%2BSQs8wnQqE2wDFvtxDlCPDABTzXO6A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:22.6609255","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A22Z&sr=b&sp=r&sig=g7WJb2Ng2TIkLdJY50OLBKAYd6DjnHvu74EjElINkcc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:22.6610527","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:17.035Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:33:22 GMT
+      mise-correlation-id:
+      - 4ddc7a89-5909-412f-a8d6-8be3993e46c5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A27Z&sr=b&sp=r&sig=SLkr%2FLetH7GTo82oFuZ15qhdd8h0NGwZZU1XXazsjog%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:27.9715565","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A27Z&sr=b&sp=r&sig=V%2F0cf7NuIvjJgerw1GKS7g%2BYD6EkSyb9FU0qu9SuWjo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:27.9714581","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A27Z&sr=b&sp=r&sig=8%2FiqrdWSZW6EFINqRmygsIr9HAfjxcZHI%2BHOb1VwSRc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:27.9715726","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:17.035Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:33:27 GMT
+      mise-correlation-id:
+      - f241e327-52e4-41ec-b013-ee82b7d473d9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A33Z&sr=b&sp=r&sig=nI3iGHWXqJXJ%2Be8sG9LU3o6tXY1RCPoProMya6QWdSQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:33.3008831","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A33Z&sr=b&sp=r&sig=eN9dYdT%2BmIcT9IvQQiPYlwWktYJjGjoTgLbUqWygSlc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:33.300797","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A33Z&sr=b&sp=r&sig=65aizxE6DO%2BQ2vezPVUMLq8%2BEx89Aeb2829jY56BuEc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:33.3009055","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:17.035Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -714,9 +822,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:08 GMT
+      - Tue, 24 Oct 2023 12:33:33 GMT
       mise-correlation-id:
-      - 08e8e37a-6ce9-4dc3-a319-144777ca7a29
+      - 02e757ba-4a02-40f7-aca3-29ca0fa81d91
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,46 +844,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A13Z&sr=b&sp=r&sig=%2BZRKcaULH8asDDXWD2eJFiNvNcwLtD7yBIhAhUMo6HY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:13.8772657","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A13Z&sr=b&sp=r&sig=6r0NpmiePJQkhDhox4op7NnrlYP73eKa8SC8mhg9QYo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:13.8771905","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A13Z&sr=b&sp=r&sig=pZkEjA1olzuJug0T2oGXM6Khbt%2Fa0hHU1PLXX9mittE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:13.8772804","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:08.692Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:13 GMT
-      mise-correlation-id:
-      - 73e8235c-abd8-4e7a-a691-b6e156df21d6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A19Z&sr=b&sp=r&sig=Z8Ge9SBojlgsntPU2bILU%2FLvFBmoA2Z9VEAYLZurwLA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:19.1724835","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A19Z&sr=b&sp=r&sig=eeg%2ForgbirO7ty2SU%2BXi2Y73%2BQ6mtxq3Wg0wRGenOWI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:19.1723775","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A19Z&sr=b&sp=r&sig=zMZQ%2FOT1nSpY%2BkvbFlLoCyv%2FLpveZYfDwShBJdAoTL8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:19.172508","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:08.692Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A38Z&sr=b&sp=r&sig=M1P7J%2Bqf9uKOI4luZpk%2BfF35tuLWRNYbGCbzO0nHb3w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:38.5747913","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A38Z&sr=b&sp=r&sig=%2FcssMYUW7KBTAX%2FJ04S72CP8f4WgbUdVL%2B9rboTGrro%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:38.5746783","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A38Z&sr=b&sp=r&sig=EcdiN8bzkS87%2FwLwxoeMdeQ0faKGg1E3idIBDOx63io%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:38.574807","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:17.035Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -786,9 +858,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:19 GMT
+      - Tue, 24 Oct 2023 12:33:38 GMT
       mise-correlation-id:
-      - cacf4f2d-7ec1-4484-ab84-0b48f35616ea
+      - eee6ce21-0940-4b46-819d-a8c6102f6c04
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,118 +880,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A24Z&sr=b&sp=r&sig=DPWZJc2JCr7C8wGTCiOYvvSYvA3KtAZyk1ro4I48i%2FY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:24.5033715","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A24Z&sr=b&sp=r&sig=x0Q0YtvjM5igndzigA6S4dN%2B7VH6ehouRZG2paTYLfA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:24.5032905","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A24Z&sr=b&sp=r&sig=KhMOY1r%2BQ52UVfqM3uwGEEJxBcWUpO38pA6BS5C3Z3Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:24.5033913","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:08.692Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3189'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:24 GMT
-      mise-correlation-id:
-      - eaa6a07f-7592-45cc-82c0-cefa831374d6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A29Z&sr=b&sp=r&sig=UuKJQkur8Kli3%2BMzYIFara1YVlrg3knipv1mHLnGADo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:29.7874138","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A29Z&sr=b&sp=r&sig=CvJNhcqQdGCaShaBuHWF3jdD4ak944nWOtePd3xaY5g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:29.7873366","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A29Z&sr=b&sp=r&sig=BBPu09fktXzBDTdtlTdLG%2F7CGJQPCitOGkUl4brOMmM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:29.7874289","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:08.692Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:29 GMT
-      mise-correlation-id:
-      - a28b68ca-0de3-4933-a049-2d4cafcd109b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A35Z&sr=b&sp=r&sig=%2BwcEvmkrSHdg5VQqqPPYf6R13inB9G6zs8mb3y%2BHhNg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:35.0547362","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A35Z&sr=b&sp=r&sig=8fSUk1M4t9elLVGN2jrdjiGrcAiZPXYJA23ubP4ANrM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:35.0546337","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A35Z&sr=b&sp=r&sig=qdLQ8PaKZSNzZ6fnrJqqtWZ8z6C2ORRPgwwIesRegSs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:35.0547584","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:08.692Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:35 GMT
-      mise-correlation-id:
-      - fb8f4437-575b-46bc-8687-e4e69043bb33
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A40Z&sr=b&sp=r&sig=B9uNE0kM%2BSoERofdOSnf4UxoLIc7YLkjck%2Bi%2FjdmV4s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:40.3705442","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A40Z&sr=b&sp=r&sig=vp8HCuQOhb1q0hG0g7wJKZVX6bb%2FrHB%2FF0T2et%2BhxIs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:40.3704734","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A40Z&sr=b&sp=r&sig=sGjLuGlCXa%2Bz6OqjtuLWiaEKbbSA3EB2g93RN23UvLk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:40.3705592","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:08.692Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A43Z&sr=b&sp=r&sig=CeRqRO%2FMzWBZH9e1ZJj9EDlUJ4F5fAOK1PiTbD5AInM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:43.8717411","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A43Z&sr=b&sp=r&sig=%2BuzF3S5uF01JMMsxZRWDrSFrw%2BB15oNsUt2XoVq5%2BNk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:43.8716335","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A43Z&sr=b&sp=r&sig=FdnFEu2kK%2BOA0Z5Mlq3gsHPk%2Fx5HPVqgitkCF4DFxs8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:43.8717675","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:17.035Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -930,9 +894,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:40 GMT
+      - Tue, 24 Oct 2023 12:33:43 GMT
       mise-correlation-id:
-      - de47f646-c5f6-4e43-943f-265e9ea4d968
+      - 2f09901a-acd9-45a5-ac43-cf35148686a5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -952,10 +916,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A45Z&sr=b&sp=r&sig=pytUadNVGYrLZMUF5pU0w8Nw%2BliIK58s%2BS7Liysccng%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:45.6925087","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A45Z&sr=b&sp=r&sig=PIIu0ZrO5iwYqiazF7uYH4Xoe2r6sRUBf8GIhtenmN0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:45.6923914","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A45Z&sr=b&sp=r&sig=xqfz4MxTaOUdlsHQHKCPOylrZK6Q2TbwXb1cPz%2Fz5h4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:45.6925264","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:08.692Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A49Z&sr=b&sp=r&sig=AeCmuOu19MhQeLyw2dc4TK9rIHhIhKGJ1Bl5fl%2BnOMo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:49.135513","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A49Z&sr=b&sp=r&sig=XoyGsv32YYIRwZHFzlf4JovF%2FRADG8nVQs2EPc9aySs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:49.1354421","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A49Z&sr=b&sp=r&sig=GA%2FUBX2Cv01Ra%2BRxTQmyxlEiLCGfp2A9jj2S3qO74KI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:49.1355271","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:17.035Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:33:49 GMT
+      mise-correlation-id:
+      - b30b923f-66d0-4f74-bf9d-f1f59c5ee1d0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A54Z&sr=b&sp=r&sig=N5bz%2BrZK6tY%2FbchkkKIzUrv9XYWuqGGa%2F%2FhQYdH1%2BGQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:54.4034914","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A54Z&sr=b&sp=r&sig=L%2Bxno0gSsSpomnFP77MFGMcgp1wJfyyDOfxPmohpSog%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:54.4034188","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A54Z&sr=b&sp=r&sig=n8806Q82tcXhIcIPgoQC2FL0VswKur0Ng7DMpmrFZ5k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:54.4035064","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:17.035Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:33:54 GMT
+      mise-correlation-id:
+      - 5e6e16a1-f840-481d-949f-350fd40fdf05
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A59Z&sr=b&sp=r&sig=cil0j0cnTypYMjwhOQn8cyVzuISSpEpYZdgo8i0UFWY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:59.6706435","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A59Z&sr=b&sp=r&sig=UushyoMVbojLF7rnJwvyhANrpJcW%2FH7DNWCnGcyb2Wg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:59.6705751","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A59Z&sr=b&sp=r&sig=LgNxISL6wmHBjnxIIkUzbe%2F90CKGv7N6CxZJZvrBcLI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:59.6706576","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:17.035Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -966,9 +1002,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:45 GMT
+      - Tue, 24 Oct 2023 12:33:59 GMT
       mise-correlation-id:
-      - de999f86-642e-47ff-b5a5-0fa1cd91ae24
+      - a1b96cef-24d4-4ae2-ab86-1e7c7fa987a9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -988,10 +1024,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A51Z&sr=b&sp=r&sig=oiiF6R4LCsVzA2UWaVuuGXvxf1uEoPymtsIKFg7j8JQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:51.0348027","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A51Z&sr=b&sp=r&sig=juLPmuuqzuxUyl8vLmMITjc3BJofai%2F43IahTwN0jEM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:51.0347299","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A51Z&sr=b&sp=r&sig=C8hZ%2BpPyfRoNh5pjn9gvE7O2YkUAA1%2FuC4uai%2F5AfTk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:51.034817","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"CONFIGURING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:50.55Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A05Z&sr=b&sp=r&sig=ozGjPTeXMC7ei0tImUPPV5ltZJ8tyqCifYTWZTrxgg4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:05.1066756","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A05Z&sr=b&sp=r&sig=K%2FErpMDykymPVb0NMklMQh1KdocqbtpSQvVGIVdGmPs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:05.1066084","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A05Z&sr=b&sp=r&sig=UYutsKlcpgDiiFUwfMdNpCEETX8Jp2WQzQ7lkWczS9g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:05.10669","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3182'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:34:05 GMT
+      mise-correlation-id:
+      - 69808b7d-e266-4f4f-b1ff-f77febd645dc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A10Z&sr=b&sp=r&sig=vXYknIoKAQTmfuAAdI6uLSt6OcQzgQpesZWrqQHMBoc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:10.3515725","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A10Z&sr=b&sp=r&sig=COPvzYA62QarVVSpYe9YWNwplSB4wLEGHd0WanD6L7k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:10.3514721","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A10Z&sr=b&sp=r&sig=pSvdhkIJRM1OfCBakvowZ93IFS%2FYu3r0789QuqRlMt4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:10.3515941","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:34:10 GMT
+      mise-correlation-id:
+      - 03d91eb3-073f-4385-b246-b351575bd993
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A15Z&sr=b&sp=r&sig=ektw8eBK8Q00AIqkok7yKETviXw4g0fxsWityMlC9Y4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:15.6395537","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A15Z&sr=b&sp=r&sig=htCTnMAiNh3DjemOpV41hff%2BZ1h1Q%2FDwV5pCgqoyFB4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:15.6394951","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A15Z&sr=b&sp=r&sig=jgH31dktp2JMt7XOJq2cKmUR%2Fk0zwSEGsQV1ReV6iKA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:15.6395679","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1002,9 +1110,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:51 GMT
+      - Tue, 24 Oct 2023 12:34:15 GMT
       mise-correlation-id:
-      - c906f367-d8b5-4498-85d5-ac6a8d7dfea8
+      - f4e75f63-fddb-4baa-a4b3-2cfee25ead30
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1024,23 +1132,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A56Z&sr=b&sp=r&sig=JSDV4A2G6PIo6Zq0w%2FuivPh0l88lMyQo7nrA9Wn6XHM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:56.3553808","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A56Z&sr=b&sp=r&sig=FUWjpjgihjvD3nRMmxYZ5D9TP7nA7QDj0ylP3IwiSNg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:56.3553045","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A56Z&sr=b&sp=r&sig=dBLbjymZv44qts2Q2zSKJH1e12mnatTydAJxA%2BlIO4A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:56.3553948","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A20Z&sr=b&sp=r&sig=YBXB70irWVXSs7%2FjqVdkaKK%2FxP7GrQ2iOL3lonyIYIE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:20.9076865","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A20Z&sr=b&sp=r&sig=Oh1nExLx%2FazajKUSFXd%2FMM8YLTah7yG%2FMjT1U8oLyJs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:20.9075995","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A20Z&sr=b&sp=r&sig=9gyy0OAz6ACxpYy5J0yTa22tWIwEdPp198rJ1iZ4Lfk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:20.9077087","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3184'
+      - '3192'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:56 GMT
+      - Tue, 24 Oct 2023 12:34:20 GMT
       mise-correlation-id:
-      - 371baf9a-8a8f-452a-a158-216e8567e3c9
+      - 6c6f30fc-047f-42ea-af8e-65e5a23e90b5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,10 +1168,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A01Z&sr=b&sp=r&sig=cp6LWbZRday8qoipzA5%2Faa5TKFze3FadXBr08ZtgcuY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:01.6862901","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A01Z&sr=b&sp=r&sig=58VTurLZkD0MyFfdXr%2BmhFPZI1qbQC8oVCsNIwgTpog%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:01.6862017","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A01Z&sr=b&sp=r&sig=ftAGo2QGOJsF92kCmzjL78PnoM0IJmwaXiwkvHOfRr4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:01.686313","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A26Z&sr=b&sp=r&sig=5hmdJzbMafyvb8JvBrIy44RV15B4FNJPwTOoteevDRw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:26.2044149","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A26Z&sr=b&sp=r&sig=n1c03PSoNEkJjOpS2tB9C3s0gKM%2FGCbGjCm0NbiDC48%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:26.204346","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A26Z&sr=b&sp=r&sig=myQU00PNkWkwfdeUN1NSrIlp23qYBxHZmQKWxkzrnDk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:26.2044286","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1074,9 +1182,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:58:01 GMT
+      - Tue, 24 Oct 2023 12:34:26 GMT
       mise-correlation-id:
-      - 416d3e9f-1bb1-468a-bc12-7a230e8ccb18
+      - 951543ef-5205-4afb-8846-1f164165baf9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1096,23 +1204,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A07Z&sr=b&sp=r&sig=92FYHkv8IL1KfDyh3pIsvfStn5gOxSdWxZikioJqj1g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:07.0137286","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A07Z&sr=b&sp=r&sig=3Eqkq0zLc%2BeeRS21WbuG8yyrbL7uRB81VOKWMGp0qE0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:07.0136418","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A07Z&sr=b&sp=r&sig=d89dKrsKeyzWLBUEo8URJdiHNEa8hlzCDH6Plh7MtPo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:07.013786","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A31Z&sr=b&sp=r&sig=Nf1FLVfxjnZvoinSeQm4s7rOwOjy1XnLCDwQSg%2BVeL8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:31.5254602","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A31Z&sr=b&sp=r&sig=05NPlQArxiP1j0ekkSKs%2F%2F%2FDB8jFOtbyF%2F8aWPetd50%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:31.5253915","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A31Z&sr=b&sp=r&sig=slgpyNHNcmzlmM6ybEeuyVrSIQNi8D1mH8hzjpaLjVo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:31.5254757","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3181'
+      - '3192'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:58:07 GMT
+      - Tue, 24 Oct 2023 12:34:31 GMT
       mise-correlation-id:
-      - d88a087e-d1c5-43eb-b4bd-f47a74825f69
+      - 82533fdc-9fe4-40e1-9762-381ffad29da2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1132,23 +1240,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A12Z&sr=b&sp=r&sig=e202kvpnW5eLLgjYPafuKNVpN0IJV5n9FfrNWqUTt8k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:12.2838259","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A12Z&sr=b&sp=r&sig=jYI4aHV%2Bwp8Zg0WcY5xBeZksbTg%2BJxM4ufxXCyqCpkA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:12.2837353","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A12Z&sr=b&sp=r&sig=8doAKMyqpLBYZOE2YlELmXQRFzs3b9Y4Xux2OOyC2Cw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:12.2838472","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A36Z&sr=b&sp=r&sig=YHcAHCbj7Hb5hETsUbn0y4azUcfN7ZsSVx4wYQxzG2E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:36.8250513","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A36Z&sr=b&sp=r&sig=lNw9RAHQKxhd%2BJdEhPqrKCSJA1W3dY2EBU4JHfiNUhw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:36.8249568","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A36Z&sr=b&sp=r&sig=zwU1KuBYr%2FL1RRbEiv%2BkD%2BtDvTlESy79wvs4F8Rf%2Bsk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:36.8251246","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3184'
+      - '3192'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:58:12 GMT
+      - Tue, 24 Oct 2023 12:34:36 GMT
       mise-correlation-id:
-      - c6652d87-f636-4c42-9ddb-64798bdde30c
+      - e2c362bf-6ae0-4082-b453-7cc4fada51a4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1168,10 +1276,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A17Z&sr=b&sp=r&sig=qYQOs6IpEK1hkUHyzEi9%2BKBv4doqbd98r8oJ73K2ths%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:17.5378547","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A17Z&sr=b&sp=r&sig=2dWZKNVYxdLbBLqc%2F8z4jaSZJzTr%2BGOSfjXGiIS4qDM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:17.5377821","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A17Z&sr=b&sp=r&sig=5YOkXkBFXYpnai3uCEnYSD%2FAK%2FcHgcp57OS6mj9Q5aU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:17.5378686","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A42Z&sr=b&sp=r&sig=sbJ0eoMRNY%2F7Fb5b8QTHh9jSrFCAGPm%2BmyAgeWmyOZI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:42.0867296","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A42Z&sr=b&sp=r&sig=th%2BAQg0gFKDMnRsWL%2FZ%2Fx5lg04Iic4AoHita1i9HBVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:42.0866475","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A42Z&sr=b&sp=r&sig=IqpAONxj0UIwEbEazUIx0YmiQ3QhmoX9Saa8WSiehjs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:42.0867457","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:34:42 GMT
+      mise-correlation-id:
+      - 884ff853-ceb7-41b4-b22d-b2512f496e00
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A47Z&sr=b&sp=r&sig=lURHNxdsIY1WWLP7VraxbFJ6s%2B%2FnJRZ%2Bys7TAiQZStM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:47.367046","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A47Z&sr=b&sp=r&sig=CJOJubbEm1iGgRw8NeMvU%2FIDMKoWTshs7rMOUStl1lM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:47.366957","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A47Z&sr=b&sp=r&sig=HONtGA1eILiJjDsy%2F%2B2gUTyZ781uGbZ93FDXSFxPdeQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:47.3670641","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:34:47 GMT
+      mise-correlation-id:
+      - fb723fbd-7505-4698-907a-1ce5108702ad
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A52Z&sr=b&sp=r&sig=iAUCPAL4jCSOYatv0Cv58FBhYNaaa0ZB0MBIAJ6OS1c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:52.7204084","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A52Z&sr=b&sp=r&sig=%2FN4IIL8qGoAaq1UXLoViz%2BHCGsyF7e3%2FnFkS2otYZ3M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:52.7202928","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A52Z&sr=b&sp=r&sig=M%2B86GaVhHqf%2BrweIl%2FF7Rz7at3aI8%2FoqJVzoF4hsoqE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:52.7204354","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:34:52 GMT
+      mise-correlation-id:
+      - 832d6c7f-9ed3-4f7f-822a-38c752c6eaa1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A58Z&sr=b&sp=r&sig=X1js05eE6%2B1j2QC7D8E1nkb7GlfGb8aHfmBpLsIIyS8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:58.0556208","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A58Z&sr=b&sp=r&sig=%2FHbNSisMmpFcFBsEdtNR8XNWAeXbepPj5D6oNomy8ng%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:58.0555366","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A58Z&sr=b&sp=r&sig=RRrWUfbL%2Bna4DrGL1%2FYm1ehei40bqK2RJh3wO6zsfEE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:58.0556429","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1182,9 +1398,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:58:17 GMT
+      - Tue, 24 Oct 2023 12:34:58 GMT
       mise-correlation-id:
-      - 3721190b-a742-4403-9db3-e101dd7f962c
+      - b1490102-f0b2-4054-9fa2-e73632359060
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1204,82 +1420,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A22Z&sr=b&sp=r&sig=AaCOBGBJuy4Z2Vf7eKNroeNUxc1XUtGFyOUc3QJrdjI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:22.8043734","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A22Z&sr=b&sp=r&sig=imFxGUv7ORzkeW5PZTzQCEMa5vn8mraaEK6qro8YojA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:22.8042825","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A22Z&sr=b&sp=r&sig=vp%2B5qImo%2FB4uETvsJOxbpoO0KusIZ9ZaYtVCDGGrgTk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:22.8043866","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3184'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:22 GMT
-      mise-correlation-id:
-      - 1e1a493f-14cd-41cf-8d81-7bac4e7040a9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A28Z&sr=b&sp=r&sig=KtfIz1x1SXrNN6wjkRRyxRgUnP2mup3qTLp%2FzfD61uA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:28.0879569","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A28Z&sr=b&sp=r&sig=28ktbTtflsJd7Re%2F4oT%2F9aTlcANjYHLwzoSGczBGqWg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:28.0878767","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A28Z&sr=b&sp=r&sig=LYh5Afs98E5juCDYf6caAQx5imz3Cu8FHP%2FPDUIX%2BF8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:28.0879716","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:28 GMT
-      mise-correlation-id:
-      - 29bef93e-a3b3-474a-911f-2c9ab5785070
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A33Z&sr=b&sp=r&sig=v03%2FJ0zM16whCA9bLL61NQfwd0Vks8AdPeUeqQVPZvs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:33.4313923","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A33Z&sr=b&sp=r&sig=8EKLALdJ7TbW1NWyo9s70WFaYRI8sjrS5Mo8fRJMaCg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:33.4312815","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A33Z&sr=b&sp=r&sig=F%2FgTqllel%2BERNt9lDEelqZTtrmn5KuJS%2FexJrqH5k5I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:33.4314172","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A03Z&sr=b&sp=r&sig=LdVs79S0pKVXeEec0dknwBZuDEhDX8l%2B4cgC6RiuVfA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:03.3190737","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A03Z&sr=b&sp=r&sig=b4lgmqd%2BQ75EnBlLtB1SnA3E0fHITJodpZ2O7alMu3M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:03.3189852","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A03Z&sr=b&sp=r&sig=ex3wsByUBeWvYR4IpXlA8qU%2B7AnBzy4u4QnBqWF1at8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:03.3190945","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1290,9 +1434,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:58:33 GMT
+      - Tue, 24 Oct 2023 12:35:03 GMT
       mise-correlation-id:
-      - a3ffc5c1-c406-4a1e-8650-214aabc8661b
+      - eb480222-6d28-4be9-8595-2a2327474504
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1312,10 +1456,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A38Z&sr=b&sp=r&sig=k5YxcPzwjh9IkK20woCT%2BL3m6YNGaqaYPbVC0wp4gCM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:38.7319888","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A38Z&sr=b&sp=r&sig=BsJR5HwOU7BqJ%2FgURqeuNdsMPDyAoQtWT7y7R3ttcXs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:38.7319014","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A38Z&sr=b&sp=r&sig=l416%2FjqaQSUy6TzeMuUrIHpfz7Agw6XBd9hcEO%2FoK%2BQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:38.7320108","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A08Z&sr=b&sp=r&sig=%2Fp3niq5KHt4ML7O4fr1F0rfz7N6FeyVyOqv99PY0tzk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:08.586203","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A08Z&sr=b&sp=r&sig=%2FAjpyDDhm8qAw4QgdJit5BPIvy48p%2BhzYBPTQ5aJw7g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:08.5861123","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A08Z&sr=b&sp=r&sig=LxkUMny%2BimRHSvwywiUJD2Ny2vs49CspRgGOQ9ezlNY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:08.586228","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:08 GMT
+      mise-correlation-id:
+      - f49f7bca-4c07-4f9c-a348-c7577f8822b6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A13Z&sr=b&sp=r&sig=UkvSV47jk7i9IBs0O1BXBjJpU%2BSwg3phQ%2BPPTG5%2FS5c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:13.9060889","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A13Z&sr=b&sp=r&sig=%2B9PraCAUsj675fKyjH%2BEennKYkiioq3LGkNZJ5sLIlk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:13.9059927","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A13Z&sr=b&sp=r&sig=BGrNtD815ESo67grGaxWLQuA0%2BMFscyRJkV4xnHlWtY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:13.9061164","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:13 GMT
+      mise-correlation-id:
+      - b58b1d67-0ab2-443a-8ef4-8e7fa5537784
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A19Z&sr=b&sp=r&sig=8Y7zml6XRgvQjmKwhKhhUFtvYVR6POeAWpfA0mV4aWs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:19.2294485","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A19Z&sr=b&sp=r&sig=Ci9L5JiPr0uFlmoLFoomEwfC%2BXdovum%2B4OcEh0GbcCM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:19.2293622","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A19Z&sr=b&sp=r&sig=a9Pmz7Wj7VTzt4GnSrl3%2Bgp%2FSMYofxJLQk5qSw5e35U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:19.2294711","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1326,9 +1542,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:58:38 GMT
+      - Tue, 24 Oct 2023 12:35:19 GMT
       mise-correlation-id:
-      - e9da50cc-a9f2-42ba-a561-3bf9825f915d
+      - f68905aa-420d-4cb1-807b-ecf8bd541dd8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1348,82 +1564,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A44Z&sr=b&sp=r&sig=aa1muKqRIMsirSYCWWuZihT4HZybH6Xy%2FpceBH0%2F27I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:44.0762897","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A44Z&sr=b&sp=r&sig=mYSRcU%2B3B1dPfx6fbPdMKei6Lmem5qSXPbjFbBTXSJM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:44.0761846","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A44Z&sr=b&sp=r&sig=oKUreASgE3UVntP%2FyvEVLJwLFB5q%2F5spppaTgWGExw0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:44.0763147","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:44 GMT
-      mise-correlation-id:
-      - 4680f9d9-118c-4022-a72d-3d213be5b159
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A49Z&sr=b&sp=r&sig=G%2FeFcjGkgJicrYrOToq3C1rsTCQ1ByjlrtFUVfeL170%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:49.4050347","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A49Z&sr=b&sp=r&sig=PxBkTuYrtTafDsP05rooF4Hz26lUMJck6SkuN9Lwsbg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:49.404946","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A49Z&sr=b&sp=r&sig=oNCbt5wxv9ueL8sGboUN%2BVxH7IF2buLU8hZwUylSqdQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:49.4050554","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3183'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:49 GMT
-      mise-correlation-id:
-      - 137955fa-c9b8-42f3-bce2-48d930f695c0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A54Z&sr=b&sp=r&sig=xuLUgCRBjG9Matxzts45GTy7o9yiSOoGvEM3YqmtLpg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:54.7320329","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A54Z&sr=b&sp=r&sig=mAQ15PHpgkGVgs20quHhgdcAkDvp9Aliy1CUO%2BTk8io%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:54.7319609","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A54Z&sr=b&sp=r&sig=odqs44u4RPgG6ZdjB0YdvzWBJ99ke7Rer1%2Fk%2BRcHfj4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:54.7320692","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A24Z&sr=b&sp=r&sig=HKekQVuISo1ZkQxqxQ1cGjABxEYH76BZJmUOf7Zria8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:24.5406702","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A24Z&sr=b&sp=r&sig=Z0N26ol0rrInokYvTKjJWTUYfqhroGg15X%2B4aHCzrQo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:24.5405813","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A24Z&sr=b&sp=r&sig=k4uShGhbQgDqyGdxU9n8nPhPb8QRpXe9%2Bu4KQ2XIOso%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:24.5406861","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1434,9 +1578,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:58:54 GMT
+      - Tue, 24 Oct 2023 12:35:24 GMT
       mise-correlation-id:
-      - 032f12ad-5db0-4263-80d3-1e376bdb12dc
+      - b3e68593-0aed-4d48-82f8-1f084e01f338
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1456,46 +1600,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A00Z&sr=b&sp=r&sig=J8IBguKHTSJDt9TRZOYHy1k2pdIescPdxyt%2B6aZgjB4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:00.0484489","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A00Z&sr=b&sp=r&sig=M%2BD6CHbsw0jX%2BzpCjnHNS7N1%2FkUL0KaXkfOr%2FOq0yvM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:00.0483549","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A00Z&sr=b&sp=r&sig=SDHbIYvYDr31ad3DxqcgajYtLV7oOez7IA%2BaBRiCjwY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:00.0484719","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:00 GMT
-      mise-correlation-id:
-      - 62bfdeee-be93-4f15-82d8-a8dd0560b549
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A05Z&sr=b&sp=r&sig=xjK5KLjjrwX9%2Fwq4HYk2TdooZYWuHLof6DBEbpBsMwY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:05.3891673","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A05Z&sr=b&sp=r&sig=ItooIGtXstrFkwCttul14ghZ74EPWTWE8kjEiWyH0cs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:05.3890386","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A05Z&sr=b&sp=r&sig=EVRsjWDGRVj6K19Uzen%2BnKnVTRVR8rVaPD4P5H%2F6sEw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:05.3891889","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A29Z&sr=b&sp=r&sig=UHU5bACj4KnaTHGmUXppH%2FeFb9kKt%2Fgjz1R4IZditlI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:29.9146629","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A29Z&sr=b&sp=r&sig=tTMXiB0zPbNIsOJNSnvbDtdFMDeDTxiHAg6IJ3RGufs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:29.9145967","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A29Z&sr=b&sp=r&sig=dFIsmnr2EagZFVpobi0mZFY7O9GqnsrdrFgw0y0okxg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:29.9146793","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1506,9 +1614,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:05 GMT
+      - Tue, 24 Oct 2023 12:35:29 GMT
       mise-correlation-id:
-      - 593fd35f-3a68-4a94-b66d-4aaa6a601046
+      - 045d8a43-6edd-451c-ac95-f4dba65ddb9c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1528,23 +1636,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A10Z&sr=b&sp=r&sig=DFDa1xWTTQjuf%2FsheaKy9DP954xuHJdQTlqM5wP7NEw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:10.6841512","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A10Z&sr=b&sp=r&sig=ESVO8PH6cjTDUEnlgXBigSCRbEoH9kwHB3diVRz8vi4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:10.6840751","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A10Z&sr=b&sp=r&sig=fiCqCByfhD7vH3V%2BKYYyfHVNdkh66ICZypxkAHrXB8s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:10.684165","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A35Z&sr=b&sp=r&sig=nuoVl7xSOKqa3MVgO5FXlRlBAJDWVLu1S6FdduE%2FUaw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:35.2156685","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A35Z&sr=b&sp=r&sig=2msu0q%2BLpLH8JNE51ER3JBPvS%2BKF4BWG2Cxd53Fx5Vo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:35.2155946","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A35Z&sr=b&sp=r&sig=laGWOVr0XxgVyfRdfqr0K7sdVEafNN3p7DMgnHrw0jw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:35.2156821","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3183'
+      - '3188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:10 GMT
+      - Tue, 24 Oct 2023 12:35:35 GMT
       mise-correlation-id:
-      - df5bc503-8af7-4385-8799-3a2af1d1edf1
+      - 27760d99-f561-496d-a406-cacec6127fd1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,82 +1672,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A15Z&sr=b&sp=r&sig=rJVFbT6Deyi8RYsfrZkv8yuHWE1R53yhj%2F%2FQpQNemXs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:15.9510869","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A15Z&sr=b&sp=r&sig=H0r%2Ftdq9p0RNiHXT3%2Ft9zP79Jk%2BevZ3evdjhbQJ6jJM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:15.9509993","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A15Z&sr=b&sp=r&sig=yfSZAnP2JK6D9buYquS%2FSSE0Ze7l6O4LvG0Chsq6Avg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:15.9511082","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:15 GMT
-      mise-correlation-id:
-      - 131b6630-70aa-4212-b328-78a8bfe0c7a2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A21Z&sr=b&sp=r&sig=0t7nyvyY%2FO5qKaEMLrnpG9myRSKJPgIp%2FXiOrWZhpzE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:21.2484894","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A21Z&sr=b&sp=r&sig=8fGoIAR0o6X5AL%2B7Ekn7uVJrOgVBJCVQU%2BWZbV28Oyk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:21.2483938","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A21Z&sr=b&sp=r&sig=cm6Ia21E%2B%2FmYyXLKb1kh1ei7wVSTOkX8CsRKxpHVEBQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:21.2485101","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:21 GMT
-      mise-correlation-id:
-      - a4313d35-1415-4acb-b945-f225d7df04fd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A26Z&sr=b&sp=r&sig=%2FFaXqDBJTMgEq%2BbEJ1J1E1NKevCMqKH10dUs5nNA1Qg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:26.5724897","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A26Z&sr=b&sp=r&sig=02i9H8cuUhXac5%2FFZFXhAAfYMPpgjLOvIJoApHA5gac%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:26.572403","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A26Z&sr=b&sp=r&sig=B0lA3dB8iHdSwUyi71%2BAv3ImW5PS799pWg9fvY%2BLZ78%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:26.5725039","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A40Z&sr=b&sp=r&sig=PQhPtuuP3z4OkaNvPc6q68PZXm0Y2p%2B6Zmk7yfMSLFg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:40.539909","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A40Z&sr=b&sp=r&sig=gzJZXzIZXLcZvZzKTx8hFkDihxGAP142qjiyYnzHqnM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:40.5398421","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A40Z&sr=b&sp=r&sig=HaIaHm9qrBO0Dg5VS%2FU9NHma%2FdiikmrGQ2ua%2Bh9s9Ec%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:40.5399233","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1650,9 +1686,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:26 GMT
+      - Tue, 24 Oct 2023 12:35:40 GMT
       mise-correlation-id:
-      - 45f1cadd-d250-4398-b877-0c3bda4ee7c6
+      - 97eb5a47-9cd9-4889-a19f-ed619b57d65f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,10 +1708,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A31Z&sr=b&sp=r&sig=7o%2Fr8iJEbcSaM2EYXJ56cBJvBpv5IULRr57WJfnCzKQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:31.8981995","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A31Z&sr=b&sp=r&sig=565vCEMW%2Bhrq0PErHddaUJT0U2M23o4zihlZD3HT37c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:31.8981077","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A31Z&sr=b&sp=r&sig=qog9P1MkOQM%2FNQISMJk487wUI1ALjPdWY6I0%2BMz2B8c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:31.8982135","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A45Z&sr=b&sp=r&sig=jKe47ngCXGkd3e%2B2nQPGmuuI8bkzaegI06e%2F8RokOtk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:45.8313115","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A45Z&sr=b&sp=r&sig=FN%2Beh3%2Ff1hGpG12y9T7OhpwHjxlZUiPpDPT0Wvs03mA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:45.8312368","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A45Z&sr=b&sp=r&sig=%2B1rYw9pnZfA2QxMhTlRTMXPtmIzLML%2B8Jq9iLsFDh7g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:45.8313256","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:45 GMT
+      mise-correlation-id:
+      - 08487c91-b2d8-4e38-9f1c-906e57fef75d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A51Z&sr=b&sp=r&sig=S%2BAFTilUokF%2FQN3IT%2Fd8gnkjf7fSPrgTjEn8roqq6LY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:51.0940097","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A51Z&sr=b&sp=r&sig=UlnCSVjmVUng5i8nqti%2Fxosfn1tHj3NRul2bn%2BxkdZo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:51.0939031","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A51Z&sr=b&sp=r&sig=Ynt1E0voXyZJvO1mKH5YDfe7VKEieSQDOIO9o0O6r3Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:51.0940356","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:51 GMT
+      mise-correlation-id:
+      - b9dffdce-e309-460e-a9c1-5ec0be129a54
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A56Z&sr=b&sp=r&sig=k3NnlSXITykmB9%2FSIziqgpy35EIqHToknolhPcIv0qs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:56.349255","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A56Z&sr=b&sp=r&sig=HBCrKGf3jNg0Kxd8VaNNGmzoAOX86QMW2NxgC41%2Fcc8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:56.3491751","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A56Z&sr=b&sp=r&sig=r7%2Fxv%2BoJnCYKmgWOxIztpflvd6P%2BgtFDTNxNFyYg3WU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:56.3492695","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:56.313Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1686,154 +1794,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:31 GMT
+      - Tue, 24 Oct 2023 12:35:56 GMT
       mise-correlation-id:
-      - 3e604e2a-f614-4ee9-b16f-155546a859a4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A37Z&sr=b&sp=r&sig=RwaSH%2ByX%2BYn1nnJm9AzE9EaeeKyS8Z6ObLcGzMz7OSs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:37.2031153","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A37Z&sr=b&sp=r&sig=yWb8akswDKaeXgQEUZxcGXytUwbJxCN%2Bo2HnOMSb5CA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:37.2030481","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A37Z&sr=b&sp=r&sig=jUhkFIbfhseGaCuo4qkFl9cK83tKBXNNUH772BRRu1g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:37.2031298","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:37 GMT
-      mise-correlation-id:
-      - 8a16da18-9b70-4f09-8223-405e0dd940fb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A42Z&sr=b&sp=r&sig=HDxOa%2Ftr8XoGPSdsOGKtAk8TdgDaeFBQGwNzL1GpD1w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:42.5346641","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A42Z&sr=b&sp=r&sig=CqAtPQpHM8V44mXUKHgLFVevli0kEjXZ%2BDmoquPfOV8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:42.53458","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A42Z&sr=b&sp=r&sig=654%2FzXAcVbtcoBnBx9dbxMqdZZxPemg1olZH2yfU7BE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:42.5346781","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3184'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:42 GMT
-      mise-correlation-id:
-      - 0da554ea-1d60-4238-b2f6-1404277b9eea
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A47Z&sr=b&sp=r&sig=V4f8MGdybIi%2FzFJmshUZIlEqiX3tQe6L1r6ZAEvaPRw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:47.7980693","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A47Z&sr=b&sp=r&sig=HKnOc0HgToQX6Jrilw%2BH2SwjSzrQU6i5AMfSNcwxxIE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:47.7979962","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A47Z&sr=b&sp=r&sig=OV%2FWAWPFP3pNPA6zed2ZV68y5Q3mplnPN6rk9OZdkbs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:47.7980833","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:08.48Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:55.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:47 GMT
-      mise-correlation-id:
-      - 5bcda248-cc01-4a86-9da0-a8fcae324dcb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A53Z&sr=b&sp=r&sig=XeshralMaEhPa08iJc9Cu3gwnfgBI6CKhg%2BLD%2F6RaYo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:53.0830478","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A53Z&sr=b&sp=r&sig=0f66Ujdk12RrDH1kewKCCNQOB6x1030q%2Fb1CuwC14Jw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:53.0829535","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A53Z&sr=b&sp=r&sig=MXgdakkJwHHBW3YhQFXxUaaaz%2FBz%2FMLe5uEKwFos4Hs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:53.0830726","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-18T20:57:08.48Z","endDateTime":"2023-10-18T20:59:48.846Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:48.941Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3325'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:53 GMT
-      mise-correlation-id:
-      - 91818177-d4c9-48a6-a4d2-b0a7898da4b0
+      - fecd3c79-b0bf-4262-87f2-cc4a15c13ce4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1856,7 +1819,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:08.7073742Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:08.7073742Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:16.3081565Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:16.3081565Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1865,9 +1828,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:53 GMT
+      - Tue, 24 Oct 2023 12:35:57 GMT
       etag:
-      - '"75000769-0000-0100-0000-6530466a0000"'
+      - '"d3003d48-0000-0100-0000-6537b9520000"'
       expires:
       - '-1'
       pragma:
@@ -1897,24 +1860,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A54Z&sr=b&sp=r&sig=pwhA3NDKuFNf%2FxhfErg%2FmsyfIbDsx4V0FpIvxnhKWf8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:54.7266226","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A54Z&sr=b&sp=r&sig=x3zFHhDL15WJEenbeWFDnjATGWoosPVyN3zkBOuiC4U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:54.7265478","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A54Z&sr=b&sp=r&sig=qtGzutLJfiadAPI%2B39A9ddiCthdJjdhIxS1ycJdpkpg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:54.7266376","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-18T20:57:08.48Z","endDateTime":"2023-10-18T20:59:48.846Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:48.941Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A58Z&sr=b&sp=r&sig=YByBdk%2BdkFGIDbtMyeCwRfDMozUL%2FR7%2BzPfMsS0JmLY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:58.5661632","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A58Z&sr=b&sp=r&sig=0qPIex1YLTUwgmXNp%2FPGptXXeDabuW9x%2BnQzHBpwy%2Fo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:58.5660917","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A58Z&sr=b&sp=r&sig=G0iIiJg0tQVGCUPmh92IncOsYwGW9deUNPDl2tvZ05I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:58.5661776","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-24T12:33:16.778Z","endDateTime":"2023-10-24T12:35:56.323Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:57.847Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3333'
+      - '3341'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:54 GMT
+      - Tue, 24 Oct 2023 12:35:58 GMT
       mise-correlation-id:
-      - 977ae1a0-14b7-405a-8889-88a50660660a
+      - a1053779-66d4-44e3-af4e-4a3c1a50be43
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1937,7 +1900,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:08.7073742Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:08.7073742Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:16.3081565Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:16.3081565Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1946,9 +1909,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:55 GMT
+      - Tue, 24 Oct 2023 12:35:59 GMT
       etag:
-      - '"75000769-0000-0100-0000-6530466a0000"'
+      - '"d3003d48-0000-0100-0000-6537b9520000"'
       expires:
       - '-1'
       pragma:
@@ -1978,24 +1941,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://8fba736a-b3f5-4c86-9fa0-ab1a67215fe3.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
+    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4edda639-cf21-4b33-bac0-f6606c8e634c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e37b96b6-c4df-47a3-bca3-04bbf740f4b6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f43616cf-018e-4d5b-bd12-4e03babe3c81":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/f608e081-d695-44ce-b98e-c2376828fc3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A56Z&sr=b&sp=r&sig=dNwcmNs64a3EHa6bSp2XzBchjBzc0R7u4tXkKv%2BUb24%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:56.9765507","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/4e8d1f5d-9181-4299-92c3-9ff5250bcf1e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A56Z&sr=b&sp=r&sig=OJcxy%2FP3YWBkxtn%2BWuzKdV5bT6rNVy4sOpy1Moak3mQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:56.9764682","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/15340bd4-9961-44ab-8a40-253ceab64835/fd52cccb-2d6c-482d-aca2-454d8e55eeca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A56Z&sr=b&sp=r&sig=uN6I%2BxYjv592uwvK1mYcWFOtKHWCIJmOPSeBn3Q%2F1Ok%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:56.9765724","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-18T20:57:08.48Z","endDateTime":"2023-10-18T20:59:48.846Z","executedDateTime":"2023-10-18T20:57:07.197Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-18T20:57:08.11Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:48.941Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A00Z&sr=b&sp=r&sig=fe3MpTTVRhf35%2F1ecC8Tzyd%2Bx10RTpLpV8dUc%2F1h%2Fow%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:00.8324531","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A00Z&sr=b&sp=r&sig=jj2D%2BVPoi7d5jXhIGaajaRXF6ZUgefoB68yLU%2FGAkK4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:00.8323015","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A00Z&sr=b&sp=r&sig=gods%2Bf5nGm17BBc5P7C8NHSFotaWZdnM4OYOOtskYfU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:00.8324859","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-24T12:33:16.778Z","endDateTime":"2023-10-24T12:35:56.323Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:59.026Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3337'
+      - '3343'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:56 GMT
+      - Tue, 24 Oct 2023 12:36:00 GMT
       mise-correlation-id:
-      - 7f401af7-257d-43cf-8f90-cdcf95bddea1
+      - 942414da-fa06-4405-ac2e-5c2a04f65972
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_list.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_list.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:15:49.7188431Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:15:49.7188431Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:22:23.8309943Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:22:23.8309943Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:24 GMT
+      - Mon, 09 Oct 2023 19:22:57 GMT
       etag:
-      - '"920179d0-0000-0100-0000-652427380000"'
+      - '"56009c8a-0000-0100-0000-652452f10000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:16:24 GMT
+      - Mon, 09 Oct 2023 19:22:58 GMT
       mise-correlation-id:
-      - a2fe91e7-a4e8-4c56-b4c7-5858e94b3644
+      - 965000dd-8634-482b-978f-06946be98fbe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"26e5a276-6438-43d3-ba8f-444a3e943a00": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "e69e3b14-ea35-4cf4-8556-f44855504138":
+      {"passFailMetrics": {"73af9c2b-ed02-4034-9a10-831e20d4c103": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "3c4dc432-850e-40d3-8e36-64a66c6d7004":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "7297c302-9c68-48e5-85d9-56d0c4c5f464": {"aggregate": "avg", "clientMetric":
+      "50"}, "19ad2e87-5597-4382-be43-659c39d4f6b8": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:16:25.392Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:25.392Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:22:59.047Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:59.047Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:25 GMT
+      - Mon, 09 Oct 2023 19:22:59 GMT
       location:
-      - https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+      - https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 03831b4c-118a-4eac-8fa2-79a37b59ceee
+      - 76723c94-2c03-4c16-870f-a40f1885e3d3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:26 GMT
+      - Mon, 09 Oct 2023 19:22:59 GMT
       mise-correlation-id:
-      - c3bf4254-5da2-4ed4-8625-c1248b4ed5b0
+      - 972409a8-5445-4c93-97ac-c4e11eb53549
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A26%3A27Z&sr=b&sp=r&sig=rI59CCWhC%2BQpGEXZN0ATBPW1M3MtZ6UYZt1ZosbtIbM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:26:27.5688478","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A32%3A59Z&sr=b&sp=r&sig=vWXtl7kC7SdyS8W%2FYdvyFUeVRljfQ05wUhPVfvgzGmE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:32:59.886451","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:27 GMT
+      - Mon, 09 Oct 2023 19:22:59 GMT
       location:
-      - https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 737fe9f6-c1f9-4b3d-8ffe-5678c7f0e3de
+      - 5dcd0959-71ba-4884-b882-f86781adad85
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A26%3A27Z&sr=b&sp=r&sig=UQRD3Va0o49LjNIfSARyuvqhk2Aitp7jMFEZyxhWUYI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:26:27.8462875","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A00Z&sr=b&sp=r&sig=mphcEdTZm8U%2BNCBRi25zXHKKwrOnifkjsXsdrT%2FmGUU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:00.159645","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '552'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:23:00 GMT
+      mise-correlation-id:
+      - 34da202f-3511-4c98-92e7-36df7e6fc8b4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A05Z&sr=b&sp=r&sig=MBTUoPgNlFP%2FaLJyvoAVkMnNh9lvUUKvTNv7eBDCOcI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:05.4808337","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:23:05 GMT
+      mise-correlation-id:
+      - 7ad12f19-f760-4bdc-ab26-4107c3cfa152
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A10Z&sr=b&sp=r&sig=dIeQmX2CbmBRWduhgq2zFFH5jxCY9uWJ4xrwBBP%2BQQo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:10.7549851","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:23:10 GMT
+      mise-correlation-id:
+      - b4d69714-7927-4477-ac39-9d855fa3254a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A16Z&sr=b&sp=r&sig=QQGJDQc5oOUhdm6v9lVlskREzW8v9kQ9A%2BZQWjaoUI8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:16.0362847","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:27 GMT
+      - Mon, 09 Oct 2023 19:23:16 GMT
       mise-correlation-id:
-      - 1fa6078d-36c1-4031-8387-f5e40a3d63c2
+      - 86281673-8362-4953-8329-3f30792833f9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,132 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A26%3A33Z&sr=b&sp=r&sig=6IAouEvAdWT48Avtl5VgLjY5rNVSS%2BFPie%2Bm%2B3RiVps%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:26:33.1220761","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A16Z&sr=b&sp=r&sig=4Me5nRVGTb6jhR%2BA477gM1d7Il8cNX0n5RcJS%2FGZ8iI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:16.3025372","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:22:59.047Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:15.62Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '1578'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:33 GMT
+      - Mon, 09 Oct 2023 19:23:16 GMT
       mise-correlation-id:
-      - 5732c5c8-db42-4a76-848a-1f0e606f6b10
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A26%3A38Z&sr=b&sp=r&sig=x7p76gkVQqlZq9tHbzICexFzFI7zuVepT6xyPxRIsv4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:26:38.4001651","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:16:38 GMT
-      mise-correlation-id:
-      - 8d595e7c-bb3b-4708-a65f-2c7077cc65db
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A26%3A43Z&sr=b&sp=r&sig=mqFXYq51bx6E4TJQYLjJ%2FO3gx7S7k%2F%2F%2FPhB%2B4f0yNzE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:26:43.6623741","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '557'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:16:43 GMT
-      mise-correlation-id:
-      - 868ad63c-b22c-4bd2-9199-c9c85013b847
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A43Z&sr=b&sp=r&sig=GUYSWctVg%2BAFUa15PaGb%2FS65k3dQYZSgDgfCOenf4l0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:43.9236011","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:16:25.392Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:41.305Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1579'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:16:43 GMT
-      mise-correlation-id:
-      - 98d31e0d-c4cc-401b-951a-dee94e93f1e2
+      - fd920eba-aaaa-45c4-b361-896b0e28d127
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:15:49.7188431Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:15:49.7188431Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:22:23.8309943Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:22:23.8309943Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:45 GMT
+      - Mon, 09 Oct 2023 19:23:18 GMT
       etag:
-      - '"920179d0-0000-0100-0000-652427380000"'
+      - '"56009c8a-0000-0100-0000-652452f10000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A46Z&sr=b&sp=r&sig=OG%2FX299R%2F%2BbGxqK8bl%2BLKjSpIOkL3jYHSo%2BPm5yE5hU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:46.1910827","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:16:25.392Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:41.305Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A19Z&sr=b&sp=r&sig=6JxwyVqVmxqLtfk5eXyR7Pzx9xlZmawwZDm04JQbJQg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:19.0047543","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:22:59.047Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:15.62Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1597'
+      - '1586'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:46 GMT
+      - Mon, 09 Oct 2023 19:23:19 GMT
       mise-correlation-id:
-      - 9902abbf-7247-45b6-b029-fd1a21bcd9d6
+      - e70bb71d-fa71-4ed5-8308-89dc680ba4e3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:15:49.7188431Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:15:49.7188431Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:22:23.8309943Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:22:23.8309943Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:47 GMT
+      - Mon, 09 Oct 2023 19:23:19 GMT
       etag:
-      - '"920179d0-0000-0100-0000-652427380000"'
+      - '"56009c8a-0000-0100-0000-652452f10000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:16:48 GMT
+      - Mon, 09 Oct 2023 19:23:20 GMT
       mise-correlation-id:
-      - 3d228ff8-88eb-448b-8202-7507537d88e1
+      - 61965f93-63a1-444a-b47b-ac40c5ab588f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A49Z&sr=b&sp=r&sig=zg7jzXdqvxrLopQvk3GMd1dTpPSti2nl1%2FM2EiXvWlQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:49.3044632","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A49Z&sr=b&sp=r&sig=zg0u6nJOzmnRlz3cLXib1v7XrEtraHHjnFw8Jtd49eo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:49.3043329","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A49Z&sr=b&sp=r&sig=jzpRNcE4hjTWd9Is%2B0Vu%2FgdQEfvad%2FiEh1gSx8hmRG4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:49.304486","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.233Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A23Z&sr=b&sp=r&sig=TuD%2BHKeg60bcvZGPz3xoCv%2BsWv4zleBctepLwdTCpZ8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:23.1261476","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A23Z&sr=b&sp=r&sig=UVeewWtTBZ7iuX5VjEJ4J%2BZehMO0Bi0vnCcHv8PYP8Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:23.1260509","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A23Z&sr=b&sp=r&sig=gvbam%2F%2Fr7h8P3x%2BoYlFv1wtvMC8spDRtmVJNNgv5Ivo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:23.1261741","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:23.037Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3145'
+      - '3150'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:16:49 GMT
+      - Mon, 09 Oct 2023 19:23:23 GMT
       location:
-      - https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+      - https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 8df04030-910b-4845-99e6-5201703ddc35
+      - 4ad85b38-cf4b-48e9-b150-f6a2d276a435
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,442 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A49Z&sr=b&sp=r&sig=%2BHgHouAG2pfh7uHRo4CIhoLZoe9nDI9Ue8j0fVnNwpM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:49.7640422","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A49Z&sr=b&sp=r&sig=%2F9rTMg3XDiiVsLxtv0WyVg%2FpGKmp999qqNT1fZzd17k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:49.7639723","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A49Z&sr=b&sp=r&sig=V9TVMxdiMBCt6y38XmNDtBY%2BGSN7eaTYfui%2FZu67auE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:49.76406","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.624Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:16:49 GMT
-      mise-correlation-id:
-      - 7f0b51d8-337e-493e-bbc6-1f58808489a1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A55Z&sr=b&sp=r&sig=PcA9SOuNkXU4n8EQrRZx%2Fjfdye4Ge7AYKcDbLfVKCxA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:55.0908643","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A55Z&sr=b&sp=r&sig=fpYRJowHtqwMRL6U2%2FmSmg2RE6X8qB4Y8zy0%2Bdt1rjo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:16:55.0907769","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A16%3A55Z&sr=b&sp=r&sig=b7o6vBrf9okFXp3%2FEhBxOr%2FyRkWK00sZ2Wn0jEmxz2g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:16:55.0908863","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:16:55 GMT
-      mise-correlation-id:
-      - e23fcadd-23a8-4a37-a4ea-785e1f025897
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A00Z&sr=b&sp=r&sig=N9lVEaY3mTApgYiuFDHrTeM7J2A2VJobezxVHTUe4p4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:00.3695153","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A00Z&sr=b&sp=r&sig=mt%2FllvMVvTspTN9l%2FiORL1w2u%2Bqa55B7zVTthFrlDpk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:00.3694351","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A00Z&sr=b&sp=r&sig=hhYQssV3yKYclmZS5reflEzAHUHMo955NjD7xXl%2BGXs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:00.3695318","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:00 GMT
-      mise-correlation-id:
-      - 170d9bc3-cfe7-48f8-ab2c-824b019bdc4c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A05Z&sr=b&sp=r&sig=VKDFlQwjpDYlDeQzQgF255kd7CjMee8k767UqiLoydA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:05.6453591","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A05Z&sr=b&sp=r&sig=iQ66H1nRGYcwBTppjFuwIAwNnGZ9CRVHq9bB3EjRjAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:05.6452715","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A05Z&sr=b&sp=r&sig=QtZorhOsJY3g5iy6KCSm%2B93hFQWoqB9wEvVC7%2FWL8iI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:05.6453832","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:05 GMT
-      mise-correlation-id:
-      - 84dbbd25-4d23-42c5-b4b0-816a1518b854
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A10Z&sr=b&sp=r&sig=XTdVl0ccF9SzS%2FOZq2gUDCGVuwT3ZwVbaQdPWrT%2BRr8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:10.9255778","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A10Z&sr=b&sp=r&sig=ZlsqNzXIpn87bDlmpNVq2sIfsAV3B64vCVnJBTMjfR8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:10.925506","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A10Z&sr=b&sp=r&sig=FryLCNml5VZSRl22p%2F97I5xgyPwhiM5wV8lgiAwN90I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:10.9255944","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3189'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:10 GMT
-      mise-correlation-id:
-      - 53171c0b-3b1d-4674-ad20-2b5bc1189131
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A16Z&sr=b&sp=r&sig=gh%2F0nD5dWIjGfBSgYhhI%2F5Y%2BGnAQ%2BN%2BlyPY58ZCwo%2Fo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:16.1977155","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A16Z&sr=b&sp=r&sig=w85HSv5XgONKVQUbMO9BX%2BqJTG1uAIDAR53x23Gjnko%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:16.1976166","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A16Z&sr=b&sp=r&sig=xX4f%2BjctWWRuspSoNOA6rCaAgNb6mYkrhO0K7MOwK%2Fc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:16.1977435","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:16 GMT
-      mise-correlation-id:
-      - c2d9866c-6d4b-45f9-85ed-da84ceea6c44
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A21Z&sr=b&sp=r&sig=JVNuWL1%2BfdCUqfVp13ih3VuqBdXPVmBPvV1FvJHz6NQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:21.4934282","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A21Z&sr=b&sp=r&sig=rvLUm9ijnWJLyw4flo7ypXAQ6VeiYl7grG7zz52w3vA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:21.4933495","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A21Z&sr=b&sp=r&sig=AdB2O4OdNNqbOVQcx%2BnRtAVvPKQqBIOHmgu0QwOgB1A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:21.4934448","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:21 GMT
-      mise-correlation-id:
-      - c04bdd77-c171-47c2-9aae-c2bd79bb2b32
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A26Z&sr=b&sp=r&sig=nFNzNqA4FulpOlgNhV0pA2qJLb68zvGvVhJRUpBLijs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:26.8224182","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A26Z&sr=b&sp=r&sig=%2FrJ0VDYN1EDZz42o7wIaap2UMs9uOqWtenqcwnmJ2JI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:26.8223424","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A26Z&sr=b&sp=r&sig=VdTx7FySA8nEpb8pvoUv4dnqbqdjZICbVJIF3VzIP1M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:26.8224363","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:26 GMT
-      mise-correlation-id:
-      - 51b6460c-d285-426d-9a5d-ce3854256a72
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A32Z&sr=b&sp=r&sig=38VkLZbUMgepymDvK20YSqY9kmbn9nMVUGEAqhNWsgM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:32.0919414","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A32Z&sr=b&sp=r&sig=0hqEGuBKsf8FWZxo00mdx04i%2FFn2FTUgjLs2nJzMObU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:32.0918623","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A32Z&sr=b&sp=r&sig=hlz1B2i5TUWb1jUyx%2Be86fK8aCreAuxtpVNz99gNIdE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:32.0919591","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:32 GMT
-      mise-correlation-id:
-      - 9f0c6ec6-b3be-47f9-bada-411942fb1a4e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A37Z&sr=b&sp=r&sig=k0sQsF%2Fmkrpx2y0eqZdHbCMbEmpnsb41HzxuK80FZXg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:37.378173","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A37Z&sr=b&sp=r&sig=8ZzBULVBfjEuEmFLadlmjFYf5SdMtK0ZX%2FQV9tvv35w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:37.3780942","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A37Z&sr=b&sp=r&sig=q%2F%2BltUhN%2FWFozuQQjtN2BYJo1Nrra2X%2Fzu8Z9zQwoXQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:37.3781899","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:16:49.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3195'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:37 GMT
-      mise-correlation-id:
-      - 443f8d5a-17f3-439d-b06f-dbad0305a701
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A42Z&sr=b&sp=r&sig=oVPr6%2BafGm8hIYY%2Fx5ruB1rcTepTNANJCQxkxdReRLY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:42.6595145","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A42Z&sr=b&sp=r&sig=PPjo2Wb6vUNhlsViYIHfr%2FOtCTVnblNPVopw14FCH7E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:42.6594265","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A42Z&sr=b&sp=r&sig=zE1wSc9t3%2FLqzVGYooVvfxe2uFFPGItEmT6iUJHfD68%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:42.6595388","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:38.955Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:42 GMT
-      mise-correlation-id:
-      - 87c1c913-65a9-4b23-a41a-455962074e0e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A47Z&sr=b&sp=r&sig=YNp8Vm0hGBEonNW1CsMG8DjtS8SNOXX3EnCYCvVhVBE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:47.9397693","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A47Z&sr=b&sp=r&sig=5T6yeudHjXOp3N3i3wtmXB%2BdOAJ5XGqV4WpDW5JR5Tg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:47.9396828","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A47Z&sr=b&sp=r&sig=Wr7kHx8dIc42AN%2BzIaoD0%2Begbplx9JhALP8lQP8Xoyc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:47.9397865","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:47 GMT
-      mise-correlation-id:
-      - 263e2710-a8b3-4813-92ff-71bcc445b3f9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A53Z&sr=b&sp=r&sig=3H26gtaYumqWQ7zDIpZJdjvu%2BA%2FQOmynsQl5Cbeq%2F6I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:53.214394","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A53Z&sr=b&sp=r&sig=u7cWBRQLGdNnQEGfgG7Bl7D7NEOauUyN1QrMgqxVO78%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:53.2143266","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A53Z&sr=b&sp=r&sig=jEAFbYsXywpZKLQ3xpy1hcW8btCY0iLe3KBk8RRFydA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:53.214409","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A23Z&sr=b&sp=r&sig=1MMilVsPHz4OFFQ2uqcuJ6Djb8BnQQUKPxZ0V9fRO1w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:23.6037907","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A23Z&sr=b&sp=r&sig=ZvBpXdxNd474YoBTiRdTDgOPzeGwFYmbZ8EjnYwQwhw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:23.6036931","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A23Z&sr=b&sp=r&sig=JRtRvNT%2BMdZveCNFFHQaBVZJrBBDpebYp55CY2THe60%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:23.6038109","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:23.484Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1146,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:53 GMT
+      - Mon, 09 Oct 2023 19:23:23 GMT
       mise-correlation-id:
-      - 383d2189-a078-40a8-9be8-d19e82617700
+      - de46958b-5c89-40cc-8763-e14423e2105e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1168,226 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A58Z&sr=b&sp=r&sig=8L03FQOmXWN%2B%2BZJ5IZAIFJKO78LqLgxUq88ZmkElhsU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:58.4921219","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A58Z&sr=b&sp=r&sig=6Iqu2wl8UWnmUEERVNVVwaWV590BPS%2FFXvYBRC68%2Bw4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:58.4920425","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A58Z&sr=b&sp=r&sig=PFe3zSaC9pNVwUjKL3aoCzKiGpiGaL1qmidBXiZL2ng%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:58.4921358","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3189'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:58 GMT
-      mise-correlation-id:
-      - 168194e1-0a97-4b72-bdc7-a644597c16a5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A03Z&sr=b&sp=r&sig=4tu7ZWY2p5Za2V1kvw0RE9hm3Nqqb69mXcesw7XpWvM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:03.7672617","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A03Z&sr=b&sp=r&sig=HlmrX%2BlTV38T5SFRUbynQPWuHNGuTTkTKDLF3%2BjfK7s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:03.7671849","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A03Z&sr=b&sp=r&sig=nXCY%2Bylf7wX6leMoUotU3BoLGdAjDIxIFYe01ayMdxU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:03.7672783","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:03 GMT
-      mise-correlation-id:
-      - 5d54dfca-2581-4f00-98c6-9d4f3c392571
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A09Z&sr=b&sp=r&sig=XAgmEzX7tMgJQ48U3qUEtSPJcyVaW0cSh3d7fqP9xlY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:09.0328756","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A09Z&sr=b&sp=r&sig=e6L5YOhjVXTCDxbpuGYUQ%2BZJLxTdhv8%2FG8mqUvaG%2Bf8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:09.0327857","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A09Z&sr=b&sp=r&sig=jtRcNcyhKjqqhiKhUEE5LSpXCkeEV%2BzEnmZfaQk6UF0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:09.0328959","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3189'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:09 GMT
-      mise-correlation-id:
-      - 6307f3c3-1954-4f98-8139-8e67c53c1bec
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A14Z&sr=b&sp=r&sig=JDkb%2FYGr%2Fhz4pPEOf9DyDJfyWl2LZxnubGVtFxNxOuI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:14.3013058","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A14Z&sr=b&sp=r&sig=GpavvQrefLGgylV1iuP2AHpIBvQuDuZYBQ8hLqkSWFM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:14.3012015","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A14Z&sr=b&sp=r&sig=mfE56A2J0NxMa6wyl4sD2f64wASb8Y%2FLvivXrbQDsu0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:14.3013329","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:14 GMT
-      mise-correlation-id:
-      - 716ee4ea-d8a3-4677-8410-e93331d2cc2b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A20Z&sr=b&sp=r&sig=xl6F80d3uf6sVHu15wavaH%2FL%2B25JHYLKO1ie2G9Ec6I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:20.2710152","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A20Z&sr=b&sp=r&sig=Tm1Ugoff4QlAhYjeN4SBQdNjgA5JoIHvIfFZ4T4fx5M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:20.270934","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A20Z&sr=b&sp=r&sig=2j0MwZ3sniXD7XpZQoi1pPhp6LmUzaThsfIzpSfYzGI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:20.2710297","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3184'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:20 GMT
-      mise-correlation-id:
-      - 4caf0b89-1897-4552-8b9d-ca91875922ee
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A25Z&sr=b&sp=r&sig=wh4oHcH5DfUh9DU6Br8LTBFtdZrx72clJW6QZwhU%2Bec%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:25.9081112","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A25Z&sr=b&sp=r&sig=3RkaJ9QyUHNmfr86IIMHyI9eSBlt%2B5ThSk3L3%2F%2BBoLk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:25.9080409","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A25Z&sr=b&sp=r&sig=cKHTUEHwY6tgf6BIwtMksVYzzH32qAAcpYG07UzVRE0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:25.9081264","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3189'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:25 GMT
-      mise-correlation-id:
-      - cf793f53-2ac6-4472-a31f-5ccf4020b7ff
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A31Z&sr=b&sp=r&sig=P0xmczkYxwIwuRkC1l29ZTM5djfKBDGC546at26IqG8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:31.2018596","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A31Z&sr=b&sp=r&sig=%2FDVNqOcGvq2wGk4GQQZ9JnVIJRj3bT65Ng2OYTW%2FpDE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:31.2017699","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A31Z&sr=b&sp=r&sig=uNcWAmB%2BQn2NvNr4KcTyQaM%2F6rWHD%2B6bK9FDSA4qNi8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:31.2018826","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A28Z&sr=b&sp=r&sig=pF8k6PWsMJx5mQp9Xj0Ath0Jk6kB9pqdw6hhvIcCmHs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:28.9380715","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A28Z&sr=b&sp=r&sig=cfNPQhet%2F8gzb%2BxOEqGRQ3ilHMyThR72A%2B0RhIaoViw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:28.9379582","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A28Z&sr=b&sp=r&sig=m1U40YWathHAsIR641ZK7p8yGvM88H0p9AhGcQkzE8c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:28.9380944","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:23.699Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1398,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:31 GMT
+      - Mon, 09 Oct 2023 19:23:29 GMT
       mise-correlation-id:
-      - f11d2b64-4054-4fe8-9ee1-fd310735cf92
+      - 8eabcb2b-a2d0-4170-bbbc-1c85bf2fa0e4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1420,10 +772,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A36Z&sr=b&sp=r&sig=xCKDgXlbV94iKspdcVgLCZRqmNA%2BC0D4rOEMzwYRDCE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:36.4660506","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A36Z&sr=b&sp=r&sig=8ie%2Ffe%2FGmS2pSvWV5puBo%2FWS4R0rnylGwoH%2FerabLhw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:36.4659769","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A36Z&sr=b&sp=r&sig=OxFs%2BjN7iINkznHfxr9Phntu4yvOtDRKZSITEor2v7o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:36.4660663","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A34Z&sr=b&sp=r&sig=M51N7BENfWOnArxOofRaFXNiLc7eWGHsBeHFyQkFL%2B4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:34.3224458","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A34Z&sr=b&sp=r&sig=lQrXkx7Tee%2F9L8hvmuzhfhDgJOcgFjs72A2W9A%2FE2XE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:34.3223758","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A34Z&sr=b&sp=r&sig=r06i7LBsGpNYxIDPjxfm%2FBVQHyA%2BKsZov%2FjhNgghaYE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:34.322462","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:23.699Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:23:34 GMT
+      mise-correlation-id:
+      - 7e911c5a-ada9-49c5-9fbf-f59c4e68be87
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A39Z&sr=b&sp=r&sig=8hksfGmnsPIAeN%2B91JTSfpMAwXDR8QpG2853Q%2Bc6%2Fvg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:39.6936896","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A39Z&sr=b&sp=r&sig=z4hE06ludETpGK6g0XtgrXdh9PNnnpAM63EfYYN7jpE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:39.6936121","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A39Z&sr=b&sp=r&sig=wv%2BF%2BNJ4Ap3AinuVkRNsxcmdEXClL5voiCvBgmLGlKM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:39.6937076","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:23.699Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:23:39 GMT
+      mise-correlation-id:
+      - d0f0e741-b1f9-4bec-bc4d-750eda8d3a63
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A45Z&sr=b&sp=r&sig=k50aZRx7KXb2GWyLc8IMLlFz%2B2uksgqn67MWWVsyDpg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:45.0269685","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A45Z&sr=b&sp=r&sig=8aia2Hk1rtq6bg1qtqd2cX2PaaI5VQDEm1F0dKPgKMA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:45.0268691","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A45Z&sr=b&sp=r&sig=dTIZMvmx8aBqSIrdWs4P7IngtJULkfuOP7ijGhRnLcA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:45.0269933","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:23.699Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:23:45 GMT
+      mise-correlation-id:
+      - e96a022a-19b4-4537-b8b4-f7bd279377cd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A50Z&sr=b&sp=r&sig=BiZBHWZHsAQsCBluUxXk2A1UY9sK9sbHdWvB3%2BEJBf4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:50.3031565","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A50Z&sr=b&sp=r&sig=MKTKkacZR%2BqIdG6Jus9EKyUNWCkZqhVodTRgsg%2BYWKA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:50.3030138","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A50Z&sr=b&sp=r&sig=8fPmjX7afyIXiwQtixFiKTCJd4Jj1xdDwvT62e4%2FFVs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:50.3031805","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:23.699Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1434,9 +894,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:36 GMT
+      - Mon, 09 Oct 2023 19:23:50 GMT
       mise-correlation-id:
-      - 2ad2bed6-5dc3-4beb-91ab-4bdd6044e318
+      - 5cc052f6-1986-45be-9c9b-bf37fce6d785
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1456,23 +916,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A41Z&sr=b&sp=r&sig=LEkq9Cwf6%2BDEfeUIF2PYiw7MRWiLDunykNCGMZ4VKIM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:41.7367843","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A41Z&sr=b&sp=r&sig=mf8MSpCCyb6yGSVzC03zkJxVd4qRr7d3uz5Srk1KZGA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:41.7366835","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A41Z&sr=b&sp=r&sig=nt8uQMiZiMRYVcENj%2BwdpNO8C7MRLTKPw%2FuU943Z3n4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:41.7368089","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A55Z&sr=b&sp=r&sig=a6nw3sXS9rDXrDRrBASTLQAYaeNfkXfYcqOsi9cHgx8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:55.6315341","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A55Z&sr=b&sp=r&sig=yXRxl2YXRpwNCL5a6ZOiYG8JOvTlYO403N4RXyj4y88%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:55.631441","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A55Z&sr=b&sp=r&sig=6voOfo%2BUw73BDh4MUAm0Brk9uXusGSN1Uv2a0NrEOTs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:55.6315554","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:23.699Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3187'
+      - '3186'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:41 GMT
+      - Mon, 09 Oct 2023 19:23:55 GMT
       mise-correlation-id:
-      - b1d52c9d-3d89-4785-be55-3a8bccface23
+      - aa18c4d0-79c5-4a31-bbf2-b963a3a1f40b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1492,262 +952,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A47Z&sr=b&sp=r&sig=dM96MstZAcgq61ADPIktSP4ICp%2FIuZDO8Og1lXdqn0E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:47.0240559","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A47Z&sr=b&sp=r&sig=wzIa%2BhJZzSEV7tDDURKDGTwgQYyxQxEivQ2L%2BeZU3Rc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:47.0239879","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A47Z&sr=b&sp=r&sig=%2FWHoveke4PBAOUhzQ8TyIKGihhd7WvGcaExJS6g5Spk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:47.0240694","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3189'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:47 GMT
-      mise-correlation-id:
-      - b4d67e7b-81ae-4f2d-8ddd-8ad776372ad5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A52Z&sr=b&sp=r&sig=SMnaIClJ68r%2FaxshH2CvKZ4kGq8XtYNmH%2BH4kYrLrk8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:52.3007133","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A52Z&sr=b&sp=r&sig=7Dh5P033EepBJw5cIn6d%2Bn9c4adv457lmWZZ3qCLWvM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:52.3006407","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A52Z&sr=b&sp=r&sig=lHwI43ddI5bvwP7mt%2FXqnKVhlq7C51YkTAZggqlf7zk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:52.3007309","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3189'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:52 GMT
-      mise-correlation-id:
-      - a2a48625-c758-4f06-ba59-9d944559fec9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A58Z&sr=b&sp=r&sig=1e6hlCY95MWRc6pShMfnPWSH7%2Fs5cslchgj1EpZAzOs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:58.3793884","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A58Z&sr=b&sp=r&sig=FIYfZ9M2JqMxBoDxa%2FBVC7%2FofX6KeiJQ9OaGAsgUAY0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:58.3792934","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A58Z&sr=b&sp=r&sig=2KptcuxsUZ6izQeXyIe3j%2FzltWh4KQtCQLUvWwFj0LE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:58.3794069","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3189'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:58 GMT
-      mise-correlation-id:
-      - e5065ebd-dc51-475f-b2e8-fcb646b9830f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A03Z&sr=b&sp=r&sig=MeIZ4gOk1tOjOhONrd3Pc1vJzZ7Af3C443Lu09jrdyU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:03.6424991","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A03Z&sr=b&sp=r&sig=qXtAaz8VW1akJ%2FfewqAnS9%2FsAyr7TE3QSJkLkEuwzKI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:03.6424081","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A03Z&sr=b&sp=r&sig=AirTxD%2Fg%2Bi%2Bguaez8xvUivhEmE3Go1t9mL6qY0cx5ec%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:03.6425149","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:03 GMT
-      mise-correlation-id:
-      - dc21298a-b971-42ab-8692-b8563c1ab91f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A08Z&sr=b&sp=r&sig=RNFialESGVppTJnn9jaCWTM8msIeTHol31ryNII8tlA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:08.9332262","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A08Z&sr=b&sp=r&sig=As3nlv88me94kXDwCgLOsnXUXlmxF2KRQigDB7F%2F84M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:08.9331534","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A08Z&sr=b&sp=r&sig=Z1QdMtfPCMphMsot41MJTTPpRdaSkFz%2B0d0Kmk2%2Bkw4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:08.9332401","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:08 GMT
-      mise-correlation-id:
-      - 159c6183-d746-4096-b012-5ebc16393628
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A14Z&sr=b&sp=r&sig=Yvgv%2FvHkiOYW2ZInTLPeJvG10gQKRtTGd%2B0PX4I9JDY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:14.214443","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A14Z&sr=b&sp=r&sig=WuAZdcGeiCPQW3TRgBQjGVL7q0cxJjwLkUgmBs3c9Y0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:14.2143521","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A14Z&sr=b&sp=r&sig=XoZR4dytUz3R%2Fuyf%2FN78sXqiZ1WcAewmTgr9uRdjhrw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:14.2144742","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:14 GMT
-      mise-correlation-id:
-      - 25cdd740-cca4-4f5d-8f69-42b12f03bec4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A19Z&sr=b&sp=r&sig=xZnhgFn4FuqcT9kMslKQAIzw6GXy33bsMF%2BMNiXdMXY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:19.4746314","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A19Z&sr=b&sp=r&sig=lAHSb%2FSFJj%2FILvFWzdVT9VkIiVonmqT1mDWfKYFd13E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:19.4745572","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A19Z&sr=b&sp=r&sig=5S%2FzRZwMge1efe2ECN%2FwexnlNFAwYJwZyOKBODJUrWo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:19.4746477","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:19 GMT
-      mise-correlation-id:
-      - 45786eba-79e4-419f-a21f-734d1292bc6f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A24Z&sr=b&sp=r&sig=%2BPJ%2BU%2B3p0mDBhCS7TVbj1rgz%2FSkVFygNFGit5PgwCuE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:24.7594194","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A24Z&sr=b&sp=r&sig=2V%2FxZjmKEJduAMjAS6LyFCheWl%2ByRY35M627JnnWtww%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:24.7593495","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A24Z&sr=b&sp=r&sig=v6OS1CF9YDEZw64qjcAlfcI8HJ8uGpAQRCzpnUV%2BrTE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:24.759433","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A00Z&sr=b&sp=r&sig=j6kobzWJsrTd1H07lE346xzWfWgjF0fQ8HqVM%2FHcK5I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:00.9123769","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A00Z&sr=b&sp=r&sig=wMPi%2B2mf%2Fw0c2svTlmVfFIK%2B3FbCGZ3uT8BV5QMd%2BP8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:00.912307","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A00Z&sr=b&sp=r&sig=AGZJvo1VDkX5brRfSu5Yv38QIqDhUsDnuYCKiWfB3dM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:00.9124004","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:23.699Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +966,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:19:24 GMT
+      - Mon, 09 Oct 2023 19:24:00 GMT
       mise-correlation-id:
-      - df276bf6-b74c-4b6c-8531-32b64a56a4b5
+      - 04676b81-2a43-4d62-abb9-0c63a6515100
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,23 +988,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A30Z&sr=b&sp=r&sig=JvQ0u5DHMzzFShQmuYcc%2F%2F07WivET7igIXpWxKPdRpg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:30.0303228","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A30Z&sr=b&sp=r&sig=k%2Fex1dVCd%2FKzOh6UrODKOcTvNB8u9Q1L%2FmUz9uyfQB0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:30.0302441","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A30Z&sr=b&sp=r&sig=jS0Wo%2Fdr7qSyug2dlbXuZuhYu5bYmhyBbIf2rDVpngI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:30.0303405","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:16:49.624Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:43.23Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A06Z&sr=b&sp=r&sig=NkEKvu%2BVL7FlAIrDoCOGhLNcIgAspOh1vJ1ERhuBMuM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:06.2056088","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A06Z&sr=b&sp=r&sig=O78S8%2FjBAieP%2Fe0luWwsHklTx3SXcRVWa3sAou0vjzs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:06.205525","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A06Z&sr=b&sp=r&sig=9ShWTdTr4yzeIoadFggE6bpudAvSsH42VUTvyrH8hbU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:06.2056291","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONED","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:05.97Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3193'
+      - '3188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:19:30 GMT
+      - Mon, 09 Oct 2023 19:24:06 GMT
       mise-correlation-id:
-      - 42d63aa2-059f-4698-b080-31b3ae0aa37b
+      - 99da63ba-1185-4fd5-9397-cdaecb79c1da
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1816,24 +1024,816 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A35Z&sr=b&sp=r&sig=%2BmZnDf7JDHfd8sWoJuUi6e4kBtc7N5Qf6v2habrVqgs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:35.3006356","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A35Z&sr=b&sp=r&sig=zIsUTNmGzNHw5eexY5hbLt7Xh3pabqBAJZnxBX%2FPIbE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:35.3005677","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A35Z&sr=b&sp=r&sig=jcP2SIJN0kIZ7A%2Bbeh%2FJMv%2BdHiXneEspVEC5bjOU368%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:35.3006504","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-09T16:16:49.624Z","endDateTime":"2023-10-09T16:19:33.998Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:34.173Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A11Z&sr=b&sp=r&sig=47M14QSP71ATsI7sgXdof1xyrM0SZHodYrDIMCQfXOc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:11.5317812","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A11Z&sr=b&sp=r&sig=ZlZQX8zX4CuR8NcEVFISp%2B4rf6%2BodWsD9BsAC8iil6w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:11.5316958","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A11Z&sr=b&sp=r&sig=FENEott81EADNCfKNt9ut8v43kmaFdNuIrxgCDHaamg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:11.5318021","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:06.872Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3327'
+      - '3188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:19:35 GMT
+      - Mon, 09 Oct 2023 19:24:11 GMT
       mise-correlation-id:
-      - 9a5c04aa-3d8b-49b0-b8a7-5b0bf9e99922
+      - 19bc65a5-dcd5-4b95-9b36-2b49bdd2648a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A16Z&sr=b&sp=r&sig=tx5dVKp8L292Zp52aAa8QugPOJYB1dUlem5RmlirSO4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:16.8636813","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A16Z&sr=b&sp=r&sig=b1RiWu9GqXFS0%2BMaMiAa5zesp6uHPiUAttABkyLCe3E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:16.8636088","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A16Z&sr=b&sp=r&sig=C%2FEFsiMjB1sI2yKngszt%2FIO2gqouAV9vSSI%2BgWyWid4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:16.8636998","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:16 GMT
+      mise-correlation-id:
+      - e279625d-cd5a-4b0e-ad56-6937dc664e63
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A22Z&sr=b&sp=r&sig=kW8a1pmSwLWfe11zW1ktmoPg1DViT3DXAtrDwsAVF1A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:22.1330508","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A22Z&sr=b&sp=r&sig=skb7g49At8BmH4c7xNEy31mf%2BZvED4SzuWFTe%2FLUm1U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:22.1329522","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A22Z&sr=b&sp=r&sig=btS4BpbQttARx%2BHk1lpqIj83dM2JupFgSrWvAMMaHmA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:22.1330737","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:22 GMT
+      mise-correlation-id:
+      - 26b88ac8-0bed-42af-bba2-ec951789faef
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A27Z&sr=b&sp=r&sig=dfJwv17BdhjI%2F8vWU455eK%2BQexrvjNZ4%2FvvVOE4nbtg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:27.4104299","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A27Z&sr=b&sp=r&sig=q666nvkV9i%2FsvkhAEZVmhbrENajMDH%2B3DAh86Xb8srE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:27.410341","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A27Z&sr=b&sp=r&sig=%2FD76U%2FE8a3TGF923%2BZQe6cN7PGfbOUd8ylT7j4dkoj8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:27.4104512","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:27 GMT
+      mise-correlation-id:
+      - 0cbcfd44-1288-4daa-8797-a729bad834dd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A32Z&sr=b&sp=r&sig=5TL6BuIaleFxP0B4%2BgFTM4kQ%2BYsUCMxrE8WE0GhLTbo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:32.7214029","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A32Z&sr=b&sp=r&sig=0F9F5W8FyiDmnHy8nzhvt1bgOLiHmhb%2BvFhSR25sTAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:32.7212965","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A32Z&sr=b&sp=r&sig=z7IBSHxLSEucQI%2BQL4DXLZyb9mSfU7td3wr7P33R5BA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:32.7214247","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:32 GMT
+      mise-correlation-id:
+      - 90d0c036-909d-4ac3-9c50-a37738c1e322
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A38Z&sr=b&sp=r&sig=FUEVpkSwfzVHzt8mWnyWc9rONDE4LbS4dmn%2Buk1%2FnJs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:38.0498129","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A38Z&sr=b&sp=r&sig=yMBg2uh8Rl45nEOccTsofRhsb287xmp1iOv1JsQFcLM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:38.0497409","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A38Z&sr=b&sp=r&sig=7bbDq5Ogc3cpEgm9fzJObwXIa%2B8wOg6kFeD4DiTPaug%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:38.0498288","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:38 GMT
+      mise-correlation-id:
+      - 3a93ab5c-7ac6-4d69-a724-927ffdb9794d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A43Z&sr=b&sp=r&sig=pk7hrFXaFKL9AyXm1XUAoU3AFsWQ15w%2Br8LqGGGTSMc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:43.3213482","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A43Z&sr=b&sp=r&sig=PThqobFITEAX3wGfP6nMtxn2t37cTiUqzyCwvGZPxVU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:43.32126","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A43Z&sr=b&sp=r&sig=%2BXX8DXALFMNTXRqrweze5VO%2BXC3OlgOC2RLC6dqULpc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:43.3213701","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:43 GMT
+      mise-correlation-id:
+      - af84eb54-8cef-4d23-a4ea-aaefc9adef7c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A48Z&sr=b&sp=r&sig=N9FwN9n%2FsRgDtpFOv5stll2V6Wp1vvmATcLZSO9YXl4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:48.6145289","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A48Z&sr=b&sp=r&sig=6mb0MEHqfFQEiiKklyfb8lkeqEd6BdAg95ZNBv3BVrM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:48.6144545","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A48Z&sr=b&sp=r&sig=ulXjaO82y8UNKtGrnqK2LqT84xLbOFSOBD%2BZQsD4f9w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:48.6145434","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:48 GMT
+      mise-correlation-id:
+      - 9cd976fc-5e88-4386-881f-0e8361167e44
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A53Z&sr=b&sp=r&sig=6lLglfuAoV8D1XIoGaFZa0KeIcSbeYaVZTQLv59sgBE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:53.9038885","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A53Z&sr=b&sp=r&sig=taJK3zzUrFzB%2FZodz0Nz1WDw6gxSls6L0s5SQ9dxZzE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:53.9037913","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A53Z&sr=b&sp=r&sig=WXPP3WC3g5rYdG3T0I5RMTvjnHQueEGe8cbneDI9cXQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:53.9039098","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:53 GMT
+      mise-correlation-id:
+      - b65008f0-de10-47b4-bf3d-f6043b79de82
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A59Z&sr=b&sp=r&sig=wILuYXFfpWoI7RYBYE1l9ysk6jQzYCFprkJ0XDi7fg8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:59.2556829","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A59Z&sr=b&sp=r&sig=dFSD8MZ7fEpd6w%2FY671HhJPZBVGIPokz7dOGM8eOTv8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:59.2555924","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A59Z&sr=b&sp=r&sig=A2TooSYxkNCvtytHDYzPk7N5hDnsHztlAFTPGFM2ayM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:59.2557032","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:59 GMT
+      mise-correlation-id:
+      - 0e89116c-1adb-4a19-9753-c78a6e5a732b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A04Z&sr=b&sp=r&sig=joN5ALtgEtFP9Fe586%2BKsOMdRjNfpeWG4bQqtaXaP5s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:04.7175358","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A04Z&sr=b&sp=r&sig=ftRurBVClccCzlbGYYO1eltkFDDw6cHe3GpUpGCa5rM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:04.7174466","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A04Z&sr=b&sp=r&sig=6UUJHe9zWU8cmT6%2BbrfgTkH2tIAhJfFWclYdJnJmp0E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:04.7175585","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:04 GMT
+      mise-correlation-id:
+      - c7d59d25-458e-41a1-9cf6-9d8a27aa7c94
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A10Z&sr=b&sp=r&sig=H28pV4olmSRObucM2oXcYrdzjX2yBbbLzdccIGmUw5M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:10.0108915","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A10Z&sr=b&sp=r&sig=jGDiTX717Zh80uhXCFvuKIUcDhFRqgeteFEQ2iBoYqg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:10.0107939","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A10Z&sr=b&sp=r&sig=GKH%2F%2FUjoGRs7jfN%2FVxeAOm5rPX6U9c8l%2FlhaYBaaBw0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:10.0109131","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:10 GMT
+      mise-correlation-id:
+      - 505e2c23-54c7-466c-9ceb-ebad02fb9b7f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A15Z&sr=b&sp=r&sig=9xaj3BDG6Ohvgt4R9cf14Qo4XSxixsKvdhR78JQ7aGM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:15.3295952","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A15Z&sr=b&sp=r&sig=FXjQ9EQANYqVFgEpr5D8OTAYDlWvj5aLvnV9YEk7qrM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:15.3295005","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A15Z&sr=b&sp=r&sig=mqKxr2cwkM9D1%2FisZ%2FYD9MOumSvz1rl3ZuiAVRLzPKs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:15.3296186","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:15 GMT
+      mise-correlation-id:
+      - d272d765-069f-4bb1-b184-895ba8d8ecb1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A20Z&sr=b&sp=r&sig=veUblnrTTTKpfDD8u6j0fmUh0iTsKuPygYZkvLr69Us%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:20.6528515","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A20Z&sr=b&sp=r&sig=7gX69UbrfiGdTPAc%2FeurPifg4J1gaLIbYdLb5Md9xEM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:20.6527606","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A20Z&sr=b&sp=r&sig=8er1VlUWitnsP%2BaeSVo3HwlLwlPJJvjOVwLZ789GzZ8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:20.6528731","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:20 GMT
+      mise-correlation-id:
+      - c2bfc745-d5b4-48ca-ac26-4b7ef4838d11
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A25Z&sr=b&sp=r&sig=YterC4Ou27dIbzQRFvhx5muycrSBatl16HrHI%2F4F6jo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:25.9690647","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A25Z&sr=b&sp=r&sig=PPU5fsX2Ee8fSFtWSkelN2U83hk3fH28yOuvOuVkSlQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:25.9689926","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A25Z&sr=b&sp=r&sig=YvKNrgMJo89HvjAK9uVnhBqZQEaW6th4sOEovX8cDSE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:25.9690791","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:25 GMT
+      mise-correlation-id:
+      - ec1a594c-a9e9-4c13-83d5-a794fb16b1a7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A31Z&sr=b&sp=r&sig=Pw3al9DWSlj8I%2B0QkelG419Zfb%2FyqDTPYGAMlUBNLrE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:31.3329915","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A31Z&sr=b&sp=r&sig=%2FAtzrDkmjttqY3dfAjuNXtf4r%2BrPD828fDSzVwba8f8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:31.3090544","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A31Z&sr=b&sp=r&sig=0La5gbkpkywKeOmX417eFOhItqDF%2FzV74s%2FQN%2Fr7ho0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:31.333408","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:31 GMT
+      mise-correlation-id:
+      - 6f69cd2f-e1d4-49c9-8934-2645742a77f3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A36Z&sr=b&sp=r&sig=ZfcAuPK3w5h64SdhgdxJzfrdr96o5wCHvyl53hNSuc8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:36.6369875","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A36Z&sr=b&sp=r&sig=gBu1xkyfXDuRxE1epFTlXv3KFs5B5eFW1BN2YLbOmXA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:36.6368913","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A36Z&sr=b&sp=r&sig=NXHg%2FM%2FdnGmV4VVp9FHCvgnQpC%2BmImkt8GbnxQwuCD0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:36.6370137","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:36 GMT
+      mise-correlation-id:
+      - 244890f4-c1ae-4555-86a2-43464b3114c2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A41Z&sr=b&sp=r&sig=NPZ8aYtmyewLeEXgaGiEB8CDBuAvDJctH7%2Bljp%2Bh%2FQ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:41.9529052","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A41Z&sr=b&sp=r&sig=iETsOgO3katEYOUhjEk8E%2F%2Fzfgl4DjT0O5GLXP4fpLs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:41.9528203","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A41Z&sr=b&sp=r&sig=Psb90QLunBLFfSwo7KTP%2FFbLwLChL7DZdy0%2FyAiJ0cE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:41.9529202","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:41 GMT
+      mise-correlation-id:
+      - 680850d9-0f03-4c02-95e8-32044d82da3a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A47Z&sr=b&sp=r&sig=NLsmF4rPSGW8hDGqWpxJZQADE0hvEVkxTU%2BdWEyyByU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:47.2895247","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A47Z&sr=b&sp=r&sig=ZBiQOSojOgkgGfUELQAA99MX%2BzMbveUwRz5pdPzX1QY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:47.2891818","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A47Z&sr=b&sp=r&sig=7%2BdUj8vodXyxWWOoY77gmB71ahREHjm2XiqU67Hu0mw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:47.2895583","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:47 GMT
+      mise-correlation-id:
+      - ab0f45b3-4856-402d-8dbd-2db07d442212
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A52Z&sr=b&sp=r&sig=3BI%2FbryhOpUJgn%2Fc5LeyFuV4esIv8%2FEoj0%2FpuZgsgbw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:52.6075608","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A52Z&sr=b&sp=r&sig=NkAx%2F16YyxcKNLCh9hh7hr2CNcMHfeoCTN8aJ6bxl9w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:52.6074736","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A52Z&sr=b&sp=r&sig=XpNreWlp5S3Fyt0O3X9xTO0yTlTQT6QlMip3wI0dB4w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:52.6075823","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:52 GMT
+      mise-correlation-id:
+      - 40421ed2-a074-44f5-b5d4-357e856870fa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A57Z&sr=b&sp=r&sig=VbFzs7TMsPs8YU4UCjxuyTleShk4Nom8NM9%2BmWC1b3o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:57.9198499","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A57Z&sr=b&sp=r&sig=9BfkBi8IlUeQdyNVt6AlKMCAosqxORTPPP%2BOSk5UBks%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:57.9197603","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A57Z&sr=b&sp=r&sig=mJcugfoXPUnb6GjKwJLLnoQxGx1YnwkpxrYrRDIUVUU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:57.9198641","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:57 GMT
+      mise-correlation-id:
+      - 6115a8bd-20aa-44b5-b9e3-a756f3f683d5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A03Z&sr=b&sp=r&sig=VRMReSXrpsScv%2BAZxjS02oTL%2F%2B6y1AuQmyzd3kHxRVw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:03.1927402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A03Z&sr=b&sp=r&sig=sxagvVtIgTdCDfMIpLOqnf0N5SrPMqSBA%2BazWPncRIE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:03.1926676","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A03Z&sr=b&sp=r&sig=JDyzg7Bo2KM%2F2oHIgzW0IQ%2FJgWxYBmv2R3eh9SK%2FIVU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:03.192758","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:03 GMT
+      mise-correlation-id:
+      - 6fd6d423-7e5d-45c8-95a6-cb63a464c17f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A09Z&sr=b&sp=r&sig=%2FtggvwwgT8%2BcH2iWd5UqO2QCNvKmkwwFdDsYGbeLCIw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:09.0077076","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A09Z&sr=b&sp=r&sig=3I%2BVspWDhA0avsRAKoPEQVaaK5xScRU7qTU9LtWv9d4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:09.0076221","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A09Z&sr=b&sp=r&sig=cemeBV60%2BcIlHTrhQP74z8zFM%2By%2B31ThAQ0Gn1mMzkM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:09.0077316","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-09T19:23:23.484Z","endDateTime":"2023-10-09T19:26:04.923Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:26:05.823Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3329'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:09 GMT
+      mise-correlation-id:
+      - 54b21465-8aee-467b-900c-f749559a10fe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1856,7 +1856,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:15:49.7188431Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:15:49.7188431Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:22:23.8309943Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:22:23.8309943Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1865,9 +1865,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:19:35 GMT
+      - Mon, 09 Oct 2023 19:26:09 GMT
       etag:
-      - '"920179d0-0000-0100-0000-652427380000"'
+      - '"56009c8a-0000-0100-0000-652452f10000"'
       expires:
       - '-1'
       pragma:
@@ -1897,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A37Z&sr=b&sp=r&sig=OilTsvjuxXU6bnfF9QC6n7POgNVpMIGehEFjTtXvvbA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:37.5403037","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A37Z&sr=b&sp=r&sig=Deo6mYZacJyAY2cQ8Vd%2FUwLLO48sCZg3kPMynGXDZoU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:37.5402169","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A37Z&sr=b&sp=r&sig=EIC1YZ%2BhfT%2F9RCqjsfYtjZjXSexA3nx%2BvB63BxnB5cU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:37.5403207","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-09T16:16:49.624Z","endDateTime":"2023-10-09T16:19:33.998Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:34.173Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A11Z&sr=b&sp=r&sig=aZv49sBbo4vaXb3hL0udqpuj3P8B%2BZjrxdU3dPHRt9o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:11.4454278","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A11Z&sr=b&sp=r&sig=gAp4sRjjfFXoNxeKnc966OLM3g4fCKwGqX9kzz395X8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:11.4453402","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A11Z&sr=b&sp=r&sig=VDjN%2FkV8OiWcEhnNvmSbC2I5R59QhXaafyFGVQOQB8w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:11.4454499","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-09T19:23:23.484Z","endDateTime":"2023-10-09T19:26:04.923Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:26:05.823Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3337'
+      - '3333'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:19:37 GMT
+      - Mon, 09 Oct 2023 19:26:11 GMT
       mise-correlation-id:
-      - ae789387-9d74-46e9-87a0-61b27d965aae
+      - ab52da7f-cd55-4e19-b0ad-79766a9f36d2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1937,7 +1937,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:15:49.7188431Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:15:49.7188431Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:22:23.8309943Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:22:23.8309943Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1946,9 +1946,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:19:38 GMT
+      - Mon, 09 Oct 2023 19:26:12 GMT
       etag:
-      - '"920179d0-0000-0100-0000-652427380000"'
+      - '"56009c8a-0000-0100-0000-652452f10000"'
       expires:
       - '-1'
       pragma:
@@ -1978,11 +1978,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://136e3e56-9c31-4f7f-90f4-8f162f7902f7.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
+    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"26e5a276-6438-43d3-ba8f-444a3e943a00":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e69e3b14-ea35-4cf4-8556-f44855504138":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"7297c302-9c68-48e5-85d9-56d0c4c5f464":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/13f1c7ff-6a1a-44ec-a1cb-64f3efe2a5d5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A39Z&sr=b&sp=r&sig=C6bv2sQRDo7dLlPU5SBYnIYRI8oV91%2BmF0XwYwG29no%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:39.6894159","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/c5649715-877a-4474-a726-47f3f734666d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A39Z&sr=b&sp=r&sig=csh5C9ZGbD9zOWEwMb627X1VsxgsATBMs3yJYZLFdio%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:39.6893469","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/70e2e9c8-fcec-4df2-8da1-ccd1bf8bb9d1/09c27285-699f-47b0-827d-65807f701fd1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A39Z&sr=b&sp=r&sig=r2FzliAmg2XKrAOX8DHbCdTZMLp%2B6bsA0W%2FUeliCzh4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:39.6894303","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-09T16:16:49.624Z","endDateTime":"2023-10-09T16:19:33.998Z","executedDateTime":"2023-10-09T16:16:49.016Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T16:16:49.233Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:34.173Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A14Z&sr=b&sp=r&sig=1ztORDiZNth12A02MKMuf3mg710xwLv7dA50kf63Mm0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:14.0110303","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A14Z&sr=b&sp=r&sig=vUH7U3bAYpRCsgkcUw%2Br0n2HFDATre0xLV13REM%2FK0s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:14.0109616","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A14Z&sr=b&sp=r&sig=K3895nqeDDpH5D%2BpDBf8eZqcWdMTkSNNeHL0gSyrljk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:14.0110452","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-09T19:23:23.484Z","endDateTime":"2023-10-09T19:26:04.923Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:26:05.823Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1993,9 +1993,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:19:39 GMT
+      - Mon, 09 Oct 2023 19:26:14 GMT
       mise-correlation-id:
-      - 5e49ef94-ce55-43ef-9799-66217c01b438
+      - 20686c48-7edb-4499-a3a1-ea96bb3fa25f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_list.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_list.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:16.3081565Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:16.3081565Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:24:37.0997784Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:24:37.0997784Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:49 GMT
+      - Sun, 29 Oct 2023 22:25:10 GMT
       etag:
-      - '"d3003d48-0000-0100-0000-6537b9520000"'
+      - '"3c00392e-0000-0100-0000-653edba70000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:32:51 GMT
+      - Sun, 29 Oct 2023 22:25:12 GMT
       mise-correlation-id:
-      - 00d66296-865b-4e74-be93-f2b2d638e1a8
+      - 8f6ef86c-6967-4254-ba1b-e1de0b89ea9e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"8ea9774b-148e-4e8f-b05c-ee27257e0b92": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "e5edbeee-8871-48d6-8d74-cf802e7486ce":
+      {"passFailMetrics": {"0d756310-bbee-4fa6-b9b7-c66f2b831884": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "c2b6103f-53d9-4fd6-8c7c-02fb37130ec2": {"aggregate": "avg", "clientMetric":
+      "50"}, "9cb64308-d119-4505-b3dc-70abaf0ba6d3": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:32:51.622Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:32:51.622Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:25:12.841Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:12.841Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:51 GMT
+      - Sun, 29 Oct 2023 22:25:12 GMT
       location:
-      - https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+      - https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 10cddf94-49fd-4a71-a87d-3f2ad802e4be
+      - 4185c11c-feba-4aae-abd5-1eceeacce0e2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:51 GMT
+      - Sun, 29 Oct 2023 22:25:13 GMT
       mise-correlation-id:
-      - fa6cbe2f-6a65-4d13-9a34-5a7ec71acad7
+      - ec5e5987-408c-453c-a983-fb7ddf01457f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,10 +275,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A42%3A52Z&sr=b&sp=r&sig=bp0PFzgYTANTV%2BvZjXXO%2B0OdfkHDmLonoghsIsKWbVM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:42:52.5185419","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A35%3A13Z&sr=b&sp=r&sig=PkaL2NKdnyy0be51%2Fw689ABWPsAJt%2B0ObXimG4UfzbI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:35:13.7966431","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -289,11 +289,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:52 GMT
+      - Sun, 29 Oct 2023 22:25:13 GMT
       location:
-      - https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 586894d2-3363-404a-b52b-9cc44396b5cd
+      - 45ddf34b-eec9-4752-a7a9-2d002e648277
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A42%3A52Z&sr=b&sp=r&sig=82v0ugSg9YAcq3VjytcLxuE45C%2FNr14ng96IE22uMm8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:42:52.8647949","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A35%3A14Z&sr=b&sp=r&sig=KANiYa3UbgkoN28O5AYfxaco%2BjwCl%2Frlfcd%2BHRwYmXg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:35:14.1173353","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:52 GMT
+      - Sun, 29 Oct 2023 22:25:14 GMT
       mise-correlation-id:
-      - 5d179109-5301-40ac-a5c3-6fd1e5841708
+      - 421401f2-a867-4d1f-8a9f-8815a0cbcacd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A42%3A58Z&sr=b&sp=r&sig=OQnJWvmLK1uHpR9XV23w8QxK3zeFjB3uHOzD4MNQ6Z8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:42:58.1260512","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A35%3A19Z&sr=b&sp=r&sig=XSHKf%2BrDCXQT3TKn5V3dInuEsF2iERxeRbVp%2Bo94SKE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:35:19.3618449","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:32:58 GMT
+      - Sun, 29 Oct 2023 22:25:19 GMT
       mise-correlation-id:
-      - 8a0af756-80bf-474f-bb77-53575507e840
+      - 640097b3-78c3-4404-aa09-75849f21c4a6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A03Z&sr=b&sp=r&sig=7FGuSH5uG8I0xGWsqMO5gDwLnb185rxj4Qe38D7caRE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:03.384655","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A35%3A24Z&sr=b&sp=r&sig=U%2BhZz42EmVLA7vJQ1wx%2FkzktjjDT%2Bduvg9vsjbDqSlE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:35:24.597229","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '548'
+      - '554'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:03 GMT
+      - Sun, 29 Oct 2023 22:25:24 GMT
       mise-correlation-id:
-      - 8818d63a-2e11-40c4-bc11-87251eeb4f2a
+      - cf51ade1-4798-49af-b66d-8ec9d799dd59
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A08Z&sr=b&sp=r&sig=xYEsvVC1evoDRioQ759JCJAc0zBzqGUbcPvQcdHQWqg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:08.6180547","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A35%3A29Z&sr=b&sp=r&sig=zZyp6MoHBf1CTiOphfQHKEKeKOS91MmrEpXlvEH70qo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:35:29.857089","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '546'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:08 GMT
+      - Sun, 29 Oct 2023 22:25:29 GMT
       mise-correlation-id:
-      - b7d11d8e-f589-4936-a9d1-e74cd3809f3e
+      - 325b6663-8b7e-4606-b2ae-e2d9744f7c94
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A08Z&sr=b&sp=r&sig=s1W0hVQ7esrmLc9skwXt3fTGHuOWRs47XaT8xDp3T%2FA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:08.889675","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:32:51.622Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:04.722Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A30Z&sr=b&sp=r&sig=j97SLW6lLyh%2FmL5IKOOGeLqtSyN1HcurwkscEbLpKqg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:30.0933378","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:25:12.841Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:27.876Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1576'
+      - '1577'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:08 GMT
+      - Sun, 29 Oct 2023 22:25:30 GMT
       mise-correlation-id:
-      - 96e6773b-0022-4620-ad9a-692b72985ee6
+      - b6e8dbf4-80a3-4e13-9bfd-a44f21d74207
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:16.3081565Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:16.3081565Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:24:37.0997784Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:24:37.0997784Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:09 GMT
+      - Sun, 29 Oct 2023 22:25:30 GMT
       etag:
-      - '"d3003d48-0000-0100-0000-6537b9520000"'
+      - '"3c00392e-0000-0100-0000-653edba70000"'
       expires:
       - '-1'
       pragma:
@@ -538,11 +538,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A11Z&sr=b&sp=r&sig=XoZ78bmkcbn9aYa8PuFzGzQFd%2B0lxXu7pgwNaxqFIOg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:11.4625282","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:32:51.622Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:04.722Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A33Z&sr=b&sp=r&sig=WSdc4YOvV7VPyEkJgANvw9cAzXETDyOw%2F0nskAXQsRY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:33.2739681","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:25:12.841Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:27.876Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:11 GMT
+      - Sun, 29 Oct 2023 22:25:33 GMT
       mise-correlation-id:
-      - 3ce42636-0c8f-40b0-9563-39a98d051558
+      - 6403d92d-c558-47fc-8af1-eca50d44a08b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:16.3081565Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:16.3081565Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:24:37.0997784Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:24:37.0997784Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:13 GMT
+      - Sun, 29 Oct 2023 22:25:33 GMT
       etag:
-      - '"d3003d48-0000-0100-0000-6537b9520000"'
+      - '"3c00392e-0000-0100-0000-653edba70000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:33:13 GMT
+      - Sun, 29 Oct 2023 22:25:34 GMT
       mise-correlation-id:
-      - 554929e0-4cb5-4400-9896-707e3a9bec42
+      - 67d98d0d-5921-4059-8c6b-f4362184daca
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A16Z&sr=b&sp=r&sig=oiYjHVswS9ckZwDJ68%2FefLx07DrbOKKTv2xeBloZatY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:16.4328309","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A16Z&sr=b&sp=r&sig=3QPFPqWn2Ci7s6qq83xE5fATIKJWFbfVSILWxaSV4eM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:16.432699","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A16Z&sr=b&sp=r&sig=hrF5nMDGDPKo4U%2FUoPHMiydvLqNl4bh8nrVHGqMUnog%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:16.4328938","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:16.359Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A35Z&sr=b&sp=r&sig=erCHeGtost9NwikjTLYhi%2FEyijDQQCW7rUGJkjepP3M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:35.5508187","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A35Z&sr=b&sp=r&sig=MFr9vFxcASJxABb2Q1ta5CUZ1fJ6JIDA1rRnj%2BMC%2FS8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:35.550643","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A35Z&sr=b&sp=r&sig=K35aquONUAftx98H7Oh8E30beGi80SlSq4bHgXHDfok%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:35.550846","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:35.462Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3141'
+      - '3142'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:16 GMT
+      - Sun, 29 Oct 2023 22:25:35 GMT
       location:
-      - https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+      - https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - c4700b8b-ffc3-4813-a67c-75a2dc01fdc0
+      - 9792620f-f562-4683-9fd2-c59f4fb47149
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,10 +700,478 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A16Z&sr=b&sp=r&sig=NQV6pXOz61NLrPsBonggT%2FHqQ5mIOvd13rFh0afRpoU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:16.9885056","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A16Z&sr=b&sp=r&sig=aLL%2BWvD0Tt41haL9aMlWhAklnsipauJwz7q%2BDW7jrzE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:16.9884295","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A16Z&sr=b&sp=r&sig=cEzkpJ1phWOA9C4fIumxEpcZ%2BaDDmzWfY6bZIxMP0ZU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:16.9885194","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"NOTSTARTED","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:16.778Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A35Z&sr=b&sp=r&sig=qBVC%2F%2FF2FfNlSOK6tl2RhqD267kyDyAlDyLSt%2FKZQWY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:35.967319","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A35Z&sr=b&sp=r&sig=8%2FXxPdimx%2BtniW6rwqqUUWqWvnmu%2Bd%2B9G7330UUzZlo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:35.9672501","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A35Z&sr=b&sp=r&sig=gBOHiV3LGdsAJHchg%2BxKj9NbS8nFKbI6xm0zSX3pCRI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:35.9673343","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:35.462Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3153'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:25:35 GMT
+      mise-correlation-id:
+      - d4405ea5-61c8-41ec-b6e5-41729c0ecb99
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A41Z&sr=b&sp=r&sig=6GyPtaDPiL9qbtmHAWafyPHF2s9A5M6KlOeINedW8iE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:41.2891657","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A41Z&sr=b&sp=r&sig=kXxqfOuMgq%2BqS7WMplfM8pZJ7xAucTMq6MVdMOJ2hmY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:41.2890762","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A41Z&sr=b&sp=r&sig=W%2FvFmXsQ4UtOeYQX1LKweY0XBj0ZHuTdogCAiZiupfw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:41.2891881","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:36.79Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:25:41 GMT
+      mise-correlation-id:
+      - 26705dec-95d5-4671-91ec-403843d1ebec
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A46Z&sr=b&sp=r&sig=kWU9MVYTnRordJyICQUGUPXtSZ4EpGCwazjEWWVtuTk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:46.8145036","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A46Z&sr=b&sp=r&sig=sEl1Cketc1NTPw0FtxMtM5v9m2foccIFZyvch1uSdqU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:46.814412","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A46Z&sr=b&sp=r&sig=PNtw%2F%2FwWLjrHzuFNh3l9QTT16P1zDA%2F6zN8Bt%2F1%2FsbM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:46.8145288","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:36.79Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:25:46 GMT
+      mise-correlation-id:
+      - ccaf971c-ae11-4db8-9a7c-1ca1bba68916
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A52Z&sr=b&sp=r&sig=21bPZTTN%2BC2c9KZlNaxyfi72ityqokO6CVy4GWscZ6Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:52.1335263","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A52Z&sr=b&sp=r&sig=GzHGhjLsLuzbqTXnppPh%2B%2FCimyaoXO3IewMXJY1%2F%2BUk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:52.1334288","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A52Z&sr=b&sp=r&sig=YGbKdBusqSwmAY4ocsRwT%2BOkZSnRYjEYf4y5M8dUa24%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:52.1341875","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:36.79Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:25:52 GMT
+      mise-correlation-id:
+      - 791bbe6e-c2c5-4f3b-959a-4b47fd624038
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A58Z&sr=b&sp=r&sig=g9nlWE3KoN3xPnRyiLUvzUIR5VKJnoHWdtuN53gLxn8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:58.3462879","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A58Z&sr=b&sp=r&sig=i9KR0qCH88IdniQfZf2i0ctPuOkoqa9bBOJ1YKkj3%2BU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:25:58.3462213","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A25%3A58Z&sr=b&sp=r&sig=FqIUulWct1UmMdR0kH9bEDfkOApqUpmtnIOB%2BSCtV98%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:25:58.3463015","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:36.79Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:25:58 GMT
+      mise-correlation-id:
+      - 4f878781-23ac-4abf-8242-afe01bf1aa7d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A03Z&sr=b&sp=r&sig=ApMAjCRKw52OCv1qiByl%2B0chj4zB8szcqBNcH%2BLhWXs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:03.7014866","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A03Z&sr=b&sp=r&sig=2l%2BGEoFcE6M4pQ%2BDDpQV5ROab9b0paYnjMJl7t1Wdoo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:03.7014041","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A03Z&sr=b&sp=r&sig=LVg6jfhxZy9DFaKFHwgAbuixiypGSH4V5KruR%2BakHzU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:03.7015081","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:36.79Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:26:03 GMT
+      mise-correlation-id:
+      - 0c1d6555-c581-426e-bcbd-4de0969c34aa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A08Z&sr=b&sp=r&sig=L4uGueadQMfr1AV4J6kbBxpxP53p3A9gsX47rkeQc24%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:08.9479728","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A08Z&sr=b&sp=r&sig=HkkLYf8m3cVETA6Tv7XWZ5Wj4GBCkJ%2FApQk4ZYSydFw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:08.9478868","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A08Z&sr=b&sp=r&sig=dIO3dBEkfPjObTUDvbgdJB0PErNH2BsPzBtM4ikhUMQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:08.9479939","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:36.79Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:26:08 GMT
+      mise-correlation-id:
+      - d7bdeb98-c272-46b2-84aa-b84a4ef30ced
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A14Z&sr=b&sp=r&sig=bh68Sk49B8mW0ahVF%2Byy%2B8SXbD%2FH%2Ft77YhHNfp889QE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:14.2097943","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A14Z&sr=b&sp=r&sig=478MhMRN02voJ6TrJ9dbwSkeSOUV70%2FoIwdE4VwRRGA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:14.2097215","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A14Z&sr=b&sp=r&sig=%2BhlJSKacG3%2F0DXI%2BRZ%2Bek33x6uWcideMw7MgGG%2F79LQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:14.2098085","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:36.79Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:26:14 GMT
+      mise-correlation-id:
+      - 7e1367c8-d49f-44de-b9e1-04b30983c8ba
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A19Z&sr=b&sp=r&sig=enkhUeeyLJGpUdmjonpEHCtfipk%2BofVH89V2YXCEw48%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:19.5429132","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A19Z&sr=b&sp=r&sig=SFuYNcKGuxRj1ZK8FKOcRp47%2FG6DxL4RKgUI9L5u578%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:19.5428222","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A19Z&sr=b&sp=r&sig=t%2FZmA%2Bn5hNolRzm5Aq7Rf%2FqLTkUARXcmRcCUTRR6yn8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:19.5429353","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:25:36.79Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:26:19 GMT
+      mise-correlation-id:
+      - 7159f314-4ffc-48f7-9af7-fa4fc3906cda
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A24Z&sr=b&sp=r&sig=RbkNcFfhZGWEfPhFe1PR5t3zjB%2FxpMD5O9xWKv%2FB4HM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:24.8419997","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A24Z&sr=b&sp=r&sig=UcEwEJCltVd7FXfM%2B7wHp5jQsEoYDNE1Vem%2FZtxNz9U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:24.8419351","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A24Z&sr=b&sp=r&sig=56iqWh8T0quTrqcmLBov3hYGwUiLxLk%2FaTjxr0AnqoA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:24.842014","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"CONFIGURING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:21.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:26:24 GMT
+      mise-correlation-id:
+      - 7a473702-800f-47e3-8d7f-294bed7a9c5e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A30Z&sr=b&sp=r&sig=ArWy8zrmPXAUUvtXCGoZPVwNZdSi48gF2l7dMyH0YfQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:30.1558517","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A30Z&sr=b&sp=r&sig=KsHl4yVU8aEaeVju4kt6DquCuWnqlHpI%2FJqxScOk2Ow%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:30.1557728","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A30Z&sr=b&sp=r&sig=4%2B7UGklkoyANlMYHc%2B6AHUWRDJeObu4ZRYiEd4GPuSE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:30.1558666","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:26:30 GMT
+      mise-correlation-id:
+      - b33fbdc7-8aa2-432f-9b45-99ea0a51bcd5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A35Z&sr=b&sp=r&sig=v0bbld0R65KL3UnHWc38gXIC0O5oQcGNbP3CIuXJfbg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:35.5879953","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A35Z&sr=b&sp=r&sig=o%2FXlua%2F27r880nVkVCEaQp1zQoNVooRvg4SRHpA8sRE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:35.5879049","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A35Z&sr=b&sp=r&sig=BNaGo43uVUjN6Dlwr9bNbDb5LYolC3Z3hHgNxK%2BtxI0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:35.5880102","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:26:35 GMT
+      mise-correlation-id:
+      - e69baf63-1a10-475e-bb30-b049d6734ae7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A40Z&sr=b&sp=r&sig=z3pyZ6E7FOtEhxVVh9v%2Fu1GBUVGHq7P2%2BTlMD%2FrqpuU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:40.8516695","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A40Z&sr=b&sp=r&sig=QnhcMdAnWZ%2FHXsHt01c77aoJiE3OgYWhe8IxvVFdoQY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:40.8515836","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A40Z&sr=b&sp=r&sig=DBzf3uF2rSHhOadJuyfW6QR%2FEp%2FU5976kmFFz0kbHZ0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:40.8516916","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:26:40 GMT
+      mise-correlation-id:
+      - 61eb5d98-d748-44f7-a90f-f8b48eba29db
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A46Z&sr=b&sp=r&sig=sr%2BNRI8lZtEQXbmVbu4PVllfF1hux8HKoLV0vPJ5suU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:46.122287","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A46Z&sr=b&sp=r&sig=Dg%2Bfsvsw5zTJDvkDc26g0xiDOZaCBxKijUZsy%2FW09h4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:46.1221721","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A46Z&sr=b&sp=r&sig=LkxnhiclYvKndwgz0Kfw%2BT9H04AySt36uFRBiH0bu%2Fg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:46.1223109","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -714,9 +1182,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:17 GMT
+      - Sun, 29 Oct 2023 22:26:46 GMT
       mise-correlation-id:
-      - a1d14e8f-7920-4617-9858-f3d56c567aa5
+      - 119fd8af-c42f-4f76-a45d-3e8eb3d4c8b5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,370 +1204,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A22Z&sr=b&sp=r&sig=exzVqdxhgYGqfRQGpd4TjQMB40Oynjv%2B2ZOuQ8K73ec%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:22.6610266","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A22Z&sr=b&sp=r&sig=vlFkA0rqzAeD3%2BSQs8wnQqE2wDFvtxDlCPDABTzXO6A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:22.6609255","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A22Z&sr=b&sp=r&sig=g7WJb2Ng2TIkLdJY50OLBKAYd6DjnHvu74EjElINkcc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:22.6610527","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:17.035Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3189'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:33:22 GMT
-      mise-correlation-id:
-      - 4ddc7a89-5909-412f-a8d6-8be3993e46c5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A27Z&sr=b&sp=r&sig=SLkr%2FLetH7GTo82oFuZ15qhdd8h0NGwZZU1XXazsjog%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:27.9715565","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A27Z&sr=b&sp=r&sig=V%2F0cf7NuIvjJgerw1GKS7g%2BYD6EkSyb9FU0qu9SuWjo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:27.9714581","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A27Z&sr=b&sp=r&sig=8%2FiqrdWSZW6EFINqRmygsIr9HAfjxcZHI%2BHOb1VwSRc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:27.9715726","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:17.035Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3195'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:33:27 GMT
-      mise-correlation-id:
-      - f241e327-52e4-41ec-b013-ee82b7d473d9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A33Z&sr=b&sp=r&sig=nI3iGHWXqJXJ%2Be8sG9LU3o6tXY1RCPoProMya6QWdSQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:33.3008831","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A33Z&sr=b&sp=r&sig=eN9dYdT%2BmIcT9IvQQiPYlwWktYJjGjoTgLbUqWygSlc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:33.300797","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A33Z&sr=b&sp=r&sig=65aizxE6DO%2BQ2vezPVUMLq8%2BEx89Aeb2829jY56BuEc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:33.3009055","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:17.035Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:33:33 GMT
-      mise-correlation-id:
-      - 02e757ba-4a02-40f7-aca3-29ca0fa81d91
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A38Z&sr=b&sp=r&sig=M1P7J%2Bqf9uKOI4luZpk%2BfF35tuLWRNYbGCbzO0nHb3w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:38.5747913","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A38Z&sr=b&sp=r&sig=%2FcssMYUW7KBTAX%2FJ04S72CP8f4WgbUdVL%2B9rboTGrro%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:38.5746783","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A38Z&sr=b&sp=r&sig=EcdiN8bzkS87%2FwLwxoeMdeQ0faKGg1E3idIBDOx63io%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:38.574807","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:17.035Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:33:38 GMT
-      mise-correlation-id:
-      - eee6ce21-0940-4b46-819d-a8c6102f6c04
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A43Z&sr=b&sp=r&sig=CeRqRO%2FMzWBZH9e1ZJj9EDlUJ4F5fAOK1PiTbD5AInM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:43.8717411","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A43Z&sr=b&sp=r&sig=%2BuzF3S5uF01JMMsxZRWDrSFrw%2BB15oNsUt2XoVq5%2BNk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:43.8716335","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A43Z&sr=b&sp=r&sig=FdnFEu2kK%2BOA0Z5Mlq3gsHPk%2Fx5HPVqgitkCF4DFxs8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:43.8717675","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:17.035Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:33:43 GMT
-      mise-correlation-id:
-      - 2f09901a-acd9-45a5-ac43-cf35148686a5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A49Z&sr=b&sp=r&sig=AeCmuOu19MhQeLyw2dc4TK9rIHhIhKGJ1Bl5fl%2BnOMo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:49.135513","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A49Z&sr=b&sp=r&sig=XoyGsv32YYIRwZHFzlf4JovF%2FRADG8nVQs2EPc9aySs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:49.1354421","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A49Z&sr=b&sp=r&sig=GA%2FUBX2Cv01Ra%2BRxTQmyxlEiLCGfp2A9jj2S3qO74KI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:49.1355271","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:17.035Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:33:49 GMT
-      mise-correlation-id:
-      - b30b923f-66d0-4f74-bf9d-f1f59c5ee1d0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A54Z&sr=b&sp=r&sig=N5bz%2BrZK6tY%2FbchkkKIzUrv9XYWuqGGa%2F%2FhQYdH1%2BGQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:54.4034914","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A54Z&sr=b&sp=r&sig=L%2Bxno0gSsSpomnFP77MFGMcgp1wJfyyDOfxPmohpSog%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:54.4034188","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A54Z&sr=b&sp=r&sig=n8806Q82tcXhIcIPgoQC2FL0VswKur0Ng7DMpmrFZ5k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:54.4035064","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:17.035Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:33:54 GMT
-      mise-correlation-id:
-      - 5e6e16a1-f840-481d-949f-350fd40fdf05
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A59Z&sr=b&sp=r&sig=cil0j0cnTypYMjwhOQn8cyVzuISSpEpYZdgo8i0UFWY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:59.6706435","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A59Z&sr=b&sp=r&sig=UushyoMVbojLF7rnJwvyhANrpJcW%2FH7DNWCnGcyb2Wg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:59.6705751","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A59Z&sr=b&sp=r&sig=LgNxISL6wmHBjnxIIkUzbe%2F90CKGv7N6CxZJZvrBcLI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:59.6706576","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:17.035Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3189'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:33:59 GMT
-      mise-correlation-id:
-      - a1b96cef-24d4-4ae2-ab86-1e7c7fa987a9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A05Z&sr=b&sp=r&sig=ozGjPTeXMC7ei0tImUPPV5ltZJ8tyqCifYTWZTrxgg4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:05.1066756","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A05Z&sr=b&sp=r&sig=K%2FErpMDykymPVb0NMklMQh1KdocqbtpSQvVGIVdGmPs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:05.1066084","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A05Z&sr=b&sp=r&sig=UYutsKlcpgDiiFUwfMdNpCEETX8Jp2WQzQ7lkWczS9g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:05.10669","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3182'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:05 GMT
-      mise-correlation-id:
-      - 69808b7d-e266-4f4f-b1ff-f77febd645dc
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A10Z&sr=b&sp=r&sig=vXYknIoKAQTmfuAAdI6uLSt6OcQzgQpesZWrqQHMBoc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:10.3515725","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A10Z&sr=b&sp=r&sig=COPvzYA62QarVVSpYe9YWNwplSB4wLEGHd0WanD6L7k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:10.3514721","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A10Z&sr=b&sp=r&sig=pSvdhkIJRM1OfCBakvowZ93IFS%2FYu3r0789QuqRlMt4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:10.3515941","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3184'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:10 GMT
-      mise-correlation-id:
-      - 03d91eb3-073f-4385-b246-b351575bd993
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A15Z&sr=b&sp=r&sig=ektw8eBK8Q00AIqkok7yKETviXw4g0fxsWityMlC9Y4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:15.6395537","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A15Z&sr=b&sp=r&sig=htCTnMAiNh3DjemOpV41hff%2BZ1h1Q%2FDwV5pCgqoyFB4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:15.6394951","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A15Z&sr=b&sp=r&sig=jgH31dktp2JMt7XOJq2cKmUR%2Fk0zwSEGsQV1ReV6iKA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:15.6395679","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A51Z&sr=b&sp=r&sig=2G6wEuelO%2BkBflTuZ2aUfC%2BJloIVyt0I8qeplTeCK1I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:51.3771778","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A51Z&sr=b&sp=r&sig=ePQzbRbL1luyIeP%2BqGT10OZBviOYhUQeQ5orMxoOsO8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:51.3770822","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A51Z&sr=b&sp=r&sig=ErRPA6qkySiepKVO6ongcuHyymsJDYpXDmFoPvKkk28%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:51.3772021","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1110,9 +1218,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:34:15 GMT
+      - Sun, 29 Oct 2023 22:26:51 GMT
       mise-correlation-id:
-      - f4e75f63-fddb-4baa-a4b3-2cfee25ead30
+      - a32174e4-90cb-4608-a6b3-34a53ce9f083
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1132,23 +1240,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A20Z&sr=b&sp=r&sig=YBXB70irWVXSs7%2FjqVdkaKK%2FxP7GrQ2iOL3lonyIYIE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:20.9076865","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A20Z&sr=b&sp=r&sig=Oh1nExLx%2FazajKUSFXd%2FMM8YLTah7yG%2FMjT1U8oLyJs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:20.9075995","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A20Z&sr=b&sp=r&sig=9gyy0OAz6ACxpYy5J0yTa22tWIwEdPp198rJ1iZ4Lfk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:20.9077087","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A56Z&sr=b&sp=r&sig=gVZCpVnocmhG23gNHov1FyunUp6ZxRUkrNcmKrUOWn0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:56.9495851","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A56Z&sr=b&sp=r&sig=CdirNnrp4rQXFpyPpqMBkimQbpxS9a%2BIzgZcjsPRrwk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:56.949519","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A56Z&sr=b&sp=r&sig=vdGOZR8QRY9SmURzMi1OFYYVFztSWiRmu4%2F1XsaJwno%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:56.9495986","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3192'
+      - '3185'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:34:20 GMT
+      - Sun, 29 Oct 2023 22:26:56 GMT
       mise-correlation-id:
-      - 6c6f30fc-047f-42ea-af8e-65e5a23e90b5
+      - e74edaf7-689c-4fbb-937b-614131f3a7ce
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1168,262 +1276,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A26Z&sr=b&sp=r&sig=5hmdJzbMafyvb8JvBrIy44RV15B4FNJPwTOoteevDRw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:26.2044149","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A26Z&sr=b&sp=r&sig=n1c03PSoNEkJjOpS2tB9C3s0gKM%2FGCbGjCm0NbiDC48%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:26.204346","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A26Z&sr=b&sp=r&sig=myQU00PNkWkwfdeUN1NSrIlp23qYBxHZmQKWxkzrnDk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:26.2044286","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3183'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:26 GMT
-      mise-correlation-id:
-      - 951543ef-5205-4afb-8846-1f164165baf9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A31Z&sr=b&sp=r&sig=Nf1FLVfxjnZvoinSeQm4s7rOwOjy1XnLCDwQSg%2BVeL8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:31.5254602","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A31Z&sr=b&sp=r&sig=05NPlQArxiP1j0ekkSKs%2F%2F%2FDB8jFOtbyF%2F8aWPetd50%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:31.5253915","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A31Z&sr=b&sp=r&sig=slgpyNHNcmzlmM6ybEeuyVrSIQNi8D1mH8hzjpaLjVo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:31.5254757","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:31 GMT
-      mise-correlation-id:
-      - 82533fdc-9fe4-40e1-9762-381ffad29da2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A36Z&sr=b&sp=r&sig=YHcAHCbj7Hb5hETsUbn0y4azUcfN7ZsSVx4wYQxzG2E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:36.8250513","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A36Z&sr=b&sp=r&sig=lNw9RAHQKxhd%2BJdEhPqrKCSJA1W3dY2EBU4JHfiNUhw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:36.8249568","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A36Z&sr=b&sp=r&sig=zwU1KuBYr%2FL1RRbEiv%2BkD%2BtDvTlESy79wvs4F8Rf%2Bsk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:36.8251246","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:36 GMT
-      mise-correlation-id:
-      - e2c362bf-6ae0-4082-b453-7cc4fada51a4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A42Z&sr=b&sp=r&sig=sbJ0eoMRNY%2F7Fb5b8QTHh9jSrFCAGPm%2BmyAgeWmyOZI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:42.0867296","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A42Z&sr=b&sp=r&sig=th%2BAQg0gFKDMnRsWL%2FZ%2Fx5lg04Iic4AoHita1i9HBVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:42.0866475","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A42Z&sr=b&sp=r&sig=IqpAONxj0UIwEbEazUIx0YmiQ3QhmoX9Saa8WSiehjs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:42.0867457","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:42 GMT
-      mise-correlation-id:
-      - 884ff853-ceb7-41b4-b22d-b2512f496e00
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A47Z&sr=b&sp=r&sig=lURHNxdsIY1WWLP7VraxbFJ6s%2B%2FnJRZ%2Bys7TAiQZStM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:47.367046","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A47Z&sr=b&sp=r&sig=CJOJubbEm1iGgRw8NeMvU%2FIDMKoWTshs7rMOUStl1lM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:47.366957","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A47Z&sr=b&sp=r&sig=HONtGA1eILiJjDsy%2F%2B2gUTyZ781uGbZ93FDXSFxPdeQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:47.3670641","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:47 GMT
-      mise-correlation-id:
-      - fb723fbd-7505-4698-907a-1ce5108702ad
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A52Z&sr=b&sp=r&sig=iAUCPAL4jCSOYatv0Cv58FBhYNaaa0ZB0MBIAJ6OS1c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:52.7204084","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A52Z&sr=b&sp=r&sig=%2FN4IIL8qGoAaq1UXLoViz%2BHCGsyF7e3%2FnFkS2otYZ3M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:52.7202928","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A52Z&sr=b&sp=r&sig=M%2B86GaVhHqf%2BrweIl%2FF7Rz7at3aI8%2FoqJVzoF4hsoqE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:52.7204354","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:52 GMT
-      mise-correlation-id:
-      - 832d6c7f-9ed3-4f7f-822a-38c752c6eaa1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A58Z&sr=b&sp=r&sig=X1js05eE6%2B1j2QC7D8E1nkb7GlfGb8aHfmBpLsIIyS8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:58.0556208","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A58Z&sr=b&sp=r&sig=%2FHbNSisMmpFcFBsEdtNR8XNWAeXbepPj5D6oNomy8ng%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:58.0555366","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A58Z&sr=b&sp=r&sig=RRrWUfbL%2Bna4DrGL1%2FYm1ehei40bqK2RJh3wO6zsfEE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:58.0556429","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:58 GMT
-      mise-correlation-id:
-      - b1490102-f0b2-4054-9fa2-e73632359060
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A03Z&sr=b&sp=r&sig=LdVs79S0pKVXeEec0dknwBZuDEhDX8l%2B4cgC6RiuVfA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:03.3190737","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A03Z&sr=b&sp=r&sig=b4lgmqd%2BQ75EnBlLtB1SnA3E0fHITJodpZ2O7alMu3M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:03.3189852","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A03Z&sr=b&sp=r&sig=ex3wsByUBeWvYR4IpXlA8qU%2B7AnBzy4u4QnBqWF1at8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:03.3190945","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A02Z&sr=b&sp=r&sig=Osl35Nyyp6yrQA2najE3vcqKzvBseObTl1%2B78YqwwCE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:02.2046197","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A02Z&sr=b&sp=r&sig=ZN0RQpmVQMGfpjN7hQP3P3wE5pUE1CnoOhJMHSWBAVI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:02.2045365","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A02Z&sr=b&sp=r&sig=Ingo1VuwCU8zmnku2kiKSKl5xTx0MnZy%2FaCH%2FoOE9VI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:02.2046409","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1434,9 +1290,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:03 GMT
+      - Sun, 29 Oct 2023 22:27:02 GMT
       mise-correlation-id:
-      - eb480222-6d28-4be9-8595-2a2327474504
+      - 434dcedb-9de0-4ae4-ac3b-2b7886caa92e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1456,118 +1312,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A08Z&sr=b&sp=r&sig=%2Fp3niq5KHt4ML7O4fr1F0rfz7N6FeyVyOqv99PY0tzk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:08.586203","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A08Z&sr=b&sp=r&sig=%2FAjpyDDhm8qAw4QgdJit5BPIvy48p%2BhzYBPTQ5aJw7g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:08.5861123","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A08Z&sr=b&sp=r&sig=LxkUMny%2BimRHSvwywiUJD2Ny2vs49CspRgGOQ9ezlNY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:08.586228","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:08 GMT
-      mise-correlation-id:
-      - f49f7bca-4c07-4f9c-a348-c7577f8822b6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A13Z&sr=b&sp=r&sig=UkvSV47jk7i9IBs0O1BXBjJpU%2BSwg3phQ%2BPPTG5%2FS5c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:13.9060889","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A13Z&sr=b&sp=r&sig=%2B9PraCAUsj675fKyjH%2BEennKYkiioq3LGkNZJ5sLIlk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:13.9059927","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A13Z&sr=b&sp=r&sig=BGrNtD815ESo67grGaxWLQuA0%2BMFscyRJkV4xnHlWtY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:13.9061164","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:13 GMT
-      mise-correlation-id:
-      - b58b1d67-0ab2-443a-8ef4-8e7fa5537784
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A19Z&sr=b&sp=r&sig=8Y7zml6XRgvQjmKwhKhhUFtvYVR6POeAWpfA0mV4aWs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:19.2294485","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A19Z&sr=b&sp=r&sig=Ci9L5JiPr0uFlmoLFoomEwfC%2BXdovum%2B4OcEh0GbcCM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:19.2293622","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A19Z&sr=b&sp=r&sig=a9Pmz7Wj7VTzt4GnSrl3%2Bgp%2FSMYofxJLQk5qSw5e35U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:19.2294711","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:19 GMT
-      mise-correlation-id:
-      - f68905aa-420d-4cb1-807b-ecf8bd541dd8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A24Z&sr=b&sp=r&sig=HKekQVuISo1ZkQxqxQ1cGjABxEYH76BZJmUOf7Zria8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:24.5406702","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A24Z&sr=b&sp=r&sig=Z0N26ol0rrInokYvTKjJWTUYfqhroGg15X%2B4aHCzrQo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:24.5405813","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A24Z&sr=b&sp=r&sig=k4uShGhbQgDqyGdxU9n8nPhPb8QRpXe9%2Bu4KQ2XIOso%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:24.5406861","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A07Z&sr=b&sp=r&sig=zBDF4tURHg3r1nqYZlqNNSGCWu7uA3luoBHgZOTaths%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:07.4857374","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A07Z&sr=b&sp=r&sig=hqDsrMkHV5ITpx8iafOZaf3DKVPAVFLJgpJ1cyfmlYE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:07.4856541","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A07Z&sr=b&sp=r&sig=F%2FNTRcovvAPf0l27U2vI5BkJC%2FUvw2xZ2PL2CRPlbMY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:07.4857595","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1578,9 +1326,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:24 GMT
+      - Sun, 29 Oct 2023 22:27:07 GMT
       mise-correlation-id:
-      - b3e68593-0aed-4d48-82f8-1f084e01f338
+      - c0cb7d81-4847-461b-8361-7604daf019b3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,118 +1348,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A29Z&sr=b&sp=r&sig=UHU5bACj4KnaTHGmUXppH%2FeFb9kKt%2Fgjz1R4IZditlI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:29.9146629","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A29Z&sr=b&sp=r&sig=tTMXiB0zPbNIsOJNSnvbDtdFMDeDTxiHAg6IJ3RGufs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:29.9145967","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A29Z&sr=b&sp=r&sig=dFIsmnr2EagZFVpobi0mZFY7O9GqnsrdrFgw0y0okxg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:29.9146793","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:29 GMT
-      mise-correlation-id:
-      - 045d8a43-6edd-451c-ac95-f4dba65ddb9c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A35Z&sr=b&sp=r&sig=nuoVl7xSOKqa3MVgO5FXlRlBAJDWVLu1S6FdduE%2FUaw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:35.2156685","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A35Z&sr=b&sp=r&sig=2msu0q%2BLpLH8JNE51ER3JBPvS%2BKF4BWG2Cxd53Fx5Vo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:35.2155946","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A35Z&sr=b&sp=r&sig=laGWOVr0XxgVyfRdfqr0K7sdVEafNN3p7DMgnHrw0jw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:35.2156821","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:35 GMT
-      mise-correlation-id:
-      - 27760d99-f561-496d-a406-cacec6127fd1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A40Z&sr=b&sp=r&sig=PQhPtuuP3z4OkaNvPc6q68PZXm0Y2p%2B6Zmk7yfMSLFg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:40.539909","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A40Z&sr=b&sp=r&sig=gzJZXzIZXLcZvZzKTx8hFkDihxGAP142qjiyYnzHqnM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:40.5398421","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A40Z&sr=b&sp=r&sig=HaIaHm9qrBO0Dg5VS%2FU9NHma%2FdiikmrGQ2ua%2Bh9s9Ec%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:40.5399233","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3189'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:40 GMT
-      mise-correlation-id:
-      - 97eb5a47-9cd9-4889-a19f-ed619b57d65f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A45Z&sr=b&sp=r&sig=jKe47ngCXGkd3e%2B2nQPGmuuI8bkzaegI06e%2F8RokOtk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:45.8313115","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A45Z&sr=b&sp=r&sig=FN%2Beh3%2Ff1hGpG12y9T7OhpwHjxlZUiPpDPT0Wvs03mA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:45.8312368","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A45Z&sr=b&sp=r&sig=%2B1rYw9pnZfA2QxMhTlRTMXPtmIzLML%2B8Jq9iLsFDh7g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:45.8313256","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A12Z&sr=b&sp=r&sig=Hq2lmzRcY%2BYwiCmH9R%2B%2FF7DMm7TWVt6Y6iZs6%2Bv0MX8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:12.7418392","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A12Z&sr=b&sp=r&sig=1%2B1z8GFIb3ygonlL91yjZWoKu7A7YFLx5p66g9tSASc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:12.7417707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A12Z&sr=b&sp=r&sig=WevgW6RR%2BtFOSarHgXgbzj80372MUdyeVLafDtcCBQ4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:12.7418537","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1722,9 +1362,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:45 GMT
+      - Sun, 29 Oct 2023 22:27:12 GMT
       mise-correlation-id:
-      - 08487c91-b2d8-4e38-9f1c-906e57fef75d
+      - 6283d024-01aa-47e6-a724-04ae9f716769
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,10 +1384,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A51Z&sr=b&sp=r&sig=S%2BAFTilUokF%2FQN3IT%2Fd8gnkjf7fSPrgTjEn8roqq6LY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:51.0940097","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A51Z&sr=b&sp=r&sig=UlnCSVjmVUng5i8nqti%2Fxosfn1tHj3NRul2bn%2BxkdZo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:51.0939031","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A51Z&sr=b&sp=r&sig=Ynt1E0voXyZJvO1mKH5YDfe7VKEieSQDOIO9o0O6r3Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:51.0940356","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:04.264Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A18Z&sr=b&sp=r&sig=F7WZXkhpEiXjU6HwmrHbdTjabUB7T4Af8X%2Fh7NwCbYU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:18.3043193","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A18Z&sr=b&sp=r&sig=CKYNx0KiakaXRHHjwSI1erYEnb3VRyci48pyLxoMOxc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:18.3042273","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A18Z&sr=b&sp=r&sig=VBs15QSYVJTiLkUS4a1OBpNf1Xr5rg%2Bovum0GfTByAU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:18.3043449","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:27:18 GMT
+      mise-correlation-id:
+      - 60309a37-8bd1-4633-878b-c53a98c62798
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A23Z&sr=b&sp=r&sig=dumA4Fmmxzxxph75Zu%2FT5vrBuF%2BmeUscujiuYcm23Ro%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:23.5500872","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A23Z&sr=b&sp=r&sig=%2BazEFlvPxMpjAeRavhDONAOJrY27ZTZo1ytDy3A9hQ0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:23.5500013","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A23Z&sr=b&sp=r&sig=e3I1lVm%2Bbsu5co9Uubej9%2FiAnZ%2BSzQdkoFaWPKXhGQg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:23.550102","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:27:23 GMT
+      mise-correlation-id:
+      - 90cdfdc1-6c4f-4ee4-af56-11b512039fb7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A28Z&sr=b&sp=r&sig=t78O7SEAd%2BuzTTck6rhsTrO4r%2BvZsiMBUYXzK%2FwLx%2FU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:28.7971174","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A28Z&sr=b&sp=r&sig=BOkkjiwhMHDdrBh3AJsUH9WV5YRl9IimJsRv%2FTD9mDk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:28.7970477","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A28Z&sr=b&sp=r&sig=yk2P3C4xM%2BEzmHs84KS5XPn4aI9K%2FIn9Xxz%2BvzO3afA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:28.7971315","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:27:28 GMT
+      mise-correlation-id:
+      - a283bdce-019b-41e7-9239-0cde34c7e9a0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A34Z&sr=b&sp=r&sig=wP0E7EfcCSolYQ%2BLMZV6X1lcHgYcJm2GhKEwsctpNw0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:34.0966936","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A34Z&sr=b&sp=r&sig=wMlchQfjekuQod6SWrhby%2FfVe3eyg60qRg%2FMBdRdiiU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:34.0966172","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A34Z&sr=b&sp=r&sig=Wke6Ke%2FUkwjp94JnnmKoj2wBdsk2jA%2F9fR6DyzYtKkI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:34.0967088","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +1506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:51 GMT
+      - Sun, 29 Oct 2023 22:27:34 GMT
       mise-correlation-id:
-      - b9dffdce-e309-460e-a9c1-5ec0be129a54
+      - e93edf8c-f71c-462a-848a-a55cb92dd31b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,10 +1528,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A56Z&sr=b&sp=r&sig=k3NnlSXITykmB9%2FSIziqgpy35EIqHToknolhPcIv0qs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:56.349255","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A56Z&sr=b&sp=r&sig=HBCrKGf3jNg0Kxd8VaNNGmzoAOX86QMW2NxgC41%2Fcc8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:56.3491751","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A56Z&sr=b&sp=r&sig=r7%2Fxv%2BoJnCYKmgWOxIztpflvd6P%2BgtFDTNxNFyYg3WU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:56.3492695","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-24T12:33:16.778Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:56.313Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A39Z&sr=b&sp=r&sig=u17L1YLlbeoy1iYWcR%2FkWPynXC9vvaZSLXnIB%2BRfq7c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:39.7249121","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A39Z&sr=b&sp=r&sig=zXVVm4Pb3uyL1x5a1vkpTAZjnj1fc30aw7x%2BEmtLrYE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:39.7248234","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A39Z&sr=b&sp=r&sig=Y%2FbBae3KuG9G%2BPpDc17v3oDDZCkTaA8ohhX2xlwm0%2Fo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:39.7249369","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:27:39 GMT
+      mise-correlation-id:
+      - 836ff894-9382-43fc-bd7f-d16958a17bdd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A45Z&sr=b&sp=r&sig=r2p9etLKXR4KF2B7fVYQOUX0vZseEaadbqnoq%2FyjNJs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:45.0000286","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A44Z&sr=b&sp=r&sig=Imz4eFwxlb7DeTe7dZyFuB0at3cHZi7Sb06osdPw7vg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:44.9999209","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A45Z&sr=b&sp=r&sig=%2B%2BqDT2dV44yED9DBpj5ggyn%2BUzHU5MtLR%2FPzjHck5o4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:45.0000534","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:27:45 GMT
+      mise-correlation-id:
+      - bf7317a8-f436-477f-b18e-054510314f65
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A50Z&sr=b&sp=r&sig=hehalNGjHN4crfTjmrsJHCo5FM3EPIkqnW2oF3wDD10%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:50.8094357","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A50Z&sr=b&sp=r&sig=REJ4lCFNH8ci0Mpzwjxd21StyPXvd%2BHH6Bqi2s7xqC8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:50.8093683","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A50Z&sr=b&sp=r&sig=5g8Dha7VeiPcR306S%2BplOrfao6M123Q3D%2BnyTk0R0lY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:50.8094505","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1794,9 +1614,226 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:56 GMT
+      - Sun, 29 Oct 2023 22:27:50 GMT
       mise-correlation-id:
-      - fecd3c79-b0bf-4262-87f2-cc4a15c13ce4
+      - 059ec170-2bc1-4cca-bb91-b9518cd0c1d5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A56Z&sr=b&sp=r&sig=pvdiCcUBoWRYwWAXL74mmjI0A1YFGin%2Fx8EQcNByn%2F0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:56.1225825","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A56Z&sr=b&sp=r&sig=3nYBKiBcr%2BTL8ClHHjkR5jnxL6uw%2BeKUKzvdsNo8SBI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:56.1225134","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A56Z&sr=b&sp=r&sig=GJkI7oFjSz4cd32sv3iLlKWAGHFbiTsH7gVTqXUHQBs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:56.1225967","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:27:56 GMT
+      mise-correlation-id:
+      - 25bc3c43-f0b6-479b-a5e7-c738f507f617
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A01Z&sr=b&sp=r&sig=72x2sc5P42EjkAZU2CvSUz71YfPZ%2F31PZnJ31rd%2BFMw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:01.4342166","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A01Z&sr=b&sp=r&sig=f0P5wfXw5Dzs8ThDaVBVjNuquQY%2F1PP4icGMrBEIOS0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:01.4341317","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A01Z&sr=b&sp=r&sig=RnztZXKlPgWHOiqTQEUpPWGQBIwfAqspyrnahOKgb%2Fo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:01.4342373","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:01 GMT
+      mise-correlation-id:
+      - b814714a-de23-4cf8-b374-d4175c7e68de
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A06Z&sr=b&sp=r&sig=mzEWZcSQcSmZhDpGlicL%2FAlL%2FQJm0Pm8m6BYiy%2FKi4s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:06.7065209","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A06Z&sr=b&sp=r&sig=ppiW584wZ6t5YE%2F55mrlcus6RM2XQ7jZRy0bmdfV6%2Fc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:06.7064552","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A06Z&sr=b&sp=r&sig=vowkzg%2BRTe9HokQgKvlGOoKIMfDHbQh%2BHU2Tq%2FMlyX4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:06.7065357","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:06 GMT
+      mise-correlation-id:
+      - 6e681dae-639f-451f-9e64-1588e74c801c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A12Z&sr=b&sp=r&sig=y09EeXqfMlqegbr8QjOXAWKMlHzjPUm%2FkELDLip31Gw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:12.0247886","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A12Z&sr=b&sp=r&sig=UmecqSZknzsaTRqmckc36XS4IMT7qzzaOJcNJwGICxM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:12.0247135","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A12Z&sr=b&sp=r&sig=XO4caqw7Hi%2FvM1pHMFdmyM6kMOSZnYHHaWjtzFCZsWs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:12.0248031","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:12 GMT
+      mise-correlation-id:
+      - f6dc7bf5-d02a-4959-86e2-d59d7d81353f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A17Z&sr=b&sp=r&sig=RT32JhOfE28bD%2Fy6Ab%2F%2FsLhIbcPh1KSbZSYzajk9q6o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:17.33432","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A17Z&sr=b&sp=r&sig=fZ%2FTfVu51t03nJ1LG%2FzREqTnloUX5CxzoltG98VlBig%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:17.3342507","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A17Z&sr=b&sp=r&sig=8IKeYWY1FTmfsGvyoYSNsE1YCYmiBo7cIvsng7Tov9Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:17.3343348","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:25:36.568Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:25.644Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:17 GMT
+      mise-correlation-id:
+      - 1e4ce3d4-24e5-4974-a8e6-42d6f4f0b43a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A22Z&sr=b&sp=r&sig=4gY4mMHTeFgDjdopv3RkwwA4VZFC0D%2BCXjg24klkVqE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:22.6738171","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A22Z&sr=b&sp=r&sig=IDQ80ykMwCU1hU5h7XI2wvbYQNnvs4lqqw1VEPl2ngQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:22.6737458","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A22Z&sr=b&sp=r&sig=Gj3eW3tZWeGwbYmSPGWF23twF95iZ1Y1YwA7Y5ghf5U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:22.6738321","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-29T22:25:36.568Z","endDateTime":"2023-10-29T22:28:18.865Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:18.969Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3319'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:22 GMT
+      mise-correlation-id:
+      - cee92943-18b3-489d-a7fa-c130d40f034a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1819,18 +1856,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:16.3081565Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:16.3081565Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:24:37.0997784Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:24:37.0997784Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:57 GMT
+      - Sun, 29 Oct 2023 22:28:23 GMT
       etag:
-      - '"d3003d48-0000-0100-0000-6537b9520000"'
+      - '"3c00392e-0000-0100-0000-653edba70000"'
       expires:
       - '-1'
       pragma:
@@ -1860,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A58Z&sr=b&sp=r&sig=YByBdk%2BdkFGIDbtMyeCwRfDMozUL%2FR7%2BzPfMsS0JmLY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:58.5661632","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A58Z&sr=b&sp=r&sig=0qPIex1YLTUwgmXNp%2FPGptXXeDabuW9x%2BnQzHBpwy%2Fo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:58.5660917","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A58Z&sr=b&sp=r&sig=G0iIiJg0tQVGCUPmh92IncOsYwGW9deUNPDl2tvZ05I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:58.5661776","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-24T12:33:16.778Z","endDateTime":"2023-10-24T12:35:56.323Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:57.847Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A24Z&sr=b&sp=r&sig=chp0%2BSvU4fb4NX469FBD%2BBms4aoWuflobErIrM%2FGYtk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:24.8065371","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A24Z&sr=b&sp=r&sig=rkP1A79sO%2F0v7M1PlYcc2BkwsJc8DHe2AwXHk4TOmgU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:24.806457","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A24Z&sr=b&sp=r&sig=gXZLgWrGuuflR91wDq90lHTITVGM%2FitcWQTusfybj2E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:24.806552","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-29T22:25:36.568Z","endDateTime":"2023-10-29T22:28:18.865Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:18.969Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3341'
+      - '3337'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:58 GMT
+      - Sun, 29 Oct 2023 22:28:24 GMT
       mise-correlation-id:
-      - a1053779-66d4-44e3-af4e-4a3c1a50be43
+      - 38cb9fb9-6b10-4427-8c88-da0b2f49f86c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1900,18 +1937,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:16.3081565Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:16.3081565Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:24:37.0997784Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:24:37.0997784Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:59 GMT
+      - Sun, 29 Oct 2023 22:28:25 GMT
       etag:
-      - '"d3003d48-0000-0100-0000-6537b9520000"'
+      - '"3c00392e-0000-0100-0000-653edba70000"'
       expires:
       - '-1'
       pragma:
@@ -1941,24 +1978,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://cb1f0211-b44a-4ec7-8f07-156e84eb4d8a.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
+    uri: https://aee8bc8f-a5f7-418f-b4fb-10f47deb677b.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"8ea9774b-148e-4e8f-b05c-ee27257e0b92":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e5edbeee-8871-48d6-8d74-cf802e7486ce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c2b6103f-53d9-4fd6-8c7c-02fb37130ec2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/f4cf2531-6025-4916-b2d3-7409f2462ec8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A00Z&sr=b&sp=r&sig=fe3MpTTVRhf35%2F1ecC8Tzyd%2Bx10RTpLpV8dUc%2F1h%2Fow%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:00.8324531","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/94a6876a-1da9-4da7-a9b8-26ec8719ff26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A00Z&sr=b&sp=r&sig=jj2D%2BVPoi7d5jXhIGaajaRXF6ZUgefoB68yLU%2FGAkK4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:00.8323015","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/383c84a6-982b-4059-a4ed-1fe2d4a82e5c/b27813f1-6b5d-41ee-a2ae-029f1f0a361f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A00Z&sr=b&sp=r&sig=gods%2Bf5nGm17BBc5P7C8NHSFotaWZdnM4OYOOtskYfU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:00.8324859","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-24T12:33:16.778Z","endDateTime":"2023-10-24T12:35:56.323Z","executedDateTime":"2023-10-24T12:33:15.228Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-24T12:33:16.359Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:59.026Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0d756310-bbee-4fa6-b9b7-c66f2b831884":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4d08beae-2fa0-4e01-8ada-75e9b1bbf79d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9cb64308-d119-4505-b3dc-70abaf0ba6d3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/a4ed494b-91e3-4c0f-a628-60fac5b5aac7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A26Z&sr=b&sp=r&sig=xsZuq7ye1oCvCA3H16B8kvX5sw8prsyM8MktivphKGY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:26.9363262","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/31125482-0c70-452a-b791-145bdf68365d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A26Z&sr=b&sp=r&sig=L7Ru5U0VLOzGxyQih8bx9d9WOYdiOcgDMsBWe3qrMcU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:26.9362566","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9eb53c7f-31d3-4d24-92a2-4b1eda4cb7ac/5df4eb1e-4787-4e74-878e-94fc2184d184?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A26Z&sr=b&sp=r&sig=%2F4uw1KTkdqcJ9qp5%2FEe6UkrGwzfuz4ExeySbUX4c2Kw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:26.9363407","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-29T22:25:36.568Z","endDateTime":"2023-10-29T22:28:18.865Z","executedDateTime":"2023-10-29T22:25:35.169Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-29T22:25:35.462Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:18.969Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3343'
+      - '3333'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:00 GMT
+      - Sun, 29 Oct 2023 22:28:26 GMT
       mise-correlation-id:
-      - 942414da-fa06-4405-ac2e-5c2a04f65972
+      - f32a60b5-d3c3-4328-9f54-94e141a34390
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_list.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_list.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:22:23.8309943Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:22:23.8309943Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:11.5473273Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:11.5473273Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:57 GMT
+      - Fri, 13 Oct 2023 13:56:44 GMT
       etag:
-      - '"56009c8a-0000-0100-0000-652452f10000"'
+      - '"d901843a-0000-0100-0000-65294c7c0000"'
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:22:58 GMT
+      - Fri, 13 Oct 2023 13:56:45 GMT
       mise-correlation-id:
-      - 965000dd-8634-482b-978f-06946be98fbe
+      - 6f9531af-543c-4e82-a7a4-ae15dfa79a5f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"73af9c2b-ed02-4034-9a10-831e20d4c103": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "3c4dc432-850e-40d3-8e36-64a66c6d7004":
+      {"passFailMetrics": {"21dcff02-9053-48b3-8d3e-f94737c67bf0": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "feff087a-df0d-417a-9f30-5e85216ba2a7":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "19ad2e87-5597-4382-be43-659c39d4f6b8": {"aggregate": "avg", "clientMetric":
+      "50"}, "ea26e3cf-d9ab-47d7-a700-f50560e0402d": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -104,13 +104,13 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:22:59.047Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:22:59.047Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:56:46.091Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:46.091Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:59 GMT
+      - Fri, 13 Oct 2023 13:56:46 GMT
       location:
-      - https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+      - https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 76723c94-2c03-4c16-870f-a40f1885e3d3
+      - 090d5333-bb8b-4789-849a-198658069e30
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -143,9 +143,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:59 GMT
+      - Fri, 13 Oct 2023 13:56:46 GMT
       mise-correlation-id:
-      - 972409a8-5445-4c93-97ac-c4e11eb53549
+      - 41ffd95e-977c-4002-a6af-8bc60eba6f85
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -273,27 +273,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A32%3A59Z&sr=b&sp=r&sig=vWXtl7kC7SdyS8W%2FYdvyFUeVRljfQ05wUhPVfvgzGmE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:32:59.886451","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A06%3A46Z&sr=b&sp=r&sig=GVRAIYobCGjChrr1wA7ePkaRaVn%2FdC22sW%2B7MJcMJGY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:06:46.8584521","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:22:59 GMT
+      - Fri, 13 Oct 2023 13:56:46 GMT
       location:
-      - https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 5dcd0959-71ba-4884-b882-f86781adad85
+      - 1b7c3c08-827b-426f-9045-04c364a45aaa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -311,48 +311,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A00Z&sr=b&sp=r&sig=mphcEdTZm8U%2BNCBRi25zXHKKwrOnifkjsXsdrT%2FmGUU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:00.159645","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '552'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:23:00 GMT
-      mise-correlation-id:
-      - 34da202f-3511-4c98-92e7-36df7e6fc8b4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A05Z&sr=b&sp=r&sig=MBTUoPgNlFP%2FaLJyvoAVkMnNh9lvUUKvTNv7eBDCOcI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:05.4808337","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A06%3A47Z&sr=b&sp=r&sig=qLqINYwPhJuDj%2F7CBuXYHahtPWzOUcaksiY2ARStYcQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:06:47.1422642","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:05 GMT
+      - Fri, 13 Oct 2023 13:56:47 GMT
       mise-correlation-id:
-      - 7ad12f19-f760-4bdc-ab26-4107c3cfa152
+      - 733ef210-c7a8-41d1-ade6-c16f06f1ed50
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -383,48 +347,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A10Z&sr=b&sp=r&sig=dIeQmX2CbmBRWduhgq2zFFH5jxCY9uWJ4xrwBBP%2BQQo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:10.7549851","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:23:10 GMT
-      mise-correlation-id:
-      - b4d69714-7927-4477-ac39-9d855fa3254a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A16Z&sr=b&sp=r&sig=QQGJDQc5oOUhdm6v9lVlskREzW8v9kQ9A%2BZQWjaoUI8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:16.0362847","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A06%3A52Z&sr=b&sp=r&sig=zEd4dJoYkeMLLcCuI017CopnwA9ZtuIjb2WrwpV2tl4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:06:52.3970443","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:16 GMT
+      - Fri, 13 Oct 2023 13:56:52 GMT
       mise-correlation-id:
-      - 86281673-8362-4953-8329-3f30792833f9
+      - c7f2a359-6710-4254-8c0f-479bcbeffe85
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -455,26 +383,98 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A16Z&sr=b&sp=r&sig=4Me5nRVGTb6jhR%2BA477gM1d7Il8cNX0n5RcJS%2FGZ8iI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:16.3025372","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:22:59.047Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:15.62Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A06%3A57Z&sr=b&sp=r&sig=39p%2FhpstyKLR%2BUIkPGz7SMNN8gJ2Xl7QgoK1ldruXQg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:06:57.649524","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1578'
+      - '552'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:16 GMT
+      - Fri, 13 Oct 2023 13:56:57 GMT
       mise-correlation-id:
-      - fd920eba-aaaa-45c4-b361-896b0e28d127
+      - a2f014c7-321f-41d5-805c-373b057632a9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A02Z&sr=b&sp=r&sig=TAVf7PrqNeJancr%2BV3ck3c5rBd4EEJ1CDdot6gWnoiE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:02.9081753","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:57:02 GMT
+      mise-correlation-id:
+      - 0bee71d0-88a2-48ba-b198-a94123f47fb0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests/list-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A03Z&sr=b&sp=r&sig=2o1uM3AMneBas7jXGEWDiFkfFlNutd31ndCusiYvwNc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:03.1547694","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:56:46.091Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:59.771Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1575'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:57:03 GMT
+      mise-correlation-id:
+      - 744e1fa5-28c7-4be0-9aa4-8c5a96f99e8f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:22:23.8309943Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:22:23.8309943Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:11.5473273Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:11.5473273Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:18 GMT
+      - Fri, 13 Oct 2023 13:57:03 GMT
       etag:
-      - '"56009c8a-0000-0100-0000-652452f10000"'
+      - '"d901843a-0000-0100-0000-65294c7c0000"'
       expires:
       - '-1'
       pragma:
@@ -536,26 +536,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A19Z&sr=b&sp=r&sig=6JxwyVqVmxqLtfk5eXyR7Pzx9xlZmawwZDm04JQbJQg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:19.0047543","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:22:59.047Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:15.62Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A04Z&sr=b&sp=r&sig=IIVmQy0DYkp7HPCNZ%2BLlGpM7soJ0GrJyYTBwxuhgcAE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:04.9331926","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"list-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:56:46.091Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:59.771Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1586'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:19 GMT
+      - Fri, 13 Oct 2023 13:57:04 GMT
       mise-correlation-id:
-      - e70bb71d-fa71-4ed5-8308-89dc680ba4e3
+      - 6c67e95c-b53b-42bd-96b8-b09f1f273b2d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:22:23.8309943Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:22:23.8309943Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:11.5473273Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:11.5473273Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:19 GMT
+      - Fri, 13 Oct 2023 13:57:06 GMT
       etag:
-      - '"56009c8a-0000-0100-0000-652452f10000"'
+      - '"d901843a-0000-0100-0000-65294c7c0000"'
       expires:
       - '-1'
       pragma:
@@ -617,9 +617,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:23:20 GMT
+      - Fri, 13 Oct 2023 13:57:07 GMT
       mise-correlation-id:
-      - 61965f93-63a1-444a-b47b-ac40c5ab588f
+      - f7cc04fa-7e5e-498b-b27e-af48bf775300
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -660,27 +660,27 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A23Z&sr=b&sp=r&sig=TuD%2BHKeg60bcvZGPz3xoCv%2BsWv4zleBctepLwdTCpZ8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:23.1261476","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A23Z&sr=b&sp=r&sig=UVeewWtTBZ7iuX5VjEJ4J%2BZehMO0Bi0vnCcHv8PYP8Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:23.1260509","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A23Z&sr=b&sp=r&sig=gvbam%2F%2Fr7h8P3x%2BoYlFv1wtvMC8spDRtmVJNNgv5Ivo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:23.1261741","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:23.037Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A09Z&sr=b&sp=r&sig=PnHhNle0lChl5wOVvBtUydn3x8HnPluJ7dg2Bgx%2BPMQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:09.0676441","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A09Z&sr=b&sp=r&sig=noNfaSj0qx5p%2B%2BPMP%2FF5TPGYx1o%2BwlWUF6ivtA5gU8E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:09.0675396","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A09Z&sr=b&sp=r&sig=mKA%2FiycRp5KRxdThCTOkh1%2FZPI8Svip250A3aatgtFM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:09.0676748","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:08.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3150'
+      - '3152'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:23 GMT
+      - Fri, 13 Oct 2023 13:57:09 GMT
       location:
-      - https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+      - https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 4ad85b38-cf4b-48e9-b150-f6a2d276a435
+      - 43e58682-2f19-4c5e-bc5e-5266818354b8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -698,25 +698,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A23Z&sr=b&sp=r&sig=1MMilVsPHz4OFFQ2uqcuJ6Djb8BnQQUKPxZ0V9fRO1w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:23.6037907","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A23Z&sr=b&sp=r&sig=ZvBpXdxNd474YoBTiRdTDgOPzeGwFYmbZ8EjnYwQwhw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:23.6036931","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A23Z&sr=b&sp=r&sig=JRtRvNT%2BMdZveCNFFHQaBVZJrBBDpebYp55CY2THe60%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:23.6038109","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:23.484Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A09Z&sr=b&sp=r&sig=7c00diKPs4z3CQ%2BR9qiRsvdKb2V25N0zEyIvOaTamIM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:09.483822","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A09Z&sr=b&sp=r&sig=%2F81dTZmRNE4PF4fvO5ou1tM4B4inkqDY6BcBwRq9iYU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:09.4837527","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A09Z&sr=b&sp=r&sig=ozh1qxpcjklg%2BI2yE0oPswagbTDOXPdn2gJOrHPTFSo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:09.4838368","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"NOTSTARTED","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:09.366Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3185'
+      - '3188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:23 GMT
+      - Fri, 13 Oct 2023 13:57:09 GMT
       mise-correlation-id:
-      - de46958b-5c89-40cc-8763-e14423e2105e
+      - 2bc5ae9c-82ab-48c6-9873-153529b81699
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -734,25 +734,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A28Z&sr=b&sp=r&sig=pF8k6PWsMJx5mQp9Xj0Ath0Jk6kB9pqdw6hhvIcCmHs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:28.9380715","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A28Z&sr=b&sp=r&sig=cfNPQhet%2F8gzb%2BxOEqGRQ3ilHMyThR72A%2B0RhIaoViw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:28.9379582","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A28Z&sr=b&sp=r&sig=m1U40YWathHAsIR641ZK7p8yGvM88H0p9AhGcQkzE8c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:28.9380944","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:23.699Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A14Z&sr=b&sp=r&sig=Ovh15FmDo%2FHZ1I%2BRBBptI1AO0yHz72Ov90sMFVceYlk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:14.732582","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A14Z&sr=b&sp=r&sig=Mn5cGvDFde3Gd2sKQPPvGRlJZRfbXzrmopuz2klyoMc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:14.7325013","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A14Z&sr=b&sp=r&sig=82YHHECUmRB1un%2BO19Z8vIIJ9Q88BnPiwZYo0v5MZxk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:14.7325995","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:09.476Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3191'
+      - '3190'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:29 GMT
+      - Fri, 13 Oct 2023 13:57:14 GMT
       mise-correlation-id:
-      - 8eabcb2b-a2d0-4170-bbbc-1c85bf2fa0e4
+      - f64a8e1b-ece9-453b-9b17-8adcecb7a845
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -770,25 +770,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A34Z&sr=b&sp=r&sig=M51N7BENfWOnArxOofRaFXNiLc7eWGHsBeHFyQkFL%2B4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:34.3224458","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A34Z&sr=b&sp=r&sig=lQrXkx7Tee%2F9L8hvmuzhfhDgJOcgFjs72A2W9A%2FE2XE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:34.3223758","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A34Z&sr=b&sp=r&sig=r06i7LBsGpNYxIDPjxfm%2FBVQHyA%2BKsZov%2FjhNgghaYE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:34.322462","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:23.699Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A20Z&sr=b&sp=r&sig=B6l2UmTXdZ1kW26SApOt0bPF47oG5FGOAfzmXrwf3BA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:20.043117","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A20Z&sr=b&sp=r&sig=%2BNT8Qlhd2mw0W27rMt2W%2FtXyZcl4h5mt8707GTW4IyM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:20.043025","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A20Z&sr=b&sp=r&sig=3HQFJyoUz1tZmWpZNY6r38kjFOPRVkwegqdeXDZzzb0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:20.043139","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:09.476Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3196'
+      - '3186'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:34 GMT
+      - Fri, 13 Oct 2023 13:57:20 GMT
       mise-correlation-id:
-      - 7e911c5a-ada9-49c5-9fbf-f59c4e68be87
+      - 1e4101a5-2b4c-4c7f-818f-f3a8da1c184b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -806,84 +806,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A39Z&sr=b&sp=r&sig=8hksfGmnsPIAeN%2B91JTSfpMAwXDR8QpG2853Q%2Bc6%2Fvg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:39.6936896","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A39Z&sr=b&sp=r&sig=z4hE06ludETpGK6g0XtgrXdh9PNnnpAM63EfYYN7jpE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:39.6936121","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A39Z&sr=b&sp=r&sig=wv%2BF%2BNJ4Ap3AinuVkRNsxcmdEXClL5voiCvBgmLGlKM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:39.6937076","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:23.699Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3195'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:23:39 GMT
-      mise-correlation-id:
-      - d0f0e741-b1f9-4bec-bc4d-750eda8d3a63
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A45Z&sr=b&sp=r&sig=k50aZRx7KXb2GWyLc8IMLlFz%2B2uksgqn67MWWVsyDpg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:45.0269685","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A45Z&sr=b&sp=r&sig=8aia2Hk1rtq6bg1qtqd2cX2PaaI5VQDEm1F0dKPgKMA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:45.0268691","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A45Z&sr=b&sp=r&sig=dTIZMvmx8aBqSIrdWs4P7IngtJULkfuOP7ijGhRnLcA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:45.0269933","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:23.699Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:23:45 GMT
-      mise-correlation-id:
-      - e96a022a-19b4-4537-b8b4-f7bd279377cd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A50Z&sr=b&sp=r&sig=BiZBHWZHsAQsCBluUxXk2A1UY9sK9sbHdWvB3%2BEJBf4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:50.3031565","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A50Z&sr=b&sp=r&sig=MKTKkacZR%2BqIdG6Jus9EKyUNWCkZqhVodTRgsg%2BYWKA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:50.3030138","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A50Z&sr=b&sp=r&sig=8fPmjX7afyIXiwQtixFiKTCJd4Jj1xdDwvT62e4%2FFVs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:50.3031805","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:23.699Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A25Z&sr=b&sp=r&sig=%2FxfSGKJxv8k1G823Spvsdo5C0NCZGP%2FAHCFyr%2FWFBk0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:25.3192306","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A25Z&sr=b&sp=r&sig=ouyZquJOwkyEMpN3YYxHUtaBVROVIu7NCafEcZ16pgY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:25.3191514","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A25Z&sr=b&sp=r&sig=0FyajoBPTzs7uRLnGSVflBhQLHP3%2FlJiWgPzhSZM9mM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:25.3192507","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:09.476Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -894,9 +822,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:50 GMT
+      - Fri, 13 Oct 2023 13:57:25 GMT
       mise-correlation-id:
-      - 5cc052f6-1986-45be-9c9b-bf37fce6d785
+      - db74678c-c080-4e8b-ac12-87a2c5778ae5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -914,25 +842,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A55Z&sr=b&sp=r&sig=a6nw3sXS9rDXrDRrBASTLQAYaeNfkXfYcqOsi9cHgx8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:55.6315341","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A55Z&sr=b&sp=r&sig=yXRxl2YXRpwNCL5a6ZOiYG8JOvTlYO403N4RXyj4y88%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:23:55.631441","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A23%3A55Z&sr=b&sp=r&sig=6voOfo%2BUw73BDh4MUAm0Brk9uXusGSN1Uv2a0NrEOTs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:23:55.6315554","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:23.699Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A30Z&sr=b&sp=r&sig=orPm6P3lKtTqdBd0MH%2FLjyrgbXBdd0N%2Fyp8TQdSrY3Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:30.6404816","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A30Z&sr=b&sp=r&sig=p4jypik5oPdLYPZycJkABka7y4mk51gpoMDX2p2EpVM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:30.6404064","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A30Z&sr=b&sp=r&sig=i7StTgSzfaPSZVvi%2BOE39B2XdoHvu9jtJViIQv%2FBEuE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:30.6404956","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:09.476Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3186'
+      - '3193'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:55 GMT
+      - Fri, 13 Oct 2023 13:57:30 GMT
       mise-correlation-id:
-      - aa18c4d0-79c5-4a31-bbf2-b963a3a1f40b
+      - 83b39e89-8e9f-4827-85d3-ac2710da5e1e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -950,25 +878,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A00Z&sr=b&sp=r&sig=j6kobzWJsrTd1H07lE346xzWfWgjF0fQ8HqVM%2FHcK5I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:00.9123769","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A00Z&sr=b&sp=r&sig=wMPi%2B2mf%2Fw0c2svTlmVfFIK%2B3FbCGZ3uT8BV5QMd%2BP8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:00.912307","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A00Z&sr=b&sp=r&sig=AGZJvo1VDkX5brRfSu5Yv38QIqDhUsDnuYCKiWfB3dM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:00.9124004","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:23.699Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A35Z&sr=b&sp=r&sig=D1hrylwo4u%2BACJTbwGEGLZ42lm9Ve1788lYSavCqZlc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:35.9504405","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A35Z&sr=b&sp=r&sig=OU1XI5GDH%2BY%2BWy2gRM2Czha0h6KK7SUJOE%2FRitmqZ40%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:35.9503537","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A35Z&sr=b&sp=r&sig=QxyNRqfS1dy9zz3fQRWcBGjSNsjyAza%2FB9V%2FL1Pl7%2BY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:35.9504638","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:09.476Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3194'
+      - '3199'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:00 GMT
+      - Fri, 13 Oct 2023 13:57:35 GMT
       mise-correlation-id:
-      - 04676b81-2a43-4d62-abb9-0c63a6515100
+      - 7a64e116-6a9d-40ea-bfef-a6f232e7faba
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -986,25 +914,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A06Z&sr=b&sp=r&sig=NkEKvu%2BVL7FlAIrDoCOGhLNcIgAspOh1vJ1ERhuBMuM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:06.2056088","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A06Z&sr=b&sp=r&sig=O78S8%2FjBAieP%2Fe0luWwsHklTx3SXcRVWa3sAou0vjzs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:06.205525","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A06Z&sr=b&sp=r&sig=9ShWTdTr4yzeIoadFggE6bpudAvSsH42VUTvyrH8hbU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:06.2056291","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONED","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:05.97Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A41Z&sr=b&sp=r&sig=QaFXhJsx4lG32PQmkIFUAEGI2WYt7a0bMNMaHrTXnsI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:41.1987406","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A41Z&sr=b&sp=r&sig=oKNkcw2nLUf94XEvevLjMg%2FZN8Lqu9H9ypajRyuTmMo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:41.1986551","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A41Z&sr=b&sp=r&sig=25FYlDK8jYtubizcsFTcT9tHgxioQ9Dd4Hbc65VUA7E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:41.1987633","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:09.476Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3188'
+      - '3187'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:06 GMT
+      - Fri, 13 Oct 2023 13:57:41 GMT
       mise-correlation-id:
-      - 99da63ba-1185-4fd5-9397-cdaecb79c1da
+      - 0251250b-c540-4ecc-bebf-f0e923b62b01
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1022,552 +950,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A11Z&sr=b&sp=r&sig=47M14QSP71ATsI7sgXdof1xyrM0SZHodYrDIMCQfXOc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:11.5317812","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A11Z&sr=b&sp=r&sig=ZlZQX8zX4CuR8NcEVFISp%2B4rf6%2BodWsD9BsAC8iil6w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:11.5316958","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A11Z&sr=b&sp=r&sig=FENEott81EADNCfKNt9ut8v43kmaFdNuIrxgCDHaamg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:11.5318021","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:06.872Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:11 GMT
-      mise-correlation-id:
-      - 19bc65a5-dcd5-4b95-9b36-2b49bdd2648a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A16Z&sr=b&sp=r&sig=tx5dVKp8L292Zp52aAa8QugPOJYB1dUlem5RmlirSO4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:16.8636813","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A16Z&sr=b&sp=r&sig=b1RiWu9GqXFS0%2BMaMiAa5zesp6uHPiUAttABkyLCe3E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:16.8636088","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A16Z&sr=b&sp=r&sig=C%2FEFsiMjB1sI2yKngszt%2FIO2gqouAV9vSSI%2BgWyWid4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:16.8636998","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:16 GMT
-      mise-correlation-id:
-      - e279625d-cd5a-4b0e-ad56-6937dc664e63
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A22Z&sr=b&sp=r&sig=kW8a1pmSwLWfe11zW1ktmoPg1DViT3DXAtrDwsAVF1A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:22.1330508","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A22Z&sr=b&sp=r&sig=skb7g49At8BmH4c7xNEy31mf%2BZvED4SzuWFTe%2FLUm1U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:22.1329522","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A22Z&sr=b&sp=r&sig=btS4BpbQttARx%2BHk1lpqIj83dM2JupFgSrWvAMMaHmA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:22.1330737","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:22 GMT
-      mise-correlation-id:
-      - 26b88ac8-0bed-42af-bba2-ec951789faef
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A27Z&sr=b&sp=r&sig=dfJwv17BdhjI%2F8vWU455eK%2BQexrvjNZ4%2FvvVOE4nbtg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:27.4104299","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A27Z&sr=b&sp=r&sig=q666nvkV9i%2FsvkhAEZVmhbrENajMDH%2B3DAh86Xb8srE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:27.410341","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A27Z&sr=b&sp=r&sig=%2FD76U%2FE8a3TGF923%2BZQe6cN7PGfbOUd8ylT7j4dkoj8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:27.4104512","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:27 GMT
-      mise-correlation-id:
-      - 0cbcfd44-1288-4daa-8797-a729bad834dd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A32Z&sr=b&sp=r&sig=5TL6BuIaleFxP0B4%2BgFTM4kQ%2BYsUCMxrE8WE0GhLTbo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:32.7214029","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A32Z&sr=b&sp=r&sig=0F9F5W8FyiDmnHy8nzhvt1bgOLiHmhb%2BvFhSR25sTAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:32.7212965","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A32Z&sr=b&sp=r&sig=z7IBSHxLSEucQI%2BQL4DXLZyb9mSfU7td3wr7P33R5BA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:32.7214247","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:32 GMT
-      mise-correlation-id:
-      - 90d0c036-909d-4ac3-9c50-a37738c1e322
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A38Z&sr=b&sp=r&sig=FUEVpkSwfzVHzt8mWnyWc9rONDE4LbS4dmn%2Buk1%2FnJs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:38.0498129","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A38Z&sr=b&sp=r&sig=yMBg2uh8Rl45nEOccTsofRhsb287xmp1iOv1JsQFcLM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:38.0497409","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A38Z&sr=b&sp=r&sig=7bbDq5Ogc3cpEgm9fzJObwXIa%2B8wOg6kFeD4DiTPaug%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:38.0498288","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:38 GMT
-      mise-correlation-id:
-      - 3a93ab5c-7ac6-4d69-a724-927ffdb9794d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A43Z&sr=b&sp=r&sig=pk7hrFXaFKL9AyXm1XUAoU3AFsWQ15w%2Br8LqGGGTSMc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:43.3213482","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A43Z&sr=b&sp=r&sig=PThqobFITEAX3wGfP6nMtxn2t37cTiUqzyCwvGZPxVU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:43.32126","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A43Z&sr=b&sp=r&sig=%2BXX8DXALFMNTXRqrweze5VO%2BXC3OlgOC2RLC6dqULpc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:43.3213701","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:43 GMT
-      mise-correlation-id:
-      - af84eb54-8cef-4d23-a4ea-aaefc9adef7c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A48Z&sr=b&sp=r&sig=N9FwN9n%2FsRgDtpFOv5stll2V6Wp1vvmATcLZSO9YXl4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:48.6145289","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A48Z&sr=b&sp=r&sig=6mb0MEHqfFQEiiKklyfb8lkeqEd6BdAg95ZNBv3BVrM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:48.6144545","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A48Z&sr=b&sp=r&sig=ulXjaO82y8UNKtGrnqK2LqT84xLbOFSOBD%2BZQsD4f9w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:48.6145434","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:48 GMT
-      mise-correlation-id:
-      - 9cd976fc-5e88-4386-881f-0e8361167e44
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A53Z&sr=b&sp=r&sig=6lLglfuAoV8D1XIoGaFZa0KeIcSbeYaVZTQLv59sgBE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:53.9038885","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A53Z&sr=b&sp=r&sig=taJK3zzUrFzB%2FZodz0Nz1WDw6gxSls6L0s5SQ9dxZzE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:53.9037913","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A53Z&sr=b&sp=r&sig=WXPP3WC3g5rYdG3T0I5RMTvjnHQueEGe8cbneDI9cXQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:53.9039098","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3184'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:53 GMT
-      mise-correlation-id:
-      - b65008f0-de10-47b4-bf3d-f6043b79de82
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A59Z&sr=b&sp=r&sig=wILuYXFfpWoI7RYBYE1l9ysk6jQzYCFprkJ0XDi7fg8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:59.2556829","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A59Z&sr=b&sp=r&sig=dFSD8MZ7fEpd6w%2FY671HhJPZBVGIPokz7dOGM8eOTv8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:59.2555924","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A59Z&sr=b&sp=r&sig=A2TooSYxkNCvtytHDYzPk7N5hDnsHztlAFTPGFM2ayM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:59.2557032","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3184'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:59 GMT
-      mise-correlation-id:
-      - 0e89116c-1adb-4a19-9753-c78a6e5a732b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A04Z&sr=b&sp=r&sig=joN5ALtgEtFP9Fe586%2BKsOMdRjNfpeWG4bQqtaXaP5s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:04.7175358","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A04Z&sr=b&sp=r&sig=ftRurBVClccCzlbGYYO1eltkFDDw6cHe3GpUpGCa5rM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:04.7174466","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A04Z&sr=b&sp=r&sig=6UUJHe9zWU8cmT6%2BbrfgTkH2tIAhJfFWclYdJnJmp0E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:04.7175585","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:04 GMT
-      mise-correlation-id:
-      - c7d59d25-458e-41a1-9cf6-9d8a27aa7c94
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A10Z&sr=b&sp=r&sig=H28pV4olmSRObucM2oXcYrdzjX2yBbbLzdccIGmUw5M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:10.0108915","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A10Z&sr=b&sp=r&sig=jGDiTX717Zh80uhXCFvuKIUcDhFRqgeteFEQ2iBoYqg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:10.0107939","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A10Z&sr=b&sp=r&sig=GKH%2F%2FUjoGRs7jfN%2FVxeAOm5rPX6U9c8l%2FlhaYBaaBw0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:10.0109131","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:10 GMT
-      mise-correlation-id:
-      - 505e2c23-54c7-466c-9ceb-ebad02fb9b7f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A15Z&sr=b&sp=r&sig=9xaj3BDG6Ohvgt4R9cf14Qo4XSxixsKvdhR78JQ7aGM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:15.3295952","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A15Z&sr=b&sp=r&sig=FXjQ9EQANYqVFgEpr5D8OTAYDlWvj5aLvnV9YEk7qrM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:15.3295005","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A15Z&sr=b&sp=r&sig=mqKxr2cwkM9D1%2FisZ%2FYD9MOumSvz1rl3ZuiAVRLzPKs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:15.3296186","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:15 GMT
-      mise-correlation-id:
-      - d272d765-069f-4bb1-b184-895ba8d8ecb1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A20Z&sr=b&sp=r&sig=veUblnrTTTKpfDD8u6j0fmUh0iTsKuPygYZkvLr69Us%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:20.6528515","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A20Z&sr=b&sp=r&sig=7gX69UbrfiGdTPAc%2FeurPifg4J1gaLIbYdLb5Md9xEM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:20.6527606","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A20Z&sr=b&sp=r&sig=8er1VlUWitnsP%2BaeSVo3HwlLwlPJJvjOVwLZ789GzZ8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:20.6528731","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:20 GMT
-      mise-correlation-id:
-      - c2bfc745-d5b4-48ca-ac26-4b7ef4838d11
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A25Z&sr=b&sp=r&sig=YterC4Ou27dIbzQRFvhx5muycrSBatl16HrHI%2F4F6jo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:25.9690647","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A25Z&sr=b&sp=r&sig=PPU5fsX2Ee8fSFtWSkelN2U83hk3fH28yOuvOuVkSlQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:25.9689926","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A25Z&sr=b&sp=r&sig=YvKNrgMJo89HvjAK9uVnhBqZQEaW6th4sOEovX8cDSE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:25.9690791","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3184'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:25 GMT
-      mise-correlation-id:
-      - ec1a594c-a9e9-4c13-83d5-a794fb16b1a7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A31Z&sr=b&sp=r&sig=Pw3al9DWSlj8I%2B0QkelG419Zfb%2FyqDTPYGAMlUBNLrE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:31.3329915","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A31Z&sr=b&sp=r&sig=%2FAtzrDkmjttqY3dfAjuNXtf4r%2BrPD828fDSzVwba8f8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:31.3090544","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A31Z&sr=b&sp=r&sig=0La5gbkpkywKeOmX417eFOhItqDF%2FzV74s%2FQN%2Fr7ho0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:31.333408","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A46Z&sr=b&sp=r&sig=%2Be%2Buo6awV7CeLnK1r%2FKH9UOVYBLGE%2FYHCQDaqFJQrMs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:46.4457268","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A46Z&sr=b&sp=r&sig=G7H0KuJYyilsBDnSpiQNf2fNpV%2BcjRbr9eAr3KNcKtA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:46.4456186","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A46Z&sr=b&sp=r&sig=Doo0ejMitvhHr9EURrtt47uV67rY31HVfUNb1XIToms%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:46.4457496","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:09.476Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1578,9 +966,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:31 GMT
+      - Fri, 13 Oct 2023 13:57:46 GMT
       mise-correlation-id:
-      - 6f69cd2f-e1d4-49c9-8934-2645742a77f3
+      - 58eee598-8aa0-45e9-9f27-669a864698a7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1598,12 +986,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A36Z&sr=b&sp=r&sig=ZfcAuPK3w5h64SdhgdxJzfrdr96o5wCHvyl53hNSuc8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:36.6369875","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A36Z&sr=b&sp=r&sig=gBu1xkyfXDuRxE1epFTlXv3KFs5B5eFW1BN2YLbOmXA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:36.6368913","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A36Z&sr=b&sp=r&sig=NXHg%2FM%2FdnGmV4VVp9FHCvgnQpC%2BmImkt8GbnxQwuCD0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:36.6370137","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A51Z&sr=b&sp=r&sig=oUpkWXwr%2BJrPMnBJiFiufuEMx1tNr6Rx4UIauV8JRqo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:51.6807884","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A51Z&sr=b&sp=r&sig=g4zn2BaYRG1fFkjIAk3qDTKjhs3NJmuvzDt79DfcqqM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:51.6807075","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A51Z&sr=b&sp=r&sig=8h3pAuSMB0o%2BPUa2KglCKYDUmrr8ssWWcfx9SlMIbYw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:51.6808097","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"CONFIGURING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:48.122Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1614,9 +1002,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:36 GMT
+      - Fri, 13 Oct 2023 13:57:51 GMT
       mise-correlation-id:
-      - 244890f4-c1ae-4555-86a2-43464b3114c2
+      - 69b6dea1-0519-4d10-8ef3-5ddbfcf2dbc6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1634,12 +1022,48 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A41Z&sr=b&sp=r&sig=NPZ8aYtmyewLeEXgaGiEB8CDBuAvDJctH7%2Bljp%2Bh%2FQ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:41.9529052","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A41Z&sr=b&sp=r&sig=iETsOgO3katEYOUhjEk8E%2F%2Fzfgl4DjT0O5GLXP4fpLs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:41.9528203","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A41Z&sr=b&sp=r&sig=Psb90QLunBLFfSwo7KTP%2FFbLwLChL7DZdy0%2FyAiJ0cE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:41.9529202","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A56Z&sr=b&sp=r&sig=8nKTCarAQ9RNc7w2ra4%2BdRepnTUd7fyWCzy2eIqSVTo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:56.9461369","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A56Z&sr=b&sp=r&sig=jwRSm9AOcaRDyRLippgnrg3PDogEI%2FsmHW8oC8xxI3k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:56.9460718","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A56Z&sr=b&sp=r&sig=Aj3q1z3NBIAlG2TTSULA6jOj4dZ9UWFtmF3Wi2FjkdE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:56.94615","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:57:56 GMT
+      mise-correlation-id:
+      - cfad6195-a885-4444-991a-94f473b0b342
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A02Z&sr=b&sp=r&sig=XOW%2FSEzim67viW3EhsQsQb07MqaCwjG%2B8NK2FnYnb4Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:02.1938276","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A02Z&sr=b&sp=r&sig=al2xWxJ%2Fuv6%2BvjNG7BSJk2%2BYhW6NVKRhG%2B9zKhAz8Jw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:02.1937597","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A02Z&sr=b&sp=r&sig=FZkBXHI6guBE1dt7OIIg4z1hwVhFdJPJab%2BmJPB7LOg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:02.1938444","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1650,9 +1074,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:41 GMT
+      - Fri, 13 Oct 2023 13:58:02 GMT
       mise-correlation-id:
-      - 680850d9-0f03-4c02-95e8-32044d82da3a
+      - e38b0baa-00eb-488f-839d-39a3f5ffe03f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1670,25 +1094,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A47Z&sr=b&sp=r&sig=NLsmF4rPSGW8hDGqWpxJZQADE0hvEVkxTU%2BdWEyyByU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:47.2895247","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A47Z&sr=b&sp=r&sig=ZBiQOSojOgkgGfUELQAA99MX%2BzMbveUwRz5pdPzX1QY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:47.2891818","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A47Z&sr=b&sp=r&sig=7%2BdUj8vodXyxWWOoY77gmB71ahREHjm2XiqU67Hu0mw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:47.2895583","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A07Z&sr=b&sp=r&sig=46xN85pebGTb2CUt5iXHFM8nHs4%2FazTMKyYTDF47VrM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:07.4899629","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A07Z&sr=b&sp=r&sig=WH4%2BuEJ39wnW%2Fb2JETdn7WgC50a%2B43uO0iHH%2FMgcHsY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:07.4898707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A07Z&sr=b&sp=r&sig=UogrZwJiWVgSZokZN12RSWbiJFy5j8M%2Bh4wqDZV722I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:07.4899787","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3188'
+      - '3194'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:47 GMT
+      - Fri, 13 Oct 2023 13:58:07 GMT
       mise-correlation-id:
-      - ab0f45b3-4856-402d-8dbd-2db07d442212
+      - 7b595208-c1ed-4a02-970d-4fff2f14fe73
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1706,25 +1130,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A52Z&sr=b&sp=r&sig=3BI%2FbryhOpUJgn%2Fc5LeyFuV4esIv8%2FEoj0%2FpuZgsgbw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:52.6075608","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A52Z&sr=b&sp=r&sig=NkAx%2F16YyxcKNLCh9hh7hr2CNcMHfeoCTN8aJ6bxl9w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:52.6074736","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A52Z&sr=b&sp=r&sig=XpNreWlp5S3Fyt0O3X9xTO0yTlTQT6QlMip3wI0dB4w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:52.6075823","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A12Z&sr=b&sp=r&sig=dpX40k1Q05S9y1r%2FiuWXtGvXwbykKsWQw1hfFGVNLFU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:12.820822","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A12Z&sr=b&sp=r&sig=2zBx%2FwZ17CKuG30Uy5qM6xtzIkyHnEKjTXt%2BWFZgvEE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:12.820738","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A12Z&sr=b&sp=r&sig=8Q79sA7U83c1OteVzTbfOIFMg3l%2Fwi8V6vatxti%2BORM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:12.8208392","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3192'
+      - '3190'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:52 GMT
+      - Fri, 13 Oct 2023 13:58:12 GMT
       mise-correlation-id:
-      - 40421ed2-a074-44f5-b5d4-357e856870fa
+      - 08c37549-b92b-4d8a-8708-37fa0328f588
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1742,12 +1166,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A57Z&sr=b&sp=r&sig=VbFzs7TMsPs8YU4UCjxuyTleShk4Nom8NM9%2BmWC1b3o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:57.9198499","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A57Z&sr=b&sp=r&sig=9BfkBi8IlUeQdyNVt6AlKMCAosqxORTPPP%2BOSk5UBks%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:57.9197603","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A57Z&sr=b&sp=r&sig=mJcugfoXPUnb6GjKwJLLnoQxGx1YnwkpxrYrRDIUVUU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:57.9198641","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A18Z&sr=b&sp=r&sig=9rxd4G1Alaf5qozovOD1JI3Ve481LVw3kVAD1AIPM6w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:18.3062111","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A18Z&sr=b&sp=r&sig=IUO0cyjuL7xwvFqkdwQ5WqWE2QEd4of0nHXF0cXf2iM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:18.3061496","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A18Z&sr=b&sp=r&sig=vuJ%2FyiY3cuNEn%2FrAOkkU8fuYUYy8UrWJtR9HuQ84my8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:18.3062265","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +1182,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:57 GMT
+      - Fri, 13 Oct 2023 13:58:18 GMT
       mise-correlation-id:
-      - 6115a8bd-20aa-44b5-b9e3-a756f3f683d5
+      - db67735e-fdc9-485a-bffe-a6c880124707
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1778,25 +1202,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A03Z&sr=b&sp=r&sig=VRMReSXrpsScv%2BAZxjS02oTL%2F%2B6y1AuQmyzd3kHxRVw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:03.1927402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A03Z&sr=b&sp=r&sig=sxagvVtIgTdCDfMIpLOqnf0N5SrPMqSBA%2BazWPncRIE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:03.1926676","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A03Z&sr=b&sp=r&sig=JDyzg7Bo2KM%2F2oHIgzW0IQ%2FJgWxYBmv2R3eh9SK%2FIVU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:03.192758","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:23:23.484Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.646Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A24Z&sr=b&sp=r&sig=CInloO9587ZDJ%2Fn7KER5a%2F2odODviqhyZlQB0ukrYV4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:24.1611259","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A24Z&sr=b&sp=r&sig=u7wbc%2Bytjl9x1ca8aftOZJZwxMBbgA4HYkvCmTx5%2FGg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:24.1610608","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A24Z&sr=b&sp=r&sig=lRJa4%2B9swEI7VaPOWrB%2BY2Qlq6TIsOS7zMgqYQziPDE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:24.1611394","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3195'
+      - '3194'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:26:03 GMT
+      - Fri, 13 Oct 2023 13:58:24 GMT
       mise-correlation-id:
-      - 6fd6d423-7e5d-45c8-95a6-cb63a464c17f
+      - 7a0d47fb-08a3-4013-af43-be93d542d230
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1814,13 +1238,553 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A09Z&sr=b&sp=r&sig=%2FtggvwwgT8%2BcH2iWd5UqO2QCNvKmkwwFdDsYGbeLCIw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:09.0077076","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A09Z&sr=b&sp=r&sig=3I%2BVspWDhA0avsRAKoPEQVaaK5xScRU7qTU9LtWv9d4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:09.0076221","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A09Z&sr=b&sp=r&sig=cemeBV60%2BcIlHTrhQP74z8zFM%2By%2B31ThAQ0Gn1mMzkM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:09.0077316","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-09T19:23:23.484Z","endDateTime":"2023-10-09T19:26:04.923Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:26:05.823Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A29Z&sr=b&sp=r&sig=NiY5GxtvKJCWUJVZ0qy934dVblnfpLkiKylqw5%2FXso4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:29.4279056","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A29Z&sr=b&sp=r&sig=7GmNoNC0FK195FCK6%2Bc3FBco5WNUGU%2BETG2yuiOHjRI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:29.4278244","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A29Z&sr=b&sp=r&sig=TjYnfK8vK9JySZ6RUzxRw4GA5aRw9XoLEXDD27%2BYeEk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:29.4279253","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:58:29 GMT
+      mise-correlation-id:
+      - 7f1ea153-7402-4d5f-a115-9baff2329333
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A34Z&sr=b&sp=r&sig=N8ssdPa7VZNE6ZXYClywR6WWCUyC%2BshPhdnbUBxm0rY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:34.7653515","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A34Z&sr=b&sp=r&sig=NcgTWWz5AqkusuLU4qYx2SEND%2FT72TMC1mkdHNsKvCg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:34.765265","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A34Z&sr=b&sp=r&sig=lmEpdL2EcKm%2F%2FUD%2BJZv4FcZ%2FBWOTM3eT1YmGUqc3FkA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:34.7653738","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:58:34 GMT
+      mise-correlation-id:
+      - eb8185dd-37e5-45b8-a686-f9df28458462
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A40Z&sr=b&sp=r&sig=FJbCcQR4C66TzM82iRlbbRrDmNRSVPySXa0M1UuqVFQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:40.0801403","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A40Z&sr=b&sp=r&sig=qwhOsUJcoOp5vcJ7lOYyUe9oTxy6iGtsUqb%2BRy95ofU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:40.0800532","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A40Z&sr=b&sp=r&sig=M0B5DFke1JNj7c2g4PfhGpbxdGGAf345CbxNWvKPB4w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:40.0801558","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:58:40 GMT
+      mise-correlation-id:
+      - 7c8bf3d5-84d6-438b-a075-f12cc10095bb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A45Z&sr=b&sp=r&sig=gKVUINPswQbcC%2FNh2wKFGXFCE6PxrqwMOLoVxJzZdP8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:45.8489463","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A45Z&sr=b&sp=r&sig=oQ110Bklh3PBBobsfuByokQkpybV1tSXI%2FD9WJSIxzA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:45.8488779","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A45Z&sr=b&sp=r&sig=N9KscRCMmJpGTICu9BIR0ECH%2BJMczBZf79a7jnPPLO8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:45.8489612","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:58:45 GMT
+      mise-correlation-id:
+      - 6609dc65-395c-4e58-a248-a3fa13a7c300
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A51Z&sr=b&sp=r&sig=uNEZ1rw2Jsxuq2Eos1SLqe9isS%2BFMTiY5bRKj6M8HXM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:51.1594613","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A51Z&sr=b&sp=r&sig=LYKP85Jrns6Pa9%2Fjbh6T7dzBF6dGHa5Z22Jraxab%2BZQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:51.159345","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A51Z&sr=b&sp=r&sig=YZYep0g8zenDALbtcLdN3G1%2FMoaDJEVFZ2ptct3LJ48%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:51.1594851","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:58:51 GMT
+      mise-correlation-id:
+      - 6a1ede3a-cc0a-4999-a674-580407274394
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A56Z&sr=b&sp=r&sig=H9yoBGBfn86CCnDnpq9IbgxHfs150SJjPnFw127Uzro%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:56.4155531","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A56Z&sr=b&sp=r&sig=zwrZSzS%2BqXahMw%2FhRfl%2BJ0NW2MaXhEExTOaBJoBZVzc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:56.4154755","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A56Z&sr=b&sp=r&sig=4%2BUezJ98YFTaDxqiWYYx6LCyKTKXmpuStG4FV%2FnjBp4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:56.4155683","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:58:56 GMT
+      mise-correlation-id:
+      - 3e9e0deb-7cb9-4d6d-a74e-ba163fce1944
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A01Z&sr=b&sp=r&sig=1BB%2FegsBLYM8hYdkvNZIxtwdNrS4GDmoiFbvV2vOBnc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:01.6603659","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A01Z&sr=b&sp=r&sig=EB2HoH9XlrQBwgqFDTlm31OYMFkJBN%2BMlonmKXiQL94%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:01.6602718","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A01Z&sr=b&sp=r&sig=4ciiP5w3nhtReE4FqDahEhvrr4q2sC48nTw%2BkDqQp6k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:01.6603822","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:01 GMT
+      mise-correlation-id:
+      - 3bfa5f87-e067-4860-99a4-5d12ff6adb2b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A06Z&sr=b&sp=r&sig=FPP8gXQ%2FLKyM7ejjRDx%2BW19VR5aeNvzEizlit6VmeMc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:06.9229983","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A06Z&sr=b&sp=r&sig=ccGKJaYWQU34beQVrQykR0kp%2BA1er3NZ1ar2Yy8HaeE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:06.9228933","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A06Z&sr=b&sp=r&sig=4hmTbMoHSIzYGKQXfslO5U%2BxEOsJAgjs22wON4DT4s8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:06.9230234","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:06 GMT
+      mise-correlation-id:
+      - a7ecedf7-c8ee-48c9-b490-c24f7a766132
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A12Z&sr=b&sp=r&sig=jUn5RcjC7nBSQ341bhBrojZyupJHNcK1DgJ63G1m5Lg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:12.2464809","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A12Z&sr=b&sp=r&sig=oQezobBlZkmOWkpy37dU3nL%2FcoyRIBHYle8KlDFm%2BXY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:12.2463751","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A12Z&sr=b&sp=r&sig=MnwxXFw4Ln2lRpbUpj0J3IfjNC0Li2TaKN5aGP0okeI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:12.2465042","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:12 GMT
+      mise-correlation-id:
+      - fdd34ac5-352e-4cb4-95cf-859b787bfec8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A17Z&sr=b&sp=r&sig=ANH13hXXcNUcdWqagZsUS%2FzAuPf5D2js8kD1JKszZl8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:17.4914869","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A17Z&sr=b&sp=r&sig=mP1U%2BMqkqoloEtcZ%2BSS8OHi3gZHzuDCSgHSmopYO%2F%2BY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:17.4914157","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A17Z&sr=b&sp=r&sig=OqggfFdLzYWfsbjt0J7PapBgAmqk8yuGY%2BU5pyr92gk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:17.491502","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:17 GMT
+      mise-correlation-id:
+      - aa1b95e3-94c2-4ce2-82a6-756e4bba6bc3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A22Z&sr=b&sp=r&sig=JOwGQwEvo%2BCYkLAz0oPURtDxfDVweCpIl6aPSPAKBJ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:22.7279088","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A22Z&sr=b&sp=r&sig=B93bnT17RgXto8k9wPE01%2Fsyp9%2F2j4eazHKC7ZvkTVE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:22.7278208","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A22Z&sr=b&sp=r&sig=V5eGH82%2FoA5s52nuEuM4Fk6jSUmY%2BJrI4nPUAodL0vc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:22.7279245","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:22 GMT
+      mise-correlation-id:
+      - d8315664-84d1-47f3-a343-621ab63373fa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A28Z&sr=b&sp=r&sig=pE95JKizlqv%2FlIMV3hThNvpPopzniI1JAE%2BJOLlWqSE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:28.0236106","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A28Z&sr=b&sp=r&sig=HLq7AwmcxYoM6ePMSgetKMbjt%2BWXPGQJ3U6fvGeo4ns%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:28.023523","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A28Z&sr=b&sp=r&sig=Mh%2FNMhBJQ%2FskbgEMUvOGbUvs8Tg25gB0X3CdJk%2Fot0g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:28.0236267","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:28 GMT
+      mise-correlation-id:
+      - 0f42c283-ff60-4157-9e90-505053335ece
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A33Z&sr=b&sp=r&sig=knpgWhdn1ya4igb%2F57LHABiyqyZPi38NuP6u6s0nKi4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:33.3506086","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A33Z&sr=b&sp=r&sig=c%2Brf%2Fmk5Asm9YGP7OnqmpwDsxynr1lcKMdnno28M39c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:33.3504997","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A33Z&sr=b&sp=r&sig=CvvrDZ5iBroUqFsAu3zaZBF1NsDxhl5LDsJcx%2FZDkwg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:33.3506348","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:33 GMT
+      mise-correlation-id:
+      - 2e471a3c-1c58-4022-b9ca-25a7cdc91574
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A38Z&sr=b&sp=r&sig=B3TTiE6U3kiNze%2BUYlKRxKm2KQKUTM4FavoaQo7fZP8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:38.6601903","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A38Z&sr=b&sp=r&sig=4ZczFfWIs0epo01RZ7wCb7faR91v5VgyYKY7mwKrYhw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:38.6601057","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A38Z&sr=b&sp=r&sig=CUAjAqicwXjoK6ummlC5GQ2vEYt06tQpDA06iZ3HRCE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:38.6602127","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:38 GMT
+      mise-correlation-id:
+      - 344374ef-0ace-4f7a-b182-4f55ad02c4de
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A43Z&sr=b&sp=r&sig=mOdndX2p%2BNlD%2BrLmhw9iwVQOuPNSd0A0CCp47v8bTi8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:43.9198317","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A43Z&sr=b&sp=r&sig=x099tmXPfx7YpsPe43CBoq5HwdmAJUcEdc2tWTDjX54%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:43.9197302","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A43Z&sr=b&sp=r&sig=JMKuWMiUmwpQy9SziQFjRoTXxMIzQIZNpbOMReGs11o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:43.9198577","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:09.366Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:53.206Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:43 GMT
+      mise-correlation-id:
+      - 5d003067-33a5-4ef4-adb3-a71e2636afdc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs/list-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A49Z&sr=b&sp=r&sig=nk9jIZAP%2Ba6XnW83KRc3Vn90qtQr8wehiu0ppLwTyPo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:49.1753245","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A49Z&sr=b&sp=r&sig=2dQ2h9fZ1iZ1h6%2BlttEG0UQyoGi7slRYNBKzoOE9h%2Bs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:49.1752349","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A49Z&sr=b&sp=r&sig=%2FLRiPaERVQRCWN7qeq7OR44%2BvO24E8NYmcXjSBsPy%2BE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:49.1753453","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-13T13:57:09.366Z","endDateTime":"2023-10-13T13:59:46.942Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:59:47.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1831,9 +1795,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:26:09 GMT
+      - Fri, 13 Oct 2023 13:59:49 GMT
       mise-correlation-id:
-      - 54b21465-8aee-467b-900c-f749559a10fe
+      - 1ff69579-a194-4615-ad28-f676458bb3d7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1856,7 +1820,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:22:23.8309943Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:22:23.8309943Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:11.5473273Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:11.5473273Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1865,9 +1829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:26:09 GMT
+      - Fri, 13 Oct 2023 13:59:49 GMT
       etag:
-      - '"56009c8a-0000-0100-0000-652452f10000"'
+      - '"d901843a-0000-0100-0000-65294c7c0000"'
       expires:
       - '-1'
       pragma:
@@ -1895,26 +1859,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A11Z&sr=b&sp=r&sig=aZv49sBbo4vaXb3hL0udqpuj3P8B%2BZjrxdU3dPHRt9o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:11.4454278","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A11Z&sr=b&sp=r&sig=gAp4sRjjfFXoNxeKnc966OLM3g4fCKwGqX9kzz395X8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:11.4453402","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A11Z&sr=b&sp=r&sig=VDjN%2FkV8OiWcEhnNvmSbC2I5R59QhXaafyFGVQOQB8w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:11.4454499","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-09T19:23:23.484Z","endDateTime":"2023-10-09T19:26:04.923Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:26:05.823Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A51Z&sr=b&sp=r&sig=ESnrPocPflu2mwqNadYeEcxzRK5wn5eHSxmj0lvPx6A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:51.1324332","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A51Z&sr=b&sp=r&sig=XOXib3Llm9QIFZ%2FVqwrQNsmYsp5db2Mtq2HWMxTemLM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:51.132351","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A51Z&sr=b&sp=r&sig=Ko9%2FWYV46k03sSNQEx48Xpnf6EmnWXogq7s%2Fyd44G6M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:51.1324538","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-13T13:57:09.366Z","endDateTime":"2023-10-13T13:59:46.942Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:59:51.114Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3333'
+      - '3334'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:26:11 GMT
+      - Fri, 13 Oct 2023 13:59:51 GMT
       mise-correlation-id:
-      - ab52da7f-cd55-4e19-b0ad-79766a9f36d2
+      - db70b77b-557b-4fe2-8333-2a662efd0c0f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1937,7 +1901,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:22:23.8309943Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:22:23.8309943Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:11.5473273Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:11.5473273Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1946,9 +1910,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:26:12 GMT
+      - Fri, 13 Oct 2023 13:59:52 GMT
       etag:
-      - '"56009c8a-0000-0100-0000-652452f10000"'
+      - '"d901843a-0000-0100-0000-65294c7c0000"'
       expires:
       - '-1'
       pragma:
@@ -1976,13 +1940,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dde0bd17-a4e8-499d-abc8-9d17296ce719.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
+    uri: https://dc28611b-8b6c-4e7a-9200-c26236c26e3f.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=list-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"73af9c2b-ed02-4034-9a10-831e20d4c103":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c4dc432-850e-40d3-8e36-64a66c6d7004":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"19ad2e87-5597-4382-be43-659c39d4f6b8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/ec8294ab-2634-485f-8a5c-bde3f1537557?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A14Z&sr=b&sp=r&sig=1ztORDiZNth12A02MKMuf3mg710xwLv7dA50kf63Mm0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:14.0110303","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/88c7281f-da96-4f0e-97b9-0fc68139662f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A14Z&sr=b&sp=r&sig=vUH7U3bAYpRCsgkcUw%2Br0n2HFDATre0xLV13REM%2FK0s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:14.0109616","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/619bfea5-ef0e-499c-9007-55856473673f/6f262d68-3fe3-4d1e-95d4-8b89f849e1d6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A14Z&sr=b&sp=r&sig=K3895nqeDDpH5D%2BpDBf8eZqcWdMTkSNNeHL0gSyrljk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:14.0110452","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-09T19:23:23.484Z","endDateTime":"2023-10-09T19:26:04.923Z","executedDateTime":"2023-10-09T19:23:21.392Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-09T19:23:23.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:26:05.823Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"21dcff02-9053-48b3-8d3e-f94737c67bf0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"feff087a-df0d-417a-9f30-5e85216ba2a7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ea26e3cf-d9ab-47d7-a700-f50560e0402d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/1728879f-8ecf-4ca3-b39b-48deb7b85954?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A53Z&sr=b&sp=r&sig=BUfVh1W0UJuIwkHSQLUD7XWie1YfwK7%2BuwOTe%2FPRksw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:53.1473781","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/7dc0ea49-b5c8-4c10-8da2-b5a9fe6fa135?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A53Z&sr=b&sp=r&sig=PUrwN5JEa6Yu4W2Sn3D9JKTLS0tzmj2fmvzoK6GYjAE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:53.1472512","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/83a6838b-5c50-44a8-97e4-e5fa37e5a527/eb062e25-516a-49bd-8ed6-a9a15767deb0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A53Z&sr=b&sp=r&sig=MgUeFnKgr1VNhbOtrR0sKbeLBc2xQIKRIgPWIF7Lw%2BI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:53.1474041","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"list-test-run-case","displayName":"list-test-run-case","testId":"list-test-case","status":"FAILED","startDateTime":"2023-10-13T13:57:09.366Z","endDateTime":"2023-10-13T13:59:46.942Z","executedDateTime":"2023-10-13T13:57:08.013Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/list-test-case/testRunId/list-test-run-case","createdDateTime":"2023-10-13T13:57:08.998Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:59:51.114Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1993,9 +1957,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:26:14 GMT
+      - Fri, 13 Oct 2023 13:59:53 GMT
       mise-correlation-id:
-      - 20686c48-7edb-4499-a3a1-ea96bb3fa25f
+      - 29901350-e809-4ce2-92a5-c9dd65dd66d9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_metrics.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_metrics.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:33.5819664Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:33.5819664Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.1836047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.1836047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:07 GMT
+      - Tue, 24 Oct 2023 12:33:27 GMT
       etag:
-      - '"75002f65-0000-0100-0000-653046470000"'
+      - '"d300ce49-0000-0100-0000-6537b9780000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:56:09 GMT
+      - Tue, 24 Oct 2023 12:33:28 GMT
       mise-correlation-id:
-      - ca5d8877-14ec-46f4-b798-285516a7fafe
+      - f0466664-f359-4db6-ad6e-bfe6fe800ecb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "120"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"ad6239e5-ee49-4305-88ea-6645fb367519": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":
+      {"passFailMetrics": {"4667c381-5ad7-4857-9d62-8ab4a8f1da09": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "45a56dce-3d5e-4f56-b47d-8fa8affc416c":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "6989712e-0ea0-425d-be3b-2e3ced72ea8a": {"aggregate": "avg", "clientMetric":
+      "50"}, "d241522f-d46f-43be-bb57-877d354d4d90": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:09.777Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:09.777Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:33:29.326Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:29.326Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:09 GMT
+      - Tue, 24 Oct 2023 12:33:29 GMT
       location:
-      - https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+      - https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 0b232f4d-5d0c-40d5-9072-a89933a9e6fd
+      - 8856d95f-3822-4a5d-846f-1ea8b67f3bd6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:10 GMT
+      - Tue, 24 Oct 2023 12:33:29 GMT
       mise-correlation-id:
-      - 3143b958-e376-4163-9430-702ab20cb8cf
+      - 316ac083-6fc5-418e-a31a-8ff7f5db6cff
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,10 +275,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A11Z&sr=b&sp=r&sig=zaQ9zyGXO5sYbMh4EYTiyji2uT7RenRb972XxcaUlLY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:11.6174987","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A30Z&sr=b&sp=r&sig=y47XogD9M7wNDgNOAWYd4UMR872MIWlqkwv8WsRmn5Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:30.3546107","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -289,11 +289,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:11 GMT
+      - Tue, 24 Oct 2023 12:33:30 GMT
       location:
-      - https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - f0286cd6-db54-41a3-9862-0166a9a2d924
+      - 9fc3f07b-f577-4fc0-a581-5ebfbaa66cd7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,46 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A11Z&sr=b&sp=r&sig=gVamZ6JHswe8EDGzR5siG4c%2FJuCF6Ne%2F34mI5Ad%2BCa4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:11.8751518","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:56:11 GMT
-      mise-correlation-id:
-      - ad8dadad-1724-499d-8b4e-4cc0d4536865
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A17Z&sr=b&sp=r&sig=%2FtyBNj5jTuuSohdTA96nFiiwYt0gTaZCspBOccjayj4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:17.2120867","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A30Z&sr=b&sp=r&sig=5%2Fhb6IOzud8mVVwzZ1jxs8wfSWEq8lhogiauHGjXPAA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:30.6912413","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:17 GMT
+      - Tue, 24 Oct 2023 12:33:30 GMT
       mise-correlation-id:
-      - 92f61685-35f2-4b07-bbf2-e9c94f34286c
+      - 46f154c5-e53a-46b3-88d2-4d4e0cf1aca8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A22Z&sr=b&sp=r&sig=9vJuuoGoXFGNJiZJLwRphX1eYETW7zK8XONKDNpyrC8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:22.5394417","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A35Z&sr=b&sp=r&sig=J%2BTXPHng3ov6D3zhf0ug7D8GKdtXCx7JbSGK59Y6XNE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:35.9703206","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:22 GMT
+      - Tue, 24 Oct 2023 12:33:35 GMT
       mise-correlation-id:
-      - e541b39c-f31e-4f8d-9fb3-4e15473d70e2
+      - c8b95a4d-06e7-497d-aeaa-69e08714f416
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A27Z&sr=b&sp=r&sig=VQEZEEppFwQVmrYCMff2waSjvChwo3RwrSMqP0wfyls%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:27.8833649","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A41Z&sr=b&sp=r&sig=oHexem5QSIsM%2FxhVcvUdNBDsewr0xENiszzKOJi6ykU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:41.3190722","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:27 GMT
+      - Tue, 24 Oct 2023 12:33:41 GMT
       mise-correlation-id:
-      - c99695b7-df89-475e-9697-bacada542973
+      - cd1a6e3b-396e-4220-abd1-a34d0e58f2c2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +421,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A28Z&sr=b&sp=r&sig=yxvQNIRr3aLdtmm%2FJx7A1HVSr79cppx1CpbtHXF9TYw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:28.1485841","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:09.777Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:26.055Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A46Z&sr=b&sp=r&sig=5efsOx%2Fz%2Br77k%2Fke%2FGEHW5C1mEt5q3ksDFxdcElrtPE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:46.6008817","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1581'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:28 GMT
+      - Tue, 24 Oct 2023 12:33:46 GMT
       mise-correlation-id:
-      - fdab9b09-f4bd-41de-a1d5-241b30aba9b3
+      - f86d26ad-9a9f-4d4f-917e-6e5f6a52caca
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A46Z&sr=b&sp=r&sig=b8x7SVLPl2pS22bf%2B6tp23r69LRPOmkBKRdg3B%2B7SPU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:46.8864435","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:33:29.326Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:44.593Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1583'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:33:46 GMT
+      mise-correlation-id:
+      - 2464903d-85ae-4b44-b47a-d5e56710fcfb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:33.5819664Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:33.5819664Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.1836047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.1836047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:29 GMT
+      - Tue, 24 Oct 2023 12:33:48 GMT
       etag:
-      - '"75002f65-0000-0100-0000-653046470000"'
+      - '"d300ce49-0000-0100-0000-6537b9780000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A30Z&sr=b&sp=r&sig=CMlRYP8jnzs24zY3w5IwqP2BQ77Z5NVF8XeTnW1qvBM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:30.6377865","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:09.777Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:26.055Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A49Z&sr=b&sp=r&sig=qQpbyZJjwFPtsAuDJoV4XGIqhMA2enT3UAZ7%2Bm66yTo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:49.3658443","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:33:29.326Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:44.593Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1591'
+      - '1593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:30 GMT
+      - Tue, 24 Oct 2023 12:33:49 GMT
       mise-correlation-id:
-      - 2fdb5610-bad4-499c-ac10-7c7d7254b849
+      - 18815837-ef27-4363-8ffc-d2731bc56b55
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:33.5819664Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:33.5819664Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.1836047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.1836047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:32 GMT
+      - Tue, 24 Oct 2023 12:33:50 GMT
       etag:
-      - '"75002f65-0000-0100-0000-653046470000"'
+      - '"d300ce49-0000-0100-0000-6537b9780000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:56:33 GMT
+      - Tue, 24 Oct 2023 12:33:51 GMT
       mise-correlation-id:
-      - 9f028389-eb76-4f8d-9b90-3d91d08aeb1c
+      - 594230f3-2093-4796-8b79-8679be26f877
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,10 +662,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A34Z&sr=b&sp=r&sig=7w3Pz63mTdsYOVGykJg0Q%2BT0%2BltM%2BeEiIaWf2OLHdmU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:34.8481443","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A34Z&sr=b&sp=r&sig=MT9o6JVIpRRw4NHCaxJAOJAkJJ7Q0FxfEdeXQKZoLgQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:34.8480253","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A34Z&sr=b&sp=r&sig=mgvAdrGs032LSAjWW8rdADqL7Hnzrz2S19tGz7hEYvw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:34.8481698","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:34.775Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A52Z&sr=b&sp=r&sig=ZFzMGBvQiiW6vSR6HcEimGrU03sgaTaQky7nPVMwxpU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:52.7045123","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A52Z&sr=b&sp=r&sig=ob8Iyk6QQQOHP4xINAYtSTGXLpLYQldSmxUbhCS7loE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:52.7044068","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A52Z&sr=b&sp=r&sig=VgXoyUC2jQY%2B%2Bae5%2BbI11KZso8KNrUl0hdR4espGumE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:52.7045324","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:52.631Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -676,11 +676,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:35 GMT
+      - Tue, 24 Oct 2023 12:33:52 GMT
       location:
-      - https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+      - https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 71f5c8ae-7751-4dec-a453-dfa8c942fdb9
+      - a11c7a56-95eb-493b-ae61-89b5de94a3ff
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A35Z&sr=b&sp=r&sig=%2Fz2r9rp2Irhi7haMP9%2BED%2BsqySlzUIyKLLF9z4teCJU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:35.3541301","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A35Z&sr=b&sp=r&sig=3nSpJqblgqSK4vYHVpaUEh7nFq4W%2FCQ%2FQG8AY3lqIVk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:35.350744","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A35Z&sr=b&sp=r&sig=z697IfPyYmVVLYo8FsIgdrnGxe3Oa2CZUZbE8WwWBnU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:35.3541585","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"NOTSTARTED","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:35.199Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A53Z&sr=b&sp=r&sig=M83S88ZXykn1uEWLUtPyFNnRcINFtzqx4c11ghnZrtc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:53.1999864","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A53Z&sr=b&sp=r&sig=jEl9O0keiBkQcarDTSYIYwWrMGkzAvfam4okEUsmDYg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:53.1998977","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A53Z&sr=b&sp=r&sig=REqkc1IzKUcxkwpNs%2BRHHHle0%2BuwpS9x9ZjH9RWts8A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:53.2000077","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:52.631Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3204'
+      - '3154'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:35 GMT
+      - Tue, 24 Oct 2023 12:33:53 GMT
       mise-correlation-id:
-      - ddf32ff9-a172-4460-b882-e8bffb1dbc99
+      - 37c95afe-4d83-4b76-b52f-6a47785518f2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A40Z&sr=b&sp=r&sig=rpUjLvn0byxJj54EPffjzTIlM7tH8d1hioZ5J3M7SuM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:40.6106448","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A40Z&sr=b&sp=r&sig=J5Cnw7KiipFrj7zMYEbYtM6Zlm%2FTypOFzxW3Kjw9Wxs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:40.6105499","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A40Z&sr=b&sp=r&sig=YY9NAs7Qvrxe4s%2BuUmeYgUYSonScbyppR2TxGvilILw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:40.6106655","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:35.374Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A58Z&sr=b&sp=r&sig=DeQYCKzHr761H2cEj9YXLuw7CdKXuIrpa%2BswuvA2R8A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:58.4569904","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A58Z&sr=b&sp=r&sig=aMSUrxQq9Tu45xGgPk3R%2B5PzaTftS17N2uJTQN6h%2FAY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:58.4568969","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A58Z&sr=b&sp=r&sig=FzpuEyFAiyAZ%2FM4gdb0I%2BwcKRM2kBptjtEv%2FQmTdvWs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:58.4570393","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:54.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3201'
+      - '3209'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:40 GMT
+      - Tue, 24 Oct 2023 12:33:58 GMT
       mise-correlation-id:
-      - 2c2c2fa4-d043-4228-9b14-2aabf2b81a71
+      - 8534bfec-40dd-4519-aaea-2759773a64b2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A46Z&sr=b&sp=r&sig=X45E2kZmgKofL8Os5yxqTdXa5%2BRV8UlhgVZ8zDNoFTg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:46.0718124","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A46Z&sr=b&sp=r&sig=zySXV4zzW6vuDVeNsbNZMpNHd8iRuxluHpRc1mZht8Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:46.071745","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A46Z&sr=b&sp=r&sig=8iQghm%2FK12S8a5RCE3PJ6AH%2BAhyrnS%2FeKqGFccw3cxg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:46.0718264","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:35.374Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A03Z&sr=b&sp=r&sig=LcP%2FzyFIf8YzHAQ49s92ClgDGN%2FpcVBz0WECsJvDlEQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:03.7544078","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A03Z&sr=b&sp=r&sig=j8TpMrvsAxb%2Bc5Q2umRzM0Yv%2B6CT50z4eBwILQ3rDg4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:03.7543295","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A03Z&sr=b&sp=r&sig=d5PLvpb94PszaWq%2BfXX2uYa8kGO%2BuXLaDTPX0TgDLKY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:03.7544241","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:54.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3204'
+      - '3209'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:46 GMT
+      - Tue, 24 Oct 2023 12:34:03 GMT
       mise-correlation-id:
-      - 7bc02d99-0aff-403e-8318-ee70cf914839
+      - 08f29ee9-2c98-4c2f-a82c-2d2531682069
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A51Z&sr=b&sp=r&sig=YGgdrILZZuRTGaqImFEqbIpSINhrDxWycJT6sPUBnug%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:51.3306555","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A51Z&sr=b&sp=r&sig=sQRKz5LYOi%2BbHTJIvc%2FUnAdFw0NO0LGb3eWPMRdgiCM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:51.330559","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A51Z&sr=b&sp=r&sig=ltVylZdnf1mbpMq6dasiGrXGXsARj6Mzmfb7AZJMHOY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:51.3306706","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:35.374Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A09Z&sr=b&sp=r&sig=cxTKTCVRh3T3zT%2F%2FCLMLXTWXkIME1CSmB0q4TCfCUck%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:09.0951432","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A09Z&sr=b&sp=r&sig=pmvRN%2BPHcW%2B06Df7Qp4ZiY%2BQvOkVqkPeMc1ZHFxYIvA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:09.0950356","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A09Z&sr=b&sp=r&sig=5g6QUGGZR22GgcMpxkIynRauiFHNR8RN2Hz0bH7M38w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:09.0951651","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:54.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3200'
+      - '3207'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:51 GMT
+      - Tue, 24 Oct 2023 12:34:09 GMT
       mise-correlation-id:
-      - 28b2c785-c2c9-4a3c-8a13-42aac052cfb8
+      - 48941b5e-8d6d-4bb7-a0a5-b3c8c9cea1b9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,46 +844,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A56Z&sr=b&sp=r&sig=50B1Ciumn8%2FIOQbw7dX2PG91ot0%2FGhm93707ku4v%2FEM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:56.6075814","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A56Z&sr=b&sp=r&sig=RzNab5I6elUl4ppVOaBRE8dojagzflpoZDw3mDNABLI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:56.6074923","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A56Z&sr=b&sp=r&sig=t1UypXwA1gAT057f9HRWlzNVDMOG75dwBMtJ9SUq12E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:56.6075997","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:35.374Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:56:56 GMT
-      mise-correlation-id:
-      - 5b73e8e6-6ab4-4686-a77e-735dfb368c58
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A01Z&sr=b&sp=r&sig=BGDZVc9C0hRXRbdS69UN4QbC8UqfGF2NBqYY339eR%2Fo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:01.8787855","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A01Z&sr=b&sp=r&sig=xkPfW1esJbUucSPCschwGPkdTJRU41%2FKU%2Fa5KI0Lh2M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:01.8786876","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A01Z&sr=b&sp=r&sig=2i6ovb1qLZkByHCWJuUrZlOy6dkJbcwnr7CUkC0z%2BoY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:01.8788071","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:35.374Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A14Z&sr=b&sp=r&sig=uan5rK5M3njWIFss20%2B3u%2BCEGSE8GEP3Z0Mr1chWxXw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:14.3973229","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A14Z&sr=b&sp=r&sig=vvgiDN87wRGTEM4HKUd519n8B398UxBmQj2Vaz4%2BlC4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:14.3972355","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A14Z&sr=b&sp=r&sig=1IAopfZepzflod8MPtpTT7YnYY%2FdqHmAk9NfwKpJdV4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:14.3973447","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:54.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -894,9 +858,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:01 GMT
+      - Tue, 24 Oct 2023 12:34:14 GMT
       mise-correlation-id:
-      - 61e7d11d-5a55-41a6-bde3-00a82f07d374
+      - 44594c95-a7b2-46c3-9a0b-ad8ac9d18008
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -916,23 +880,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A07Z&sr=b&sp=r&sig=XwKE%2Fzx3lRIPd%2Fr7KlwigchorFZ%2Fd4Q3IlNC7e3s9Lk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:07.1411548","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A07Z&sr=b&sp=r&sig=j%2FZ0xUG%2BBzRkFIpYOOP2aTafP4Cy%2B3LgG7n9%2FaeCluI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:07.1410664","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A07Z&sr=b&sp=r&sig=woa%2FebwCYdkZ3wpeXkaZ%2BGK%2BI79VzyKS37uL%2BgrQ0gU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:07.1411774","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:35.374Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A19Z&sr=b&sp=r&sig=%2FGeiI6Qe6dfQdh%2BA%2F6r9q3bwOeQZ4RSYdsjrEQVXdeU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:19.6718026","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A19Z&sr=b&sp=r&sig=kpdYrwWkdphZwkJHaeztFzWSJ0wXxSyRMxLotwTgqxs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:19.6717142","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A19Z&sr=b&sp=r&sig=aCVObohdQlrvwphh%2FsSeMipkUz%2FW1tQEaDexYT2wGb4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:19.6718238","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:54.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3219'
+      - '3207'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:07 GMT
+      - Tue, 24 Oct 2023 12:34:19 GMT
       mise-correlation-id:
-      - c563d222-b185-4e19-b0a2-1d41feb4d26b
+      - 3e5e9617-50a4-4094-b4cf-959c6c5176ef
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -952,658 +916,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A12Z&sr=b&sp=r&sig=WsOuz1F6pgqeWi%2BHALV0tydF5m2xGaUOKGAjPRDnOao%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:12.3943727","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A12Z&sr=b&sp=r&sig=9tu83NRnlaLdJ1fFG%2F2CAYRIGzCupgeqapEEEbXSU68%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:12.3943018","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A12Z&sr=b&sp=r&sig=Q64%2FaiRqqgZtZIz9C9uE3%2BtvqwCuYxcOCh6TdqKkqVs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:12.3943872","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:35.374Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:12 GMT
-      mise-correlation-id:
-      - c653e229-cc5b-4587-b311-c7f15a413ce0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A17Z&sr=b&sp=r&sig=W4OtS%2F4he%2Bx29aKo9GTNa%2BhiZ1jeeTXqW8YHqSxJOrM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:17.6819623","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A17Z&sr=b&sp=r&sig=V3YnQ6k37QMsdA6B59tyeIRRRbq%2FJ5i%2FXGW%2FLX2%2FrOM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:17.6818634","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A17Z&sr=b&sp=r&sig=e4Agi8r5fhc214NoJ4gxEvm0eRtkypXIJDxhOJ0%2Fq%2BI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:17.6819789","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:35.374Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3215'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:17 GMT
-      mise-correlation-id:
-      - 83efef63-3e3f-49ca-b2c9-7ce89b440a2c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A22Z&sr=b&sp=r&sig=%2BvlJuMCcc1w6qF%2BZl42ruqLqvfMWbwE12FlcfgUG%2FvA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:22.9685351","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A22Z&sr=b&sp=r&sig=9YlZB03Rrq0usoYhiigJtrY3tySjgqZ0mUNAC5jzsaA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:22.968469","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A22Z&sr=b&sp=r&sig=a81OvoxuUQyxdJm4RPXThEXEYOCtNgvsd%2Bl%2BagOai6Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:22.968551","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:22 GMT
-      mise-correlation-id:
-      - e431354a-2441-4057-9665-0ee469e86c35
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A28Z&sr=b&sp=r&sig=ocgRyqQhX1TB5MI%2Bp3b1dC62LZBYPGHll8f5j7cgQfM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:28.2329199","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A28Z&sr=b&sp=r&sig=KsJ9Gb5jIh%2BhRZKgzUpjHoNEvkWoMdgIjpIkE01DakM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:28.2328462","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A28Z&sr=b&sp=r&sig=6Ne8hCjR%2BPAKF23VB0v3WcMoF%2BGQPNeIGrozYiQ%2BFSc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:28.2329346","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:28 GMT
-      mise-correlation-id:
-      - c2348554-9afa-43c9-bbed-03863f5d33f8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A33Z&sr=b&sp=r&sig=HMhTHQyWHkf9U2kCKJNbeL53llBxUdBFuj184i0qE4U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:33.504429","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A33Z&sr=b&sp=r&sig=t3Grauq7MPLLG%2BgfiFwnO%2BlJtTkqgDItDFdfkyE0Qf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:33.504352","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A33Z&sr=b&sp=r&sig=WnYfYzyVmiy8FJ5PpOtCbcI2jg3JTXaPC87qy5Yb8pw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:33.5044431","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:33 GMT
-      mise-correlation-id:
-      - 1ef674de-a20c-484e-996b-27cdd0c98ddd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A39Z&sr=b&sp=r&sig=6t0cH6OeJNTXS6sTD5QDEA9fJhmDa9rKgaTbN7NG%2FrI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:39.4050284","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A39Z&sr=b&sp=r&sig=ffEw4sy3QO36wvwKnT%2Byym5nefTuky9kbjvVBmiKy0c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:39.4049546","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A39Z&sr=b&sp=r&sig=C4DkFtMIpCUwowFf6Cu9t%2FRKgFqVjxokl14Ms239jbk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:39.4050428","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:39 GMT
-      mise-correlation-id:
-      - 887c3924-bc0e-4d2a-a715-61ba726e5ac0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A44Z&sr=b&sp=r&sig=iAj1qxteG5mHSSf3VSN6RgOkSwL%2FcTX8E2WCSt7j84E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:44.6758549","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A44Z&sr=b&sp=r&sig=2xj5V4SzI5i9EuoGz%2FpKIGsRr4gWi5A5kI77gjz83Jc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:44.6757704","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A44Z&sr=b&sp=r&sig=j1OoXPlhCU4SesmnF%2BJH75ZYlSWmKbxGAPuTz5T7MuY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:44.6758762","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:44 GMT
-      mise-correlation-id:
-      - 5114bde9-a9b4-440b-bdde-7c24cc71f36b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A50Z&sr=b&sp=r&sig=yRyAFApK0LGPquZQmgpH8nzQcCdDBTatrfaxqg2u%2B%2B4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:50.0081717","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A50Z&sr=b&sp=r&sig=xVH1U%2F9D7lBVtZp4bMkVTI8YQR%2B2dD3PaTbHEvzH2x4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:50.0080843","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A50Z&sr=b&sp=r&sig=ix6g9GkpW0RzaVyAeX1umBDkLqgY8R6T%2FqOS3qqk7lM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:50.0081862","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:50 GMT
-      mise-correlation-id:
-      - 0b1d4ad3-ec57-4073-a9cf-fa32c5421f39
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A55Z&sr=b&sp=r&sig=aIbKy05OzCDJJejefTI%2BLD35KkiBcgy4GtYVZp10Oyc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:55.3494507","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A55Z&sr=b&sp=r&sig=y%2BzGUQkZSEGupv94IIPghutpZ886DpXV4MGjEMz2H9Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:55.3493782","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A55Z&sr=b&sp=r&sig=pWcbL5Ib4aoPcYDCbFFkWV%2FMR3YugOAx7xR00mOJ6QM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:55.3494651","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:55 GMT
-      mise-correlation-id:
-      - 84dacb78-0a2d-441c-81a2-b346c3936e5f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A00Z&sr=b&sp=r&sig=ryZmJ7GvpVXKJ8j1k2pPAkXICgn%2BO4sFElSUSRJhGKM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:00.6707564","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A00Z&sr=b&sp=r&sig=pNVFgLWEnaQG0jtYkpyGrH0yUwyPRxyxeU%2FuS%2BK3ATI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:00.6706748","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A00Z&sr=b&sp=r&sig=Uqo%2BaXNbfQBThimVMxeKwSEQ3%2BLysL2Yil996NxV6A0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:00.6707762","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:00 GMT
-      mise-correlation-id:
-      - 3b39954c-d58b-418d-8f23-157d6f943fda
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A05Z&sr=b&sp=r&sig=x1l6td0MA9u3G0cU0xVAtgWfbmzTN5gEKA0NjdqPikY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:05.9881313","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A05Z&sr=b&sp=r&sig=%2FxvEQ%2BgJgrXDeHuuqXb3FGpeu6OlmOeRCq7PjDaDwf8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:05.9880354","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A05Z&sr=b&sp=r&sig=yPOC%2FhGPrXYjKm%2FUc%2FCDDrp5at3CE4gR5YALdLfCkf0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:05.9881451","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:05 GMT
-      mise-correlation-id:
-      - 78f0fc96-9de0-43c1-93e3-61aefcc7a231
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A11Z&sr=b&sp=r&sig=O8bV5yGbq2V1tQnf%2Fz3ZOKkiJ0VHYiPHD%2Fw8K08dAsI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:11.2899386","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A11Z&sr=b&sp=r&sig=Ho9Ts%2BvjPeZm1fSFhHeZ9ZU4xtQ09VGBm53sKmYqx6M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:11.2898613","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A11Z&sr=b&sp=r&sig=xXJDC6czPgbgVnRKY3aA64uvWd1LTljIPYLNns6Swj0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:11.2899524","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:11 GMT
-      mise-correlation-id:
-      - 186d3fcb-7505-4816-ac74-2f41a7ed921b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A16Z&sr=b&sp=r&sig=3oeHK3q4qf4QSkZpYfG3D5OvbxzowaCdIIHv1ZhzIbs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:16.5510985","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A16Z&sr=b&sp=r&sig=jIdR4cOI7YJvWh7J3GXw9hA556Cyf4FpfcO32ieDQf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:16.551014","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A16Z&sr=b&sp=r&sig=7aTdPrO5yfFYMdLlsQ54zEyD04fgUfh8WbhEfiFuU8E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:16.5511127","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:16 GMT
-      mise-correlation-id:
-      - c53d7186-e65c-4843-b088-fa97d2a69156
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A21Z&sr=b&sp=r&sig=4H5QXBvYngjYeR1P27MkhK26OEk10caplzJM14sVJvo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:21.8125297","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A21Z&sr=b&sp=r&sig=wNhwH5HhmFPJagGQFDQt0RrTt0NsiwBJ5OiassIvtN4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:21.8124067","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A21Z&sr=b&sp=r&sig=pnt%2F7S4RjdlUcYSiHKVyqtXsPckwW0cVtDWQAAdwS3Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:21.8125478","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:21 GMT
-      mise-correlation-id:
-      - 8a7618bc-f6ec-4c25-ae86-9cd4700bda07
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A27Z&sr=b&sp=r&sig=b04PNZCDW2CQDZwS4hDYEwdhUZkZVpBZ8qNfMwaLLWM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:27.1052861","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A27Z&sr=b&sp=r&sig=uAiMmGYU4VE2cfQ1emAE5iYffK8jMwfKOu6QLGZVkXw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:27.1051816","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A27Z&sr=b&sp=r&sig=knR3vhb3ku5Ih22QI7nrpiAkmS1HhgiDx%2BXl7wIyVos%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:27.1053095","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:27 GMT
-      mise-correlation-id:
-      - bee41383-9818-4feb-b9e9-a2da6cb21508
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A32Z&sr=b&sp=r&sig=RpjM8XsqKgQOAp4XUobvcXrJVZq6Ft%2BEvywM3gsnExo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:32.3888212","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A32Z&sr=b&sp=r&sig=2aGRlMzSp4PD%2BqzIq3Yryx%2BfreukNJRjh23oB188vUE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:32.3887518","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A32Z&sr=b&sp=r&sig=5lbacI%2FRDLSi3DvgfAPQBiNnqP%2Fxro%2Fkkas2EO44154%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:32.388835","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:32 GMT
-      mise-correlation-id:
-      - 5d515e4b-faee-40da-86a2-e59cfe99b064
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A37Z&sr=b&sp=r&sig=w6nOPUHiNk5lBQpKuZY7pjdWcZEKNuYx6y5MbBA08KU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:37.6444164","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A37Z&sr=b&sp=r&sig=3cieKIrjP1PNkiIECvBUENlOPCjqNlY%2B7XPDzOgzHkU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:37.6443461","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A37Z&sr=b&sp=r&sig=xGQyjpnnLflEHYvTGgCXW4CMQkbEz5H0Ws0tI%2BlFsSc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:37.6444299","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:37 GMT
-      mise-correlation-id:
-      - ba73a18a-5d06-4bb7-9922-cc53057a39c4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A42Z&sr=b&sp=r&sig=7zJVZ87Ktoj03Hu35mbavbKrg1O9wo7ea%2FZGCK8EiA0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:42.9640885","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A42Z&sr=b&sp=r&sig=O0ePefkiNEYOdYXKuQ6pS2FktH6ZA63MdWnXpgUstPw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:42.9640194","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A42Z&sr=b&sp=r&sig=ud7y%2B4SCYnUffmpjqbZJ41hWLwSDJkMd25bcKHwUtzY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:42.964103","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:42 GMT
-      mise-correlation-id:
-      - 65b93c27-d88c-4cc9-ac87-be48091c2cfc
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A48Z&sr=b&sp=r&sig=i3vdMfWUuJDuWcaaxf%2BluytCBiDL5O4bte%2BBsBr6oG0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:48.2801476","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A48Z&sr=b&sp=r&sig=CK38SDE7%2BtUM3SOfQUYFaCzBWQQofzHzLtssnCBKDOg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:48.2800727","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A48Z&sr=b&sp=r&sig=oXGZwQa7l2Bljaz%2F%2B8hJHo27MO9NeX0q%2FzfjDC4GHl0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:48.2801627","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A24Z&sr=b&sp=r&sig=be%2BR3n8quhQR1ecxpyN8aXEY7262LiTVoEemFDgUT%2Fw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:24.978679","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A24Z&sr=b&sp=r&sig=6ZUFKutD1ebfqVrqhQkp%2F7nW0D3lTSDjezaPBKP7qsU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:24.9785937","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A24Z&sr=b&sp=r&sig=GFESsuFQcs1%2B1vMQQ7QQ70h19QMMZTqKP%2BWql9SDDDY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:24.9787006","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:54.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1614,9 +930,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:58:48 GMT
+      - Tue, 24 Oct 2023 12:34:24 GMT
       mise-correlation-id:
-      - 040f9d76-07a6-4a2c-a264-4995f294fda7
+      - 72fba203-9ad2-4d09-8c7d-6d8d77bf1a2f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,10 +952,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A53Z&sr=b&sp=r&sig=CWNg%2BUTivG23qHglhbzgmFAtYoWAqKfh%2FrHT%2FF6vLtk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:53.5949422","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A53Z&sr=b&sp=r&sig=EdvHeZy8bPijfHgfnM9GQ3T1JWzBIHkQvqL0d9MWOAU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:53.5948674","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A53Z&sr=b&sp=r&sig=Mz501hKxHuOpowT2xU93%2BqifWlYsMuCTLhxpt2tLhvc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:53.5949565","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A30Z&sr=b&sp=r&sig=qME6L6rzD4OlZZF4ue2NOgoMMmJTbzm08KFgv1lLLjk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:30.2977805","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A30Z&sr=b&sp=r&sig=Wp%2FyGJUQsAn0xum4Ouccrgki6ozKkqt0vh9PX7vc9eU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:30.2976923","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A30Z&sr=b&sp=r&sig=vcXPOxWcyp1ktf%2BH898SQ%2FfpIfBhbc9nPzlWapFcQg4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:30.2978012","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:54.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:34:30 GMT
+      mise-correlation-id:
+      - d4935101-397e-44a7-b609-96b2bbdffde2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A35Z&sr=b&sp=r&sig=oIQRzh8v3PFBnCDgdLOKX6j9MMQNy2t9ZLNKOTGU6eI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:35.6276096","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A35Z&sr=b&sp=r&sig=FY14csWbO13Mbk%2BkahMmPIvL%2Bed4yJGOs1ROQjRrkE8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:35.6275332","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A35Z&sr=b&sp=r&sig=bEyR4%2BwbDuXG9gp1TsgxlCsgUivjtMvJEEqvEhyGccA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:35.6276244","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:54.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:34:35 GMT
+      mise-correlation-id:
+      - 3b638aed-cb86-4537-a0a5-aaa162155d32
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A40Z&sr=b&sp=r&sig=2LZzI2RCbmL9Fwb0ISOKFdnP8vb1cVvVsYcSoa%2FSIig%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:40.8929159","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A40Z&sr=b&sp=r&sig=7zQjrnJnYVoyaH3r%2BzebY4MaCYPskTqYS0VHGd14m4A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:40.8928296","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A40Z&sr=b&sp=r&sig=sg8Rc3LM42b%2FMDwi8TXUGW199YkaIWsoobjotEzzZhg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:40.8929336","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:37.933Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1650,9 +1038,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:58:53 GMT
+      - Tue, 24 Oct 2023 12:34:40 GMT
       mise-correlation-id:
-      - 65575ee6-d9a2-4ba6-8fff-19fac73d05d8
+      - 32cb04d5-b4d2-4913-be06-d09684263145
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,23 +1060,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A58Z&sr=b&sp=r&sig=8Lo0NlX2r2sC9SpmrbsTwojnuJvNgYQBpabT0JLGST4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:58.9301931","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A58Z&sr=b&sp=r&sig=yUJ7dbrNenvZAsd8pjjJ8h5eTmQmlg%2B8c0uUWasPhxg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:58.9301257","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A58Z&sr=b&sp=r&sig=92qj69MCYNGDSJxToBxQvxarfjUeHWxrSwhfzUtz2ZM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:58.9302078","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A46Z&sr=b&sp=r&sig=FXiROE9r3IL07m925HtArLzHXocn0bWgY56Wuj%2FWYok%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:46.1665265","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A46Z&sr=b&sp=r&sig=uaahWJdXd92uRJ%2FBRW%2B5ZQxlTiPdjZX%2F38ymjlfSXp8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:46.1664409","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A46Z&sr=b&sp=r&sig=41pnh9uwkccIt5QhEnmG%2BueDRB9WYEfJhWH%2FpQC1gc8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:46.1665479","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3196'
+      - '3206'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:58:58 GMT
+      - Tue, 24 Oct 2023 12:34:46 GMT
       mise-correlation-id:
-      - 25077ab2-e933-4e9a-baed-39830e40389b
+      - d8b21d8d-ff76-49be-86bb-f3e3ce104cd5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,23 +1096,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A04Z&sr=b&sp=r&sig=gxE3YER3LsFZThGF6Ig5RXvyc9mUaJAf8%2Bgr21GtPLo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:04.220941","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A04Z&sr=b&sp=r&sig=L9hFqtDNgKrii7jofE8ZjLKkk1v01UOJjvS9hF3cwSo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:04.2208707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A04Z&sr=b&sp=r&sig=beLNQHAPELEp8mxQCLicJR5uhmt5u%2FQF%2BfZFARoTMGI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:04.220957","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A51Z&sr=b&sp=r&sig=VujOfdYHQEfF1D%2BwZaykGnmeX9j5hu1n8IppO6wZuqc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:51.5068558","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A51Z&sr=b&sp=r&sig=kTVg9FIKbrYDx%2B6l24Q8t7YDHqzHO8rdBS5AFxCpg5k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:51.5067852","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A51Z&sr=b&sp=r&sig=FgQeDezttj2GWAnsvDDS33qFHB%2Bq77%2FzsSqlrRfP2CQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:51.506871","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3198'
+      - '3201'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:04 GMT
+      - Tue, 24 Oct 2023 12:34:51 GMT
       mise-correlation-id:
-      - 8cbafec8-5fe9-4644-9240-4bad4cf877ea
+      - 48cf1864-f905-45f9-bee5-965ed771fb94
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,23 +1132,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A09Z&sr=b&sp=r&sig=gaW6y6RSIB8sKzGHiMpazTC41EuL%2FEf4Bv4ndd%2BdpA8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:09.4796312","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A09Z&sr=b&sp=r&sig=O8lTYkIsgOVnBhvJdbuxZtVHVpmz26aNli%2F6i043a%2Bk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:09.4795598","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A09Z&sr=b&sp=r&sig=q1nE8%2F7s88ZkR%2BlBB%2Fx3LyKaXyzwTSvv3J%2Fd0V51NiQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:09.4796782","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A56Z&sr=b&sp=r&sig=NJyC2VniR50az03R1gm4hnYxPw7H1MGPSNrb3PuvbVo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:56.8086985","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A56Z&sr=b&sp=r&sig=B0fgpoeTbfBZ13adbTJmSkzbbyGBV0eziHmTASPh470%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:56.8086051","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A56Z&sr=b&sp=r&sig=fgV45T8EvoR03IrPN6YadNkDMhkMnZtAq%2B3jugn4V9s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:56.808714","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3210'
+      - '3195'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:09 GMT
+      - Tue, 24 Oct 2023 12:34:56 GMT
       mise-correlation-id:
-      - 087e4b35-943d-4ec7-ad11-019e3a8389c5
+      - 955f0354-8fb4-4c69-882b-66bd971081b0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,10 +1168,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A14Z&sr=b&sp=r&sig=8m6OPnKoeh4yOy2RFORRe6Yrc3%2Fc%2Bxmd9Tt9zECw8mk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:14.7884809","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A14Z&sr=b&sp=r&sig=SJGLxbDXC8x4r%2BiNnCb9vKZ%2FMlrxz2oqEs3ejN66dS4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:14.7883711","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A14Z&sr=b&sp=r&sig=0bXjFIjPurbJzpRvo4diM46b%2BQiK%2FGdq1A%2FvWv1k2kY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:14.7884956","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A02Z&sr=b&sp=r&sig=YlPGqilFeymLyK48lfUyFY4J%2B5HvO9viJkcLzocsVnE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:02.0864822","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A02Z&sr=b&sp=r&sig=k4Q1QFd%2BLfvH4KW4hC6q7PyKOFxmdXds2bz%2FlBS6foU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:02.0864044","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A02Z&sr=b&sp=r&sig=KZj21FMrUwdct0phtdnSM%2F1vyExMQmdaSmcwu5HGGjY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:02.0865037","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:02 GMT
+      mise-correlation-id:
+      - 6fde9546-5dfc-41e3-b0c3-4a6c65a66bcf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A07Z&sr=b&sp=r&sig=u4JeTvzx0dCa1%2BAZICpER%2FINs2mM0C5XW78UmHvg%2BfE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:07.3574265","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A07Z&sr=b&sp=r&sig=2PZbi7kqgi9Fxy%2FE8zAAS%2F9hCXiZFT14AYBlNHzNfiI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:07.357359","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A07Z&sr=b&sp=r&sig=Rpo%2FLY9cSkM7hRMSjSbT7%2FalRYk4phS5d9pvTbugNkQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:07.3574411","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3207'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:07 GMT
+      mise-correlation-id:
+      - 87b7fb6e-1792-47b4-bf39-103fc1d04932
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A12Z&sr=b&sp=r&sig=ddp8RaqjqRLyhCRGKJz69b%2BxNEP6Iy3wQd775tzyrSQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:12.7081593","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A12Z&sr=b&sp=r&sig=G5FlRhFt41lq8paTKVi6xchkwnP%2F9%2BJH%2FV4%2FTdZZOqU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:12.7080677","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A12Z&sr=b&sp=r&sig=0HY5sszoXbT8FIUsvLv56%2F6bCKVOx%2BE5zJ2Xed2dbiQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:12.7081819","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1794,9 +1254,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:14 GMT
+      - Tue, 24 Oct 2023 12:35:12 GMT
       mise-correlation-id:
-      - ba8a67c8-6e2f-4a82-aeb7-61239b992474
+      - 65d831de-43e5-41e0-a6b3-9362205f2711
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1816,118 +1276,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A20Z&sr=b&sp=r&sig=e1QF%2BA%2Fy%2F2bgJCVySanAkGnkSwDET93296lm8tAAxjM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:20.1238007","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A20Z&sr=b&sp=r&sig=9VUlw6SafzTWGT0X2zAWgdfPj2Mt1uDiHR0qrgBuHe8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:20.123722","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A20Z&sr=b&sp=r&sig=JbhLXg56aqSbhtszNEJOMZYGrekhXlJQ9yozAkIIJBI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:20.1238142","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:20 GMT
-      mise-correlation-id:
-      - 55fde5f2-0651-4c4c-bead-63824d925061
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A25Z&sr=b&sp=r&sig=kMQVw3F0IygfnWvrWOI7mYTl56Nqi1cqfjxzBmMic2k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:25.4095617","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A25Z&sr=b&sp=r&sig=DYuAZL1Xa7tu2GHfnthJkYs4cNyZKe4CNK0rCN0zvl0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:25.4094818","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A25Z&sr=b&sp=r&sig=Q%2BCelCI9%2F3HeH47tuxckEkcqyVlFkiZ1Pn2ZoTkFmXY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:25.4095793","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:25 GMT
-      mise-correlation-id:
-      - 679e8e22-22ce-4f1c-8221-6e4d37fc51d0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A30Z&sr=b&sp=r&sig=dPGz%2B4zb6iu7zPuQhx9d58w6d7HnvwiVmPpqWpp2nuE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:30.6956574","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A30Z&sr=b&sp=r&sig=gci95DmRpLI307U76GefnpvbGg9QUCfV6DeI1eBa4xs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:30.6955711","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A30Z&sr=b&sp=r&sig=MR2gxIKog4QieKTeTPK8bvQ5ByR8FvPmir1qgMODZyk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:30.6956788","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:30 GMT
-      mise-correlation-id:
-      - 9b619d40-2a12-4432-bcb0-db40a7ad2ec5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A35Z&sr=b&sp=r&sig=CJeUnK7ohfUFiKXEU98sFCsYcMcrOAX%2B1tEj817jdi0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:35.9754114","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A35Z&sr=b&sp=r&sig=RuAxjqWMyTNGiGAFNWC0yyACmPOHaHZ7kBAmhZl8UFw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:35.9753328","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A35Z&sr=b&sp=r&sig=kSM%2BTX2ZtC2pdu4Cduy6NH13%2BPiUXkFazBV4%2BV7okOQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:35.9754264","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A18Z&sr=b&sp=r&sig=Kcof8lk8YNcoTLI%2BvP%2FRihSeKSel4fAIsBczE5vjpUU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:18.0145853","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A18Z&sr=b&sp=r&sig=UqSzW9IMVlltnfF%2B9juR0WiaQ21Fkf5CtPynDUPLy1k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:18.0144837","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A18Z&sr=b&sp=r&sig=uyqiOIK42GdWe5meMnttth6DaH47%2FvYuwhGt9Ic5htc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:18.0146085","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1938,9 +1290,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:35 GMT
+      - Tue, 24 Oct 2023 12:35:18 GMT
       mise-correlation-id:
-      - c1ba0c39-7588-4149-8200-10ed60daea54
+      - c1f850df-09e3-401c-9a1c-6df73f5b5f64
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1960,23 +1312,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A41Z&sr=b&sp=r&sig=7ObxsgPxTSF5NUFsF55APob4LrqdUi0CdWQZpRoRZ24%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:41.2975471","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A41Z&sr=b&sp=r&sig=4ygl649gJW0XHE3G60o6Vq333I%2FTI8xoVI3Kq0HG0Z0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:41.2974739","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A41Z&sr=b&sp=r&sig=prEIRmcLfUMW1qVVYY03%2Bo2ZxE0uy%2FyFH%2FoxvOVy7Is%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:41.297561","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A23Z&sr=b&sp=r&sig=DPKHYr8Erf4rfuk11OH1SRcWzH%2BkQKR%2BL5zh7ds2Y98%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:23.282031","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A23Z&sr=b&sp=r&sig=AiQnkAqVGDiD5rVB7AtaTS7jTsGf0YRqOKx5aURkWv4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:23.2819468","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A23Z&sr=b&sp=r&sig=wujUppJJgyACfA3L9K2UJgbsoIAEUzsYjiOwrxSqSwM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:23.2820459","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3201'
+      - '3197'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:41 GMT
+      - Tue, 24 Oct 2023 12:35:23 GMT
       mise-correlation-id:
-      - 8bcc9eb2-5c88-41d7-a5e0-1efa51b85aab
+      - b1e37b07-63fb-4e60-98f9-6af415f07027
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1996,46 +1348,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A46Z&sr=b&sp=r&sig=8nh3zFn0oPpq7rMAb0qhGuCeQ0PNE7cS8Fqc5TDmOi0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:46.5637693","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A46Z&sr=b&sp=r&sig=ebEm0YxMWS6cyrC3%2F2llCzOFGqaBvL53j6dHVMGzN1Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:46.5637003","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A46Z&sr=b&sp=r&sig=bxBnGCT4NaZPZPme7hItd58JHBwSe0LPvIzOdlDNILY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:46.5637848","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:46 GMT
-      mise-correlation-id:
-      - 5c67afe2-e288-451e-b750-964dca53f204
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A51Z&sr=b&sp=r&sig=IDeFsxugRe0hVEDqGekUXoYjK3tz9KFijWECAhoxRG0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:51.8519044","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A51Z&sr=b&sp=r&sig=zjHAnK%2FQmtcaGUpBEkuYj%2FzTyXRy4Wp%2FJVuMy2msrZg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:51.8518289","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A51Z&sr=b&sp=r&sig=%2FkVBheVfOGzawzntKHibulZ72kGYQk3fzQ0wOS4BjJQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:51.8519188","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A28Z&sr=b&sp=r&sig=sZbXTMwVRjWD%2Fy60hubE26%2BM4KbfXUTPqeojmQ9eU6s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:28.5860252","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A28Z&sr=b&sp=r&sig=smvo8lH4dxUXPcIHxRQR0vxyv41tPR1M4z7j%2BYBdnRY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:28.5859392","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A28Z&sr=b&sp=r&sig=B3wI%2BPugLwWN7sPSvRxoMJw7Vbg9rtxIjzIGiPnPZpc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:28.5860464","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2046,9 +1362,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:51 GMT
+      - Tue, 24 Oct 2023 12:35:28 GMT
       mise-correlation-id:
-      - 6bf06fc9-73cf-433d-96c0-fbb1ccea4978
+      - 94d08ed4-d37e-4e03-8413-35078a1d4420
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2068,118 +1384,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A57Z&sr=b&sp=r&sig=5f%2F0nBdx%2BoI%2B2b36obt123KZQOIounPJ55tEjJecE%2Bk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:57.1732847","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A57Z&sr=b&sp=r&sig=dt7f4STbprf2IY7F1H8b8JwQ5jP9DQiRr47Gqzyye7w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:57.1732103","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A57Z&sr=b&sp=r&sig=A9DUE42FRbfAW7zKHXH08MMiJXtagoZkQkUv7NGwGqI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:57.1732993","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:57 GMT
-      mise-correlation-id:
-      - e08e26e0-c494-42f7-88e8-a834ff71cbc3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A02Z&sr=b&sp=r&sig=5y5rbQopIdt%2BK83kV9L%2B8IcIi0mKeoxywDzRfg2XrQs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:02.4593449","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A02Z&sr=b&sp=r&sig=HEO8SLq%2FKn6U7BXcfUAv4I5L8ozmU5EZsGca0IX7bnQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:02.459266","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A02Z&sr=b&sp=r&sig=3IC3O9BEaC9wUB60trSy9ocMU97VVGWdCmCh6UF7h14%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:02.4593672","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:00:02 GMT
-      mise-correlation-id:
-      - 2cdeaa69-e930-49da-9418-475ed246f3c1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A07Z&sr=b&sp=r&sig=DH5Ey%2FzGNwyMUu1ydcxhfVaVTcgTe592JVD45UruoDo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:07.7196949","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A07Z&sr=b&sp=r&sig=sUJKXRO1RlWCsMLC8%2FXpzI%2Ff1hbITx55x2DiQdVO%2FY0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:07.7196213","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A07Z&sr=b&sp=r&sig=LbkQyh5iOEw2U9X%2FoRG3hlcqgDxSXOvMsY3RLAR7oxA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:07.7197105","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:00:07 GMT
-      mise-correlation-id:
-      - c61aa0f8-5f00-4449-abf5-3f9e2b701b38
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A13Z&sr=b&sp=r&sig=3ax3Vgax6DirEIIbe13o5QlpA83mCnFomG%2F1Il960%2Fo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:13.0491737","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A13Z&sr=b&sp=r&sig=whtWNffj0OWl4Y4sRC6ISXiPdGjz9Afdm2ThcrxJE0g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:13.0490972","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A13Z&sr=b&sp=r&sig=LU%2Bw%2Bgkfv68mYNQphWis5X2F8DXupxSAa%2BSHlYpK6JE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:13.049188","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A33Z&sr=b&sp=r&sig=iGtZca3eOMb%2BuGjku7fTvJLtpWm9KgJjBAGdQwlVOhg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:33.891047","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A33Z&sr=b&sp=r&sig=Gw0Q7HSLgy7nvoN721ya%2B6G4lXIJHKYt1f0Jy06pSGk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:33.8909628","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A33Z&sr=b&sp=r&sig=OBDWe%2F7aMHpbuTwGPidB5%2F0C%2Fh367E7bXEK0IFHU4PU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:33.8910679","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2190,9 +1398,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:00:13 GMT
+      - Tue, 24 Oct 2023 12:35:33 GMT
       mise-correlation-id:
-      - 3b9643e7-e967-4d54-b619-e119f1037d2d
+      - f111e018-863c-480a-b14b-7f01796458cc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2212,23 +1420,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A18Z&sr=b&sp=r&sig=EiMFoeGPxUVwtw0AhJr3U2K9arfUKfg6bIiHZa6X8zY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:18.3872708","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A18Z&sr=b&sp=r&sig=8o9p2%2BKBYyfjti3ooA9cy5PHih1Uvccb9O6OZY7WY20%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:18.3871977","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A18Z&sr=b&sp=r&sig=OCIRRTbN8FQ8PGw8szmzM%2BzOJsZcUY7UQ9G%2BZEABOsM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:18.3872856","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A39Z&sr=b&sp=r&sig=zSWufuZii8w5wYwiCCJAgbrZg8wFOTenAONfOqwu0U8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:39.218112","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A39Z&sr=b&sp=r&sig=u9L9%2BMOieefibQzgmu5%2FgGYMiRyDa%2BbOEC8Ha6w5nWk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:39.2180022","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A39Z&sr=b&sp=r&sig=gRc%2FkLiM212WViOOo79lHPZo7TQeWyE9Mik9mfafGZ4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:39.2181346","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3200'
+      - '3201'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:00:18 GMT
+      - Tue, 24 Oct 2023 12:35:39 GMT
       mise-correlation-id:
-      - ee60e8e2-ec73-4646-80a9-a5962a7cde74
+      - cf9ce9e8-04a3-4691-8663-b478f370f0bb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2248,46 +1456,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A23Z&sr=b&sp=r&sig=ZL%2FIqGVwiwF%2BIKpAzDC8SMaFTmwUgCM7oG2n7XYqx0U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:23.7195661","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A23Z&sr=b&sp=r&sig=4x6PR1GA7J4dt%2FAyQP%2FK9BrZTpJUYsljE7lglx91yG8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:23.7194852","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A23Z&sr=b&sp=r&sig=rQVYoFMsXpRtKIrjFn1OwKNge7rRC3y%2FUTqyFVrWVck%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:23.7195846","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:00:23 GMT
-      mise-correlation-id:
-      - 7d90d3c1-b642-48e3-8e72-782575aefde8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A29Z&sr=b&sp=r&sig=HhxLYbjra52HV%2FPsGD9nT7KzV9D45AR9Lp2y4Lv3ZkU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:29.0369074","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A29Z&sr=b&sp=r&sig=7Iz59fCl%2FSD8FjPTKvT6GrQkMwXNRPXIaGTS8WRyjGk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:29.0368366","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A29Z&sr=b&sp=r&sig=aV%2BgX4BMOn%2B4uvosJ68ZypVsJ6dvxu34pZc4RsHLwck%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:29.0369217","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A44Z&sr=b&sp=r&sig=Yoy0RdrX%2Fw0FURuJ9MotFk5UyWhrMnajncTbp4cC2wI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:44.5269127","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A44Z&sr=b&sp=r&sig=1dv123N8ifvHe56EiKPTvg4Ht66CfOq0cb2al6F6w%2BA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:44.5268407","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A44Z&sr=b&sp=r&sig=Q0%2BuOOCO7ucWugx%2FF6r47VxIHkjY9xkvkmBRDBKtdy4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:44.5269265","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2298,9 +1470,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:00:29 GMT
+      - Tue, 24 Oct 2023 12:35:44 GMT
       mise-correlation-id:
-      - 754a37cc-ec5e-4a1a-b2ac-335d72455daa
+      - ff46fd75-9a94-4680-a41d-4a4f370b7000
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2320,23 +1492,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A34Z&sr=b&sp=r&sig=VJ4v3XUZbAzE%2FC%2BfZJyXZdFFISFd1Lr2aNWgb4aQPVY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:34.347575","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A34Z&sr=b&sp=r&sig=73DjkaMZIZc0zAIY42h6s2GUew3gc%2Fm25mIQwWbhmwQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:34.3474719","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A34Z&sr=b&sp=r&sig=JAEDBbnA7HZur97vfsbAv4Za3U4h9g4VEWkbWUiwuhI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:34.347599","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A49Z&sr=b&sp=r&sig=W7RNU2Enf7m3vihrMT9rGXEjoh7iwf1wVElNJmbhHso%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:49.873944","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A49Z&sr=b&sp=r&sig=EX%2BH3tsOeaNAfL%2FRw4LO%2FmH%2FPsbSSeroyCGfT8IYVds%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:49.8738306","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A49Z&sr=b&sp=r&sig=nTQmPzd0ffbxWHiCVhYIsRAzgKzG0hOi42oW1tYy90o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:49.8739707","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3198'
+      - '3201'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:00:34 GMT
+      - Tue, 24 Oct 2023 12:35:49 GMT
       mise-correlation-id:
-      - 4bf8d6d4-4b14-40cc-982a-d915b660e34c
+      - 57450b4b-638d-49df-bdf8-2af7b6e2e756
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2356,46 +1528,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A39Z&sr=b&sp=r&sig=o%2Flt9RWQlEW0Ho4TkGywnLwhzWN49JuTZKSOKos6IQY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:39.6769484","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A39Z&sr=b&sp=r&sig=MTf8zGufIB5w2r5HRWEjoBuVMWC0fW45%2FQhKOXcy8gs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:39.6767772","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A39Z&sr=b&sp=r&sig=6ct5s2YHEPuTqf82zJ%2Fs7i9WRBgmI72m4izk4OsIEN8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:39.6769739","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:00:39 GMT
-      mise-correlation-id:
-      - acf5f8f7-2e69-4fbb-8615-7382824f4de8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A44Z&sr=b&sp=r&sig=2ax%2FwmGhz9mUM8WJyYrlrGYPu4eNkyp0KcXM0%2FYPr7g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:44.9921645","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A44Z&sr=b&sp=r&sig=O2LdGQqNzSTOSB6rj9R9pF7ie8X5kk2fv7rp0YMsOYA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:44.9920786","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A44Z&sr=b&sp=r&sig=LtXL61IiyW2s346mdIL%2FCMTJ6EroekcyBE47qDgIwDw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:44.9921864","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A55Z&sr=b&sp=r&sig=QIrWAFWRvaV8nb4zh%2Bp0ZZsxhhVILi4FvMumz%2Bx9Qoo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:55.1365171","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A55Z&sr=b&sp=r&sig=yxBw6IxaefJMhGqchinJ3OmZVGGhpha7FWf51C1umQw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:55.1364284","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A55Z&sr=b&sp=r&sig=rWwbltoj8gFIxG7EopjkMUDWOhYnueUM%2F3QttZ0zWM8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:55.1365389","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2406,9 +1542,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:00:44 GMT
+      - Tue, 24 Oct 2023 12:35:55 GMT
       mise-correlation-id:
-      - ae911aa2-176a-4f3b-b72d-e785cd32bb76
+      - f3722f86-2259-476b-84f6-84aa7e13e851
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2428,46 +1564,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A50Z&sr=b&sp=r&sig=7xxxdJ4WkYK4a390E9gTpSG2TNFV9VnYYZQGXeWeA%2Bg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:50.3202618","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A50Z&sr=b&sp=r&sig=VOXZ29T9g7KF4x0naUK1NSwF%2Bj3c%2BIo75aFhRqcAbAg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:50.3201841","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A50Z&sr=b&sp=r&sig=KAK9viQF3biqCzyg432kRlDKcLLH5VV49rU84%2BJaiMM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:50.3202764","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:00:50 GMT
-      mise-correlation-id:
-      - 4963f376-eb29-4e89-9011-e97a32caff5e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A55Z&sr=b&sp=r&sig=aO1t2PWKDioVqBnY7t%2F3hQsnI3ndQd3%2BxgNfRbuetBw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:55.6001152","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A55Z&sr=b&sp=r&sig=i56ZSjFtu1N4BukwM%2BMEp93Vdxjis1TH5%2FCLikFxY1A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:55.6000476","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A55Z&sr=b&sp=r&sig=Qp66Go%2FMIEsFJVZ357R1PTzLSXawrI%2FvlWl8U4CNRhE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:55.6001318","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A00Z&sr=b&sp=r&sig=z4ar1gk7PhhpV4FiJNo0J%2BNONV5PmHMqFYw%2BRxNs0D4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:00.5143339","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A00Z&sr=b&sp=r&sig=BoQ7ZN%2FodLt1sDoxIz8Wt%2BSS9UHa3QfG1HfeTXJ0%2F8I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:00.5142618","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A00Z&sr=b&sp=r&sig=jRRh0k81HGbQS9H1yKhuXwBLiVecNW5ocrP86R%2BsKKU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:00.5143478","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2478,9 +1578,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:00:55 GMT
+      - Tue, 24 Oct 2023 12:36:00 GMT
       mise-correlation-id:
-      - ccc367ec-e882-47ca-a5aa-cded99fac8e2
+      - b8b60444-e2be-4eff-94fd-9455f8c17a7a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2500,23 +1600,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A00Z&sr=b&sp=r&sig=XTKPkiLOeEo%2FCHelC6gjMyyfEoOk8aVbUZcF8Ly89M8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:00.8921376","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A00Z&sr=b&sp=r&sig=ajJHjt5F1ao%2BexJWBHote5kEOCLJd7tn6OT9l%2FT53qk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:00.8920247","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A00Z&sr=b&sp=r&sig=vdMnDkygBCNI7LSm4m4RoRAuTH2nHLb6Xw6fM%2Fk1X1I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:00.8921593","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A05Z&sr=b&sp=r&sig=hsx581pC4gWihMxcwVFCaIoJSs1dsUCjEwrZwBgtwp4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:05.8486353","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A05Z&sr=b&sp=r&sig=PHQCfOHNq4Qd9Yo%2B4YEX78TCUxEy457HSiu146MiIUI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:05.8485526","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A05Z&sr=b&sp=r&sig=0sXOgm0hmzQE8l2Rw%2BylL4lJ89ywobcidclyfY87qbY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:05.8486574","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3202'
+      - '3198'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:00 GMT
+      - Tue, 24 Oct 2023 12:36:05 GMT
       mise-correlation-id:
-      - 75740685-10f7-440c-83b2-85e2620fd26a
+      - 7194b9e2-fada-421f-b5bc-e6d7b9787e54
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2536,23 +1636,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A06Z&sr=b&sp=r&sig=0WPbsLVcsZIMoIup5uGSAQuOjjkzok%2FhdlFjQ%2Fc9tCc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:06.2062351","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A06Z&sr=b&sp=r&sig=ZoJ%2FmKBMeN%2F%2BurnhdE%2FsDlftEE7uoIsDwR%2BBzJXr2dg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:06.2061502","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A06Z&sr=b&sp=r&sig=QuAlvtUstsy47f80%2B5%2BdFO0VfGJPIcbB60GSgVNm1m0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:06.206255","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A11Z&sr=b&sp=r&sig=xviqLeP4NUYjk4SzXmdJEuf4Qr4y13uQIE6h1JE4yGs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:11.1141423","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A11Z&sr=b&sp=r&sig=2KWVjqPF1sHStDX%2FBtEb9IDL1bJhQAXL81HVXETKE4E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:11.1140543","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A11Z&sr=b&sp=r&sig=YFaq75Jvb69HoyQQ3aQb6S1%2BNb%2BD8DeKnDsbErkyfmA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:11.1141643","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3211'
+      - '3200'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:06 GMT
+      - Tue, 24 Oct 2023 12:36:11 GMT
       mise-correlation-id:
-      - 5a76fcd3-528c-4edf-95a7-cafa89163f7e
+      - 28a07884-2d33-43ad-8931-7129e9fe4c67
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2572,10 +1672,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A11Z&sr=b&sp=r&sig=7L1O4SHc99KT3LcRhMfcBcocsrdtUwK1uRYht2dm3rw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:11.5180309","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A11Z&sr=b&sp=r&sig=juAc94aljs%2FA0E0AWOQEV9fdiouDR0ZYJVAzdhoDHHc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:11.5179353","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A11Z&sr=b&sp=r&sig=CfXxP9HgLRQNUPBpGjqugizvFmC4JNbgfzmVA9rtrzU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:11.5180461","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A16Z&sr=b&sp=r&sig=ZjbO0GgIKw56nApccPoINWSFFWjNWjYV8VaIDDpbv1w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:16.3884217","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A16Z&sr=b&sp=r&sig=93%2BMVokDlVDTv9J5PGguNuOrriGa6Vg7IPwQ2wsVTD8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:16.3883275","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A16Z&sr=b&sp=r&sig=eIuk0IInPFvEJqzYyg2AIyMNqagUulk8lHKY1CLx3BI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:16.3884438","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2586,9 +1686,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:11 GMT
+      - Tue, 24 Oct 2023 12:36:16 GMT
       mise-correlation-id:
-      - b296ed2d-1dc3-4036-8989-74218e27ba76
+      - 2c10b9e1-1cb9-4b85-a829-c13937f2bacb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2608,23 +1708,923 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A16Z&sr=b&sp=r&sig=5mYhiUVpgSdJVY18COwMuOuJ5J1Ez59JhF6qGC7Hpzc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:16.8470838","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A16Z&sr=b&sp=r&sig=pLl3lrJ2rm1DxGnjFsIxe%2FcgPdlVosJfKSQ%2FDuamgQw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:16.8470122","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A16Z&sr=b&sp=r&sig=sG7AFHa5J1Zpyca%2FFGsFn%2Fy%2BVBcTmRo9hQlfGwJi5lg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:16.8470981","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-18T20:56:35.199Z","endDateTime":"2023-10-18T21:01:11.605Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:12.483Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A21Z&sr=b&sp=r&sig=YiyWoEzScV98toIFfps5D68OaSt%2BCRMwtXJsA%2BtfXrg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:21.711854","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A21Z&sr=b&sp=r&sig=%2BOzmsZXjXdKiW11OgG3%2B9%2FDiDrHHhHy4J6BP936gdeE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:21.7117652","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A21Z&sr=b&sp=r&sig=bClJxWkNYrUWv%2BGODzAeipKd%2B0fyAkX%2F09J4kpYAwT0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:21.7118769","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3240'
+      - '3209'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:16 GMT
+      - Tue, 24 Oct 2023 12:36:21 GMT
       mise-correlation-id:
-      - 4c962163-5267-486e-b748-28425eea352b
+      - cb1c63a7-e60f-4f68-849c-4334e2de118a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A27Z&sr=b&sp=r&sig=Dl9ZNxK0SuT67Z20AymfL8LAv%2BA2fC3cFUbxdrzvfLw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:27.0610954","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A27Z&sr=b&sp=r&sig=siM7Ocf3IqTxaAmiJ45YXsGYwTcfnE7aC9iZr%2FZzhNE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:27.0610111","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A27Z&sr=b&sp=r&sig=1UFDIbwTdDsfV4N9Pv5ii6SFO67uJu2UI3SYMQgRS98%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:27.0611161","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:27 GMT
+      mise-correlation-id:
+      - 76ab60bb-c06c-4aa4-91ea-7de85d0c55d9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A32Z&sr=b&sp=r&sig=xVJCV4NccVUdL5djcTHk2TIXFqzcA0VaHvSY%2Fl7%2FKlw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:32.3442845","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A32Z&sr=b&sp=r&sig=P42uXKKnn6Kz6hqbTH6evgD1J1W4QZ7df8UYVpTWTus%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:32.3441931","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A32Z&sr=b&sp=r&sig=vLhtYtXN6ji3APmEB4RiQPgVyXxmgj1XmPg4rv74D2c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:32.3443063","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:32 GMT
+      mise-correlation-id:
+      - f00c8fdf-d4c8-4285-9dd1-d36204aa22c2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A37Z&sr=b&sp=r&sig=TQl5atucvBioGNXau0fKdIm2NTRWw6Ki3xOVG7weZZ0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:37.6392909","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A37Z&sr=b&sp=r&sig=UMvna4YZyepbTo4%2FdL%2BOOACKk3f%2F8M7uS7aW14XWPsk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:37.6392006","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A37Z&sr=b&sp=r&sig=dsSmy0HZMUdLiHSNpxcxh3aqISF59yc3jagLCEs1wsw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:37.6393125","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:37 GMT
+      mise-correlation-id:
+      - 997278da-bda2-4ca5-abbd-660bf829693a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A42Z&sr=b&sp=r&sig=wLNj1Mvd2Wbpc4NYIqthK%2BaYCFbtl4kak8j25qhRdKI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:42.9365513","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A42Z&sr=b&sp=r&sig=ZfOtM2cTRBmI41NjqCxrT%2BlZhnZSpu6KT6rRwMW9jBw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:42.9364541","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A42Z&sr=b&sp=r&sig=5bKa3EUXE%2Bgst%2FJc9kGCGhuE%2BZN3Pl4hGwVhCQaXpyw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:42.936577","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:42 GMT
+      mise-correlation-id:
+      - 3eb910ac-37ed-44ee-97fb-8aac1716ae56
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A48Z&sr=b&sp=r&sig=m3ic%2FYxHXExIsR6rL1qVF1dZ3IBSlYvmtu2Z45dOvTI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:48.2098254","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A48Z&sr=b&sp=r&sig=FAc1AUYufDdxMM%2F5qwo8aV1JD99kAIki4u0EOkYjI7o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:48.2097654","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A48Z&sr=b&sp=r&sig=UDFX5qHXqLncrULsJbnKrZAivzIroeo2oE2pfngEZHI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:48.2098402","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:48 GMT
+      mise-correlation-id:
+      - 9f9d0c77-b03d-49e8-8f40-669f75e93a4e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A53Z&sr=b&sp=r&sig=KKaw2qHIzAdAqh94S2sM8KT%2BIs5i%2FJ9YpZLGOtiBoU0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:53.572815","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A53Z&sr=b&sp=r&sig=xmoDOgTACEeKpREUEBXxSMxDRUtFwbe%2BYrMpmNdn0PA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:53.5727443","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A53Z&sr=b&sp=r&sig=qHrq9%2BzYPGdBXVX9YiFuekM%2BzS9oBJRRR4oY17DkAew%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:53.5728295","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:53 GMT
+      mise-correlation-id:
+      - cf37ee38-ca3c-4218-b436-5de4a66a1c79
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A58Z&sr=b&sp=r&sig=2clyerZQTOK0Fi2yDxOkaCic3EA3eQMJtCkTRdNvi5E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:58.8818615","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A58Z&sr=b&sp=r&sig=ukZpg0x4ByfZ9Rnu9sznTs70MxVGm4geL54eo9oSt0c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:58.8817786","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A58Z&sr=b&sp=r&sig=HhfNjzBpOHrCzSS%2BbS21LXw%2Fd0iH%2FeG3RIhDgu7SH9w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:58.8818777","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:58 GMT
+      mise-correlation-id:
+      - 36f9bc87-a34a-475a-a12d-769ac49125d5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A04Z&sr=b&sp=r&sig=WeY955vwh4colQPPftiFhafobhEZnaz1NWss0bXGHfo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:04.1794894","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A04Z&sr=b&sp=r&sig=EvB2xe%2B60hXpy6FQMKk%2BzII1Xj2A1PttTT1fbkjJiEs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:04.1794126","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A04Z&sr=b&sp=r&sig=qbWO1rECGg6yWwGHqadSGgoS4mvbNNVpQBfW4O6oxKw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:04.1795044","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:37:04 GMT
+      mise-correlation-id:
+      - e4b7ccec-da56-44fb-9f55-79885442c48d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A09Z&sr=b&sp=r&sig=1MYYBiKqVzqDcRs7lWaNjXs29B4H41taVqzfVRkIqFM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:09.4997395","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A09Z&sr=b&sp=r&sig=sVBgfLPN%2Fx545fxAXK1CNglaUfiR2suyrGsRGy1bka0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:09.4996687","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A09Z&sr=b&sp=r&sig=kxDEtuaYwlypm6PzGA5L6NBI0BzZ7B3DqAJrmRWbAu4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:09.4997527","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:37:09 GMT
+      mise-correlation-id:
+      - f60d82fb-fe9d-42af-ab31-e4320d37c757
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A14Z&sr=b&sp=r&sig=0NVPLc1nnCIpjlVzLX3vdlBEtfGsD4A3%2BhXCs%2Bk7EE4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:14.9900289","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A14Z&sr=b&sp=r&sig=rkEowMKZ3g0K30dGZEhO2jwqZZhTaAJR4m2WI1Vr10k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:14.9899479","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A14Z&sr=b&sp=r&sig=KlGvVR9bxGQveFTznQSHZEdV7wb5rPJXHPcmE1r7PM4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:14.9900447","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:37:15 GMT
+      mise-correlation-id:
+      - 7a4b688e-f957-437a-961b-6e5443d1190b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A20Z&sr=b&sp=r&sig=4jxDEgIHyqlRsfanORQnfurKPSt5B4XuZZi4y7Q8l70%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:20.3144569","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A20Z&sr=b&sp=r&sig=UzSZxUnY%2FGMJeupB%2FDxQczOgFHFe13zWQxS7OOQ%2FSi8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:20.3143615","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A20Z&sr=b&sp=r&sig=hLxSkojqSa45bAW8HCKS6YH1rf5JWyfV2AQjxx4616s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:20.314482","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:37:20 GMT
+      mise-correlation-id:
+      - 41da0d87-a3e5-4459-a9a6-5ecc0d9ea75c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A25Z&sr=b&sp=r&sig=dyzDRBBO9vYJI3vW%2BRGr7KuBi9ZR1pOtiXnZlTx1N7g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:25.5901094","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A25Z&sr=b&sp=r&sig=B%2BPIiopcgg6rAedcXBTyybwJGB63lodr8YVrv4FZDsE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:25.5900354","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A25Z&sr=b&sp=r&sig=%2BMMTKNCNNf0oxEYJfpoECScoRV9JpQtNUVIjkHhVjPQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:25.5901243","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:37:25 GMT
+      mise-correlation-id:
+      - e6680ccb-01e5-4b62-8e26-8b271a38983d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A30Z&sr=b&sp=r&sig=c4JNCl%2FHtpddj9R9pMK9TdbCZ%2BCfqsvw3Cte60nhDi4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:30.9540866","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A30Z&sr=b&sp=r&sig=7IZKMESrPmHWqXcC1XwQkZJL0T1U6NRtAeoebV8WN4I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:30.9539963","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A30Z&sr=b&sp=r&sig=sbiFj5wA7pb6G%2FMw8OzJz93kvTHPokuhXSi%2FutxOHnw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:30.954109","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:37:30 GMT
+      mise-correlation-id:
+      - 67283345-1e44-44ad-9554-251b1e9e7aa9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A36Z&sr=b&sp=r&sig=oJhmSbhLeJZ2tiOLihmU7SA0OfYrlDnRHQH0oo0u0RY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:36.2330313","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A36Z&sr=b&sp=r&sig=XDm%2BifVRE5Z0FFNj8wXuZB6me6fET34Jpc9ZZ0beVf8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:36.2329533","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A36Z&sr=b&sp=r&sig=Pl72TAeLyJsBTk3gItqY%2FpNnzR2qVFnO2yYvJZyri5A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:36.2330458","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:37:36 GMT
+      mise-correlation-id:
+      - 1cc5b0ab-c56d-4875-9036-30d7d93a1f1e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A42Z&sr=b&sp=r&sig=te0I4Jp9XAZRKyGkPuPWO2A9Mei7YSWorIBoREPGW4I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:42.1312906","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A42Z&sr=b&sp=r&sig=e0ZIcGOGzgXN6ZVqZeH7hUnYXrrXHg%2BTC%2Fl7PVSnrmI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:42.1311882","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A42Z&sr=b&sp=r&sig=0LM2aPE1xg2ux3JE3DYzrcJ%2BBEDPv2WDunV3lHcJFwI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:42.1313139","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:37:42 GMT
+      mise-correlation-id:
+      - a37c2e94-cc74-443c-996f-86814185cd37
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A47Z&sr=b&sp=r&sig=1ZKAkazDwvPPvy%2Bbc6kGwGhBVMqx2dsNbMqSlp0SBjM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:47.8384317","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A47Z&sr=b&sp=r&sig=zJl8dQFu%2Fb%2Bf0oqgNpT65uzTeYzP5usUKWAlthUYrtg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:47.8383277","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A47Z&sr=b&sp=r&sig=wBP9V14K%2F1kwfVTwy6mAVdf0T2k9vhkCvL%2FQcZl1yK4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:47.8384564","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:37:47 GMT
+      mise-correlation-id:
+      - cf60905d-4fc8-4630-bc77-faac32e773e3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A53Z&sr=b&sp=r&sig=yAwkKxJ2M%2BL%2FrZ37UV6UVM4%2FEtmLEZ%2Bof5PrxgYSORY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:53.4718481","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A53Z&sr=b&sp=r&sig=zknf%2FaR4bpmWscC9ooRTiexA%2FMJdNFmj72ugufldPPk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:53.4717673","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A53Z&sr=b&sp=r&sig=y111A4WcP9a1sZ6FJZqO3pAvp9GR9GoKAi%2BkumZcqeY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:53.4718623","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:37:53 GMT
+      mise-correlation-id:
+      - b9b6c909-5565-4b70-ae26-b59b460c241e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A58Z&sr=b&sp=r&sig=C05TQAfW58%2B2riBE3vxH2nUon379aZUihxBgtXVagJ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:58.7543118","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A58Z&sr=b&sp=r&sig=KkHzSIpR0zoAEorj5V5FsZZDZEhXKSXyxGIAXIJ89AY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:58.7542086","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A58Z&sr=b&sp=r&sig=T1Y2TDWyTmXE8TlFW%2BHMaU9kaDJvXN9RrQEep3UvYGU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:58.7543257","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:37:58 GMT
+      mise-correlation-id:
+      - ba5d3fe7-7304-41db-99e1-9b8a52ab9a4a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A04Z&sr=b&sp=r&sig=UmJige73aDgVNIajKUkoDjZ9dMKnfxU%2BehuHXHNZQmc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:04.0414127","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A04Z&sr=b&sp=r&sig=ScCqmrHNtjVtaOwG6QuUlVmVfzo50leCGgepSyGf4ug%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:04.0413377","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A04Z&sr=b&sp=r&sig=meC7MlnmtSLmUKDYrpaYDDlaH9qcKvy9JeDilKHXKbQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:04.0414266","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:38:04 GMT
+      mise-correlation-id:
+      - 259541ed-f238-4cbb-8d57-a6a8899a3e1f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A09Z&sr=b&sp=r&sig=HhUvrW%2FVC8O1S7wcnUSIEFQ%2BvKxDPnmf4iDyghHkyUk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:09.3385752","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A09Z&sr=b&sp=r&sig=Bi7qGeOppYP473a9c5A%2FLeSnKICjbPluVA8c5MzwZyY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:09.3384825","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A09Z&sr=b&sp=r&sig=ZYi8cr2GKP%2BNbGi5d1kDpulxl9i9ubNUbgaJ%2FJhCLpo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:09.3385926","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:38:09 GMT
+      mise-correlation-id:
+      - fb88a079-2c43-4eb8-8ba4-16f8d3e11932
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A14Z&sr=b&sp=r&sig=2%2F68y%2BulGzVECsvexgrcbnE6fzsnueD7VmWa8%2BNlX%2BU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:14.6539722","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A14Z&sr=b&sp=r&sig=CleBU38HpsdtjGN7uYuu0NTnQx1%2FcQpULcfDXuEN1yo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:14.6539051","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A14Z&sr=b&sp=r&sig=ZdRFjU8IYCNIQ%2B3RNn2S5jgTso%2BbCsck5z9xJd8gtno%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:14.653987","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3207'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:38:14 GMT
+      mise-correlation-id:
+      - 65fa84cf-fe76-4242-b963-2f1881ed0478
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A20Z&sr=b&sp=r&sig=rOVNhCJwADvrJrDygy9waRgXMBWhc3cDAsicVWglKxc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:20.0689149","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A20Z&sr=b&sp=r&sig=%2BSsUg9rqKXhbNXDxLADwobrghWZMC8BbdfQhuQzJUWY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:20.0687791","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A20Z&sr=b&sp=r&sig=RvYZPV4CaKnqNZK6cZDeP6SS%2FzTerh0n4DN6eVgMcFY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:20.06893","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:38:20 GMT
+      mise-correlation-id:
+      - eb720156-5b35-4471-a1f3-0bf339d93f3b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A25Z&sr=b&sp=r&sig=jBhRkDyvjvg3yGXIP5piML5srbXyfUZ5om5HV%2B5L7Xg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:25.4334673","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A25Z&sr=b&sp=r&sig=Mr9DkOKAdmOtkECSZOc9pmmc9pFzL3N%2BNlHvtFzOM3Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:25.4333888","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A25Z&sr=b&sp=r&sig=pAaag8OEpxJvdkv3xds1nGlOG%2FjRJhCGOt9kaWSO0Gg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:25.4334816","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:38:25 GMT
+      mise-correlation-id:
+      - 6d27a324-6fbe-4dab-af8a-0681efc8fee7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A30Z&sr=b&sp=r&sig=vFEzYbUZv5ENTJhrZiIdme2HIlMovSS09Q5cyO7zoDI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:30.710938","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A30Z&sr=b&sp=r&sig=p7TbbU2uozTdzPwdmen%2F%2B%2FMclmEjxy1xr6WbU7FuNco%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:30.7108694","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A30Z&sr=b&sp=r&sig=PASx9Fb3tspvnSShnSA%2FiZJba7OqsNp5JZU4yt8X6kI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:30.7109513","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:38:30 GMT
+      mise-correlation-id:
+      - b11ae37e-4564-46af-9f0e-945354c8d680
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A36Z&sr=b&sp=r&sig=kqlmoCbquPFaSHTCTPJCxVs8vtMRXLe6Q0hZrkIqvFM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:36.0699647","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A36Z&sr=b&sp=r&sig=ErKm8Wx1d14V%2FpIyPm0nSNgj52rZeD%2F8AuwiRurrHDY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:36.069892","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A36Z&sr=b&sp=r&sig=UljSKyiz1sA10vx6IyQWQz31Qg%2FJYKPZU4xLqgTSIWs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:36.0699791","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-24T12:33:54.041Z","endDateTime":"2023-10-24T12:38:32.64Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.822Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:38:36 GMT
+      mise-correlation-id:
+      - ecfe3a72-76b4-41d3-860d-2b93f6b10831
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2647,7 +2647,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:33.5819664Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:33.5819664Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.1836047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.1836047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2656,9 +2656,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:17 GMT
+      - Tue, 24 Oct 2023 12:38:37 GMT
       etag:
-      - '"75002f65-0000-0100-0000-653046470000"'
+      - '"d300ce49-0000-0100-0000-6537b9780000"'
       expires:
       - '-1'
       pragma:
@@ -2688,23 +2688,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=metric-test-case&api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=metric-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A19Z&sr=b&sp=r&sig=sz8lznxnOLdGAnBwUJ4tLZel4l7eTO7WoWyvDLrJ7Uw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:19.1234147","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A19Z&sr=b&sp=r&sig=YlBteSDUCMoYKqNHkFtPPdBorpfwFGLIcH3bUzb74%2Bs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:19.1233084","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A19Z&sr=b&sp=r&sig=W9t5H%2B8vqPGyZzFVtcleifXrWZqjTSpGInMtrZUKvbw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:19.1234391","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A19Z&sr=b&sp=r&sig=tELbZnFQNXCH6dWO%2BBFOWQpARmma4bE6vr2ejgV1sPw%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:19.1234612","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A19Z&sr=b&sp=r&sig=gbKtw4YH8yrTef4cfngxE2nCtCB6Zng8vE%2FSeuj%2Ba0I%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:19.1234847","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-18T20:56:35.199Z","endDateTime":"2023-10-18T21:01:11.605Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:19.051Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A38Z&sr=b&sp=r&sig=cTroUD6jGUaQknGXuWjDvJh4RXmHtPw9taHxCRfq84U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:38.6652915","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A38Z&sr=b&sp=r&sig=9HuEU27R8U2CxjUbAGQQ%2F2XWaA84hqQCEzusyGbzHeQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:38.6652092","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A38Z&sr=b&sp=r&sig=aeA%2FsXXw3w6KMJIXjvgrg3PgnYBphLkC3zzJaJ4L9%2FU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:38.6653134","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-24T12:33:54.041Z","endDateTime":"2023-10-24T12:38:32.64Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.822Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4411'
+      - '3247'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:19 GMT
+      - Tue, 24 Oct 2023 12:38:38 GMT
       mise-correlation-id:
-      - 8f7e7d2e-37e5-4cba-a678-25c4054f7ca0
+      - 41921ed4-635a-4d79-8df0-0ed78371a148
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2727,7 +2727,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:33.5819664Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:33.5819664Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.1836047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.1836047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2736,9 +2736,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:19 GMT
+      - Tue, 24 Oct 2023 12:38:41 GMT
       etag:
-      - '"75002f65-0000-0100-0000-653046470000"'
+      - '"d300ce49-0000-0100-0000-6537b9780000"'
       expires:
       - '-1'
       pragma:
@@ -2768,23 +2768,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A21Z&sr=b&sp=r&sig=1Oadzn2ApcmhFcKG1GkgZTkfL5XJAHCNslxJwwXBFYU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:21.4907834","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A21Z&sr=b&sp=r&sig=2Ci%2Bx1pyjG5wYWp%2FsKPwmo8RN0Q%2FFhyghxSqi5Yk57E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:21.4906868","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A21Z&sr=b&sp=r&sig=S%2Fc7yV6ya64EzV5eGekuB2Zq3wVnwtGLuLqgWgxj%2BXQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:21.4908096","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A21Z&sr=b&sp=r&sig=36FG85j42kRrtvduwm%2Fz9ZpkzGUhy2W64AOXHYPIqtk%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:21.4908353","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A21Z&sr=b&sp=r&sig=Ka3t%2FYsrLty2apDXIwyErpqEtfpqIIzx%2B2IfMVbBZW8%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:21.490864","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-18T20:56:35.199Z","endDateTime":"2023-10-18T21:01:11.605Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:19.169Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A42Z&sr=b&sp=r&sig=uwPtDsThcKw8ePDKRjTKvNi3Hj7HwWQTruFmoMSRAK0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:42.8481108","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A42Z&sr=b&sp=r&sig=nmcyjtWtxekoTvxcO2Iz0BeaPRyBSqJmXsqe77%2BaEAs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:42.8480304","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A42Z&sr=b&sp=r&sig=caMH6lG9RSj32xaSqxcr4nFhE8waI2UCvWRhLpN%2FiJ8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:42.8481253","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A42Z&sr=b&sp=r&sig=eHEtc6j4D5bR34KQhI7Lh5V%2F6PKNHMu6FMWUCiERorU%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:42.8481393","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A42Z&sr=b&sp=r&sig=j%2FjfomER089MnNESM5Gu9RnyQFqbKm1O9eUGEdZ4ddw%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:42.8481533","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-24T12:33:54.041Z","endDateTime":"2023-10-24T12:38:32.64Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:39.7Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4404'
+      - '4394'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:21 GMT
+      - Tue, 24 Oct 2023 12:38:42 GMT
       mise-correlation-id:
-      - 972745c8-9a0e-4005-af79-e89ce7971200
+      - 23f36dff-30d7-4db3-b58a-2d73758a4a51
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2804,7 +2804,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"dimensions":[{"description":"Request Name","name":"RequestName"}],"description":"No
@@ -2823,9 +2823,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:21 GMT
+      - Tue, 24 Oct 2023 12:38:43 GMT
       mise-correlation-id:
-      - fa902514-6f13-430b-911c-976d146a8435
+      - 5e8f0369-1776-497a-86f1-cbef9116a9b4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2849,23 +2849,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-18T20:57:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:58:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:59:00.000Z","value":1.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-24T12:34:00.000Z","value":1.0},{"timestamp":"2023-10-24T12:35:00.000Z","value":1.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '181'
+      - '128'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:22 GMT
+      - Tue, 24 Oct 2023 12:38:43 GMT
       mise-correlation-id:
-      - 0f5eb566-5408-4bfb-a2ea-70e45db8c32c
+      - 47509e61-e09c-4179-9c7a-3caa194023f7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2889,23 +2889,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=ResponseTime&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=ResponseTime&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-18T20:57:00.000Z","value":46.0},{"timestamp":"2023-10-18T20:58:00.000Z","value":16.0},{"timestamp":"2023-10-18T20:59:00.000Z","value":14.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-24T12:34:00.000Z","value":171.0},{"timestamp":"2023-10-24T12:35:00.000Z","value":1750.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '184'
+      - '133'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:22 GMT
+      - Tue, 24 Oct 2023 12:38:43 GMT
       mise-correlation-id:
-      - e3bdf80e-534e-460b-8d1f-7221dbb51aa9
+      - 56dc2d95-6471-4ef5-af4b-c1c4177b2f05
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2929,23 +2929,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=TotalRequests&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=TotalRequests&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-18T20:57:00.000Z","value":33.0},{"timestamp":"2023-10-18T20:58:00.000Z","value":65.0},{"timestamp":"2023-10-18T20:59:00.000Z","value":22.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-24T12:34:00.000Z","value":15.0},{"timestamp":"2023-10-24T12:35:00.000Z","value":58.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '184'
+      - '130'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:22 GMT
+      - Tue, 24 Oct 2023 12:38:44 GMT
       mise-correlation-id:
-      - 6b4be6b9-e484-4df4-a197-683cabebfc05
+      - 92697b54-b361-41a5-862c-de3da07c2706
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2969,7 +2969,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=Errors&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=Errors&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"data":[]}]}'
@@ -2983,9 +2983,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:23 GMT
+      - Tue, 24 Oct 2023 12:38:44 GMT
       mise-correlation-id:
-      - 909925b4-22e0-492a-8fb4-2788035bdf70
+      - 078240ed-c21c-4d41-92fc-041ac323d11c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3008,7 +3008,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:33.5819664Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:33.5819664Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.1836047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.1836047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -3017,9 +3017,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:25 GMT
+      - Tue, 24 Oct 2023 12:38:45 GMT
       etag:
-      - '"75002f65-0000-0100-0000-653046470000"'
+      - '"d300ce49-0000-0100-0000-6537b9780000"'
       expires:
       - '-1'
       pragma:
@@ -3049,23 +3049,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A26Z&sr=b&sp=r&sig=wFc8FcjN%2FwcwZPF4zE5wHPKboQ8reO5iqHEb3K9Wb0s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:26.1676288","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A26Z&sr=b&sp=r&sig=QieDfN46R4UpLZmm0aa0GIzAcCWXzcdkLtWjsV7E0pw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:26.1675498","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A26Z&sr=b&sp=r&sig=oaVF1MPkPCKU9NCLNdaF9eJwYHjFkczG1NRosgwpcd8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:26.1676436","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A26Z&sr=b&sp=r&sig=OOr6MLDbhUByvc7nyhPNoyeOkkOlQMh9caHdEKDdle4%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:26.1676573","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A26Z&sr=b&sp=r&sig=VRnhApQnR0d53l%2FdhKeYHLFo055xwaz85BKY%2BBzv330%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:26.1676718","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-18T20:56:35.199Z","endDateTime":"2023-10-18T21:01:11.605Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:19.169Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A46Z&sr=b&sp=r&sig=rrDlm6PkGYeBEd%2FHlTNkT2j%2BDPttg6bkIOkPR2WY0t4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:46.9410828","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A46Z&sr=b&sp=r&sig=tjmg7ZqXLFfx%2B8gQZJQ7CYVtAgAQnnx5WYo0O1awAPI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:46.9409886","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A46Z&sr=b&sp=r&sig=58XF5KY4mz6UhHez%2FKr80yqcX7UEgp2m19EaCwW2TiY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:46.9411054","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A46Z&sr=b&sp=r&sig=Cb3vDbWHMZ0U5OMIgba1p1mOrWP6xlyCXuunWDznCwk%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:46.9411269","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A46Z&sr=b&sp=r&sig=IHoGlDhoULkb33f3KUL1Z4zvXgk2T1A%2B0QhNf2MSyWs%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:46.9411512","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-24T12:33:54.041Z","endDateTime":"2023-10-24T12:38:32.64Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:39.7Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4395'
+      - '4396'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:26 GMT
+      - Tue, 24 Oct 2023 12:38:46 GMT
       mise-correlation-id:
-      - 34e2071d-cd78-4c8e-b1a0-c9ad1a342da5
+      - 1089b7f4-9134-4afc-bd28-dd7362dc2a55
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3089,23 +3089,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-18T20:57:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:58:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:59:00.000Z","value":1.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-24T12:34:00.000Z","value":1.0},{"timestamp":"2023-10-24T12:35:00.000Z","value":1.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '181'
+      - '128'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:26 GMT
+      - Tue, 24 Oct 2023 12:38:47 GMT
       mise-correlation-id:
-      - 895d746f-9d43-4e6b-b88d-1fa3259eef79
+      - fe816c82-8148-4802-ad85-9c39b9fc27e0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3128,7 +3128,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:33.5819664Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:33.5819664Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.1836047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.1836047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -3137,9 +3137,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:27 GMT
+      - Tue, 24 Oct 2023 12:38:48 GMT
       etag:
-      - '"75002f65-0000-0100-0000-653046470000"'
+      - '"d300ce49-0000-0100-0000-6537b9780000"'
       expires:
       - '-1'
       pragma:
@@ -3169,23 +3169,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A29Z&sr=b&sp=r&sig=GBhGD2ufqqTbGuN%2F4jH0qRF7ZxJ05wd4YAIoS9J28uc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:29.1271958","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A29Z&sr=b&sp=r&sig=3P64OGPneYApFzmmJiIW3HteXaV%2FhCqV2dknBbxWpWc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:29.1271267","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A29Z&sr=b&sp=r&sig=gWjzV3t8gex560bNJSyPcN3XFXR%2FU%2BAW4GVyIhtMVmI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:29.1272113","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A29Z&sr=b&sp=r&sig=uAdmkttywRVPe0kSmTbXpDooeYLm6in6%2FT1zKivn7lE%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:29.1272241","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A29Z&sr=b&sp=r&sig=hM%2FkGpzMcdjelA0YLfkE%2FyszhF9fNgya9DBVYAkoGxM%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:29.1272379","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-18T20:56:35.199Z","endDateTime":"2023-10-18T21:01:11.605Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:19.169Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A49Z&sr=b&sp=r&sig=JBY1vp%2F4QTcUFEe2dZVInKL8kAniF0xwYIya4r8Uyr0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:49.8021713","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A49Z&sr=b&sp=r&sig=GuuD0w10uyVcdUwe%2FZedQih0RJxOlf%2B2Zy3s7DPJQTA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:49.8020842","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A49Z&sr=b&sp=r&sig=w1OVXMGNYHCqnCJYO6umNM%2FSQnjrJNqGnjmXMR623sc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:49.8021954","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A49Z&sr=b&sp=r&sig=tsXZ%2Bp91KooKTsrpnexZm5YTLW1S7ggTll4abVhTzvA%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:49.8022136","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A49Z&sr=b&sp=r&sig=HYesIJF%2BCkGTODPTmOOon27tdfl7vmYWwVNj3HTa3sM%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:49.8022271","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-24T12:33:54.041Z","endDateTime":"2023-10-24T12:38:32.64Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:39.7Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4403'
+      - '4398'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:29 GMT
+      - Tue, 24 Oct 2023 12:38:49 GMT
       mise-correlation-id:
-      - 155b4ffb-4689-4157-9d6f-631ea0a3d6b3
+      - c91ef123-aa2a-4e0c-8420-a6f808e803e3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3205,7 +3205,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"dimensions":[{"description":"Request Name","name":"RequestName"}],"description":"No
@@ -3224,9 +3224,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:29 GMT
+      - Tue, 24 Oct 2023 12:38:50 GMT
       mise-correlation-id:
-      - 55d0dc2b-d920-450a-a569-8cf7b173fca9
+      - f8ec5ea8-1aa5-4af2-a4f4-c005858114e9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3246,7 +3246,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":["HTTP Request"]}'
@@ -3260,9 +3260,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:29 GMT
+      - Tue, 24 Oct 2023 12:38:50 GMT
       mise-correlation-id:
-      - e8bb8484-ae00-433d-a0d8-091cfeebcaef
+      - 2a220ca4-ad63-40b2-8e9f-6dff83c88bc3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3286,10 +3286,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-18T20:57:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:58:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:59:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+      string: '{"value":[{"data":[{"timestamp":"2023-10-24T12:34:00.000Z","value":1.0},{"timestamp":"2023-10-24T12:35:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
         Request"}]}]}'
     headers:
       api-supported-versions:
@@ -3297,13 +3297,13 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '247'
+      - '194'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:30 GMT
+      - Tue, 24 Oct 2023 12:38:50 GMT
       mise-correlation-id:
-      - 751dc3ef-b954-4446-9393-5cadc2df593b
+      - 2858a2b9-d5ce-4b8f-a022-fcf7e955365d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3326,7 +3326,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:33.5819664Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:33.5819664Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.1836047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.1836047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -3335,9 +3335,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:31 GMT
+      - Tue, 24 Oct 2023 12:38:52 GMT
       etag:
-      - '"75002f65-0000-0100-0000-653046470000"'
+      - '"d300ce49-0000-0100-0000-6537b9780000"'
       expires:
       - '-1'
       pragma:
@@ -3367,167 +3367,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A32Z&sr=b&sp=r&sig=yCEp%2FFfUDGCuW6te86vS%2F5JU%2BeR%2BFIMe4g4YRgvBO0A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:32.4187398","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A32Z&sr=b&sp=r&sig=ywwO3KyIisAZX4o%2FqWMXtYSXc%2BKgIZywKBJtp3Jjn1E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:32.4186629","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A32Z&sr=b&sp=r&sig=xA4EJJOKX56Tho%2BSPhi%2Fr3mL199D2x3jCH%2FvCc04v%2Bo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:32.4187549","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A32Z&sr=b&sp=r&sig=3IJdClSuXPajgPbCUoSmxX0GnMGxZyyaJ6RmMm4S11Y%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:32.4187689","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A32Z&sr=b&sp=r&sig=ZozHnncYVnJJ7EEkLJOhxsLOijRxmp97p1uQWwHwP8w%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:32.4187826","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-18T20:56:35.199Z","endDateTime":"2023-10-18T21:01:11.605Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:19.169Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '4409'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:01:32 GMT
-      mise-correlation-id:
-      - 50f6abae-239b-4327-a9aa-086e5e12c01a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
-  response:
-    body:
-      string: '{"value":["HTTP Request"]}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '26'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:01:32 GMT
-      mise-correlation-id:
-      - 763f73e6-de50-45ff-be3f-87ebf32ebd16
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"filters": [{"name": "RequestName", "values": ["HTTP Request"]}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '66'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: POST
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
-  response:
-    body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-18T20:57:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:58:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:59:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
-        Request"}]}]}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '247'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:01:32 GMT
-      mise-correlation-id:
-      - abfd8074-cb5e-431a-84e6-b4aabe3970ed
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:33.5819664Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:33.5819664Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:01:33 GMT
-      etag:
-      - '"75002f65-0000-0100-0000-653046470000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A34Z&sr=b&sp=r&sig=zXqZxgoMVjLaiHm2GcT5V6hc6hWK9G57vcGbXARy7WA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:34.6968408","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A34Z&sr=b&sp=r&sig=VnnPWQUmKbOCiJW9wQvFbHNmqtZS2xafB6IU5VNHhKI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:34.6967503","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A34Z&sr=b&sp=r&sig=TVKRLA1oUjXiI2KiB2zeZQKztkNH3TudW4L3MvTJMKA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:34.6968623","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A34Z&sr=b&sp=r&sig=fXJ7HC5CNdFBI5Pc35%2BsVrftyrUA6qVcZTKF%2B1ycn9I%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:34.6968825","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A34Z&sr=b&sp=r&sig=B%2FtTKl5uNthv4INbH4vqDQ23sNSDuZNUeJPkOT%2BCxio%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:34.696904","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-18T20:56:35.199Z","endDateTime":"2023-10-18T21:01:11.605Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:19.169Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A53Z&sr=b&sp=r&sig=Y5YS2D365Dib6n1%2FcLiH6%2FAlhenNw8pKqzWd%2BBTuxNM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:53.3949315","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A53Z&sr=b&sp=r&sig=EYL4DM%2FSu6UDhKKKPM7TeNqDyuCEIAGVB07PccntdBI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:53.3948633","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A53Z&sr=b&sp=r&sig=kcd1Rt6NoSjUHvHDsWKTtVEINFL9x4JYW%2FqYoM0MVvY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:53.3949463","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A53Z&sr=b&sp=r&sig=gD4RV2Jlllv8bm2yYBE1fkXTImX0qhih4NHVSm3ryKc%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:53.3949599","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A53Z&sr=b&sp=r&sig=zro8LipJCxEI91v2q379D1NWcy6wFbjIrb2JZ1AlRLs%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:53.3949739","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-24T12:33:54.041Z","endDateTime":"2023-10-24T12:38:32.64Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:39.7Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -3538,9 +3381,45 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:34 GMT
+      - Tue, 24 Oct 2023 12:38:53 GMT
       mise-correlation-id:
-      - 62d8dc0a-7803-40ad-99de-2da694b20c6f
+      - a7c5edf5-2ed2-4ab1-b0b6-ed876a8c7651
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
+  response:
+    body:
+      string: '{"value":["HTTP Request"]}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '26'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:38:54 GMT
+      mise-correlation-id:
+      - 806ffa4a-0e02-4efb-a8f3-43fb7d91ab45
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3564,10 +3443,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-18T20:57:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:58:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:59:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+      string: '{"value":[{"data":[{"timestamp":"2023-10-24T12:34:00.000Z","value":1.0},{"timestamp":"2023-10-24T12:35:00.000Z","value":1.0},{"timestamp":"2023-10-24T12:36:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
         Request"}]}]}'
     headers:
       api-supported-versions:
@@ -3579,9 +3458,130 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:35 GMT
+      - Tue, 24 Oct 2023 12:38:54 GMT
       mise-correlation-id:
-      - 8bb424ed-4f7e-4ad7-b7d1-0617dcd8dde5
+      - 1dc1d9d4-e5e7-4d15-8e56-46aa6fb0885d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.1836047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.1836047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:38:55 GMT
+      etag:
+      - '"d300ce49-0000-0100-0000-6537b9780000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A57Z&sr=b&sp=r&sig=RgtNJnTa728ejXjcsdgzAzhUz2kqBFNWtKW2fPqn%2FXc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:57.4826877","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A57Z&sr=b&sp=r&sig=Zw4S4DagPWKdDUCTG8vrZUBf1pkm7riBhvQIBPaaRsQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:57.4826189","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A57Z&sr=b&sp=r&sig=dEj5FvEBOTCIUfWUAdrxql3QDWOGy8OR2ReCnNVbh64%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:57.482702","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A57Z&sr=b&sp=r&sig=eU8ut1ZiXrID6j7EC1s6Hs8tIw3nFHYLVqTxJYdauSY%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:57.4827149","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A57Z&sr=b&sp=r&sig=BH%2FJQJixyk0G0i%2FH6VU0X%2FLD7pGiuAl1vn8iIHyzzR4%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:57.4827284","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-24T12:33:54.041Z","endDateTime":"2023-10-24T12:38:32.64Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:39.7Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '4393'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:38:57 GMT
+      mise-correlation-id:
+      - e4b85588-5673-4da0-b01b-6fad45e45773
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filters": [{"name": "RequestName", "values": ["HTTP Request"]}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
+  response:
+    body:
+      string: '{"value":[{"data":[{"timestamp":"2023-10-24T12:34:00.000Z","value":1.0},{"timestamp":"2023-10-24T12:35:00.000Z","value":1.0},{"timestamp":"2023-10-24T12:36:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+        Request"}]}]}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '247'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:38:57 GMT
+      mise-correlation-id:
+      - 828ff1f4-8bf2-4601-a0dc-7dd43492b2a8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_metrics.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_metrics.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.1836047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.1836047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:39.7823896Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:39.7823896Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:27 GMT
+      - Sun, 29 Oct 2023 22:26:13 GMT
       etag:
-      - '"d300ce49-0000-0100-0000-6537b9780000"'
+      - '"3c00f92f-0000-0100-0000-653edbe50000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:33:28 GMT
+      - Sun, 29 Oct 2023 22:26:15 GMT
       mise-correlation-id:
-      - f0466664-f359-4db6-ad6e-bfe6fe800ecb
+      - 8160cdda-26a2-4e0a-a63b-8611eaf6a7ee
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "120"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"4667c381-5ad7-4857-9d62-8ab4a8f1da09": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "45a56dce-3d5e-4f56-b47d-8fa8affc416c":
+      {"passFailMetrics": {"35e90d04-0264-4063-9ebe-cdb20c627cf5": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "d241522f-d46f-43be-bb57-877d354d4d90": {"aggregate": "avg", "clientMetric":
+      "50"}, "e07ff0ee-d404-41c3-a03b-07ed42ae5071": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:33:29.326Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:29.326Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:26:16.078Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:16.078Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:29 GMT
+      - Sun, 29 Oct 2023 22:26:16 GMT
       location:
-      - https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+      - https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 8856d95f-3822-4a5d-846f-1ea8b67f3bd6
+      - 209cc909-2e97-4025-b06d-838dedffdeab
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:29 GMT
+      - Sun, 29 Oct 2023 22:26:16 GMT
       mise-correlation-id:
-      - 316ac083-6fc5-418e-a31a-8ff7f5db6cff
+      - de49c1a2-9174-4afe-b954-0b895e1b9bfb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A30Z&sr=b&sp=r&sig=y47XogD9M7wNDgNOAWYd4UMR872MIWlqkwv8WsRmn5Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:30.3546107","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A16Z&sr=b&sp=r&sig=hO58zSbz64pchPPgM9h%2FNhlIIhqT1z2JNGHTm%2Bd7d6M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:16.9231018","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:30 GMT
+      - Sun, 29 Oct 2023 22:26:16 GMT
       location:
-      - https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 9fc3f07b-f577-4fc0-a581-5ebfbaa66cd7
+      - 6f3451bf-9d50-4113-bdf3-d8803206163b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A30Z&sr=b&sp=r&sig=5%2Fhb6IOzud8mVVwzZ1jxs8wfSWEq8lhogiauHGjXPAA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:30.6912413","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A17Z&sr=b&sp=r&sig=lbZ5L1qlh7A62Z8s9%2BdvxPgNpmYsK5Gl6ai4K3mBFJc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:17.2032504","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:30 GMT
+      - Sun, 29 Oct 2023 22:26:17 GMT
       mise-correlation-id:
-      - 46f154c5-e53a-46b3-88d2-4d4e0cf1aca8
+      - 8c5b27f7-3451-4f4a-8366-705096148b78
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,10 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A35Z&sr=b&sp=r&sig=J%2BTXPHng3ov6D3zhf0ug7D8GKdtXCx7JbSGK59Y6XNE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:35.9703206","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A22Z&sr=b&sp=r&sig=zm73njlsuzFJucUQj%2F3gSS37blN75M4nqiuHOQknpbI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:22.5812994","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:35 GMT
+      - Sun, 29 Oct 2023 22:26:22 GMT
       mise-correlation-id:
-      - c8b95a4d-06e7-497d-aeaa-69e08714f416
+      - e0b411cd-d9b0-4a58-b89b-8a8a11a9afba
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A41Z&sr=b&sp=r&sig=oHexem5QSIsM%2FxhVcvUdNBDsewr0xENiszzKOJi6ykU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:41.3190722","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A28Z&sr=b&sp=r&sig=kh42dVkO9SrRI6Fq3lBuAQKyjxQFA2XwYH%2FzgK3%2BGzY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:28.2651421","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:41 GMT
+      - Sun, 29 Oct 2023 22:26:28 GMT
       mise-correlation-id:
-      - cd1a6e3b-396e-4220-abd1-a34d0e58f2c2
+      - 9024b8ba-6712-4e8e-8dd7-4e5fac0645f9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A46Z&sr=b&sp=r&sig=5efsOx%2Fz%2Br77k%2Fke%2FGEHW5C1mEt5q3ksDFxdcElrtPE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:46.6008817","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A33Z&sr=b&sp=r&sig=gXISOQSIINbMaTGTM8U8P09ctBwpaDKoyVzKKTzXmg8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:33.5798842","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:46 GMT
+      - Sun, 29 Oct 2023 22:26:33 GMT
       mise-correlation-id:
-      - f86d26ad-9a9f-4d4f-917e-6e5f6a52caca
+      - abf8548b-715d-452c-ab80-3e9e1a813340
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A46Z&sr=b&sp=r&sig=b8x7SVLPl2pS22bf%2B6tp23r69LRPOmkBKRdg3B%2B7SPU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:46.8864435","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:33:29.326Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:44.593Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A33Z&sr=b&sp=r&sig=iS2lXd9KJqXMEBUWZbVAy9sGaMlYwl3lIEP3%2Fsq6DvA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:33.8318408","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:26:16.078Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:30.724Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1583'
+      - '1581'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:46 GMT
+      - Sun, 29 Oct 2023 22:26:33 GMT
       mise-correlation-id:
-      - 2464903d-85ae-4b44-b47a-d5e56710fcfb
+      - 354990ba-472c-422d-a0ae-1ec43172dda0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.1836047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.1836047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:39.7823896Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:39.7823896Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:48 GMT
+      - Sun, 29 Oct 2023 22:26:35 GMT
       etag:
-      - '"d300ce49-0000-0100-0000-6537b9780000"'
+      - '"3c00f92f-0000-0100-0000-653edbe50000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A49Z&sr=b&sp=r&sig=qQpbyZJjwFPtsAuDJoV4XGIqhMA2enT3UAZ7%2Bm66yTo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:49.3658443","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:33:29.326Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:44.593Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A36Z&sr=b&sp=r&sig=n8vK%2BTRbuHxIm8m4Qb9P%2B%2Fvj%2BJ4p2rahQ07C8K3Gzag%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:36.1515575","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:26:16.078Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:30.724Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1593'
+      - '1599'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:49 GMT
+      - Sun, 29 Oct 2023 22:26:36 GMT
       mise-correlation-id:
-      - 18815837-ef27-4363-8ffc-d2731bc56b55
+      - 8bde8222-f7e7-417f-b3c8-12b586ebe920
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.1836047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.1836047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:39.7823896Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:39.7823896Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:50 GMT
+      - Sun, 29 Oct 2023 22:26:37 GMT
       etag:
-      - '"d300ce49-0000-0100-0000-6537b9780000"'
+      - '"3c00f92f-0000-0100-0000-653edbe50000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:33:51 GMT
+      - Sun, 29 Oct 2023 22:26:38 GMT
       mise-correlation-id:
-      - 594230f3-2093-4796-8b79-8679be26f877
+      - 44006d41-a9ad-436d-8aac-64ef5fe6a89f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A52Z&sr=b&sp=r&sig=ZFzMGBvQiiW6vSR6HcEimGrU03sgaTaQky7nPVMwxpU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:52.7045123","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A52Z&sr=b&sp=r&sig=ob8Iyk6QQQOHP4xINAYtSTGXLpLYQldSmxUbhCS7loE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:52.7044068","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A52Z&sr=b&sp=r&sig=VgXoyUC2jQY%2B%2Bae5%2BbI11KZso8KNrUl0hdR4espGumE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:52.7045324","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:52.631Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A39Z&sr=b&sp=r&sig=butRMXfFhijdpy2OR0utLcp17nOKQF0u1rnrhlIirRo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:39.1160003","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A39Z&sr=b&sp=r&sig=B7iDQR2kejsNJesSwF7044fx%2BEtcA6BvuErKWP2yEc8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:39.115798","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A39Z&sr=b&sp=r&sig=wZZiZEySJ9CeYV%2FnCdWmOzuNtJu41gCZHwoM32eVlos%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:39.1160674","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.023Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3156'
+      - '3153'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:52 GMT
+      - Sun, 29 Oct 2023 22:26:39 GMT
       location:
-      - https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+      - https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - a11c7a56-95eb-493b-ae61-89b5de94a3ff
+      - 3a146cab-4492-49db-a911-bd4c9ef52425
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,10 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A53Z&sr=b&sp=r&sig=M83S88ZXykn1uEWLUtPyFNnRcINFtzqx4c11ghnZrtc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:53.1999864","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A53Z&sr=b&sp=r&sig=jEl9O0keiBkQcarDTSYIYwWrMGkzAvfam4okEUsmDYg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:53.1998977","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A53Z&sr=b&sp=r&sig=REqkc1IzKUcxkwpNs%2BRHHHle0%2BuwpS9x9ZjH9RWts8A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:53.2000077","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:52.631Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A39Z&sr=b&sp=r&sig=Ld4mZBoEa0iGL%2FOgte2HB2DP78cnPQ0RIQ903cRw7IU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:39.529093","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A39Z&sr=b&sp=r&sig=96RuyUCiwuCPZmkEDLtZhP3EFJX4l837vN6IJgM1zhc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:39.529024","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A39Z&sr=b&sp=r&sig=2ehmqW01nM8CMhC9Dljixf0BXNER3iGMv%2Be%2FG9GP970%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:39.5291071","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.023Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -714,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:53 GMT
+      - Sun, 29 Oct 2023 22:26:39 GMT
       mise-correlation-id:
-      - 37c95afe-4d83-4b76-b52f-6a47785518f2
+      - f47f8c6e-27ef-4d09-b7f4-414eb4f9ccc3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,514 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A58Z&sr=b&sp=r&sig=DeQYCKzHr761H2cEj9YXLuw7CdKXuIrpa%2BswuvA2R8A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:58.4569904","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A58Z&sr=b&sp=r&sig=aMSUrxQq9Tu45xGgPk3R%2B5PzaTftS17N2uJTQN6h%2FAY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:58.4568969","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A58Z&sr=b&sp=r&sig=FzpuEyFAiyAZ%2FM4gdb0I%2BwcKRM2kBptjtEv%2FQmTdvWs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:33:58.4570393","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:54.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3209'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:33:58 GMT
-      mise-correlation-id:
-      - 8534bfec-40dd-4519-aaea-2759773a64b2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A03Z&sr=b&sp=r&sig=LcP%2FzyFIf8YzHAQ49s92ClgDGN%2FpcVBz0WECsJvDlEQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:03.7544078","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A03Z&sr=b&sp=r&sig=j8TpMrvsAxb%2Bc5Q2umRzM0Yv%2B6CT50z4eBwILQ3rDg4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:03.7543295","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A03Z&sr=b&sp=r&sig=d5PLvpb94PszaWq%2BfXX2uYa8kGO%2BuXLaDTPX0TgDLKY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:03.7544241","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:54.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3209'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:03 GMT
-      mise-correlation-id:
-      - 08f29ee9-2c98-4c2f-a82c-2d2531682069
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A09Z&sr=b&sp=r&sig=cxTKTCVRh3T3zT%2F%2FCLMLXTWXkIME1CSmB0q4TCfCUck%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:09.0951432","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A09Z&sr=b&sp=r&sig=pmvRN%2BPHcW%2B06Df7Qp4ZiY%2BQvOkVqkPeMc1ZHFxYIvA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:09.0950356","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A09Z&sr=b&sp=r&sig=5g6QUGGZR22GgcMpxkIynRauiFHNR8RN2Hz0bH7M38w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:09.0951651","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:54.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3207'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:09 GMT
-      mise-correlation-id:
-      - 48941b5e-8d6d-4bb7-a0a5-b3c8c9cea1b9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A14Z&sr=b&sp=r&sig=uan5rK5M3njWIFss20%2B3u%2BCEGSE8GEP3Z0Mr1chWxXw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:14.3973229","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A14Z&sr=b&sp=r&sig=vvgiDN87wRGTEM4HKUd519n8B398UxBmQj2Vaz4%2BlC4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:14.3972355","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A14Z&sr=b&sp=r&sig=1IAopfZepzflod8MPtpTT7YnYY%2FdqHmAk9NfwKpJdV4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:14.3973447","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:54.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:14 GMT
-      mise-correlation-id:
-      - 44594c95-a7b2-46c3-9a0b-ad8ac9d18008
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A19Z&sr=b&sp=r&sig=%2FGeiI6Qe6dfQdh%2BA%2F6r9q3bwOeQZ4RSYdsjrEQVXdeU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:19.6718026","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A19Z&sr=b&sp=r&sig=kpdYrwWkdphZwkJHaeztFzWSJ0wXxSyRMxLotwTgqxs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:19.6717142","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A19Z&sr=b&sp=r&sig=aCVObohdQlrvwphh%2FsSeMipkUz%2FW1tQEaDexYT2wGb4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:19.6718238","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:54.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3207'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:19 GMT
-      mise-correlation-id:
-      - 3e5e9617-50a4-4094-b4cf-959c6c5176ef
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A24Z&sr=b&sp=r&sig=be%2BR3n8quhQR1ecxpyN8aXEY7262LiTVoEemFDgUT%2Fw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:24.978679","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A24Z&sr=b&sp=r&sig=6ZUFKutD1ebfqVrqhQkp%2F7nW0D3lTSDjezaPBKP7qsU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:24.9785937","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A24Z&sr=b&sp=r&sig=GFESsuFQcs1%2B1vMQQ7QQ70h19QMMZTqKP%2BWql9SDDDY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:24.9787006","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:54.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:24 GMT
-      mise-correlation-id:
-      - 72fba203-9ad2-4d09-8c7d-6d8d77bf1a2f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A30Z&sr=b&sp=r&sig=qME6L6rzD4OlZZF4ue2NOgoMMmJTbzm08KFgv1lLLjk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:30.2977805","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A30Z&sr=b&sp=r&sig=Wp%2FyGJUQsAn0xum4Ouccrgki6ozKkqt0vh9PX7vc9eU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:30.2976923","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A30Z&sr=b&sp=r&sig=vcXPOxWcyp1ktf%2BH898SQ%2FfpIfBhbc9nPzlWapFcQg4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:30.2978012","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:54.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:30 GMT
-      mise-correlation-id:
-      - d4935101-397e-44a7-b609-96b2bbdffde2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A35Z&sr=b&sp=r&sig=oIQRzh8v3PFBnCDgdLOKX6j9MMQNy2t9ZLNKOTGU6eI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:35.6276096","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A35Z&sr=b&sp=r&sig=FY14csWbO13Mbk%2BkahMmPIvL%2Bed4yJGOs1ROQjRrkE8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:35.6275332","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A35Z&sr=b&sp=r&sig=bEyR4%2BwbDuXG9gp1TsgxlCsgUivjtMvJEEqvEhyGccA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:35.6276244","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:54.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:35 GMT
-      mise-correlation-id:
-      - 3b638aed-cb86-4537-a0a5-aaa162155d32
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A40Z&sr=b&sp=r&sig=2LZzI2RCbmL9Fwb0ISOKFdnP8vb1cVvVsYcSoa%2FSIig%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:40.8929159","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A40Z&sr=b&sp=r&sig=7zQjrnJnYVoyaH3r%2BzebY4MaCYPskTqYS0VHGd14m4A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:40.8928296","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A40Z&sr=b&sp=r&sig=sg8Rc3LM42b%2FMDwi8TXUGW199YkaIWsoobjotEzzZhg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:40.8929336","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:37.933Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:40 GMT
-      mise-correlation-id:
-      - 32cb04d5-b4d2-4913-be06-d09684263145
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A46Z&sr=b&sp=r&sig=FXiROE9r3IL07m925HtArLzHXocn0bWgY56Wuj%2FWYok%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:46.1665265","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A46Z&sr=b&sp=r&sig=uaahWJdXd92uRJ%2FBRW%2B5ZQxlTiPdjZX%2F38ymjlfSXp8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:46.1664409","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A46Z&sr=b&sp=r&sig=41pnh9uwkccIt5QhEnmG%2BueDRB9WYEfJhWH%2FpQC1gc8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:46.1665479","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:46 GMT
-      mise-correlation-id:
-      - d8b21d8d-ff76-49be-86bb-f3e3ce104cd5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A51Z&sr=b&sp=r&sig=VujOfdYHQEfF1D%2BwZaykGnmeX9j5hu1n8IppO6wZuqc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:51.5068558","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A51Z&sr=b&sp=r&sig=kTVg9FIKbrYDx%2B6l24Q8t7YDHqzHO8rdBS5AFxCpg5k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:51.5067852","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A51Z&sr=b&sp=r&sig=FgQeDezttj2GWAnsvDDS33qFHB%2Bq77%2FzsSqlrRfP2CQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:51.506871","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:51 GMT
-      mise-correlation-id:
-      - 48cf1864-f905-45f9-bee5-965ed771fb94
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A56Z&sr=b&sp=r&sig=NJyC2VniR50az03R1gm4hnYxPw7H1MGPSNrb3PuvbVo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:56.8086985","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A56Z&sr=b&sp=r&sig=B0fgpoeTbfBZ13adbTJmSkzbbyGBV0eziHmTASPh470%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:56.8086051","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A56Z&sr=b&sp=r&sig=fgV45T8EvoR03IrPN6YadNkDMhkMnZtAq%2B3jugn4V9s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:56.808714","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3195'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:56 GMT
-      mise-correlation-id:
-      - 955f0354-8fb4-4c69-882b-66bd971081b0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A02Z&sr=b&sp=r&sig=YlPGqilFeymLyK48lfUyFY4J%2B5HvO9viJkcLzocsVnE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:02.0864822","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A02Z&sr=b&sp=r&sig=k4Q1QFd%2BLfvH4KW4hC6q7PyKOFxmdXds2bz%2FlBS6foU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:02.0864044","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A02Z&sr=b&sp=r&sig=KZj21FMrUwdct0phtdnSM%2F1vyExMQmdaSmcwu5HGGjY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:02.0865037","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:02 GMT
-      mise-correlation-id:
-      - 6fde9546-5dfc-41e3-b0c3-4a6c65a66bcf
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A07Z&sr=b&sp=r&sig=u4JeTvzx0dCa1%2BAZICpER%2FINs2mM0C5XW78UmHvg%2BfE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:07.3574265","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A07Z&sr=b&sp=r&sig=2PZbi7kqgi9Fxy%2FE8zAAS%2F9hCXiZFT14AYBlNHzNfiI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:07.357359","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A07Z&sr=b&sp=r&sig=Rpo%2FLY9cSkM7hRMSjSbT7%2FalRYk4phS5d9pvTbugNkQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:07.3574411","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3207'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:07 GMT
-      mise-correlation-id:
-      - 87b7fb6e-1792-47b4-bf39-103fc1d04932
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A12Z&sr=b&sp=r&sig=ddp8RaqjqRLyhCRGKJz69b%2BxNEP6Iy3wQd775tzyrSQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:12.7081593","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A12Z&sr=b&sp=r&sig=G5FlRhFt41lq8paTKVi6xchkwnP%2F9%2BJH%2FV4%2FTdZZOqU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:12.7080677","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A12Z&sr=b&sp=r&sig=0HY5sszoXbT8FIUsvLv56%2F6bCKVOx%2BE5zJ2Xed2dbiQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:12.7081819","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A44Z&sr=b&sp=r&sig=iDGitHrgwzx4q%2B%2B%2FB17Mno3WrLo6xGwaOhxg6c6sihA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:44.8246189","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A44Z&sr=b&sp=r&sig=OyLZwnjYFG7cT%2BzJeV78O%2BYBsbS7mI0sGBGY9x6UCgE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:44.8245232","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A44Z&sr=b&sp=r&sig=CpyASgw4JDxUwOquFDVzeTancZovlf1%2BBQ11aor0ZBo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:44.8246418","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:40.222Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1254,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:12 GMT
+      - Sun, 29 Oct 2023 22:26:44 GMT
       mise-correlation-id:
-      - 65d831de-43e5-41e0-a6b3-9362205f2711
+      - dca5a4e5-8e60-4b8a-b8cd-50b5525a92f7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1276,262 +772,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A18Z&sr=b&sp=r&sig=Kcof8lk8YNcoTLI%2BvP%2FRihSeKSel4fAIsBczE5vjpUU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:18.0145853","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A18Z&sr=b&sp=r&sig=UqSzW9IMVlltnfF%2B9juR0WiaQ21Fkf5CtPynDUPLy1k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:18.0144837","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A18Z&sr=b&sp=r&sig=uyqiOIK42GdWe5meMnttth6DaH47%2FvYuwhGt9Ic5htc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:18.0146085","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:18 GMT
-      mise-correlation-id:
-      - c1f850df-09e3-401c-9a1c-6df73f5b5f64
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A23Z&sr=b&sp=r&sig=DPKHYr8Erf4rfuk11OH1SRcWzH%2BkQKR%2BL5zh7ds2Y98%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:23.282031","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A23Z&sr=b&sp=r&sig=AiQnkAqVGDiD5rVB7AtaTS7jTsGf0YRqOKx5aURkWv4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:23.2819468","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A23Z&sr=b&sp=r&sig=wujUppJJgyACfA3L9K2UJgbsoIAEUzsYjiOwrxSqSwM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:23.2820459","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:23 GMT
-      mise-correlation-id:
-      - b1e37b07-63fb-4e60-98f9-6af415f07027
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A28Z&sr=b&sp=r&sig=sZbXTMwVRjWD%2Fy60hubE26%2BM4KbfXUTPqeojmQ9eU6s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:28.5860252","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A28Z&sr=b&sp=r&sig=smvo8lH4dxUXPcIHxRQR0vxyv41tPR1M4z7j%2BYBdnRY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:28.5859392","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A28Z&sr=b&sp=r&sig=B3wI%2BPugLwWN7sPSvRxoMJw7Vbg9rtxIjzIGiPnPZpc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:28.5860464","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:28 GMT
-      mise-correlation-id:
-      - 94d08ed4-d37e-4e03-8413-35078a1d4420
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A33Z&sr=b&sp=r&sig=iGtZca3eOMb%2BuGjku7fTvJLtpWm9KgJjBAGdQwlVOhg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:33.891047","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A33Z&sr=b&sp=r&sig=Gw0Q7HSLgy7nvoN721ya%2B6G4lXIJHKYt1f0Jy06pSGk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:33.8909628","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A33Z&sr=b&sp=r&sig=OBDWe%2F7aMHpbuTwGPidB5%2F0C%2Fh367E7bXEK0IFHU4PU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:33.8910679","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:33 GMT
-      mise-correlation-id:
-      - f111e018-863c-480a-b14b-7f01796458cc
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A39Z&sr=b&sp=r&sig=zSWufuZii8w5wYwiCCJAgbrZg8wFOTenAONfOqwu0U8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:39.218112","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A39Z&sr=b&sp=r&sig=u9L9%2BMOieefibQzgmu5%2FgGYMiRyDa%2BbOEC8Ha6w5nWk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:39.2180022","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A39Z&sr=b&sp=r&sig=gRc%2FkLiM212WViOOo79lHPZo7TQeWyE9Mik9mfafGZ4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:39.2181346","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:39 GMT
-      mise-correlation-id:
-      - cf9ce9e8-04a3-4691-8663-b478f370f0bb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A44Z&sr=b&sp=r&sig=Yoy0RdrX%2Fw0FURuJ9MotFk5UyWhrMnajncTbp4cC2wI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:44.5269127","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A44Z&sr=b&sp=r&sig=1dv123N8ifvHe56EiKPTvg4Ht66CfOq0cb2al6F6w%2BA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:44.5268407","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A44Z&sr=b&sp=r&sig=Q0%2BuOOCO7ucWugx%2FF6r47VxIHkjY9xkvkmBRDBKtdy4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:44.5269265","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:44 GMT
-      mise-correlation-id:
-      - ff46fd75-9a94-4680-a41d-4a4f370b7000
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A49Z&sr=b&sp=r&sig=W7RNU2Enf7m3vihrMT9rGXEjoh7iwf1wVElNJmbhHso%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:49.873944","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A49Z&sr=b&sp=r&sig=EX%2BH3tsOeaNAfL%2FRw4LO%2FmH%2FPsbSSeroyCGfT8IYVds%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:49.8738306","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A49Z&sr=b&sp=r&sig=nTQmPzd0ffbxWHiCVhYIsRAzgKzG0hOi42oW1tYy90o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:49.8739707","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:49 GMT
-      mise-correlation-id:
-      - 57450b4b-638d-49df-bdf8-2af7b6e2e756
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A55Z&sr=b&sp=r&sig=QIrWAFWRvaV8nb4zh%2Bp0ZZsxhhVILi4FvMumz%2Bx9Qoo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:55.1365171","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A55Z&sr=b&sp=r&sig=yxBw6IxaefJMhGqchinJ3OmZVGGhpha7FWf51C1umQw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:55.1364284","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A55Z&sr=b&sp=r&sig=rWwbltoj8gFIxG7EopjkMUDWOhYnueUM%2F3QttZ0zWM8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:55.1365389","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A50Z&sr=b&sp=r&sig=EjKlyo1eANrMtVVrEbhu9axpCSokirWUH%2BD9QI9ykZg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:50.1653234","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A50Z&sr=b&sp=r&sig=iGED38Pf5EA4QNoUAj7h9UEUfJEjb0uDfz0jS6U%2BThg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:50.1652542","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A50Z&sr=b&sp=r&sig=XAtHjDmoB16b14HcD8LidYHDXx77jOQbovejnfO3Afk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:50.1653371","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:40.222Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1542,9 +786,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:55 GMT
+      - Sun, 29 Oct 2023 22:26:50 GMT
       mise-correlation-id:
-      - f3722f86-2259-476b-84f6-84aa7e13e851
+      - 12bb21b3-a5ff-4338-9fc3-b4cc70e84a7b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,10 +808,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A00Z&sr=b&sp=r&sig=z4ar1gk7PhhpV4FiJNo0J%2BNONV5PmHMqFYw%2BRxNs0D4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:00.5143339","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A00Z&sr=b&sp=r&sig=BoQ7ZN%2FodLt1sDoxIz8Wt%2BSS9UHa3QfG1HfeTXJ0%2F8I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:00.5142618","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A00Z&sr=b&sp=r&sig=jRRh0k81HGbQS9H1yKhuXwBLiVecNW5ocrP86R%2BsKKU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:00.5143478","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A55Z&sr=b&sp=r&sig=x0VH9Hl%2FRItANTMTddE6MBCGtnrwC9XUaJ8tvDBxC9Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:55.4943522","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A55Z&sr=b&sp=r&sig=VsPCu219zJm43PebPlCZpyf%2BrNL6r3U8NbDK2H0zy6I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:55.4942775","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A55Z&sr=b&sp=r&sig=aicGudelRyrKmR1EryCWdYZQVJ0HLElJ3bp2b%2B9WSW0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:55.4943658","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:40.222Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:26:55 GMT
+      mise-correlation-id:
+      - ec023ccd-fac5-4d8e-a83b-ac6fb7fc769d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A00Z&sr=b&sp=r&sig=3DgIxzpdt%2Bc3TcUcjrpc%2Bs4Rr7nHruj0%2FTnpQvtw16o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:00.8328586","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A00Z&sr=b&sp=r&sig=73%2FV8ObMggE%2F85rBtWD5vISDzTNLyEdfvbK58uvCp4o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:00.8327914","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A00Z&sr=b&sp=r&sig=pCAP1TwEQfaVta9rQ66pmlKtGcvw5utYoGwx0d3beKY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:00.8328731","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:40.222Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1578,9 +858,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:00 GMT
+      - Sun, 29 Oct 2023 22:27:00 GMT
       mise-correlation-id:
-      - b8b60444-e2be-4eff-94fd-9455f8c17a7a
+      - 88c1a9f5-d5de-4737-bb12-5926a1bb3114
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,46 +880,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A05Z&sr=b&sp=r&sig=hsx581pC4gWihMxcwVFCaIoJSs1dsUCjEwrZwBgtwp4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:05.8486353","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A05Z&sr=b&sp=r&sig=PHQCfOHNq4Qd9Yo%2B4YEX78TCUxEy457HSiu146MiIUI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:05.8485526","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A05Z&sr=b&sp=r&sig=0sXOgm0hmzQE8l2Rw%2BylL4lJ89ywobcidclyfY87qbY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:05.8486574","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:36:05 GMT
-      mise-correlation-id:
-      - 7194b9e2-fada-421f-b5bc-e6d7b9787e54
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A11Z&sr=b&sp=r&sig=xviqLeP4NUYjk4SzXmdJEuf4Qr4y13uQIE6h1JE4yGs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:11.1141423","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A11Z&sr=b&sp=r&sig=2KWVjqPF1sHStDX%2FBtEb9IDL1bJhQAXL81HVXETKE4E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:11.1140543","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A11Z&sr=b&sp=r&sig=YFaq75Jvb69HoyQQ3aQb6S1%2BNb%2BD8DeKnDsbErkyfmA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:11.1141643","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A06Z&sr=b&sp=r&sig=28S2PXbRN0mg85Ztw7QZtmlKKZw9jG%2Braus5m6QLMb0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:06.2039334","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A06Z&sr=b&sp=r&sig=S0wAkfpcHQ7jEdxzL2BUu6JFCDqlhxE4TPiHhL3pxpk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:06.2038524","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A06Z&sr=b&sp=r&sig=m5WqCGjth3Z97zRepxEeNZxuYyH266RpC8S%2FXkyGM4c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:06.2039492","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:40.222Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1650,9 +894,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:11 GMT
+      - Sun, 29 Oct 2023 22:27:06 GMT
       mise-correlation-id:
-      - 28a07884-2d33-43ad-8931-7129e9fe4c67
+      - 4cc046d6-51ed-4b0b-902c-f610683b254a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,190 +916,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A16Z&sr=b&sp=r&sig=ZjbO0GgIKw56nApccPoINWSFFWjNWjYV8VaIDDpbv1w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:16.3884217","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A16Z&sr=b&sp=r&sig=93%2BMVokDlVDTv9J5PGguNuOrriGa6Vg7IPwQ2wsVTD8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:16.3883275","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A16Z&sr=b&sp=r&sig=eIuk0IInPFvEJqzYyg2AIyMNqagUulk8lHKY1CLx3BI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:16.3884438","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:36:16 GMT
-      mise-correlation-id:
-      - 2c10b9e1-1cb9-4b85-a829-c13937f2bacb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A21Z&sr=b&sp=r&sig=YiyWoEzScV98toIFfps5D68OaSt%2BCRMwtXJsA%2BtfXrg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:21.711854","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A21Z&sr=b&sp=r&sig=%2BOzmsZXjXdKiW11OgG3%2B9%2FDiDrHHhHy4J6BP936gdeE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:21.7117652","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A21Z&sr=b&sp=r&sig=bClJxWkNYrUWv%2BGODzAeipKd%2B0fyAkX%2F09J4kpYAwT0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:21.7118769","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3209'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:36:21 GMT
-      mise-correlation-id:
-      - cb1c63a7-e60f-4f68-849c-4334e2de118a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A27Z&sr=b&sp=r&sig=Dl9ZNxK0SuT67Z20AymfL8LAv%2BA2fC3cFUbxdrzvfLw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:27.0610954","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A27Z&sr=b&sp=r&sig=siM7Ocf3IqTxaAmiJ45YXsGYwTcfnE7aC9iZr%2FZzhNE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:27.0610111","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A27Z&sr=b&sp=r&sig=1UFDIbwTdDsfV4N9Pv5ii6SFO67uJu2UI3SYMQgRS98%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:27.0611161","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:36:27 GMT
-      mise-correlation-id:
-      - 76ab60bb-c06c-4aa4-91ea-7de85d0c55d9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A32Z&sr=b&sp=r&sig=xVJCV4NccVUdL5djcTHk2TIXFqzcA0VaHvSY%2Fl7%2FKlw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:32.3442845","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A32Z&sr=b&sp=r&sig=P42uXKKnn6Kz6hqbTH6evgD1J1W4QZ7df8UYVpTWTus%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:32.3441931","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A32Z&sr=b&sp=r&sig=vLhtYtXN6ji3APmEB4RiQPgVyXxmgj1XmPg4rv74D2c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:32.3443063","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:36:32 GMT
-      mise-correlation-id:
-      - f00c8fdf-d4c8-4285-9dd1-d36204aa22c2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A37Z&sr=b&sp=r&sig=TQl5atucvBioGNXau0fKdIm2NTRWw6Ki3xOVG7weZZ0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:37.6392909","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A37Z&sr=b&sp=r&sig=UMvna4YZyepbTo4%2FdL%2BOOACKk3f%2F8M7uS7aW14XWPsk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:37.6392006","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A37Z&sr=b&sp=r&sig=dsSmy0HZMUdLiHSNpxcxh3aqISF59yc3jagLCEs1wsw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:37.6393125","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:36:37 GMT
-      mise-correlation-id:
-      - 997278da-bda2-4ca5-abbd-660bf829693a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A42Z&sr=b&sp=r&sig=wLNj1Mvd2Wbpc4NYIqthK%2BaYCFbtl4kak8j25qhRdKI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:42.9365513","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A42Z&sr=b&sp=r&sig=ZfOtM2cTRBmI41NjqCxrT%2BlZhnZSpu6KT6rRwMW9jBw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:42.9364541","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A42Z&sr=b&sp=r&sig=5bKa3EUXE%2Bgst%2FJc9kGCGhuE%2BZN3Pl4hGwVhCQaXpyw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:42.936577","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A11Z&sr=b&sp=r&sig=FSl%2B0ahhbuUTpk9lQg5rdyaP1zfh%2BsdjsEoeLBVp2HA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:11.6521234","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A11Z&sr=b&sp=r&sig=17WUV23yVboHpiczfFMG3yZgjkjU3HtQCpoxFuXpkOs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:11.652025","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A11Z&sr=b&sp=r&sig=9qZ8AkhpyiA0jWl5Iwh%2Fcdp0%2Bnn0kzGOkWPNuH2c6QU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:11.6521483","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:40.222Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1866,9 +930,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:42 GMT
+      - Sun, 29 Oct 2023 22:27:11 GMT
       mise-correlation-id:
-      - 3eb910ac-37ed-44ee-97fb-8aac1716ae56
+      - 58f28f1b-f335-4375-894b-6e8986053810
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1888,23 +952,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A48Z&sr=b&sp=r&sig=m3ic%2FYxHXExIsR6rL1qVF1dZ3IBSlYvmtu2Z45dOvTI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:48.2098254","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A48Z&sr=b&sp=r&sig=FAc1AUYufDdxMM%2F5qwo8aV1JD99kAIki4u0EOkYjI7o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:48.2097654","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A48Z&sr=b&sp=r&sig=UDFX5qHXqLncrULsJbnKrZAivzIroeo2oE2pfngEZHI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:48.2098402","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A16Z&sr=b&sp=r&sig=KKuDbSm9PNB%2FnbJfGFhO5I0O7f76lUYDXlN7Ar%2BpnA8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:16.9364922","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A16Z&sr=b&sp=r&sig=wyKYb9IBkmTgD4Y7LrWugRlRVIKMDpe%2FWRtmeL%2B9Bsk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:16.9363949","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A16Z&sr=b&sp=r&sig=4ym1vs2xtfy5qCNcWWaHtiS5b65qyVpGcD33B3f59Ng%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:16.9365152","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:40.222Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3198'
+      - '3204'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:48 GMT
+      - Sun, 29 Oct 2023 22:27:16 GMT
       mise-correlation-id:
-      - 9f9d0c77-b03d-49e8-8f40-669f75e93a4e
+      - ae66a448-210a-4e36-81b8-4a4425199ca2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1924,23 +988,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A53Z&sr=b&sp=r&sig=KKaw2qHIzAdAqh94S2sM8KT%2BIs5i%2FJ9YpZLGOtiBoU0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:53.572815","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A53Z&sr=b&sp=r&sig=xmoDOgTACEeKpREUEBXxSMxDRUtFwbe%2BYrMpmNdn0PA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:53.5727443","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A53Z&sr=b&sp=r&sig=qHrq9%2BzYPGdBXVX9YiFuekM%2BzS9oBJRRR4oY17DkAew%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:53.5728295","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A22Z&sr=b&sp=r&sig=fZECeSGxmq4OZbhIm0Aw8AO%2F3JZ%2B0ua9O23h7g41x2w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:22.2439874","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A22Z&sr=b&sp=r&sig=DvTkTF0N%2F31pp%2FuPJVEIvcw7yywpA%2FsFdGABP%2BBg1xI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:22.243914","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A22Z&sr=b&sp=r&sig=WeJUOSeNIOmS%2BpM6pkPZeu%2FEUsbJ989Arpjo8GYq2Vo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:22.2440017","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:40.222Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3203'
+      - '3211'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:53 GMT
+      - Sun, 29 Oct 2023 22:27:22 GMT
       mise-correlation-id:
-      - cf37ee38-ca3c-4218-b436-5de4a66a1c79
+      - 5a3309e0-de4c-49ba-8818-f35fbea8db05
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1960,23 +1024,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A58Z&sr=b&sp=r&sig=2clyerZQTOK0Fi2yDxOkaCic3EA3eQMJtCkTRdNvi5E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:58.8818615","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A58Z&sr=b&sp=r&sig=ukZpg0x4ByfZ9Rnu9sznTs70MxVGm4geL54eo9oSt0c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:58.8817786","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A58Z&sr=b&sp=r&sig=HhfNjzBpOHrCzSS%2BbS21LXw%2Fd0iH%2FeG3RIhDgu7SH9w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:58.8818777","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A27Z&sr=b&sp=r&sig=m%2Fpg6l%2F8J96%2Bv%2F71GJS1UNXCkXRtKxWOEm8NJqm9FC4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:27.4933068","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A27Z&sr=b&sp=r&sig=SaEPpnE2VkzMAf5z4uX9hE0945nuVxpwMm6%2FRASMbXg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:27.4932379","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A27Z&sr=b&sp=r&sig=4EdRThofW%2FIKr04i9pzBToRe7nDIuzQVkXUwsSzRKSQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:27.493322","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:23.959Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3200'
+      - '3206'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:58 GMT
+      - Sun, 29 Oct 2023 22:27:27 GMT
       mise-correlation-id:
-      - 36f9bc87-a34a-475a-a12d-769ac49125d5
+      - a9299486-6090-4dfb-ba8f-ff9c2fa82504
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1996,23 +1060,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A04Z&sr=b&sp=r&sig=WeY955vwh4colQPPftiFhafobhEZnaz1NWss0bXGHfo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:04.1794894","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A04Z&sr=b&sp=r&sig=EvB2xe%2B60hXpy6FQMKk%2BzII1Xj2A1PttTT1fbkjJiEs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:04.1794126","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A04Z&sr=b&sp=r&sig=qbWO1rECGg6yWwGHqadSGgoS4mvbNNVpQBfW4O6oxKw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:04.1795044","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A32Z&sr=b&sp=r&sig=jVv39TqWaSxQLRiZ%2FVLDAVeCZw9ErDo7aQDg1RPsLSI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:32.7831702","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A32Z&sr=b&sp=r&sig=UrMChajHmAqQJwmRam46q%2BNJFckYh%2BV1QMJY6ZDVlFY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:32.7830663","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A32Z&sr=b&sp=r&sig=mHGelpT8pv8%2BuuC03y2H3KCzwddqo5WFk6TeBpZymZg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:32.7831913","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3198'
+      - '3201'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:04 GMT
+      - Sun, 29 Oct 2023 22:27:32 GMT
       mise-correlation-id:
-      - e4b7ccec-da56-44fb-9f55-79885442c48d
+      - 286f53ae-2389-41f9-9492-97db0d474690
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2032,82 +1096,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A09Z&sr=b&sp=r&sig=1MYYBiKqVzqDcRs7lWaNjXs29B4H41taVqzfVRkIqFM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:09.4997395","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A09Z&sr=b&sp=r&sig=sVBgfLPN%2Fx545fxAXK1CNglaUfiR2suyrGsRGy1bka0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:09.4996687","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A09Z&sr=b&sp=r&sig=kxDEtuaYwlypm6PzGA5L6NBI0BzZ7B3DqAJrmRWbAu4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:09.4997527","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:37:09 GMT
-      mise-correlation-id:
-      - f60d82fb-fe9d-42af-ab31-e4320d37c757
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A14Z&sr=b&sp=r&sig=0NVPLc1nnCIpjlVzLX3vdlBEtfGsD4A3%2BhXCs%2Bk7EE4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:14.9900289","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A14Z&sr=b&sp=r&sig=rkEowMKZ3g0K30dGZEhO2jwqZZhTaAJR4m2WI1Vr10k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:14.9899479","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A14Z&sr=b&sp=r&sig=KlGvVR9bxGQveFTznQSHZEdV7wb5rPJXHPcmE1r7PM4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:14.9900447","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:37:15 GMT
-      mise-correlation-id:
-      - 7a4b688e-f957-437a-961b-6e5443d1190b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A20Z&sr=b&sp=r&sig=4jxDEgIHyqlRsfanORQnfurKPSt5B4XuZZi4y7Q8l70%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:20.3144569","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A20Z&sr=b&sp=r&sig=UzSZxUnY%2FGMJeupB%2FDxQczOgFHFe13zWQxS7OOQ%2FSi8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:20.3143615","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A20Z&sr=b&sp=r&sig=hLxSkojqSa45bAW8HCKS6YH1rf5JWyfV2AQjxx4616s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:20.314482","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A38Z&sr=b&sp=r&sig=4uhKRpT%2B8VJ0H2igYXiTWFR0BEa1pnXP%2BoBok2Pc900%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:38.103058","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A38Z&sr=b&sp=r&sig=r0w8XAgDDoD4IzrMI3FaowvKlha4TcaeY8iGat%2BEuRw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:38.1029876","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A38Z&sr=b&sp=r&sig=U%2B4Kdc06RiCYxGaGCSYtn3QqpqNm3R0p1trgTDMdt0Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:38.103072","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2118,9 +1110,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:20 GMT
+      - Sun, 29 Oct 2023 22:27:38 GMT
       mise-correlation-id:
-      - 41da0d87-a3e5-4459-a9a6-5ecc0d9ea75c
+      - ff60e52f-29ad-4cad-ad3b-a6cd6c01fba0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2140,23 +1132,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A25Z&sr=b&sp=r&sig=dyzDRBBO9vYJI3vW%2BRGr7KuBi9ZR1pOtiXnZlTx1N7g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:25.5901094","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A25Z&sr=b&sp=r&sig=B%2BPIiopcgg6rAedcXBTyybwJGB63lodr8YVrv4FZDsE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:25.5900354","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A25Z&sr=b&sp=r&sig=%2BMMTKNCNNf0oxEYJfpoECScoRV9JpQtNUVIjkHhVjPQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:25.5901243","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A43Z&sr=b&sp=r&sig=uYsTy7%2BKE9GU7VocHYyb7MBRkOxVxZRC5pfGzSZHCBE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:43.7668784","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A43Z&sr=b&sp=r&sig=rx2bFh0UfCZreVO8HaZh7PZh7j0OSmqOzwAnmWt6FAE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:43.7667932","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A43Z&sr=b&sp=r&sig=fc9BCjHaqBExzQYJq8eOcGcHT1N2FWTeSCeGnOKG51Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:43.7668988","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3200'
+      - '3195'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:25 GMT
+      - Sun, 29 Oct 2023 22:27:43 GMT
       mise-correlation-id:
-      - e6680ccb-01e5-4b62-8e26-8b271a38983d
+      - fecc8826-8de1-46ed-815a-217ed79f9bd7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2176,154 +1168,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A30Z&sr=b&sp=r&sig=c4JNCl%2FHtpddj9R9pMK9TdbCZ%2BCfqsvw3Cte60nhDi4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:30.9540866","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A30Z&sr=b&sp=r&sig=7IZKMESrPmHWqXcC1XwQkZJL0T1U6NRtAeoebV8WN4I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:30.9539963","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A30Z&sr=b&sp=r&sig=sbiFj5wA7pb6G%2FMw8OzJz93kvTHPokuhXSi%2FutxOHnw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:30.954109","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:37:30 GMT
-      mise-correlation-id:
-      - 67283345-1e44-44ad-9554-251b1e9e7aa9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A36Z&sr=b&sp=r&sig=oJhmSbhLeJZ2tiOLihmU7SA0OfYrlDnRHQH0oo0u0RY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:36.2330313","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A36Z&sr=b&sp=r&sig=XDm%2BifVRE5Z0FFNj8wXuZB6me6fET34Jpc9ZZ0beVf8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:36.2329533","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A36Z&sr=b&sp=r&sig=Pl72TAeLyJsBTk3gItqY%2FpNnzR2qVFnO2yYvJZyri5A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:36.2330458","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:37:36 GMT
-      mise-correlation-id:
-      - 1cc5b0ab-c56d-4875-9036-30d7d93a1f1e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A42Z&sr=b&sp=r&sig=te0I4Jp9XAZRKyGkPuPWO2A9Mei7YSWorIBoREPGW4I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:42.1312906","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A42Z&sr=b&sp=r&sig=e0ZIcGOGzgXN6ZVqZeH7hUnYXrrXHg%2BTC%2Fl7PVSnrmI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:42.1311882","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A42Z&sr=b&sp=r&sig=0LM2aPE1xg2ux3JE3DYzrcJ%2BBEDPv2WDunV3lHcJFwI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:42.1313139","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:37:42 GMT
-      mise-correlation-id:
-      - a37c2e94-cc74-443c-996f-86814185cd37
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A47Z&sr=b&sp=r&sig=1ZKAkazDwvPPvy%2Bbc6kGwGhBVMqx2dsNbMqSlp0SBjM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:47.8384317","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A47Z&sr=b&sp=r&sig=zJl8dQFu%2Fb%2Bf0oqgNpT65uzTeYzP5usUKWAlthUYrtg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:47.8383277","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A47Z&sr=b&sp=r&sig=wBP9V14K%2F1kwfVTwy6mAVdf0T2k9vhkCvL%2FQcZl1yK4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:47.8384564","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:37:47 GMT
-      mise-correlation-id:
-      - cf60905d-4fc8-4630-bc77-faac32e773e3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A53Z&sr=b&sp=r&sig=yAwkKxJ2M%2BL%2FrZ37UV6UVM4%2FEtmLEZ%2Bof5PrxgYSORY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:53.4718481","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A53Z&sr=b&sp=r&sig=zknf%2FaR4bpmWscC9ooRTiexA%2FMJdNFmj72ugufldPPk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:53.4717673","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A53Z&sr=b&sp=r&sig=y111A4WcP9a1sZ6FJZqO3pAvp9GR9GoKAi%2BkumZcqeY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:53.4718623","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A49Z&sr=b&sp=r&sig=AmrA9wOSj%2FmW%2FQ5%2BEoFrYSRJClYfj6XL%2FqZ2GPrS7pk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:49.6662221","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A49Z&sr=b&sp=r&sig=gdSFieC94gmzWMGjolwnGymvgdngSmvj%2FvZBlARK%2B9Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:49.6661495","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A49Z&sr=b&sp=r&sig=%2FUjn69%2FQOMfLICdEf2DsXPBRkiElgBhpG9gYYH12ZDQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:49.666236","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2334,9 +1182,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:53 GMT
+      - Sun, 29 Oct 2023 22:27:49 GMT
       mise-correlation-id:
-      - b9b6c909-5565-4b70-ae26-b59b460c241e
+      - 83fe4ba2-98ae-47d5-9f9c-0f540d089ea2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2356,23 +1204,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A58Z&sr=b&sp=r&sig=C05TQAfW58%2B2riBE3vxH2nUon379aZUihxBgtXVagJ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:58.7543118","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A58Z&sr=b&sp=r&sig=KkHzSIpR0zoAEorj5V5FsZZDZEhXKSXyxGIAXIJ89AY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:58.7542086","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A58Z&sr=b&sp=r&sig=T1Y2TDWyTmXE8TlFW%2BHMaU9kaDJvXN9RrQEep3UvYGU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:58.7543257","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A55Z&sr=b&sp=r&sig=HD0dX7%2F9zmwj1MhhbERZNiFMyLVUin7AqCXoKGmhCcM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:55.3354177","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A55Z&sr=b&sp=r&sig=Vd5djop%2BSodh2Zur2qu4H5ya9otgYdvxIKK2oe%2FsTNU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:55.3353281","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A55Z&sr=b&sp=r&sig=BazVxwc4jiCeA0B40%2BMFLtaR9j8VasAghZVl4ftlmKo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:55.33544","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3198'
+      - '3199'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:58 GMT
+      - Sun, 29 Oct 2023 22:27:55 GMT
       mise-correlation-id:
-      - ba5d3fe7-7304-41db-99e1-9b8a52ab9a4a
+      - 2cf47169-cd55-40d1-9dee-7587e2b85f86
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2392,23 +1240,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A04Z&sr=b&sp=r&sig=UmJige73aDgVNIajKUkoDjZ9dMKnfxU%2BehuHXHNZQmc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:04.0414127","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A04Z&sr=b&sp=r&sig=ScCqmrHNtjVtaOwG6QuUlVmVfzo50leCGgepSyGf4ug%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:04.0413377","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A04Z&sr=b&sp=r&sig=meC7MlnmtSLmUKDYrpaYDDlaH9qcKvy9JeDilKHXKbQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:04.0414266","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A00Z&sr=b&sp=r&sig=qfotXr9iF55oH15sn6ij30iZbNHuqjG48yMhQAoGgUw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:00.6195477","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A00Z&sr=b&sp=r&sig=LAQ1hzBJY5ldefmZzbSjUNGQrVj%2BFaKMycmRtPExORA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:00.6194762","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A00Z&sr=b&sp=r&sig=bCC3yP1KR4Em7nudL2g%2FBQYiDi0riypUf56t68r9Tts%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:00.6195621","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3196'
+      - '3197'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:04 GMT
+      - Sun, 29 Oct 2023 22:28:00 GMT
       mise-correlation-id:
-      - 259541ed-f238-4cbb-8d57-a6a8899a3e1f
+      - ca20726a-650c-474d-8e0e-c24043d4e445
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2428,23 +1276,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A09Z&sr=b&sp=r&sig=HhUvrW%2FVC8O1S7wcnUSIEFQ%2BvKxDPnmf4iDyghHkyUk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:09.3385752","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A09Z&sr=b&sp=r&sig=Bi7qGeOppYP473a9c5A%2FLeSnKICjbPluVA8c5MzwZyY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:09.3384825","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A09Z&sr=b&sp=r&sig=ZYi8cr2GKP%2BNbGi5d1kDpulxl9i9ubNUbgaJ%2FJhCLpo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:09.3385926","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A05Z&sr=b&sp=r&sig=A2Eec0wLQJxSNb7Eg%2BrB6anqrix18IqbYCuUpBSeBks%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:05.9931374","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A05Z&sr=b&sp=r&sig=5hocuIKGSux%2FAumgpRQ3rg80cxQDhWkQbIJyMOlV20g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:05.9930533","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A05Z&sr=b&sp=r&sig=ttn2TrONK7GFJiOaaXftc5yHe5uWl5tmHZWp%2FkcDDPY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:05.9931597","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3204'
+      - '3199'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:09 GMT
+      - Sun, 29 Oct 2023 22:28:05 GMT
       mise-correlation-id:
-      - fb88a079-2c43-4eb8-8ba4-16f8d3e11932
+      - 638c0830-7fc8-4e24-b3f9-09e0a391ec97
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2464,118 +1312,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A14Z&sr=b&sp=r&sig=2%2F68y%2BulGzVECsvexgrcbnE6fzsnueD7VmWa8%2BNlX%2BU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:14.6539722","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A14Z&sr=b&sp=r&sig=CleBU38HpsdtjGN7uYuu0NTnQx1%2FcQpULcfDXuEN1yo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:14.6539051","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A14Z&sr=b&sp=r&sig=ZdRFjU8IYCNIQ%2B3RNn2S5jgTso%2BbCsck5z9xJd8gtno%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:14.653987","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3207'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:38:14 GMT
-      mise-correlation-id:
-      - 65fa84cf-fe76-4242-b963-2f1881ed0478
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A20Z&sr=b&sp=r&sig=rOVNhCJwADvrJrDygy9waRgXMBWhc3cDAsicVWglKxc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:20.0689149","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A20Z&sr=b&sp=r&sig=%2BSsUg9rqKXhbNXDxLADwobrghWZMC8BbdfQhuQzJUWY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:20.0687791","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A20Z&sr=b&sp=r&sig=RvYZPV4CaKnqNZK6cZDeP6SS%2FzTerh0n4DN6eVgMcFY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:20.06893","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:38:20 GMT
-      mise-correlation-id:
-      - eb720156-5b35-4471-a1f3-0bf339d93f3b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A25Z&sr=b&sp=r&sig=jBhRkDyvjvg3yGXIP5piML5srbXyfUZ5om5HV%2B5L7Xg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:25.4334673","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A25Z&sr=b&sp=r&sig=Mr9DkOKAdmOtkECSZOc9pmmc9pFzL3N%2BNlHvtFzOM3Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:25.4333888","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A25Z&sr=b&sp=r&sig=pAaag8OEpxJvdkv3xds1nGlOG%2FjRJhCGOt9kaWSO0Gg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:25.4334816","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:38:25 GMT
-      mise-correlation-id:
-      - 6d27a324-6fbe-4dab-af8a-0681efc8fee7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A30Z&sr=b&sp=r&sig=vFEzYbUZv5ENTJhrZiIdme2HIlMovSS09Q5cyO7zoDI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:30.710938","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A30Z&sr=b&sp=r&sig=p7TbbU2uozTdzPwdmen%2F%2B%2FMclmEjxy1xr6WbU7FuNco%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:30.7108694","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A30Z&sr=b&sp=r&sig=PASx9Fb3tspvnSShnSA%2FiZJba7OqsNp5JZU4yt8X6kI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:30.7109513","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:33:54.041Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:41.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A11Z&sr=b&sp=r&sig=MnMg6WJ2w%2BEDnfW3PTY22RtF7V9qsrEgE68PvC%2BImng%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:11.2866242","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A11Z&sr=b&sp=r&sig=SKv89G97yIUDXNk6kwTUl9uTnuli7Q9IGwyos%2BnZqcU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:11.2865532","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A11Z&sr=b&sp=r&sig=VWB0vCL6lHghHljcyWFj%2BvIPRry3mRJT9ykz8kuyCPM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:11.2866379","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2586,9 +1326,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:30 GMT
+      - Sun, 29 Oct 2023 22:28:11 GMT
       mise-correlation-id:
-      - b11ae37e-4564-46af-9f0e-945354c8d680
+      - 91272c71-d8fd-4549-9ffc-cb2563d16bd1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2608,23 +1348,1283 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A36Z&sr=b&sp=r&sig=kqlmoCbquPFaSHTCTPJCxVs8vtMRXLe6Q0hZrkIqvFM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:36.0699647","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A36Z&sr=b&sp=r&sig=ErKm8Wx1d14V%2FpIyPm0nSNgj52rZeD%2F8AuwiRurrHDY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:36.069892","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A36Z&sr=b&sp=r&sig=UljSKyiz1sA10vx6IyQWQz31Qg%2FJYKPZU4xLqgTSIWs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:36.0699791","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-24T12:33:54.041Z","endDateTime":"2023-10-24T12:38:32.64Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.822Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A16Z&sr=b&sp=r&sig=Y1k1LYg3CIKLccT7ZjFEubwqTAH2OxLIRKD8KX%2FZzhU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:16.6003417","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A16Z&sr=b&sp=r&sig=mmXMzWmX8q%2F%2B%2FHDIlo78JEpXzs%2Fe6icHo%2FFwQLN9%2BBY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:16.6002711","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A16Z&sr=b&sp=r&sig=XCSat01Wsy5LqH%2FNepgwPkEN7hgjlvSMH9Fb1UZzrTI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:16.6003562","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3234'
+      - '3209'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:36 GMT
+      - Sun, 29 Oct 2023 22:28:16 GMT
       mise-correlation-id:
-      - ecfe3a72-76b4-41d3-860d-2b93f6b10831
+      - f84c9a89-38bd-493a-b869-016d0e0069f5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A21Z&sr=b&sp=r&sig=Cx9ga%2B4TLo31sNbXuD%2Fmz7XHwK%2BIE1oiosQKvU9IJwo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:21.9453728","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A21Z&sr=b&sp=r&sig=eKfVPSozDzpB0DIYtL59DWi6LYZEHUwAPRHqNAPDJQ8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:21.9452622","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A21Z&sr=b&sp=r&sig=FW1PRWeH1MgBEOaT%2BeVBJQTiLty5cWFyRiyPCXTPr3c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:21.9454167","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:21 GMT
+      mise-correlation-id:
+      - 1c922a18-ce43-4696-a68b-7fcab1439a8f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A27Z&sr=b&sp=r&sig=9gkFM8JrTG39iKPaYTtQpqqdcvY2xzFcHrGaBWL5Pxw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:27.2038305","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A27Z&sr=b&sp=r&sig=wN9cIo0PEZkJS2Be26pvXZqFmmxkgk8UxOL9ZPbuj%2F4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:27.2037378","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A27Z&sr=b&sp=r&sig=nNMHoDeIxetxitWLxZ%2BLsSabIxsimYWYWJR5b0PSowg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:27.2038521","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:27 GMT
+      mise-correlation-id:
+      - 0b14450a-2751-4f7b-9b8b-a013513a171d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A32Z&sr=b&sp=r&sig=RC2HEzseOBwDM54OzST8%2FY0iKDX1Ww0CNVsXH6juKHA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:32.7553691","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A32Z&sr=b&sp=r&sig=%2F8elVELfP7l88zE2KxrqgiQAgGI6ebxMVGBqEs1xBHs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:32.7552788","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A32Z&sr=b&sp=r&sig=HGKf1U9DQ138GjssuwMYos3B7e7L64zmvENcsYHTztM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:32.7553938","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:32 GMT
+      mise-correlation-id:
+      - 4cebfb95-1175-4bff-8d1d-69f6b7068b6e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A38Z&sr=b&sp=r&sig=2WbBX8bnwlIlZCPkWXH09v5en6Vx0SyfEO9REkH7KuU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:38.0206143","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A38Z&sr=b&sp=r&sig=9Ga1nR3n0bc6eV0vEj4%2BEzwsQ4fdsOmJ%2FOh%2BRACR4Zw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:38.0205443","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A38Z&sr=b&sp=r&sig=paFpSwrc1IWShtai0mYn%2FUeAFphWiJW%2FpI1mL%2B4x14k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:38.020629","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:38 GMT
+      mise-correlation-id:
+      - e44c227b-fea3-458a-a7b5-cc8b9fc3223e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A43Z&sr=b&sp=r&sig=gok4TcN%2FWLYEWhh5BGpdmtsxc3cmQiGuHhOz2MdHsno%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:43.284397","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A43Z&sr=b&sp=r&sig=m1juLUicHhDVyopn5DAgMTXp6yf5xudNXkBcYBjF%2Fv0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:43.2843227","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A43Z&sr=b&sp=r&sig=052KSZ8eSJTpXZh0%2FW%2F532Obf%2By0r1mA4KqMlw1QCLQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:43.2844127","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:43 GMT
+      mise-correlation-id:
+      - b4f46dc4-c04c-4ccb-a104-e34a488c9857
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A48Z&sr=b&sp=r&sig=ZgEIElOehClRjg1uixz1VTiSSh8i9JsIHfqe05990i4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:48.5492392","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A48Z&sr=b&sp=r&sig=VkNCvo%2F3yh76EDkaNxO7Fo3EX6TVhA4eF7rxj3FH5Ks%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:48.5491651","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A48Z&sr=b&sp=r&sig=4ndT1LE8dg%2BSuIsIgD3NSHFQWRBgck5L1FXBH7bdB6g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:48.5492529","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:48 GMT
+      mise-correlation-id:
+      - 933a133a-97b6-4e67-a62b-26f36ef87e84
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A53Z&sr=b&sp=r&sig=LnyvPRIVT%2FyONrCrHDMTASHhRjOpLIR7%2BhTo4v7Sh1U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:53.8660645","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A53Z&sr=b&sp=r&sig=7gthD3MF%2FHzFEpdBtxrhdRBQZEEPDqqvdDGMnm96Bho%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:53.8659959","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A53Z&sr=b&sp=r&sig=uVlX1zf1%2BPPHSGWjsAdREWmlb%2FahXHnLV87tfLmbbuc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:53.8660791","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:53 GMT
+      mise-correlation-id:
+      - 2950ea0b-09af-4d78-900a-c9abee49c430
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A59Z&sr=b&sp=r&sig=FbpD1qoWPXFzkJ8DstnRuITt1sbB8MJ8c%2B4ux9wvQeA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:59.3216313","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A59Z&sr=b&sp=r&sig=1ohr4zLWe3fWL499hGvIP8YhTDv%2FTdiGp%2BHiiDsYx%2B8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:59.3215606","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A59Z&sr=b&sp=r&sig=2AInaxobwGgnCRn%2F2%2FhHQfzwET45J3QvjFbe5RghY%2Bk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:59.3216461","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3207'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:59 GMT
+      mise-correlation-id:
+      - ea2a3b9a-a20e-4b5f-958e-03c3896803e9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A04Z&sr=b&sp=r&sig=H3jKgKcQEtcMv4H9F%2BZ2yQieeVx40TPpmai2zmdEBws%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:04.6129179","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A04Z&sr=b&sp=r&sig=raIdwEcYrFiLniMu1nLibUzBvr8Yn3agplzh4hc4oRE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:04.6128492","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A04Z&sr=b&sp=r&sig=18h1rsYyiw3h6lotqn%2FLqVLa7N9p8wq%2B4uWuX%2F9LZro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:04.6129378","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:04 GMT
+      mise-correlation-id:
+      - 62c0e3f2-b2fa-49a7-813c-c5eb718c670c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A10Z&sr=b&sp=r&sig=NOfCWLSsUDFc9leOCu5BsRLj4Io4P3c4IU8k1Uf9l9E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:10.0199717","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A10Z&sr=b&sp=r&sig=JaJH%2B%2BLaw6ZHop7EWZgqTseICSHTKkWaNZCIR7Ku0zU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:10.019894","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A10Z&sr=b&sp=r&sig=zQMtIE6rwN3XoGZhmQZ9M1n%2F7%2BGtMzCrdw3IsKe2QE8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:10.0199863","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:10 GMT
+      mise-correlation-id:
+      - 8fd41ba7-52e7-4677-a7d5-27981639c47a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A15Z&sr=b&sp=r&sig=Qavw9ZBLC9EUN9FxyLvfbIPBT3nBnf1ExkLDGj5zID4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:15.2785751","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A15Z&sr=b&sp=r&sig=EUtOqT8hOmeuBV2HT0XNzEGyNEmURNGhr5HZTWfexH8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:15.2784881","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A15Z&sr=b&sp=r&sig=ADKovBXrjO8BpoSacsIujZOqgh1pPBlTFEgUucw1CMY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:15.278596","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:15 GMT
+      mise-correlation-id:
+      - 835b2d98-7bdb-49ed-b087-8ed39d965e40
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A20Z&sr=b&sp=r&sig=nU3S5UDDpvxnr3Q2lMXyd2XG0GGInEhMeiC%2B5UABpFE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:20.5817404","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A20Z&sr=b&sp=r&sig=ZHKFBX45WPmGPGz2mjN4D4UoQBTXemIdy7PP7OJV%2FZM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:20.5816691","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A20Z&sr=b&sp=r&sig=4%2Bc7pWtuo8%2F5NYsMOJMESItL0Kt4Enp3bLm7MEr1%2Buw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:20.5817641","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:20 GMT
+      mise-correlation-id:
+      - 4f3e754b-a54d-48ea-8bc7-2dc14e722c69
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A25Z&sr=b&sp=r&sig=Fl8EOqbijG%2BWBSFi3PjttOGNn%2Fc%2F9XfbwmkS%2BAb%2BaN0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:25.8664788","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A25Z&sr=b&sp=r&sig=XGzbZ2mmXw6c55xmLGja2Dj%2BaHG9zYUAkylkZunpWEA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:25.8664049","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A25Z&sr=b&sp=r&sig=ZHAa3bVcBe1foCrz0ztc8Kfh1jwmcN4wg5syl4ty5o8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:25.8664934","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:25 GMT
+      mise-correlation-id:
+      - 8738ea82-a4b7-4de5-8ed6-2196e8598fdc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A31Z&sr=b&sp=r&sig=TqkWep6ITPkYBVKnAhMqFlWG7VshxPCKc3ZJ3Hc%2FlF0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:31.6031363","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A31Z&sr=b&sp=r&sig=Qt280EhJVZrOUV2I2JMu8jgR5upc2aOsK8GRm8rLYqU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:31.6030687","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A31Z&sr=b&sp=r&sig=8izXpw7B9m3ylP4%2FOnFbL1zTsCbR%2BLUC33QaBAiMFrk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:31.6031512","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:31 GMT
+      mise-correlation-id:
+      - c263c7c3-cf27-4afc-92c9-360f6fc70a75
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A36Z&sr=b&sp=r&sig=o9vXG1byG742ptEstokGBTCg5mHBAs1ZODFLzIZFbdE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:36.8692732","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A36Z&sr=b&sp=r&sig=OsdHYNfGK5lo1iO0UiddrHXonaTkjLHgoU0ur1zIDO4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:36.8692026","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A36Z&sr=b&sp=r&sig=43pRjAknGlfjmnd7YIQ4w9nBsI8QACCwQfUDc61lHT8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:36.8692888","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:36 GMT
+      mise-correlation-id:
+      - 32926fd8-2d87-45e0-9765-5c7b3964993a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A42Z&sr=b&sp=r&sig=Zmb%2FxaqCcw%2B17iM7Xn2AJMVoxdxxTDTwQFc44qGhEDI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:42.1340042","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A42Z&sr=b&sp=r&sig=0km8Lsnz73I6iCxxi8hSiPL%2FSH1oZ7EgqTsExD8z548%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:42.1339202","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A42Z&sr=b&sp=r&sig=KqQSUA3xl6KGwkQj5DdTnhm%2Ff9XDUlFGfy5LbMjrp90%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:42.1340258","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:42 GMT
+      mise-correlation-id:
+      - 6e83b216-6cf6-48b0-80c3-0aed80363c99
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A47Z&sr=b&sp=r&sig=tUgk4uHTB2ed3c9GvTPd4ABlelj%2FitknDk36vQpGIxs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:47.3940443","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A47Z&sr=b&sp=r&sig=vvIZtdmB3zK%2FB7AcgshG4IxfX5e2HleoilUydY%2B4QqQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:47.3939785","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A47Z&sr=b&sp=r&sig=29%2Fjc2t8iI%2BMS1lUh10ZyFTEL7WSn43E%2FWSiF77clJc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:47.3940587","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:47 GMT
+      mise-correlation-id:
+      - 0d7ceda7-c925-452e-87e8-f10f0a0357ab
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A52Z&sr=b&sp=r&sig=mlNlWpR9igCic6RJtwMOp1dDgBzgNs0ukWr88SRKeHI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:52.650458","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A52Z&sr=b&sp=r&sig=2ds98hP5VJVwrnemjLktHGtMJB01FXdvevfgbuEIdzs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:52.6503682","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A52Z&sr=b&sp=r&sig=bqWh%2BavnjYO1T%2FnOVR6hh%2Fuq%2FEw%2B45NGsN5NsHMbcBE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:52.6504799","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:52 GMT
+      mise-correlation-id:
+      - 7c3e8a8e-23b9-4a8e-ba55-7efedb4ace95
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A57Z&sr=b&sp=r&sig=Y6dVprlzu3zOOEuDdvkLfNCmIINCPmeyJOc0k0tH9OA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:57.8973286","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A57Z&sr=b&sp=r&sig=ppLJD%2BeSjIqCLYtBoPHeJ9QwfFDSGoGYwXydbqe6Stg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:57.8972562","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A57Z&sr=b&sp=r&sig=Ou75Gf9YWf24JIvYNauefrw7fdWTP72ETqZBVdI5UfA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:57.8973431","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:57 GMT
+      mise-correlation-id:
+      - 53801631-b3fe-4035-a339-697edb38ca09
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A03Z&sr=b&sp=r&sig=nozZF%2FgIwOKm%2FCdw6J6ZiNNBsyQGKCaJN4nq2pPpMlc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:03.1406037","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A03Z&sr=b&sp=r&sig=O6BYNFuGV5%2Bl5ulPgVCWDJRHmE%2BxUXnh0XqdcoRSYlg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:03.1405122","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A03Z&sr=b&sp=r&sig=kFgbHXCOq0Bw%2FeAlfEoybhccxxjv7%2FaPGjOPp50IVbI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:03.1406257","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:30:03 GMT
+      mise-correlation-id:
+      - 4692514e-b02e-4ac3-a701-73af176c5ded
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A08Z&sr=b&sp=r&sig=SI5lfPTLdVtzCnrOdCggF%2F9gYay9ZVheCWOUrjHwBls%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:08.4080576","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A08Z&sr=b&sp=r&sig=Ex84ee8KBvPGgGiVdmOdbIRDlGDXiH8vk%2FJZ9qjfwqo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:08.4079834","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A08Z&sr=b&sp=r&sig=xumD%2BZ8KwFd0YY4WzzEvuynO3ZXzn8lGRYoTHTeFaIM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:08.4080721","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:30:08 GMT
+      mise-correlation-id:
+      - 37f52350-2676-4d0f-905e-1337d427cd7e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A13Z&sr=b&sp=r&sig=%2B8m8HxYC665miHz%2FsGkag%2FZ%2FTQz36XzK3Tarqx0rEMc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:13.7405519","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A13Z&sr=b&sp=r&sig=cB1PTUKK9t9EEmeNqmo51IUz0TYLvROx074jw9HJtb0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:13.7404615","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A13Z&sr=b&sp=r&sig=nW4H6JnuCMZi0Sihtxi5PHy14kaSp%2BYDR6bRLAKSK%2Fs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:13.740566","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:30:13 GMT
+      mise-correlation-id:
+      - 863e09ca-566e-41e0-aa4b-dec2d7419e1b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A19Z&sr=b&sp=r&sig=RussAFh2NIFrixNLH6Ye%2FTiBZ5u2%2BIMUJU1EACAqmbU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:19.0665347","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A19Z&sr=b&sp=r&sig=Fn8a4t9Q26jpK5BIcSsCFFPyieuLTh8%2FbC0MWB1eLKc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:19.0664645","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A19Z&sr=b&sp=r&sig=avDSm8p6Ubj%2FFTcELlgFIr3Qhuv05l%2BEnW29%2B2Eg5yQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:19.0665485","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:30:19 GMT
+      mise-correlation-id:
+      - 3781284b-9c41-461f-b7bc-5509c2746560
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A24Z&sr=b&sp=r&sig=A5%2FlxCGUubnYshrtqQJkYDqiNXyBzPjIbPfqywDJZT4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:24.3208402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A24Z&sr=b&sp=r&sig=VmQLd5%2FzGwC2q4LL%2ByV4Cc9JUpDfTjApGj86D6duMiQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:24.320742","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A24Z&sr=b&sp=r&sig=HhLpzVABscVaEAbEs%2BK7ijcFaapcRObCp4NExSYhofM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:24.3208622","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:30:24 GMT
+      mise-correlation-id:
+      - e02aea22-cbe7-4d18-819e-d0aabe8e509b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A29Z&sr=b&sp=r&sig=XqKf8si1oweDSwEgjF9Tm179gHcNSFFp06zKnB94I2o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:29.5769396","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A29Z&sr=b&sp=r&sig=OVQUNoG1p3IV0IetYbbgvKQNYyPGd%2FLCqOUhRs24TAg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:29.5768807","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A29Z&sr=b&sp=r&sig=r%2Bpz2ZwZ9wRZa2nSvakcYlndmKChX52aTy4qLWH%2FeOY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:29.5769536","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:30:29 GMT
+      mise-correlation-id:
+      - aac04c8f-f275-4cda-b5cd-3e60fd83d8d4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A34Z&sr=b&sp=r&sig=1Hwy0wqTTQEUiq4kf52HaU2iYIdjXXhqHbPjrwTXzcw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:34.9136269","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A34Z&sr=b&sp=r&sig=TrnEmLxYEyUUZ5gYwpN%2FVztd4Il82P1USELqJ2ANkjk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:34.9135339","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A34Z&sr=b&sp=r&sig=0oBsG8IYN3nXji3Ci9M3buwY7oxxYJiLcEV1%2FN4UNR4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:34.913648","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:30:34 GMT
+      mise-correlation-id:
+      - 7a7e5372-57e9-4897-97ba-71a477503774
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A40Z&sr=b&sp=r&sig=8G4h8OpfLjXwgsv6o7Et1iR0N1OVYEbYgbxH3ZzieOM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:40.2552211","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A40Z&sr=b&sp=r&sig=tikzg2sB0o1K0cj3ihpK4zrycl%2FM0PJtdMCTsiYdLIE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:40.2551531","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A40Z&sr=b&sp=r&sig=GWSx7DnETL7nUfRlLWkr037X822cxaIend8L0FNO2jg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:40.2552364","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:30:40 GMT
+      mise-correlation-id:
+      - f837add2-b266-437b-a383-43fff953d281
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A45Z&sr=b&sp=r&sig=XF8%2BV3C6mKdJouy4Q42F4ROvXRsNKQYPnkWo0eLLXvQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:45.5334657","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A45Z&sr=b&sp=r&sig=j3YEaO5jUFaD5GGs21Zt2crUH441mH5hJxCTI63ILr0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:45.5333965","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A45Z&sr=b&sp=r&sig=b2%2BLUb4N%2FMs9tS%2B83Abw35j0j3H3ww31nn%2FFZThZGec%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:45.5334807","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:30:45 GMT
+      mise-correlation-id:
+      - 0483def5-dd1b-4be7-bd12-15f81ef4d29b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A50Z&sr=b&sp=r&sig=Mo%2BkRp7ivTJ0piolvssDphkxfvUn02OkJ7jFFQWPHRA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:50.9181611","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A50Z&sr=b&sp=r&sig=JvpMM1iLZU8vcXrJEhbXrfxhmTajjvroyTOYCxz7WtE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:50.9180885","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A50Z&sr=b&sp=r&sig=aLI7U9%2BAMl0VuGFpSP0G0YnvUQLKFAqPUXK%2BIU8aMmA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:50.9181762","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:30:50 GMT
+      mise-correlation-id:
+      - 9ad6c925-cf03-420a-a5b8-204894ad03a4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A56Z&sr=b&sp=r&sig=x4yA%2F56ouOvkyArJrvBmTP2HMcNxdX6Fpn%2FTOOv%2F71I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:56.2503955","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A56Z&sr=b&sp=r&sig=XDwxUDNUpk8qw0eDEwX%2BhTZOxB3l4rEdMmxxxDVgowg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:56.2503159","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A56Z&sr=b&sp=r&sig=BLyBw6%2Bqaezhz0TcL%2BtIWUA8Xu4xIwiXPtx2Ou1z2oo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:56.2504101","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:30:56 GMT
+      mise-correlation-id:
+      - 1028bf88-e3f0-4fc7-ab64-407f4cfdb286
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A01Z&sr=b&sp=r&sig=xf%2BIKzhlX4E%2BXBgJ8MTiSosrwjjDDgeo3iHbvSGXh%2Fc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:01.5472638","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A01Z&sr=b&sp=r&sig=lMxUa8n4BmFnoQLTMxZHFOlAX%2F4xQQChKSdg0zVy7Fc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:01.5471922","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A01Z&sr=b&sp=r&sig=blCpRkstHmhTamr8kqDJbw2PYd993WXf6swQQIHy7K0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:01.5472791","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:31:01 GMT
+      mise-correlation-id:
+      - 49a45789-41cc-4bc9-80d5-597721ee5024
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A06Z&sr=b&sp=r&sig=rtNpJrJJYSSuLbsD08WMZ8J6qndH3LSIFU%2FzCegETMA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:06.8171742","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A06Z&sr=b&sp=r&sig=BBTNUcyC%2BpCqq%2FN%2BXTLN7jNyKW1l5BeX3XpwLWOLxdM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:06.8171047","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A06Z&sr=b&sp=r&sig=GnexckbSs4KYIgM9vcLFNyxbU0EzNKQ57XdSKeM4svE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:06.8171892","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:31:06 GMT
+      mise-correlation-id:
+      - 61705fab-5559-4214-8595-3c0bea05b092
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A12Z&sr=b&sp=r&sig=m3vnXPrkKtQYbRbOvVDXbzPtCH8kO%2BjdwPzv6j0IMrE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:12.0835409","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A12Z&sr=b&sp=r&sig=XAuGaKMxuwBYX1fj0Dhb6FWg55CRiBctXdxwC6YAOuU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:12.0834759","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A12Z&sr=b&sp=r&sig=yBatGGr%2FuB%2F7dhUbeCEZutzXiaAQ%2FzjPygbbzol93%2FI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:12.0835565","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:31:12 GMT
+      mise-correlation-id:
+      - bdddae97-14a6-498f-a278-a733114fae8d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A17Z&sr=b&sp=r&sig=dUT%2B5FqNbtwql%2F0x8vvFX4O%2FR6FR3XVc1GewogsX310%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:17.3645908","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A17Z&sr=b&sp=r&sig=9CTYSftQ6fHxX44beW7EeM%2FNulvNzrtAjF0ngYyUQpw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:17.3645254","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A17Z&sr=b&sp=r&sig=LnwBZQToxyzptWkhJG6y9TXT6JPb%2BYZCUFk%2F7KAZHi0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:17.3646063","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:31:17 GMT
+      mise-correlation-id:
+      - ee867230-9cfd-4d60-90c6-4a202e6bf6b6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A22Z&sr=b&sp=r&sig=sGwIQ87zDNrkW9nRGYdKDWl1oHrwAlQhrx2P0Yk4Rg0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:22.7566008","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A22Z&sr=b&sp=r&sig=u8IbjM6L8pAiXpFIoq8WdxMajEZIqucJCvbseHrGdRQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:22.7565019","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A22Z&sr=b&sp=r&sig=ZDv398EZRMjzEE%2FGU%2F9O27IH7Q2c1a0ptqZ7kECOO2Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:22.7566238","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-29T22:26:40.07Z","endDateTime":"2023-10-29T22:31:19.108Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:31:20.99Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:31:22 GMT
+      mise-correlation-id:
+      - f7a5c6cb-6253-43eb-b484-3d2f30ba2318
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2647,18 +2647,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.1836047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.1836047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:39.7823896Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:39.7823896Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:37 GMT
+      - Sun, 29 Oct 2023 22:31:24 GMT
       etag:
-      - '"d300ce49-0000-0100-0000-6537b9780000"'
+      - '"3c00f92f-0000-0100-0000-653edbe50000"'
       expires:
       - '-1'
       pragma:
@@ -2688,23 +2688,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=metric-test-case&api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=metric-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A38Z&sr=b&sp=r&sig=cTroUD6jGUaQknGXuWjDvJh4RXmHtPw9taHxCRfq84U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:38.6652915","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A38Z&sr=b&sp=r&sig=9HuEU27R8U2CxjUbAGQQ%2F2XWaA84hqQCEzusyGbzHeQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:38.6652092","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A38Z&sr=b&sp=r&sig=aeA%2FsXXw3w6KMJIXjvgrg3PgnYBphLkC3zzJaJ4L9%2FU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:38.6653134","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-24T12:33:54.041Z","endDateTime":"2023-10-24T12:38:32.64Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.822Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A25Z&sr=b&sp=r&sig=CV8%2B60yS8lFbRP%2BDGpiFC5Jg4B%2F0%2FR11M4TVTykynTQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:25.4458437","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A25Z&sr=b&sp=r&sig=Q9wjkdJ2kdoWe5%2B8KG%2Ff1KGQGwzSRjWf3xgwC8hsamQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:25.4457719","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A25Z&sr=b&sp=r&sig=mk8okqxCYgXCulAQtKO2T1c8M52jJU0G3AcR97iYcb4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:25.445858","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-29T22:26:40.07Z","endDateTime":"2023-10-29T22:31:19.108Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:31:20.99Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3247'
+      - '3251'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:38 GMT
+      - Sun, 29 Oct 2023 22:31:25 GMT
       mise-correlation-id:
-      - 41921ed4-635a-4d79-8df0-0ed78371a148
+      - 72647424-e851-45e2-8502-64d38f88248c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2727,18 +2727,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.1836047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.1836047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:39.7823896Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:39.7823896Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:41 GMT
+      - Sun, 29 Oct 2023 22:31:26 GMT
       etag:
-      - '"d300ce49-0000-0100-0000-6537b9780000"'
+      - '"3c00f92f-0000-0100-0000-653edbe50000"'
       expires:
       - '-1'
       pragma:
@@ -2768,23 +2768,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A42Z&sr=b&sp=r&sig=uwPtDsThcKw8ePDKRjTKvNi3Hj7HwWQTruFmoMSRAK0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:42.8481108","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A42Z&sr=b&sp=r&sig=nmcyjtWtxekoTvxcO2Iz0BeaPRyBSqJmXsqe77%2BaEAs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:42.8480304","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A42Z&sr=b&sp=r&sig=caMH6lG9RSj32xaSqxcr4nFhE8waI2UCvWRhLpN%2FiJ8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:42.8481253","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A42Z&sr=b&sp=r&sig=eHEtc6j4D5bR34KQhI7Lh5V%2F6PKNHMu6FMWUCiERorU%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:42.8481393","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A42Z&sr=b&sp=r&sig=j%2FjfomER089MnNESM5Gu9RnyQFqbKm1O9eUGEdZ4ddw%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:42.8481533","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-24T12:33:54.041Z","endDateTime":"2023-10-24T12:38:32.64Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:39.7Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A27Z&sr=b&sp=r&sig=G%2BNuCAXeEZ7DIeRhuKlki6VKPtmNpfrut9sWPqIOlE8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:27.8794753","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A27Z&sr=b&sp=r&sig=Tj%2Frc4CNSQfhW32%2FoP5yo7T3mCxB%2FG30tSCmH6IBwHo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:27.8793874","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A27Z&sr=b&sp=r&sig=UfFOKle80Z8pDBlndXUpFc5wxQjvamemBzFPUI%2FoPYY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:27.8794977","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-29T22:26:40.07Z","endDateTime":"2023-10-29T22:31:19.108Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:31:20.99Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4394'
+      - '3238'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:42 GMT
+      - Sun, 29 Oct 2023 22:31:27 GMT
       mise-correlation-id:
-      - 23f36dff-30d7-4db3-b58a-2d73758a4a51
+      - 9e0d29d9-c115-41aa-89e3-58f0359c4f42
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2804,7 +2804,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"dimensions":[{"description":"Request Name","name":"RequestName"}],"description":"No
@@ -2823,9 +2823,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:43 GMT
+      - Sun, 29 Oct 2023 22:31:28 GMT
       mise-correlation-id:
-      - 5e8f0369-1776-497a-86f1-cbef9116a9b4
+      - 5775b2dd-4d45-4126-89f1-34b0a6bf038b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2849,23 +2849,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-24T12:34:00.000Z","value":1.0},{"timestamp":"2023-10-24T12:35:00.000Z","value":1.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-29T22:27:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:28:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:29:00.000Z","value":1.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '128'
+      - '181'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:43 GMT
+      - Sun, 29 Oct 2023 22:31:29 GMT
       mise-correlation-id:
-      - 47509e61-e09c-4179-9c7a-3caa194023f7
+      - c79cfeba-4d5f-4081-8852-c0c0750d030d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2889,23 +2889,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=ResponseTime&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=ResponseTime&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-24T12:34:00.000Z","value":171.0},{"timestamp":"2023-10-24T12:35:00.000Z","value":1750.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-29T22:27:00.000Z","value":32.0},{"timestamp":"2023-10-29T22:28:00.000Z","value":16.0},{"timestamp":"2023-10-29T22:29:00.000Z","value":16.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '133'
+      - '184'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:43 GMT
+      - Sun, 29 Oct 2023 22:31:29 GMT
       mise-correlation-id:
-      - 56dc2d95-6471-4ef5-af4b-c1c4177b2f05
+      - b849fd1c-ed3e-4db3-bfe6-64f0e448a413
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2929,23 +2929,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=TotalRequests&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=TotalRequests&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-24T12:34:00.000Z","value":15.0},{"timestamp":"2023-10-24T12:35:00.000Z","value":58.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-29T22:27:00.000Z","value":44.0},{"timestamp":"2023-10-29T22:28:00.000Z","value":48.0},{"timestamp":"2023-10-29T22:29:00.000Z","value":28.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '130'
+      - '184'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:44 GMT
+      - Sun, 29 Oct 2023 22:31:29 GMT
       mise-correlation-id:
-      - 92697b54-b361-41a5-862c-de3da07c2706
+      - 2307311c-7899-4335-bb12-b7351e76fb0f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2969,7 +2969,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=Errors&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=Errors&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"data":[]}]}'
@@ -2983,9 +2983,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:44 GMT
+      - Sun, 29 Oct 2023 22:31:30 GMT
       mise-correlation-id:
-      - 078240ed-c21c-4d41-92fc-041ac323d11c
+      - 88df0f6b-5a89-445d-bd71-2e54425aafda
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3008,18 +3008,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.1836047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.1836047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:39.7823896Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:39.7823896Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:45 GMT
+      - Sun, 29 Oct 2023 22:31:31 GMT
       etag:
-      - '"d300ce49-0000-0100-0000-6537b9780000"'
+      - '"3c00f92f-0000-0100-0000-653edbe50000"'
       expires:
       - '-1'
       pragma:
@@ -3049,10 +3049,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A46Z&sr=b&sp=r&sig=rrDlm6PkGYeBEd%2FHlTNkT2j%2BDPttg6bkIOkPR2WY0t4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:46.9410828","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A46Z&sr=b&sp=r&sig=tjmg7ZqXLFfx%2B8gQZJQ7CYVtAgAQnnx5WYo0O1awAPI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:46.9409886","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A46Z&sr=b&sp=r&sig=58XF5KY4mz6UhHez%2FKr80yqcX7UEgp2m19EaCwW2TiY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:46.9411054","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A46Z&sr=b&sp=r&sig=Cb3vDbWHMZ0U5OMIgba1p1mOrWP6xlyCXuunWDznCwk%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:46.9411269","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A46Z&sr=b&sp=r&sig=IHoGlDhoULkb33f3KUL1Z4zvXgk2T1A%2B0QhNf2MSyWs%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:46.9411512","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-24T12:33:54.041Z","endDateTime":"2023-10-24T12:38:32.64Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:39.7Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A32Z&sr=b&sp=r&sig=7GsFDxN3SYGyttZhmwx3Ve1U7A0mQV3DSn96aUVczTU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:32.8651187","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A32Z&sr=b&sp=r&sig=V0W8KROv%2FeLndJj%2F0hgC3x7bbfuTvzquzYylI4h8Kjc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:32.8650324","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A32Z&sr=b&sp=r&sig=8H1Vb533PJl9Wqzp5qGBmXofV4CHOYH8sZomDpvcrss%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:32.86514","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/f9a26422-7c17-48cc-b9ea-b6eb1a728824_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A32Z&sr=b&sp=r&sig=PR1HaEdjDr%2Ff01WvR66L8KJT9RwWPAb2Jp0RsZUJbC8%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:32.8651603","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/f9a26422-7c17-48cc-b9ea-b6eb1a728824_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A32Z&sr=b&sp=r&sig=xftWJjuJ%2Fkw%2FW9B0Cl3lqkgydMft43JPW4CNsWJnEw4%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:32.8651813","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-29T22:26:40.07Z","endDateTime":"2023-10-29T22:31:19.108Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:31:29.961Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -3063,9 +3063,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:46 GMT
+      - Sun, 29 Oct 2023 22:31:32 GMT
       mise-correlation-id:
-      - 1089b7f4-9134-4afc-bd28-dd7362dc2a55
+      - 2abed0e5-25c1-451b-a279-35daa0ee15d3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3089,23 +3089,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-24T12:34:00.000Z","value":1.0},{"timestamp":"2023-10-24T12:35:00.000Z","value":1.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-29T22:27:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:28:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:29:00.000Z","value":1.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '128'
+      - '181'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:47 GMT
+      - Sun, 29 Oct 2023 22:31:33 GMT
       mise-correlation-id:
-      - fe816c82-8148-4802-ad85-9c39b9fc27e0
+      - cf2cb718-4285-46f8-8cb7-d4b53b23beed
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3128,18 +3128,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.1836047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.1836047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:39.7823896Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:39.7823896Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:48 GMT
+      - Sun, 29 Oct 2023 22:31:36 GMT
       etag:
-      - '"d300ce49-0000-0100-0000-6537b9780000"'
+      - '"3c00f92f-0000-0100-0000-653edbe50000"'
       expires:
       - '-1'
       pragma:
@@ -3169,23 +3169,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A49Z&sr=b&sp=r&sig=JBY1vp%2F4QTcUFEe2dZVInKL8kAniF0xwYIya4r8Uyr0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:49.8021713","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A49Z&sr=b&sp=r&sig=GuuD0w10uyVcdUwe%2FZedQih0RJxOlf%2B2Zy3s7DPJQTA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:49.8020842","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A49Z&sr=b&sp=r&sig=w1OVXMGNYHCqnCJYO6umNM%2FSQnjrJNqGnjmXMR623sc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:49.8021954","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A49Z&sr=b&sp=r&sig=tsXZ%2Bp91KooKTsrpnexZm5YTLW1S7ggTll4abVhTzvA%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:49.8022136","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A49Z&sr=b&sp=r&sig=HYesIJF%2BCkGTODPTmOOon27tdfl7vmYWwVNj3HTa3sM%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:49.8022271","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-24T12:33:54.041Z","endDateTime":"2023-10-24T12:38:32.64Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:39.7Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A36Z&sr=b&sp=r&sig=VLEsxKHETMtjXkLfOhIVSWHAPX3Ba9dhIogqofasi2M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:36.915669","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A36Z&sr=b&sp=r&sig=Dj6XTOAX6fs27Ewqxucefb%2BJbyeuQpeEZ%2FUxkqIhSrM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:36.9155695","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A36Z&sr=b&sp=r&sig=n53g6bTCukRFvNKL6Tx0Z0gF0n4WBu7gmVkP4l0YvHk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:36.9156942","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/f9a26422-7c17-48cc-b9ea-b6eb1a728824_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A36Z&sr=b&sp=r&sig=nSMbn3lfaYMm0jGRHWFmv41n4CNfbJ83%2BNrXSrwM4DM%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:36.9157196","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/f9a26422-7c17-48cc-b9ea-b6eb1a728824_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A36Z&sr=b&sp=r&sig=1W9B3jy8bCrEsxEa8P%2Fknnhu8XpjwgV0Pi05EwcZvO0%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:36.9157462","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-29T22:26:40.07Z","endDateTime":"2023-10-29T22:31:19.108Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:31:29.961Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4398'
+      - '4395'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:49 GMT
+      - Sun, 29 Oct 2023 22:31:36 GMT
       mise-correlation-id:
-      - c91ef123-aa2a-4e0c-8420-a6f808e803e3
+      - d7fe4793-3ce5-4544-bc06-4c8e33472dcc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3205,7 +3205,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"dimensions":[{"description":"Request Name","name":"RequestName"}],"description":"No
@@ -3224,9 +3224,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:50 GMT
+      - Sun, 29 Oct 2023 22:31:37 GMT
       mise-correlation-id:
-      - f8ec5ea8-1aa5-4af2-a4f4-c005858114e9
+      - e6be3feb-daed-45a9-9eaf-875a109b6fec
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3246,7 +3246,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":["HTTP Request"]}'
@@ -3260,9 +3260,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:50 GMT
+      - Sun, 29 Oct 2023 22:31:38 GMT
       mise-correlation-id:
-      - 2a220ca4-ad63-40b2-8e9f-6dff83c88bc3
+      - 69772b85-ab74-4884-a7e3-564ec06e754b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3286,10 +3286,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-24T12:34:00.000Z","value":1.0},{"timestamp":"2023-10-24T12:35:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+      string: '{"value":[{"data":[{"timestamp":"2023-10-29T22:27:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:28:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:29:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
         Request"}]}]}'
     headers:
       api-supported-versions:
@@ -3297,13 +3297,13 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '194'
+      - '247'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:50 GMT
+      - Sun, 29 Oct 2023 22:31:38 GMT
       mise-correlation-id:
-      - 2858a2b9-d5ce-4b8f-a022-fcf7e955365d
+      - 88995aac-1c7d-4705-b457-8b572f3c24d4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3326,18 +3326,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.1836047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.1836047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:39.7823896Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:39.7823896Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:52 GMT
+      - Sun, 29 Oct 2023 22:31:39 GMT
       etag:
-      - '"d300ce49-0000-0100-0000-6537b9780000"'
+      - '"3c00f92f-0000-0100-0000-653edbe50000"'
       expires:
       - '-1'
       pragma:
@@ -3367,23 +3367,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A53Z&sr=b&sp=r&sig=Y5YS2D365Dib6n1%2FcLiH6%2FAlhenNw8pKqzWd%2BBTuxNM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:53.3949315","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A53Z&sr=b&sp=r&sig=EYL4DM%2FSu6UDhKKKPM7TeNqDyuCEIAGVB07PccntdBI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:53.3948633","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A53Z&sr=b&sp=r&sig=kcd1Rt6NoSjUHvHDsWKTtVEINFL9x4JYW%2FqYoM0MVvY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:53.3949463","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A53Z&sr=b&sp=r&sig=gD4RV2Jlllv8bm2yYBE1fkXTImX0qhih4NHVSm3ryKc%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:53.3949599","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A53Z&sr=b&sp=r&sig=zro8LipJCxEI91v2q379D1NWcy6wFbjIrb2JZ1AlRLs%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:53.3949739","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-24T12:33:54.041Z","endDateTime":"2023-10-24T12:38:32.64Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:39.7Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A41Z&sr=b&sp=r&sig=2OdGqMyQy4350ZxaL6bjd2202pk%2Bz%2BmktLJabMueyO0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:41.0465598","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A41Z&sr=b&sp=r&sig=KGVZQNqtepBFAStTbmpPCWAcoO3MW17w9EP359tfDGQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:41.0464779","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A41Z&sr=b&sp=r&sig=ETIXG%2FtOydJb9RlhUmuQHy38nBoMJaiiojwx%2FfEUqiw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:41.0465778","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/f9a26422-7c17-48cc-b9ea-b6eb1a728824_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A41Z&sr=b&sp=r&sig=CnMfy4%2BMnQWqH2eGmUxTM5HTuWbOT79GAd1Yat2BKWc%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:41.0465953","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/f9a26422-7c17-48cc-b9ea-b6eb1a728824_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A41Z&sr=b&sp=r&sig=XICTdyBn6REWM5lsiWleo721CSm9by%2F77BpBRcAXMvQ%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:41.0466128","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-29T22:26:40.07Z","endDateTime":"2023-10-29T22:31:19.108Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:31:29.961Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4396'
+      - '4400'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:53 GMT
+      - Sun, 29 Oct 2023 22:31:41 GMT
       mise-correlation-id:
-      - a7c5edf5-2ed2-4ab1-b0b6-ed876a8c7651
+      - 7cee22ab-38da-457d-8074-078fecf530e5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3403,7 +3403,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":["HTTP Request"]}'
@@ -3417,9 +3417,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:54 GMT
+      - Sun, 29 Oct 2023 22:31:41 GMT
       mise-correlation-id:
-      - 806ffa4a-0e02-4efb-a8f3-43fb7d91ab45
+      - 683d6d35-8441-4025-9fdd-cc48b7719fdf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3443,10 +3443,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-24T12:34:00.000Z","value":1.0},{"timestamp":"2023-10-24T12:35:00.000Z","value":1.0},{"timestamp":"2023-10-24T12:36:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+      string: '{"value":[{"data":[{"timestamp":"2023-10-29T22:27:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:28:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:29:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
         Request"}]}]}'
     headers:
       api-supported-versions:
@@ -3458,9 +3458,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:54 GMT
+      - Sun, 29 Oct 2023 22:31:41 GMT
       mise-correlation-id:
-      - 1dc1d9d4-e5e7-4d15-8e56-46aa6fb0885d
+      - 7f9f18a9-87ff-40d1-903a-d76f2fd6e3ef
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3483,18 +3483,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.1836047Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.1836047Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:39.7823896Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:39.7823896Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:55 GMT
+      - Sun, 29 Oct 2023 22:31:43 GMT
       etag:
-      - '"d300ce49-0000-0100-0000-6537b9780000"'
+      - '"3c00f92f-0000-0100-0000-653edbe50000"'
       expires:
       - '-1'
       pragma:
@@ -3524,23 +3524,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4667c381-5ad7-4857-9d62-8ab4a8f1da09":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"45a56dce-3d5e-4f56-b47d-8fa8affc416c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d241522f-d46f-43be-bb57-877d354d4d90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/e8ec407b-c950-400c-a02d-5e847ff07065?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A57Z&sr=b&sp=r&sig=RgtNJnTa728ejXjcsdgzAzhUz2kqBFNWtKW2fPqn%2FXc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:57.4826877","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/82a91f04-1435-4d54-8853-7e1631ca64f9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A57Z&sr=b&sp=r&sig=Zw4S4DagPWKdDUCTG8vrZUBf1pkm7riBhvQIBPaaRsQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:57.4826189","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/f054238a-3ca8-4008-8236-ab7e6900f1f7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A57Z&sr=b&sp=r&sig=dEj5FvEBOTCIUfWUAdrxql3QDWOGy8OR2ReCnNVbh64%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:57.482702","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A57Z&sr=b&sp=r&sig=eU8ut1ZiXrID6j7EC1s6Hs8tIw3nFHYLVqTxJYdauSY%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:57.4827149","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/aae46869-8611-4904-8df9-2d49767490ff/83c18434-af44-474f-b991-df6d51a04e85_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A57Z&sr=b&sp=r&sig=BH%2FJQJixyk0G0i%2FH6VU0X%2FLD7pGiuAl1vn8iIHyzzR4%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:57.4827284","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-24T12:33:54.041Z","endDateTime":"2023-10-24T12:38:32.64Z","executedDateTime":"2023-10-24T12:33:52.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-24T12:33:52.631Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:39.7Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A44Z&sr=b&sp=r&sig=BEC%2FqaIz0ouuTnk4TWE0YKz3LOVhJlO9mGWBykPST%2Bs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:44.40844","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A44Z&sr=b&sp=r&sig=Lv3uO2woKoQhXAcEGUuHgO6pT2HA5atjJ7eI05E2X9M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:44.4083495","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A44Z&sr=b&sp=r&sig=C9SYxRxBwkqAvr7HQFkMm2aRZC8do%2B7Ta4wXxebQOZ4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:44.4084637","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/f9a26422-7c17-48cc-b9ea-b6eb1a728824_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A44Z&sr=b&sp=r&sig=FedRtCWJilP7RNLwC6bQBqvNSepBZVyUsZ4wlUu4fcg%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:44.4084823","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/f9a26422-7c17-48cc-b9ea-b6eb1a728824_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A44Z&sr=b&sp=r&sig=sCeWYcn6fwvf864lKoZziXcCdfLYoXfTvFZH%2BVWMeUQ%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:44.4084963","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-29T22:26:40.07Z","endDateTime":"2023-10-29T22:31:19.108Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:31:29.961Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4393'
+      - '4394'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:57 GMT
+      - Sun, 29 Oct 2023 22:31:44 GMT
       mise-correlation-id:
-      - e4b85588-5673-4da0-b01b-6fad45e45773
+      - b2683d21-ffd9-4658-bfd2-4f75badfebae
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3564,10 +3564,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://29df57f1-4899-4cd1-8e98-56c50c5ccee1.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-24T12%3A33%3A54.041Z%2F2023-10-24T12%3A38%3A32.64Z&api-version=2022-11-01
+    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-24T12:34:00.000Z","value":1.0},{"timestamp":"2023-10-24T12:35:00.000Z","value":1.0},{"timestamp":"2023-10-24T12:36:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+      string: '{"value":[{"data":[{"timestamp":"2023-10-29T22:27:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:28:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:29:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
         Request"}]}]}'
     headers:
       api-supported-versions:
@@ -3579,9 +3579,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:57 GMT
+      - Sun, 29 Oct 2023 22:31:44 GMT
       mise-correlation-id:
-      - 828ff1f4-8bf2-4601-a0dc-7dd43492b2a8
+      - 330b8872-27d1-476d-a876-4530aa58b680
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_metrics.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_metrics.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:41.884927Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:41.884927Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:17.0295091Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:17.0295091Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:14 GMT
+      - Mon, 09 Oct 2023 19:23:50 GMT
       etag:
-      - '"9201fed9-0000-0100-0000-6524276b0000"'
+      - '"560052a6-0000-0100-0000-652453270000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:17:15 GMT
+      - Mon, 09 Oct 2023 19:23:52 GMT
       mise-correlation-id:
-      - 3f5c8ffc-8b50-4219-afd8-f53e5a30b359
+      - 4830d3b1-a57f-4326-a46f-2be8fdcbf6ec
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "120"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "3054a5c7-383c-4ada-9127-e46acdc034ea":
+      {"passFailMetrics": {"f155be4d-d6bb-4ce7-8656-29642edd7b2c": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "ec52f15d-73f0-4c6d-a57a-8b871c34f623": {"aggregate": "avg", "clientMetric":
+      "50"}, "d5f270e7-de36-494d-b217-b4803211ab9b": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:17:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:16.089Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:23:53.273Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:53.273Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:16 GMT
+      - Mon, 09 Oct 2023 19:23:53 GMT
       location:
-      - https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+      - https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - c5a9c96f-3723-493a-8634-65b89c445136
+      - c5218776-dc0a-421c-9bef-a2ed4d7cfe52
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files?api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:16 GMT
+      - Mon, 09 Oct 2023 19:23:53 GMT
       mise-correlation-id:
-      - ba6eeb88-9569-4ab4-a05d-ad1f42696a46
+      - f089c88e-1705-4fac-a84e-e0181ae6d0d1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A16Z&sr=b&sp=r&sig=kJf2j8v%2BSowkKCfX4c2nqjNE6Q5VRf472Ni3%2FmBAS2o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:16.9722446","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A54Z&sr=b&sp=r&sig=n0NmYAKeynU69gGADZzVycrNTBIFyP8519AT6LPXaDc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:54.2953565","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:16 GMT
+      - Mon, 09 Oct 2023 19:23:54 GMT
       location:
-      - https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 4b78f012-a63f-4218-8eba-191465470b3a
+      - aeebbfc8-d672-4847-bf41-6d22e4374ef4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A17Z&sr=b&sp=r&sig=awdVltFu01ZFy8C5gBuo2l7pHi6iILVHenc8doXVNcY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:17.2349183","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A56Z&sr=b&sp=r&sig=op1jFekj6D6%2BME5hN1xauE5drx5RjdLVyD9o8RyjbzE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:56.3556724","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:23:56 GMT
+      mise-correlation-id:
+      - 31d895b1-ff6d-4b77-b68f-1fecf567694c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A34%3A01Z&sr=b&sp=r&sig=SgYsBZWuhfD3dSpQQhwqa%2B7A9KWyUXC5vUKbKaovHsg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:34:01.7048964","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:01 GMT
+      mise-correlation-id:
+      - 23c16976-a847-4e6d-875d-3b3092d60e94
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A34%3A07Z&sr=b&sp=r&sig=%2BiP79RKIXWGgsSB7yG7ZAVp0CfgbkMIirdsl0USoMNs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:34:07.8161705","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:17 GMT
+      - Mon, 09 Oct 2023 19:24:07 GMT
       mise-correlation-id:
-      - 9495a150-4e37-44e9-af02-c0857244c83b
+      - 32e585cf-c38d-4514-80b9-ed75fc520dcb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,132 +421,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A22Z&sr=b&sp=r&sig=ZuWiKLAElMM6lDAGbUX%2F%2FiKOzifDWpW31A0pQod2FG0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:22.5188694","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A08Z&sr=b&sp=r&sig=O7OPVbujBeG%2BJK8gZIIHl7Ta6lmOdIl%2BJ5K1qMM4hOk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:08.0840643","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:23:53.273Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:06.52Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '1582'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:22 GMT
+      - Mon, 09 Oct 2023 19:24:08 GMT
       mise-correlation-id:
-      - d46feefd-0d36-4163-b20d-26ef81f0bef3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A27Z&sr=b&sp=r&sig=dcxqK%2BFDr8BHrg2FwsV%2BcI5s4w91jl3CZcLgKmn%2Fqac%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:27.9184944","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:27 GMT
-      mise-correlation-id:
-      - 209e2442-4381-4755-89ad-891ee7ee7661
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A33Z&sr=b&sp=r&sig=oUrrOzHWIyuQWxbd5c%2FpwUO7lANLpCAB8sEJNwV6Cfo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:33.1965542","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:33 GMT
-      mise-correlation-id:
-      - 49d328e4-e0f1-42fd-9929-b9c3da6640c4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A33Z&sr=b&sp=r&sig=Y9c6YoxBzI0chfCh1JnLVK1B20fMVXfIc0e6eUYH43I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:33.4593795","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:17:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:29.913Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1579'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:33 GMT
-      mise-correlation-id:
-      - 9c055795-d285-424f-9de0-fad0b1fa3834
+      - 8879b130-bb79-45e0-b5d9-4876b3713c00
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +461,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:41.884927Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:41.884927Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:17.0295091Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:17.0295091Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:34 GMT
+      - Mon, 09 Oct 2023 19:24:09 GMT
       etag:
-      - '"9201fed9-0000-0100-0000-6524276b0000"'
+      - '"560052a6-0000-0100-0000-652453270000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +502,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A35Z&sr=b&sp=r&sig=Gn3lESg%2BAl1FIf1Mkbs2sVOwJS9TsgwVFxLzkQU24pM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:35.0459691","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:17:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:29.913Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A10Z&sr=b&sp=r&sig=ZTCCOjvVVedWyzoZDOJVL7eut3x%2Fi22ZU2wjPfoopbc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:10.6191079","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:23:53.273Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:06.52Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1593'
+      - '1592'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:35 GMT
+      - Mon, 09 Oct 2023 19:24:10 GMT
       mise-correlation-id:
-      - 1b6d138a-3710-47b9-99c6-acdd2b3b66f8
+      - 2f72b568-5035-40a3-b31c-c210b6608493
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +542,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:41.884927Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:41.884927Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:17.0295091Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:17.0295091Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:35 GMT
+      - Mon, 09 Oct 2023 19:24:12 GMT
       etag:
-      - '"9201fed9-0000-0100-0000-6524276b0000"'
+      - '"560052a6-0000-0100-0000-652453270000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +583,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +596,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:17:37 GMT
+      - Mon, 09 Oct 2023 19:24:13 GMT
       mise-correlation-id:
-      - 972d65b0-3f47-490e-b9ed-2afce5e5d65b
+      - 0e8e1ee2-8cbc-47e6-8fba-eb8038ba847a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +626,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A38Z&sr=b&sp=r&sig=KDbAJq5O0XIpG8k%2FgkO5OG8hYQBmPWo8%2Frqn5dvqy5o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:38.3575591","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A38Z&sr=b&sp=r&sig=4l27ZWCb5e0P1%2Bdg0fwJfIVRsrOQNrmVoWX5Pwm1nXU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:38.3574584","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A38Z&sr=b&sp=r&sig=cjWm6m6DexAiV4qM2DvdFH5fQA9opxLYyc%2B%2B7VXtdZA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:38.3575863","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:38.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A14Z&sr=b&sp=r&sig=LEUGirQYGrVx%2FKPJ7cGO%2FcvbAJs8yDy17aiaFFJXjxw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:14.7680307","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A14Z&sr=b&sp=r&sig=7t5OtJZQiVzLanoGyHyDbkzR4ZcsKrckPl5MomowBIY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:14.7678876","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A14Z&sr=b&sp=r&sig=%2FqUwP9QZ9r49yNLRzeiNANz9PEde8ICquTBtJdEpDPQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:14.768061","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:14.697Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3160'
+      - '3155'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:38 GMT
+      - Mon, 09 Oct 2023 19:24:15 GMT
       location:
-      - https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+      - https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 1d5c7028-62c2-48bf-a675-3f5a1f8b0a41
+      - 4b84eb9d-16d8-4827-b903-a060c555ae62
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,82 +664,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A38Z&sr=b&sp=r&sig=JFz3Dtf3AcAyfYoCcdLBeXAov4rr85w9vZM%2F8191upQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:38.7968378","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A38Z&sr=b&sp=r&sig=I3Wa4P8mMJPMPSpoXJZvkvqDptbEosEqzIT%2F%2FpVWsWY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:38.796733","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A38Z&sr=b&sp=r&sig=lsfJAwOI0y%2B8ku1l2C6YyqWAWneFJG4Ul7UQcJi7wtg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:38.7968625","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:38.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3157'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:38 GMT
-      mise-correlation-id:
-      - 369ae9a4-9310-4d22-a0ec-b5a0b6e3602f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A44Z&sr=b&sp=r&sig=4b74eRuWiBewi2wJqs8oDAJUeIahSE3BFsq%2B98EbqUc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:44.1403998","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A44Z&sr=b&sp=r&sig=VxVNGc%2BilT%2FyKV6f37Vww6fLJC%2B23u9iI5PrcRXa84I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:44.1402737","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A44Z&sr=b&sp=r&sig=rhhJizEIgjAb9x1sCfXhDYsgcLIVz4PNlWcJGGRn5%2Fo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:44.1404207","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:39.711Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3207'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:44 GMT
-      mise-correlation-id:
-      - 9ce7af77-a851-435b-b362-27fbd310fdd9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A49Z&sr=b&sp=r&sig=X8k%2Bp%2BMyyPBuC3KXC%2B4Me6lUJcXwGLUv9mHMsiUSlp0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:49.4437127","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A49Z&sr=b&sp=r&sig=aDVv5mhGda70AWzP96QQLX3Xl3clsB6xqyf4U6kkPsY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:49.4436378","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A49Z&sr=b&sp=r&sig=Nv7YuVevQSO39UNB8FoNcYJnIsCrDfjteNDuc55cGHo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:49.4437273","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:39.711Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A15Z&sr=b&sp=r&sig=cZk1MHpw47HJT8khydwAJHqd1ACnjjkmY2rol1Eq2Hc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:15.2902328","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A15Z&sr=b&sp=r&sig=dcT3gW%2BKZIGI%2B2aeIY1X5hgVMsD%2FZHjWcH701T6ajn4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:15.2901381","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A15Z&sr=b&sp=r&sig=wmTOyeLjZj3ndYZXxvWs%2FkQUlC2S0suZ0KNYUvdqujs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:15.2902526","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:15.132Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -786,9 +678,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:49 GMT
+      - Mon, 09 Oct 2023 19:24:15 GMT
       mise-correlation-id:
-      - 7354d7f5-c783-489d-845b-12fe43f26914
+      - f978175e-b382-4857-959f-979951815c19
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,1702 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A54Z&sr=b&sp=r&sig=Tel%2BgMQLaQg%2FZV4qyOrZP4MNoLSs0DaOiKXtNmG8Oms%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:54.7248121","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A54Z&sr=b&sp=r&sig=E0B0Vdry3j4XFaA0Lo2XrkOzz%2F0kf3QtKcbvALYtlrw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:54.7247165","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A54Z&sr=b&sp=r&sig=cObD3vAxTLi1HpJ9lrIWjO7MZdYxKAQVryatqC2OA%2FU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:54.7248356","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:39.711Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:54 GMT
-      mise-correlation-id:
-      - e572d2a7-d4f9-430e-8634-a721a57a91f1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A00Z&sr=b&sp=r&sig=%2FHBnRkGdOCpJ2Ev7TbTKSIvHiadLzUQEUR1KsvTJgrs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:00.0450831","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A00Z&sr=b&sp=r&sig=y1TV2CDeaP6rzIgpkQGaIbiA6BOQ1RgjTEkC%2BIaWBRI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:00.0449675","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A00Z&sr=b&sp=r&sig=vDB8cOlIc8vIen%2F5Gk8BDSO59bn%2BXxrp%2Fvj2DZ7vFkg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:00.0451076","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:39.711Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3207'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:00 GMT
-      mise-correlation-id:
-      - a7dfabcf-d286-4d7f-9fa1-5354a87537d6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A05Z&sr=b&sp=r&sig=4CbL%2FkbZ4lUE8pxbLksIs8wegbuOEuUNKCRvDoN588g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:05.315546","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A05Z&sr=b&sp=r&sig=LkSLazhjIQuLhtgDNWDswkLSwba4lZaJF0bNp9%2Bo%2FYs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:05.3154443","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A05Z&sr=b&sp=r&sig=ZLu6k9BPCP4lXGrFuYG0GhEI%2Bg4UkPMiwcdd9ySco0A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:05.3155704","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:39.711Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:05 GMT
-      mise-correlation-id:
-      - 4f24968f-a66f-44a7-9b3a-43bd5174ccf9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A10Z&sr=b&sp=r&sig=dqu4CDbPk5PIIdJkD6o61K9MYG2yg4Fnf%2B9ntDkr12Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:10.6002555","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A10Z&sr=b&sp=r&sig=Mpiom4wj3Gx3hM38jBqJgh5t3PM%2BPThXY9sQS%2FVMp8E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:10.600171","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A10Z&sr=b&sp=r&sig=EgxKx6bbBPdf1J9CS6KVESGKQxt38WVrNrS07JFCPlw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:10.6002702","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:39.711Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:10 GMT
-      mise-correlation-id:
-      - 9f3dc670-802c-46af-a57a-bf2ad2e4474c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A15Z&sr=b&sp=r&sig=g0WLd90RXTWrgJvrxTpG04j%2Bu%2B11lbqET6mMLv6I9k8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:15.8847262","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A15Z&sr=b&sp=r&sig=idqF5SYoq9LnL4c7ihAb1DB1FH2WeQE8FtmVoeS3Tyw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:15.884654","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A15Z&sr=b&sp=r&sig=S1x5C3sH1bpcyZ%2BfjmvmoO4Nb1zC1EmgluivQtwCiY0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:15.884741","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:39.711Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:15 GMT
-      mise-correlation-id:
-      - bd5f3ab9-ef0d-44dd-9591-fb14839a7572
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A21Z&sr=b&sp=r&sig=f2P%2Blt0O35utrktis7IgVIJmpoxIWA97raoOfGH21jo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:21.7710054","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A21Z&sr=b&sp=r&sig=7kCka%2FLWmkYlZ8U51LSgAP5pHJhyp1PhN5SkcWamq%2Fc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:21.7709264","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A21Z&sr=b&sp=r&sig=%2FGHgvj1kMyQN0WQBhy7jUbVWRUzDWxlXvHwzMPlpBVI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:21.7710237","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:39.711Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:21 GMT
-      mise-correlation-id:
-      - d5e9fd1a-ae13-47f3-862a-b2b35f18b38c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A27Z&sr=b&sp=r&sig=lFpFHKMjdhVer5%2B3QFRDoK3pxiRkcXk4f1y2Js8erKY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:27.231192","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A27Z&sr=b&sp=r&sig=6CAQULRTPZc5Gb2vHHULql%2BOqkoRAVww%2FgII9j4VLZo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:27.2308903","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A27Z&sr=b&sp=r&sig=RP0Bs5XW8hMPCODO0y9osX9XVKaAE%2FTlVhx407%2BLjXQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:27.231227","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:23.16Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:27 GMT
-      mise-correlation-id:
-      - 7fced799-34bf-4b11-8582-e1d95f4b5e56
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A32Z&sr=b&sp=r&sig=D1HCuW76hVC3cdoCJV3ex%2B%2B8COuXA%2Be8voNJTlMT2Bw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:32.518743","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A32Z&sr=b&sp=r&sig=bqn37DEZDGo5suu1NvMaKOIqe6aClqVs0WOfT6s3wqg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:32.5186367","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A32Z&sr=b&sp=r&sig=KHN0UT5BJbx5xyLHQvG65hcnz4x%2FOWvn0BOsvwj2GS8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:32.518759","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:32 GMT
-      mise-correlation-id:
-      - dcb6aaad-9a0e-404f-9d11-94b866ffd8b6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A37Z&sr=b&sp=r&sig=bB1pbX%2B7vwV6vAno2wlMa23WsjL8EUhJzF4lT57doBc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:37.9344833","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A37Z&sr=b&sp=r&sig=DpooL%2FCM2stgZ6QYoVOh6IFY5dEG149AzRfVZUj3rKI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:37.9344031","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A37Z&sr=b&sp=r&sig=TD6DX8JAhJPcqbCJjT1mqXe7NwfPIfs2SZpZZ57eKSU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:37.9344975","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:37 GMT
-      mise-correlation-id:
-      - a53e5f20-6a85-4daa-96b1-b4ac96497c87
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A43Z&sr=b&sp=r&sig=TlHms99Pgg5wule2aQpUDD6Zp22AHW38IcqGWRzVPd0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:43.214547","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A43Z&sr=b&sp=r&sig=aFNU8UHZpYzqm6sVnDmKJw6T2UDTXVhyPPpaIWLThz0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:43.2144658","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A43Z&sr=b&sp=r&sig=EssxjOLAg%2FklkC2S%2Fj4Vh%2FfmOOgbJ2dT5TTKhwVd0Ws%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:43.2145658","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:43 GMT
-      mise-correlation-id:
-      - 29ebf87b-f4ec-4872-b3e9-cfb1b41d9028
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A48Z&sr=b&sp=r&sig=7RXuR3yWJ%2FVTHK1F%2B9FOnjq4D73%2Bw%2FDUhmbcMqcG0jY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:48.4941965","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A48Z&sr=b&sp=r&sig=bv2j%2FdLZKakN32UfcoULoCDwAnt7d8vucmnjCOFClwQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:48.4941295","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A48Z&sr=b&sp=r&sig=RrClDLD9CYzB93647b3bqkpNzz9RJg%2BpVSh%2BUXH6e98%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:48.4942121","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3208'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:48 GMT
-      mise-correlation-id:
-      - ba84a863-8a36-4940-b8f1-c85c6801ec9d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A53Z&sr=b&sp=r&sig=FLmIz4Y%2Bs4FIMAELxomK2A4PjNM0D8srfax2SQS%2FU00%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:53.7661884","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A53Z&sr=b&sp=r&sig=McnToc3X%2BMNvi8fuQPwO%2BrbS0GOwxqiFJoR%2FalaJVRk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:53.7661043","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A53Z&sr=b&sp=r&sig=pH3c7%2FmmKnkIn1iOvrMZyf%2FtAJltAq6n46YOFU%2BFgbo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:53.7662033","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3210'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:53 GMT
-      mise-correlation-id:
-      - 0e55f261-3ec9-45d8-9601-2c7852425e21
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A59Z&sr=b&sp=r&sig=6Mv5nxu39GwkXkLKxiRI%2B0Jt1dPsldrZeaZaPUR9hHM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:59.0553883","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A59Z&sr=b&sp=r&sig=UCitHk9FvYZQpXEKgrLQoUn9p4uI4XCZlWZstQ%2Fcw9Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:59.0553168","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A59Z&sr=b&sp=r&sig=7ROZsLlRqYetTqGpYWQCfQjmHeWw%2BwmHuFgiAqQowmw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:59.055404","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:59 GMT
-      mise-correlation-id:
-      - 8accb8f7-d65e-40a5-b318-bcf4507bfdb3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A04Z&sr=b&sp=r&sig=IDwbJ44672dIWh%2BXHIOIDuhfYPq9JH5o5K25EntvoMs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:04.335345","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A04Z&sr=b&sp=r&sig=X7NvM0phOHbj10WZE2mA4zr7YbqelBsHzhF2RsUurMM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:04.3352744","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A04Z&sr=b&sp=r&sig=uH%2BKh8mT8ue5kvBxPCqbKudq7xRuo%2Brau3HXsakOL8U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:04.3353612","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:04 GMT
-      mise-correlation-id:
-      - 1c0ee004-1952-4bc0-ae8c-d77044893555
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A09Z&sr=b&sp=r&sig=TJdxX%2F0PoFmh4UKJADcSxWJO1LRsOXxCSEKf0Pi8wzk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:09.6187952","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A09Z&sr=b&sp=r&sig=YTRkaZG6EUcGennR8QJlB2dU%2BxXfvCqJdXgf7lyy93g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:09.6187044","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A09Z&sr=b&sp=r&sig=bUZq6BNKiWEhpmaKF81KQt%2FILY64VcsmxOoWzmwo4RU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:09.6188118","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:09 GMT
-      mise-correlation-id:
-      - 567aff43-768b-489f-aab9-7b675fecbeb7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A14Z&sr=b&sp=r&sig=DlEKqcg%2FAqCffy46h4uquwbKFGgkub0FtXfWZ8nlN0Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:14.9470895","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A14Z&sr=b&sp=r&sig=7FuXLTPPtw0FmX5b9%2FPfgV%2FuJFxWr0TD6ISDq8%2B8haY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:14.9469728","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A14Z&sr=b&sp=r&sig=yiOibPpoGHRdVGQdr1fI%2FOkix9ZrP7NMVT4CdWCD7JY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:14.9471122","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:14 GMT
-      mise-correlation-id:
-      - c7437b97-d732-42e9-a8b5-449262af9724
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A20Z&sr=b&sp=r&sig=BDo7DRyW76Xt8Ax2Ec4wuPaZIeDrxA4k%2BqdGTmRhYVw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:20.2146526","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A20Z&sr=b&sp=r&sig=PSI4uerBGyXvNyiWx0Hyb8cVYkoejeKm2R4mBReT6gM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:20.2145688","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A20Z&sr=b&sp=r&sig=UlkkIam5vMq4PY13n5CVlcTlcCX%2BA2crTmGznwOCKaI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:20.2146728","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:20 GMT
-      mise-correlation-id:
-      - 028f1e4f-91cd-49da-ae14-c9fc1c98183b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A25Z&sr=b&sp=r&sig=pt7NVe9IAB%2FyxpcoxSTlP7J%2B1jgHZ%2BTiohJ%2FksdjAIY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:25.4912367","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A25Z&sr=b&sp=r&sig=mcBTlL%2BHEYM6tIXP0zrUHOErLhzCkrj4Jg2XbXAHHe8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:25.4911466","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A25Z&sr=b&sp=r&sig=Ayti25uKVrbwC1II3Fi36kwLUN%2FXqgr8xGE7oE1UYbI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:25.4912587","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:25 GMT
-      mise-correlation-id:
-      - 8cd8f442-b9a3-401c-894c-4aa319441234
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A30Z&sr=b&sp=r&sig=v79gKWcDzv4fu1LglgOVGLGKk8vcERCm34s7DQtIhHk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:30.7776658","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A30Z&sr=b&sp=r&sig=SAIigixbc0RT%2BH5%2Bh86gOPfYriwBhczmELaVDThT6%2BM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:30.7775932","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A30Z&sr=b&sp=r&sig=4DjB2aXEyRasbQf17Traeo9b%2BTSR%2FtxSaiji9wrUr84%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:30.7776802","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:30 GMT
-      mise-correlation-id:
-      - 897d02eb-3910-48e8-89eb-39260443fb66
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A36Z&sr=b&sp=r&sig=xhvoDFmPZi7XpjF2vHtpQ5PbUUZOXi5yxsjYGMzN7VE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:36.076175","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A36Z&sr=b&sp=r&sig=VTaT37NMoBzR5AwoLgZJogghwLob3L5qV38RuX8c%2FA8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:36.076105","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A36Z&sr=b&sp=r&sig=6KE4TQQ2k7cisEDDWsC%2B4lDFCTvuxWIyeq8uWuEG198%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:36.0761887","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:36 GMT
-      mise-correlation-id:
-      - 9aadceda-9850-4918-9b2e-21851bae5713
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A41Z&sr=b&sp=r&sig=v6RdDTC1FPMMrsvsfFSUeBnM5iQEuW5hbEBzpuJMTJE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:41.3453623","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A41Z&sr=b&sp=r&sig=KKRVQJBAWcyCcNhTQISodOD728LwKI2uhaSHNA%2Bjupg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:41.345297","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A41Z&sr=b&sp=r&sig=w4DTYcvJQTcvKYMA%2BC6%2FvLyEHNhUlZnZ%2Fpe9N5yD6gk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:41.3453771","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:41 GMT
-      mise-correlation-id:
-      - 726b0c58-9d76-42b6-8f9c-5367ea1ddd04
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A46Z&sr=b&sp=r&sig=gfV6YcZmB7VAd6lc1qlGgqJfdwsQZtd%2BPM0hWJuKKdk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:46.639","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A46Z&sr=b&sp=r&sig=VxixszjcKbFwGNYuTwbhw5SNyszGn6CkRuIY7WVM4lM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:46.6389217","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A46Z&sr=b&sp=r&sig=qqxgRHrTDYjh1ieAgbdt8LkbEm6DjPLwdb64CbDsocQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:46.6390146","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:46 GMT
-      mise-correlation-id:
-      - 744a2c28-f47e-48da-afae-d56a81e05e80
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A51Z&sr=b&sp=r&sig=fgaTR%2BwiOe5dfwXof7EAAe1snp2Wvtvkbm0WD20wM18%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:51.9297337","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A51Z&sr=b&sp=r&sig=fDZN0Iy1aszLwv7OamJMGwjgWc1EnJKjMFvBJirbX88%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:51.9296608","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A51Z&sr=b&sp=r&sig=QMT2VSVb8O1uw4jlHtBYiD4RVgYxYTj%2BC%2B8CdjdAAro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:51.9297502","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:51 GMT
-      mise-correlation-id:
-      - 649da7a5-d4b9-43fa-af0c-11da8a004324
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A57Z&sr=b&sp=r&sig=ViWpCKp3K541TU2BUwnMg6x9y6eVqirtUwH8j%2F8D0vI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:57.2042026","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A57Z&sr=b&sp=r&sig=FMNZgd%2Bgu3eIig5Tbk0VYro7kaGS39XPmWdldhsDJX4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:57.2041348","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A57Z&sr=b&sp=r&sig=F%2Fs4M%2FkBi2nTYFkMRPuFUXd0InDZSBqJFzi%2FMNN6HkA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:57.2042191","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:57 GMT
-      mise-correlation-id:
-      - e8d230aa-0206-416e-b429-773d7c247e4c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A02Z&sr=b&sp=r&sig=AYIkR4JR0WLHdHMLooxmGiuIDULDOqCQcb5ey3f1boU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:02.4830182","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A02Z&sr=b&sp=r&sig=N%2FA8kZr7lf5G4sQHCU6q10KNJINVy6s6WrvKiGLkabE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:02.4829436","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A02Z&sr=b&sp=r&sig=IiFjfHxJi5PLW3%2BfW4ApOHEBmOHlQAM3WRMbYkAw%2FDo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:02.4830324","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:20:02 GMT
-      mise-correlation-id:
-      - d24dbcb7-c611-4dda-b237-f71c6ee6dd4b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A07Z&sr=b&sp=r&sig=KVZtH7IaHJAILz3XcHmwclUn92viVS6TNlvd6XlneSE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:07.760896","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A07Z&sr=b&sp=r&sig=5bvIj4Xqv0txcBQoj5R%2FPjuwrGa4CkW4H9OfInQ9BfU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:07.7608231","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A07Z&sr=b&sp=r&sig=burPPoQUVZul%2BVxJK%2B7NY3g8zvswBrH2zdyTW%2Fw3K4E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:07.7609103","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:20:07 GMT
-      mise-correlation-id:
-      - da2fbecd-a54d-4d61-afd4-b747d2b7ba87
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A13Z&sr=b&sp=r&sig=JLt6U8P0l7PsFAnKjMxKhr17SpXVDaJaQwnUjgpIOGA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:13.0390339","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A13Z&sr=b&sp=r&sig=hjcQEp4hoUjZoevmsM2679AmpctXQoQ39yP2lQycnpI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:13.0389631","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A13Z&sr=b&sp=r&sig=C1%2BoG%2F%2BY8H3b2RVM46UZsHSzU1q8kns6JsBMOTUr1d8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:13.0390484","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:20:13 GMT
-      mise-correlation-id:
-      - 8e8cf27a-82b6-484c-9702-aa0d3e7b0856
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A18Z&sr=b&sp=r&sig=9X2Mq5CEtTXevXy8Y84DSs7RRoc2IQQuYweKDVAsjMY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:18.3209074","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A18Z&sr=b&sp=r&sig=GJTA22mx4CIclfMQiDehVim%2B8%2FbvTbVMDQ9TvfrtHUw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:18.320841","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A18Z&sr=b&sp=r&sig=z5PJKflitHGUitNJMVRVzAtjqILg8zkX5O%2FCP%2BYBq%2Bk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:18.3209246","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:20:18 GMT
-      mise-correlation-id:
-      - b6ab1c31-0faf-4041-841a-3f3fbee225e2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A23Z&sr=b&sp=r&sig=nJ%2F15o%2FGhjJQTn78mPf5%2FHyHQxU5%2BBoLYAdUUNSJCww%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:23.606757","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A23Z&sr=b&sp=r&sig=mq%2FNGK9JMJtlH1pYipbSasGdpbP0QyyYRniObcUMHV0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:23.6066986","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A23Z&sr=b&sp=r&sig=qalHg1vjxS40AxrINPjiky6FCYGVC3H6CkKitWWb2nM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:23.6067733","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:20:23 GMT
-      mise-correlation-id:
-      - 31ed6bcd-680c-42b7-a64d-62fb58ac09a8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A28Z&sr=b&sp=r&sig=VjrFGU5RHMGY6ufa1%2BQHAmOH7CItf6hTKLet14Vq0Mw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:28.8912996","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A28Z&sr=b&sp=r&sig=J4UFg6ox6WQV5L2QUKNOdL5bCIcdtVb760ekgGRByj8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:28.8912011","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A28Z&sr=b&sp=r&sig=V095%2BoIRAHbDAcu7DCY%2B1xBYs8ybZMPXiwNlPTGqZNI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:28.8913197","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:20:28 GMT
-      mise-correlation-id:
-      - 450fae28-d997-4563-8550-1bdb50cd91c5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A34Z&sr=b&sp=r&sig=z0dfk9484OVqmPQegH8PLRk50F7I2KQ%2Flb2WAF4pijE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:34.1833968","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A34Z&sr=b&sp=r&sig=AXRARpFmHjh5%2BVIyiu1xuGWaCGzOwo3C18D%2FvvJJySw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:34.1833051","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A34Z&sr=b&sp=r&sig=TqsE3ioildB37nsCLIJlAI49S3NDv2fWVhsGuM6jsiw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:34.18342","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:20:34 GMT
-      mise-correlation-id:
-      - 4b501b52-2ac5-45db-81db-1b5d25e58ec3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A39Z&sr=b&sp=r&sig=jJXREA0RbDDZAcymdJCXSqeN%2BNnHLqIQ9miqu4xt9ak%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:39.4661623","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A39Z&sr=b&sp=r&sig=TllehZnen%2BosumJpemgVeylJTVLfCxQ7FInCfWJX74M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:39.4660909","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A39Z&sr=b&sp=r&sig=ygq85FpksFzJvR1j%2BoFGpTLp1PbO0MUGvx9aW8LrA0g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:39.4661763","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:20:39 GMT
-      mise-correlation-id:
-      - eac68533-37e2-4764-b998-84cd2aa5d611
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A44Z&sr=b&sp=r&sig=LeoD8W54GaLZuBIoKdqLRV%2FiVv8qy5tWtzIlCpectmU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:44.7694373","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A44Z&sr=b&sp=r&sig=QrOhF6koK1zGok08oSoM1fpdAUGFZmcKxWJKTDxs0Uk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:44.7693424","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A44Z&sr=b&sp=r&sig=wWMr9g3mF%2FcYB5xn8w7XIe%2FwvzzOS2ig2Nqm6H%2BXObI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:44.7694597","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:20:44 GMT
-      mise-correlation-id:
-      - 4c99c62b-f950-484b-b6c5-662a5a586a6d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A50Z&sr=b&sp=r&sig=DGuLLk9hNDV8LFWk47rNmT2CWCuICIUCkzfA0%2BsyIEs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:50.050286","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A50Z&sr=b&sp=r&sig=Flg25ZWyHODcWYBPChO24cQUHdCXU5OMN5Nqn9sSXbw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:50.0502202","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A50Z&sr=b&sp=r&sig=JBhjKoWEiEpgQ3%2FNB4IimV1zq5Mqz5ssthtRd%2BfithI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:50.0503007","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:20:50 GMT
-      mise-correlation-id:
-      - 954ece6a-5f71-4e3c-8da7-098dbbef4037
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A55Z&sr=b&sp=r&sig=eqV6k2mGsX6QKQP4kJejROmuc5NtLgyZpKBGFtXcqGI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:55.3156846","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A55Z&sr=b&sp=r&sig=4ibKU6oItLWF0879gaN3f3C2vTMe4mJ1QNRjPs2oTAk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:55.3155902","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A55Z&sr=b&sp=r&sig=KZ1op9W7Km8at0XEwpunPHKiHAUiH21ovYViGgRipoQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:55.31571","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:20:55 GMT
-      mise-correlation-id:
-      - aa9349a5-6ce3-4a06-abd4-90745834658d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A00Z&sr=b&sp=r&sig=N0oCpJS7QcLlY%2BZfo0zR15HURaQUZSvhRaFONWKXbTM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:00.6056378","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A00Z&sr=b&sp=r&sig=%2Fcl215NgdnwJoIMn5fzVYV0GpliFC7hc9zYwJrBODrQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:00.6055691","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A00Z&sr=b&sp=r&sig=zuE4LbQ1gSOHL8sc6sA2qnkp54qTlsYjL8G5gTvuaQg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:00.6056512","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:21:00 GMT
-      mise-correlation-id:
-      - 981d795f-db73-4b7a-8461-eb6dd898f06a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A05Z&sr=b&sp=r&sig=JA5fS4i%2FLwGof8%2BKY2Cc5%2FviuKv7RNNlm7pKD6C3Llc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:05.8659761","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A05Z&sr=b&sp=r&sig=TkYWXrM2d4gYEnEcVqV%2FAJ3COkBa%2FKap1cbNrRQXKck%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:05.8659043","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A05Z&sr=b&sp=r&sig=2wfp%2FcJmo9lFCoEMEqcnhqvdjwy4mrGaJ699P4Zm9E4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:05.865995","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:21:05 GMT
-      mise-correlation-id:
-      - e7dec28b-3c44-4c14-b1b0-64e900b52159
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A11Z&sr=b&sp=r&sig=MNkVDwzwJKD5LqKfVNAPJJNdpXzwvoHhHp18kA2F8VE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:11.1325701","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A11Z&sr=b&sp=r&sig=FZul6a3TrpDRfuMV6DsUTwCo5GwVOKuF5d8qev%2FoclE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:11.1325033","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A11Z&sr=b&sp=r&sig=ytkDVscpBiQURHqhmtFhV%2FnQWuqUAc7PyaVOX7SWUUw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:11.1325857","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:21:11 GMT
-      mise-correlation-id:
-      - b77ea90d-5fa1-40cc-99cf-4fd564529ffd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A16Z&sr=b&sp=r&sig=sYygbaRfOwZLoYfx%2F6O4TWA1QQF%2B8Sn%2FSBIXF3q247c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:16.9478695","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A16Z&sr=b&sp=r&sig=qAabKp6iM7MLatLee3CCkFLMYoNaeQ2PPBPOtf4s%2Bik%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:16.9478004","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A16Z&sr=b&sp=r&sig=0B9lcylhqj3Oybn%2FE2Tzuqb7zAIbaNe2I1rKSPAESGw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:16.9478851","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:21:16 GMT
-      mise-correlation-id:
-      - cdaaba4a-6ec2-45d3-8aff-2df0ef8b2e33
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A22Z&sr=b&sp=r&sig=KZTKz4ed%2FQs0QJRZI%2BxVeD54MpUvxEwFlD2au%2BDpuAo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:22.2234619","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A22Z&sr=b&sp=r&sig=HuNz%2F9Ui2Siy%2FDQaXYMcOknOOajvG0qzbuuru5xAEfc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:22.223396","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A22Z&sr=b&sp=r&sig=oFgTkHJ34Uo9N2qUVNdTSLjm%2BwzuWAk0IoM0RPXRi0Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:22.2234777","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:21:22 GMT
-      mise-correlation-id:
-      - cecbf70b-b413-4365-aca9-1c444efbe54a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A27Z&sr=b&sp=r&sig=zaNgfJdI%2BRiV1TXnKzT5YbAYvuW4qZthptzZlR%2FFwqY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:27.5222456","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A27Z&sr=b&sp=r&sig=w1dhHesYCntLB%2BUXVFQXfbNBBug9gqqhduGFkIs9w4M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:27.5221374","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A27Z&sr=b&sp=r&sig=l7%2B4eYvVtOL84%2BP%2BfIGsQxHyG9hQW910o9rjXfY%2F41o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:27.5223203","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3208'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:21:27 GMT
-      mise-correlation-id:
-      - 12c125b0-77fd-4445-a476-b4cd4c80c1bc
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A32Z&sr=b&sp=r&sig=o90rRznsAl%2B2HnyvUN0%2B1Ll3jV5BDBPAI8%2FUddYnYmE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:32.8036674","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A32Z&sr=b&sp=r&sig=Qid2ODZ2K8WwfW8XUlwHaZ4B9ligZ5IF8gGflvBQWKQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:32.8036015","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A32Z&sr=b&sp=r&sig=KvMGn0JgI1UKed0CnU8AHYA1IIaT3AI0HvBzCWRo8Xc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:32.803683","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:21:32 GMT
-      mise-correlation-id:
-      - 463a5376-3d84-44b6-a35d-66194291c83e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A38Z&sr=b&sp=r&sig=LEnNPfDfBuDn878UBhtX95JZkbdftFValBhmqd5dth0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:38.0824444","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A38Z&sr=b&sp=r&sig=hPIIjJdHcgRS7%2BgW8VUGgnjkF04KKYXLeNraOm4Qs3s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:38.0823534","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A38Z&sr=b&sp=r&sig=tsFqOg0gh5HGNLG%2BfR0sQqA%2FYXV9LOTT9YQSgOftNMc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:38.0824628","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:21:38 GMT
-      mise-correlation-id:
-      - a9a119c1-37f8-4030-b203-7b23e4aaaeae
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A43Z&sr=b&sp=r&sig=md0m8hvKeFSVmMkKPDDiZCuiRmPNVbmky0vQDvojaWs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:43.3708094","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A43Z&sr=b&sp=r&sig=5JbTvVbALpAkELE%2B4TxgEBLz6lVykJEYjwKMNGD7VuY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:43.3707405","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A43Z&sr=b&sp=r&sig=oEEKQBdjllB08qyHU%2FJQP5HgKfT6xhfiOfaTUpB9%2B9E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:43.3708232","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:21:43 GMT
-      mise-correlation-id:
-      - 4a4f85c3-fc31-42b5-ac18-749763df77b3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A48Z&sr=b&sp=r&sig=UknDD4kMHa97w1ESYoJsWMQuUNBy1CyUHw9MWYFB414%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:48.6385852","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A48Z&sr=b&sp=r&sig=QC6rjGAggMfdTMrBX8nYpwwhZn6hi2hjIuRl4OnjfWo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:48.6385152","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A48Z&sr=b&sp=r&sig=%2Bpo%2FZBt58QDWjw1VdoWnW%2FFgfXausHNH3NYJWdA1rgs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:48.6386013","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:21:48 GMT
-      mise-correlation-id:
-      - ce18b66e-09bf-4af9-b11c-594bbcace233
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A53Z&sr=b&sp=r&sig=SCaJUjVL0d6rvQ2tpS9fJgVS0OREl1vcUNGigL3yPME%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:53.9156442","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A53Z&sr=b&sp=r&sig=xK3mFADJ5XOqTzJzZbe3tDGlBBQEt9Kbi67h2%2Bw5sKg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:53.9155691","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A53Z&sr=b&sp=r&sig=5jjLvQZnVfn%2BRpOHeLyhf68Dm9OgZinZajTWr1hIcyk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:53.9156587","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:21:53 GMT
-      mise-correlation-id:
-      - 51ebf17e-b49c-410e-97ed-fa8619e95c0c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A59Z&sr=b&sp=r&sig=ZUvvhF%2B%2Bo6cf6Lw1EgDGZsMGpK5gxWmKeA%2BbdLPplbE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:59.2031999","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A59Z&sr=b&sp=r&sig=VeFeQtvF4X7%2Fo9DIFmLnBLviEZTK46f6m2KcwNx58Vc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:59.2031284","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A59Z&sr=b&sp=r&sig=sXSfWroU9%2FNOkePU6Fu4xu%2BWOCdVMPwHhgewcWjOlRw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:59.2032165","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:21:59 GMT
-      mise-correlation-id:
-      - 7cc6e6c0-568a-4136-8ab6-43dbe6423b8f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A04Z&sr=b&sp=r&sig=zh%2BWeHnnvh%2FYx%2By4jEDE7MQWxTEdiQaTuUvy%2F%2Fe%2Fvgs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:04.4699987","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A04Z&sr=b&sp=r&sig=B6q4OETXQjAh8ZU3KwaW4N6vmuC4qngaDvke1O0Slfc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:04.4699268","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A04Z&sr=b&sp=r&sig=xP8t35W5ToQoCNH%2BPb7ljtrx7WjqLpiZ%2B6d1nsD0HMw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:04.470013","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A20Z&sr=b&sp=r&sig=DE8O%2FP5Evo7mB9i%2FMAwZvkL%2Bmumm8BmLMSFJ3w%2B0rmA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:20.6449326","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A20Z&sr=b&sp=r&sig=fMhnjp6V0NHs5OOtXfkSzJjkAPTVpOCF6efUHRmjuEo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:20.6448562","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A20Z&sr=b&sp=r&sig=h5wbeQU9lYjayLSOwMQcSNqFQAPvvfht9zWIz%2F%2FAaxE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:20.6449504","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:15.344Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2514,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:04 GMT
+      - Mon, 09 Oct 2023 19:24:20 GMT
       mise-correlation-id:
-      - 6dbb5eee-5d30-43bb-9e60-4f11c6e2fc5a
+      - e4ea02b1-be20-4e18-8d22-7a5b68f31a68
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2536,10 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A09Z&sr=b&sp=r&sig=iCW73su3vQtucGYiYtcH7x2fbYHYBtpnc7iA9eAUcPU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:09.8299335","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A09Z&sr=b&sp=r&sig=0RSjZV20nxRP%2Bv4Mv0FHRg2DJp3twkSL%2B80IPv%2BA%2FYw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:09.8298629","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A09Z&sr=b&sp=r&sig=wxBJGXBfS38BeoGcbIa%2FT5ZMDFweyWS2GA1e%2B5jWjGk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:09.8299496","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A25Z&sr=b&sp=r&sig=tb1zfxXPKncAObhaD9feNpNB3jgU9BVlL19puHk1Pi8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:25.9541989","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A25Z&sr=b&sp=r&sig=90KO7oaBBNF4LRnFM%2B8MpkGwZNHSPKqCpZziAycb0rQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:25.954103","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A25Z&sr=b&sp=r&sig=%2BGpVbxgPpZxfHGnIpw901UbBa3rXtso%2B8a%2Fc%2FCBhN9s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:25.9542212","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:15.344Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2550,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:09 GMT
+      - Mon, 09 Oct 2023 19:24:25 GMT
       mise-correlation-id:
-      - 6387342a-9380-4825-ae3a-e956bf96c0f8
+      - efd8d14a-7b4f-452f-ba55-914f4ffbc186
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2572,10 +772,1738 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A15Z&sr=b&sp=r&sig=ekLbbq5IooGUP9OE5Bq0zj6eJm0zG9W28RUCypB7qU8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:15.1052996","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A15Z&sr=b&sp=r&sig=vqzOVq9EE5%2Bb7IAnUfuwL4NAEoufF%2FTIbx9GxTTgMlU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:15.1052101","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A15Z&sr=b&sp=r&sig=YBsOGJGE20JX%2FUTjrKtY%2B5ScBDQ%2FIkHSMaEo%2Fm%2BT8LI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:15.1053228","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A31Z&sr=b&sp=r&sig=%2BW37ocKbJzgBvC04nytyTfW61G4yks%2B0RMLS9efj9wY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:31.2431876","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A31Z&sr=b&sp=r&sig=DMRkjUzU9oFbFSQGScP7lL%2B%2FAB2LOoNCLPntSqzcTF4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:31.2431214","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A31Z&sr=b&sp=r&sig=p2QY7zUCOgA4vsPJRjhydFvAXjppWOAa5fWcdolBcYg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:31.2432022","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:15.344Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:31 GMT
+      mise-correlation-id:
+      - 0fa6dc20-4902-478f-971b-a724bf73e75c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A36Z&sr=b&sp=r&sig=JUfy0BDWEsJ49F74oFqNY5fRmAtjCZSeVLXhyeIUPLo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:36.5545621","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A36Z&sr=b&sp=r&sig=M9gC%2F3NjRFrojC7FdzgsQykdfUEyFBJGWt0WVbf0%2BJM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:36.5544921","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A36Z&sr=b&sp=r&sig=JUasXlQ6OxfKEfe01nMvHQWjBdNFGab3vTam4%2FhcUbM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:36.5545783","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:15.344Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:36 GMT
+      mise-correlation-id:
+      - e705e0c8-0195-4884-96c8-f6a72adcccba
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A41Z&sr=b&sp=r&sig=wCLljhLrQy4C5ogYTzUooahyolY2Fc0RYs8u75si5nU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:41.8418063","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A41Z&sr=b&sp=r&sig=tVGyAPROFSlT%2FT6ZZKsgx5xQGL6QhQqopK%2FzVW2vyBU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:41.8417114","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A41Z&sr=b&sp=r&sig=X6XDVrGb638GiJQS1X6qJMgMlUDUgVoB%2FXh8Np8GvqE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:41.8418291","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:15.344Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:41 GMT
+      mise-correlation-id:
+      - 21d64cb4-496b-44ab-a2c2-4165606683c9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A47Z&sr=b&sp=r&sig=rGFvfq0gAZIRnvUEKp9Qg%2FIAdh8AhVjmzqm92dLqGFI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:47.127966","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A47Z&sr=b&sp=r&sig=mKO94coxreGgjwW0BoQ8%2FpiI47mpi8xg1aJL00XOS5M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:47.1278943","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A47Z&sr=b&sp=r&sig=UbyYKmuKQC%2B0UFoBBgysYujJebXQ0vB6yZ%2BoLR4%2BeeM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:47.1279797","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:15.344Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:47 GMT
+      mise-correlation-id:
+      - a679da58-780c-4960-9452-615831d6d098
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A52Z&sr=b&sp=r&sig=viq4aiGmJjyJDZyDw3GkD1TxzZeRsKJU%2FjB%2BIb87d7U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:52.411756","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A52Z&sr=b&sp=r&sig=xKUYc6zKrEWU2HimC1ciyyeivKwDpJ4ze5aZjtQm8DY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:52.4116699","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A52Z&sr=b&sp=r&sig=58OBgXw5ZJizqvYBNqwtwgZjJiNAxlxKQbsjamG1qlQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:52.4117768","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:15.344Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:52 GMT
+      mise-correlation-id:
+      - a73ebab7-2da2-4483-b34a-aaaf10d34b06
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A57Z&sr=b&sp=r&sig=5edLpGGa8hGjxD9OS51MAUKhXte97Kp6R1azs7RFsEk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:57.7242448","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A57Z&sr=b&sp=r&sig=Ymm6s%2FID%2F8jHoWt3ulEcnXYPxXJH4EM37gJhOhBYUiw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:57.724167","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A57Z&sr=b&sp=r&sig=qncj0wn1%2FfhKAtcdTkfvz%2FRbhzQwTkGUntQDcGuw8sw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:57.7242588","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:15.344Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:57 GMT
+      mise-correlation-id:
+      - 05c5677f-8c34-45cd-a5ff-b78e81de4d4a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A03Z&sr=b&sp=r&sig=v5GHuq6eJidFo5W5WeZuMcLxwQ6cOGfP8LLmY8xumww%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:03.0794474","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A03Z&sr=b&sp=r&sig=CZzWMeKqcgosHsq60Ku1IaGVwuI5VRHlYJ7peMELB10%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:03.0793644","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A03Z&sr=b&sp=r&sig=oK%2F0OetvDi72Wk2TNQl4EzRcQvuN%2FlzQsk9SNGudUgg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:03.0794665","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:03 GMT
+      mise-correlation-id:
+      - 53c694a2-8027-49bf-a114-e68c0e7c8157
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A08Z&sr=b&sp=r&sig=VIpVta9TyeIKUiZPPznStfjnY7jBxWiOZatxtYH6r4w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:08.3782374","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A08Z&sr=b&sp=r&sig=fk7MHrp3Q1gEa6ZjHF1J%2BD3gzpLvj7NxFtXboPzqk6U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:08.3781557","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A08Z&sr=b&sp=r&sig=ntdzyJrr5HjHb0TJoEDEqcksgk4K0qIGbunr4dgQgsc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:08.3782576","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:08 GMT
+      mise-correlation-id:
+      - bb6a1e96-27c9-4a5a-9c9e-5b29c6e9ac18
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A13Z&sr=b&sp=r&sig=FqN1pjarQ4NuuTOb0b9%2FR4ZarSS1y%2FVLS0SvemnrzL0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:13.6921055","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A13Z&sr=b&sp=r&sig=9Yxa1LUR1phBe5Km7ijuWiiIRkHt5sPuikv1TxCrNNY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:13.6920221","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A13Z&sr=b&sp=r&sig=ol9m%2FjastVza75iPzq8qpnp72gcVY2o8liEFBsyH6sc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:13.6921229","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:13 GMT
+      mise-correlation-id:
+      - 7d6e6d09-8a93-455a-83e6-d3d4b79386fe
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A18Z&sr=b&sp=r&sig=rO14t6pWCTdrI8OzMeMR1IhpvrAiNddLvDatxTxzy3M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:18.976584","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A18Z&sr=b&sp=r&sig=F0H7ywXoyujWQF8MRE03tkhQewexM100RQuk3rcb6bk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:18.9765012","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A18Z&sr=b&sp=r&sig=miVm%2Botp5gMJtAxMaMk4kYet40SEfYNqNjx2x9iiXqU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:18.9765995","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:18 GMT
+      mise-correlation-id:
+      - 10ed8d08-9baa-4516-8386-7ef7472f5088
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A24Z&sr=b&sp=r&sig=QjOKUIdhp%2BJ%2BWbxBV9MfNnYZsVAC67fVp1A234dzOpo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:24.2544964","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A24Z&sr=b&sp=r&sig=aQyjNOUnHfFbPaVIiY%2FjvgeZc5XFpMJMTUdf6d9tnAg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:24.254404","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A24Z&sr=b&sp=r&sig=ZEaL7agu4DLeDMmemi5eGMVhstOskt2btpo7Ad4mqMo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:24.2545171","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:24 GMT
+      mise-correlation-id:
+      - 7b79aafb-faf5-4530-8219-2b4e38c42787
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A29Z&sr=b&sp=r&sig=IqriW8xyN1rj%2FuTKnBhiDmAB0%2BkyI%2BX%2B8VI0N1b%2FgxM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:29.5455839","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A29Z&sr=b&sp=r&sig=qGEJSGk7YAzGWt5%2BWetHMHngZO1NwnDHXVzgHl%2Fn8us%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:29.5454922","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A29Z&sr=b&sp=r&sig=XZssaXV08jo%2BmxXGteLfNwCgYJRTwe12MqN89eHvh1k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:29.5456008","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3209'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:29 GMT
+      mise-correlation-id:
+      - 9fa5378a-6385-4399-8ad2-210796964b44
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A34Z&sr=b&sp=r&sig=tX6y78CV%2Bd9acfRpYFLE%2B41dVrhuOkfgNDUeJXdiLwU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:34.8989174","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A34Z&sr=b&sp=r&sig=nz1Qn8AiDxoklsOaseykt8qD8tTzt%2F8PQjnwwyfI9N8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:34.8988331","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A34Z&sr=b&sp=r&sig=xZzIs6sr7ts0QhtuCy0x7UyCqoBmzIKdb%2Bl1M86KheU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:34.8989377","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:34 GMT
+      mise-correlation-id:
+      - c83c73d9-e4d7-4cdb-b885-3f5bccda2023
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A40Z&sr=b&sp=r&sig=WpuE9mW%2B3%2B1EjXDqwVIfsgPUzYEVm0wvaPGUrdbihaE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:40.2179453","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A40Z&sr=b&sp=r&sig=aUnEIGZqcmfMeeNtphdq7hCsnpQGOmqUYsoGXfWzslc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:40.2178571","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A40Z&sr=b&sp=r&sig=MffAOoHBf1QHkCGCWDyJEP6VN6bdbag%2FccP5vdrm%2Fbw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:40.2179655","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:40 GMT
+      mise-correlation-id:
+      - 2231ad18-aba2-431b-be0b-71cc4c70a74a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A45Z&sr=b&sp=r&sig=%2BXT644RNTrCSryutqlL46jx%2FX198nEvAR67dTxLP300%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:45.5371862","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A45Z&sr=b&sp=r&sig=%2F01qFFz1j1VfHZGwWJ8YjtdYOkl2oPbq8QaSk1fH7xQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:45.5370881","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A45Z&sr=b&sp=r&sig=4tiAeQ3CFr%2FLAilr%2BbWLbAzjv3lwu1C0Aw1z71xDte8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:45.5372017","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:45 GMT
+      mise-correlation-id:
+      - b8a11ad8-1d2a-41a2-a6a6-1f04a308dcb0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A50Z&sr=b&sp=r&sig=mlWWeXVKReZ71lDB7NKIlKiqu%2BYKmwNcp4HG0rjKyBM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:50.8656347","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A50Z&sr=b&sp=r&sig=QqiB86GqeCxKYoNEjAx19Gwh9cMXzJiblda%2BC1nbOdE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:50.8655399","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A50Z&sr=b&sp=r&sig=7ruIKaZIRxID8s1x%2FSTOFG9gUo%2FxuXdmQIDCQsIu1vY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:50.8656568","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:50 GMT
+      mise-correlation-id:
+      - 7be1a9bf-38e2-4747-9002-90ec0582a2c8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A56Z&sr=b&sp=r&sig=OD2H1Z84bIWTiAztoRNHgLad%2FD3UXtJRpe8XyVtriK0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:56.1390214","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A56Z&sr=b&sp=r&sig=P7GN6svkakZwrxpaZhvhNtUtw0XYHzcQ3YeFuWlFBRg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:56.1389397","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A56Z&sr=b&sp=r&sig=vGy0TW6FhgbpBxArtzwIMrtqmbSUXksKaEGnyPDO8qU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:56.1390356","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:56 GMT
+      mise-correlation-id:
+      - 85e6d449-95f7-473e-a303-d7ea6e66523f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A01Z&sr=b&sp=r&sig=ax4AwONfnntCq%2Fq%2B4zHn1t%2FoHgiUvZgW%2Fu46AWs8nMk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:01.4164151","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A01Z&sr=b&sp=r&sig=02yzvKTjxX%2B8s9eNRT2MP%2B3JHjnmCfNYYm8wCo4bS0o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:01.4163231","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A01Z&sr=b&sp=r&sig=0H%2FGfLt%2FzDAss7S7mcr%2FUV%2FuU5qdjpVzuOWjvD%2B29ic%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:01.4164374","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3215'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:01 GMT
+      mise-correlation-id:
+      - 274a8def-5e5c-43de-8fcc-52d9d77fc9a5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A06Z&sr=b&sp=r&sig=1r3I6%2B7lrN6yUbLuhsfGskZSVZzNnY4ZEiULEv2%2FdTo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:06.7404738","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A06Z&sr=b&sp=r&sig=GGRouBmj5jZ9XJ7%2Fe2%2FN0%2B80coN%2B0%2F71OUcbuUw5OXM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:06.7403814","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A06Z&sr=b&sp=r&sig=x4dHIbpE6xDMVOtiecLReclGOytAPFsnsZ36lcaOdcE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:06.7404987","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3207'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:06 GMT
+      mise-correlation-id:
+      - 7624398d-cf46-4342-ba5c-dbe77b12cc74
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A12Z&sr=b&sp=r&sig=3tWlB%2B2pzpiI8DrxPgjO%2BYZhpXn9%2Bu0nOv8qMEC8KUM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:12.0653086","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A12Z&sr=b&sp=r&sig=%2Fi93secxfQV71ZRB6LJxQ4nZFHuXmYrKhlLnlWa3IgM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:12.0652265","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A12Z&sr=b&sp=r&sig=JWjOSpMaMjsZN%2BjVTzpoYD5B2LH8jHUC0HgMVZs3jfw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:12.0653255","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:12 GMT
+      mise-correlation-id:
+      - a1ef686a-2f0f-4074-9030-0687826b9928
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A17Z&sr=b&sp=r&sig=Xty33ccFAvyfkZGYvvP8TI2dYmmsBl862173yZDOD0s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:17.3830777","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A17Z&sr=b&sp=r&sig=SXoTNLcHEt8R%2Fx5rqkw%2Bjk9mzd9jStsPSVDztjbEOUA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:17.3830028","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A17Z&sr=b&sp=r&sig=x5qbR9WW%2FcIEXpD25q3K%2B7JKQLa6IPcSKVG0AofRPDA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:17.3830939","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:17 GMT
+      mise-correlation-id:
+      - 749973ac-e58c-426a-bc2f-cc193a75fb5f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A22Z&sr=b&sp=r&sig=TyUC6Z8hbiLq2VXhHo8MDFPLK90udQ98kBOwPLvwwlo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:22.7102501","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A22Z&sr=b&sp=r&sig=SSmpAYKngXz9mtJ0%2BR%2BW29FjoMDl2rD63BEpsHZPtgE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:22.710161","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A22Z&sr=b&sp=r&sig=bVsZJjlHfY50mN5pR4%2FTLaik4oVCThnwNAKQu3uUFMc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:22.7102714","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:22 GMT
+      mise-correlation-id:
+      - efaa92c3-b174-43b6-8130-079ffa51e0ae
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A28Z&sr=b&sp=r&sig=4eFBesn1hLW2Glt5JBUGII9xMP5XwNGnpRBIfVzt7a0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:28.0350979","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A28Z&sr=b&sp=r&sig=CBa4%2BS0GRRh8r6niun65hWvbw4So2jesaI5grJbVBVE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:28.0350244","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A28Z&sr=b&sp=r&sig=7jx1zKUfXO4XAASOzpg6pl%2FZNBulObTpjHdLwe4%2BDMo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:28.0351122","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:28 GMT
+      mise-correlation-id:
+      - f9955d70-69ff-4b70-bd41-b69c1e21a77a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A33Z&sr=b&sp=r&sig=KcutpUZCEAULPrWaPRZEsnj0ty%2FWmhRyshFes%2BuaAE8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:33.3610531","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A33Z&sr=b&sp=r&sig=NrPy0FKR28qpAIsEi8j90FVh7LccIsYi4i689OQpqBw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:33.3609623","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A33Z&sr=b&sp=r&sig=Y0dnFFLrowCBNVz%2FMMX6Ol2mmu0v4WaJTDyYA2LY30E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:33.361074","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:33 GMT
+      mise-correlation-id:
+      - a3e44d46-b849-4abc-8951-c77370519b84
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A38Z&sr=b&sp=r&sig=hgr1pAeLjytvtpYxjWlLj5%2F7rYI%2FVBgLsbJM9cwvcVU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:38.6415241","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A38Z&sr=b&sp=r&sig=mCsyuNTWLfyQiw3PQ3jIvMZUIRI4zt5hn6PI7B3uBmA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:38.641422","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A38Z&sr=b&sp=r&sig=pgpw68qMfwfxBsjL7DxBzq6kvJJH%2BZdCmkYM%2B3Et8ps%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:38.6415466","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:38 GMT
+      mise-correlation-id:
+      - 04f00985-13da-48af-8633-b453df817175
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A44Z&sr=b&sp=r&sig=yoQeHeLCjGUdlhPjtQitccnsvGqv3mMzjZsNFVIJptM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:44.0328785","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A44Z&sr=b&sp=r&sig=tdvTtUHglt3knpJm8Esm51GMmm1pS870qb8eLfDHOOU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:44.0328042","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A44Z&sr=b&sp=r&sig=HrQiOh337DbN7S9nuA4495Gtq0cw%2FPK4MrW7BqFbdYc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:44.0328967","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:44 GMT
+      mise-correlation-id:
+      - be91ce7a-f1fb-4741-9622-4590fabd8eab
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A49Z&sr=b&sp=r&sig=9HNHnvYmLJmKe%2BcGZJ9qh9UBJGzA%2Fbau190atS%2F73h4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:49.3250037","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A49Z&sr=b&sp=r&sig=sX53mE91%2B5vvDnZxjMjOG7nElHopRVVsHszuLInKUMs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:49.3249173","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A49Z&sr=b&sp=r&sig=eUor%2Bx6VPISZefV%2Bnlopmg8Ms%2BydUZjm59Eb6mWMIgc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:49.325025","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:49 GMT
+      mise-correlation-id:
+      - 6dd27419-2aa6-4496-a1b2-35e01efe0655
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A54Z&sr=b&sp=r&sig=gV0ZyqnrYHbnptX%2B2kLZtChxmPDOpgpJKYJd2EiTN3E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:54.6594824","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A54Z&sr=b&sp=r&sig=6Kz3XDjRBUY8HFlgBYCDy71H98cQuNLVXdt34mES4p0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:54.6594109","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A54Z&sr=b&sp=r&sig=6%2FakahXrFl3kQXKqnTtdtaNJV9yQ%2B2QUB1wcW2TulMA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:54.6594986","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:54 GMT
+      mise-correlation-id:
+      - 3cd9cd85-e4ad-43ed-880e-1d86563ed5ab
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A00Z&sr=b&sp=r&sig=%2BY3tFc9d0esRWwHmwh76VCRTuI2aMWmPGGbHFtml9rA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:00.0056742","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A00Z&sr=b&sp=r&sig=l6fm2yE%2FfMRHzk8SPgGBvr8ISHtNNOESv3M1jVVEkL8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:00.0055511","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A00Z&sr=b&sp=r&sig=DXO9V%2F71ZzqZDEWc3QGqGQoGIE2OmtH5pO6m1ICqass%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:00.0056948","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:27:00 GMT
+      mise-correlation-id:
+      - a590fb57-4309-4b60-8692-99fd5af2abae
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A05Z&sr=b&sp=r&sig=H%2FerKWHVySm41azw2rOFLjxOI3gl%2FiX4crFMiRaxcQI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:05.3066169","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A05Z&sr=b&sp=r&sig=S385OEsnHdqPIXvZs%2FSISoZPSnukcXm1Kjr5tlHzANc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:05.3065337","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A05Z&sr=b&sp=r&sig=lvgRx1LOVHZfSTjSAsq14WMLMz5ix1gnoa4WSZZbOXA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:05.3066375","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:27:05 GMT
+      mise-correlation-id:
+      - 8703bc64-60eb-473f-b108-6f0941f203c1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A10Z&sr=b&sp=r&sig=ERmkN52hcoIFKSF6jFowMqEXBxB%2BIq%2F4SUFBg129ucY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:10.6385468","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A10Z&sr=b&sp=r&sig=FM%2BeDlbQWUpsVRiCHlR9xiNtCPSzOXuguJpWMFiE23c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:10.6384539","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A10Z&sr=b&sp=r&sig=kvK3Grs%2F4b1xW93Mih1YumnN2HlZtBqo6HkWs7AF9sg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:10.6385695","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:27:10 GMT
+      mise-correlation-id:
+      - f8002582-2316-46eb-9e97-fe526f4b5efc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A15Z&sr=b&sp=r&sig=5QiuxjZff%2FI62syOaQ1bpVxQJx9rET9jM5VdUf98LF0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:15.961066","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A15Z&sr=b&sp=r&sig=Zscy%2FXs8SCe7OCL6Jk8ZUOoXffU5FT0WEv%2B4nrMlVjM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:15.9609902","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A15Z&sr=b&sp=r&sig=2yC43wo%2FKNENb15ktOMfghuQG2KmuJHF8OnHE9zow4o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:15.9610805","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:27:15 GMT
+      mise-correlation-id:
+      - 3aedeb2c-7a56-4bbc-83d5-e12679984ce0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A21Z&sr=b&sp=r&sig=HDJQnJ2XSXt4FxUy7o1HsyWnDiwI%2Bag8eC3x7zkFFXY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:21.2836944","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A21Z&sr=b&sp=r&sig=U6APH0WeczRr373GRMrpmppukNqA7pzj3qGJ8ek2qf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:21.2836007","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A21Z&sr=b&sp=r&sig=7YjKr8FEeHO7%2B3OlpvOvPJwWPkJWu%2FMWiT9PAVpY6ME%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:21.2837189","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:27:21 GMT
+      mise-correlation-id:
+      - 05fcb2be-7d6b-44b6-83c5-bb89a95cfe37
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A26Z&sr=b&sp=r&sig=zOBeuUWTMR3pvNImxpEFKLVGehldTZhbghzuDQnM%2BW0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:26.6440849","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A26Z&sr=b&sp=r&sig=9u3bMyE2jv8E5N%2BsjVG7ngSwxpszmZqfIKvI%2BWPd39U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:26.6439992","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A26Z&sr=b&sp=r&sig=8jXSboL6yl5I%2BVW1ZIsf10dai8BbkkJdMGZtJ1OrNDA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:26.6441063","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:27:26 GMT
+      mise-correlation-id:
+      - 80408d40-ecf9-4bde-9dd9-c304a6a2cb7a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A31Z&sr=b&sp=r&sig=g7qXB4XAvmW04QWJqA%2FtOih03n8DRlABbrwYEffuc4E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:31.921939","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A31Z&sr=b&sp=r&sig=JARh7qBVuqrWFRkbNFbnPIYUAuDT9HbQolC4CVL07as%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:31.9218541","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A31Z&sr=b&sp=r&sig=jHzXLUQlV9U2wGCmfBOuUNLImaYlTpCeZsuvHoKq1tw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:31.921959","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:27:31 GMT
+      mise-correlation-id:
+      - 69766336-2ffa-44c3-a212-c6566ab7a079
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A37Z&sr=b&sp=r&sig=TXSvJapRsiVm9NNHgRNV5cZkeKQvkt1QQkNZl%2BHA%2FfE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:37.2682355","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A37Z&sr=b&sp=r&sig=uLxRkujrl29cPReKzauW1Il5vQYiBCcvDTlNQkWpRL0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:37.268139","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A37Z&sr=b&sp=r&sig=gR%2BuXzJij9W8EyK9%2Bvv%2F%2BXzDQbrO2CLtEMhhI67L%2B1g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:37.2682502","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:27:37 GMT
+      mise-correlation-id:
+      - 259f2982-5a9d-463a-8c7f-3081f7243762
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A42Z&sr=b&sp=r&sig=rLgzas86E9fsgzuQFb%2BBclgJNbIG1vV0bJl3CPsRp7k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:42.5819072","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A42Z&sr=b&sp=r&sig=dgd%2BWu4CC0h8kgo1WWYWqJQvgceZLmUlQmRqGQDjICg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:42.5817956","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A42Z&sr=b&sp=r&sig=Cm9TN1MB6z85VaAF64YFuBajxFMz7mBt%2BeXDJfTOFXE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:42.5819305","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:27:42 GMT
+      mise-correlation-id:
+      - 3d6758c4-be6f-4e59-a57c-fa7f206550da
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A47Z&sr=b&sp=r&sig=d77sBJZh%2BsrFNuShavy%2FGn8ZlYwyh0SnrKJ6KxQGR6Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:47.9112973","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A47Z&sr=b&sp=r&sig=tFwJNtgU1V5TJd4RGNMegsWEuVZEfzAdVP%2FJHOPpsxM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:47.911216","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A47Z&sr=b&sp=r&sig=TBaP%2FLWDwuMz%2BveBGoGegnpPrqtNa1nz4OoG8ZAYEFQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:47.9113125","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:27:47 GMT
+      mise-correlation-id:
+      - b8e354aa-a950-4520-9402-b13e54d68fa7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A53Z&sr=b&sp=r&sig=P6UWSU%2BTppyfnfB9CEgBMEGYqTTVTIPqpBLVhR6RdsY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:53.1877384","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A53Z&sr=b&sp=r&sig=pScOK4at7hkLtwVm9Mm2Xk5BZC%2FdiHYcBjqZg%2F76cUo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:53.1876681","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A53Z&sr=b&sp=r&sig=ktIbL6pTuhRSVUauUzHfjI1Ce%2BbyUBqIZYZV0%2Bhje0E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:53.1877535","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:27:53 GMT
+      mise-correlation-id:
+      - 52a351d7-e158-470b-b9da-f35fa55f54e2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A58Z&sr=b&sp=r&sig=B2o034emO1qnTn95i55NfPuTZ%2FLFxgXztqKWLF1JoEc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:58.4859815","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A58Z&sr=b&sp=r&sig=fIdPFuSopURw2c4Th0eV0xyZSoHz6WspFkBf1nk2xsA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:58.4858712","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A58Z&sr=b&sp=r&sig=0D3BZYxrOnASJ9D6UMPCwIAIrSQUFlXOiJFi6qWPx0A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:58.4860094","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:27:58 GMT
+      mise-correlation-id:
+      - fb80ffb5-1149-4f4e-a498-8af7296cd5cf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A03Z&sr=b&sp=r&sig=PkT96l8KUF1A01bK43N2YctOhBLYfmIVYl%2F9mgjeAjE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:03.7694827","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A03Z&sr=b&sp=r&sig=dWLHH6YE5PPAk3E3bs30XM2uuTmnc8WyZnUorI%2FlpTA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:03.7693913","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A03Z&sr=b&sp=r&sig=rCiJTrujOWduP0VsfpvEkKrdYn%2BGnvuGfauGIx%2B%2Bjt4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:03.7694973","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:28:03 GMT
+      mise-correlation-id:
+      - da9d7dae-0afd-498c-872f-063a321f74a1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A09Z&sr=b&sp=r&sig=obuEGi9x%2Bv9FajEJO7%2Bq0LaPnVqrHaJzSpz1OBCTv54%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:09.0460928","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A09Z&sr=b&sp=r&sig=l8Fh%2F5xtB2xUuhEErftkWQCcD%2B%2F3Kf7DLjyN7tKibTQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:09.0460152","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A09Z&sr=b&sp=r&sig=MpyOoElOhRWeaDoGdZePvwjGgyQJCtQ60FyCCPZsJsg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:09.0461074","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:28:09 GMT
+      mise-correlation-id:
+      - 51df4eb9-4c66-4c6d-bffd-0b36989db8aa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A14Z&sr=b&sp=r&sig=G1yXOLJzRNBoryHApDnGbIHRdVMREjMZWqi3aELBf8A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:14.3047976","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A14Z&sr=b&sp=r&sig=hnokeb%2BhrM3AkwyZnQRzKomi1m1e8%2Bunx%2Fh7phHm8oY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:14.304729","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A14Z&sr=b&sp=r&sig=Kn%2BZpeyE62GDEg9V63VeoG5sc0ZwFCqpZ0xlp4c%2ByyQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:14.3048121","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:28:14 GMT
+      mise-correlation-id:
+      - 5b6d83a8-22ed-423b-bfc4-e459092b0d6c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A19Z&sr=b&sp=r&sig=gg0UnREdnREEku%2BE4NRnf8Md%2Fr97FcdbXRC76rPEEJ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:19.6302342","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A19Z&sr=b&sp=r&sig=fpZr2%2FWwt40NdNpQcXpVr5DNeXD4AoQIYFIE1IjcqqM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:19.6301465","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A19Z&sr=b&sp=r&sig=ftL5sp6awY%2FtXnhQlmK4judSONI%2BVQFqfYYN1te9mZ0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:19.6302543","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:28:19 GMT
+      mise-correlation-id:
+      - 68819f5d-b718-4fff-ac6b-6fc2fe148e68
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A24Z&sr=b&sp=r&sig=TgHypqq1h2dXDsFIPsc3cGPmAHM04Cu7ClMHdlAeuCs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:24.9223111","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A24Z&sr=b&sp=r&sig=FSEQpSxQtg%2B%2F9EPgX12IQRuDhUrhrS2TNbRUs%2Fc05wk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:24.9222312","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A24Z&sr=b&sp=r&sig=E%2Bt7OiR0Eaw5yzbkDHdJCRM%2FuH4pr%2BwSKX%2Fg1d7jo0E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:24.9223275","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3207'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:28:24 GMT
+      mise-correlation-id:
+      - be8a4c90-f7b0-4960-95cd-78bc6c453b52
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A30Z&sr=b&sp=r&sig=mEUIRibFwRo261UeQFg%2BL9yj4Sn0AEx2rSZZjoP9Zyk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:30.2025715","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A30Z&sr=b&sp=r&sig=ML9F9Ej%2F1u44SPws%2FtiwEJBtsN9vaZYcEiKE9v5Gz6I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:30.2024793","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A30Z&sr=b&sp=r&sig=ps2ZAy2fy1jCLSBKBKLN7aJfnI9dv41Cx30%2Fr3OMZOY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:30.2025916","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:28:30 GMT
+      mise-correlation-id:
+      - 9bac92e0-069e-44f0-992c-e2aaaf6be9d2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A35Z&sr=b&sp=r&sig=%2BiNvMGM3BXQST%2BUJ%2Bzmc1Samya7dfuOGGDvb3r0OH5w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:35.5178791","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A35Z&sr=b&sp=r&sig=vnNaOnGXmToiu3k4gx%2F0iTHKH60%2Bww0N4UDzhdELI8A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:35.5178078","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A35Z&sr=b&sp=r&sig=d4uFpxu572Szl0m9ISw%2FfBq1gY5ZaO%2FgAlVpolJYN1c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:35.5178942","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3207'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:28:35 GMT
+      mise-correlation-id:
+      - 7ef2030b-7a96-4832-baa2-1413b3acdcf6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A40Z&sr=b&sp=r&sig=qeLT4HHl%2FKnh2%2FhY9XtWMdwczQUeuj88j0%2BFtUmSiJM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:40.848702","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A40Z&sr=b&sp=r&sig=Sb2E8NJzH%2BAwQvGValeTP8XsDSyPfnTiB%2Fw57p8Or0s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:40.8486418","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A40Z&sr=b&sp=r&sig=x%2FyEbbnvmjmV2lR3UQV201X4yWROOfsONHqlBPjJ%2FeE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:40.8487184","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:28:40 GMT
+      mise-correlation-id:
+      - 892bb9b2-5a3f-4609-9d25-5a0ca90c6f8b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A46Z&sr=b&sp=r&sig=Xk7yxfPnWLTKwPU7OCuzb%2F6P2LbOI%2BP8sPIOBf7hGj8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:46.1660819","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A46Z&sr=b&sp=r&sig=tHD%2FNdJFX7Jv1B%2BYwmNRCpU8emzKDZQcVJ%2BkCOK%2Ffgw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:46.1660131","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A46Z&sr=b&sp=r&sig=%2BiRU7Kk318QoZCtj3k8oOoLsLZe7Htoex%2Bm3CZQ0QEs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:46.166096","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2586,9 +2514,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:15 GMT
+      - Mon, 09 Oct 2023 19:28:46 GMT
       mise-correlation-id:
-      - 0c5fa5be-98aa-4d84-9390-1393d7b7aa9d
+      - 241aadff-d5cb-4ac3-a29c-aeca744a2dbf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2608,23 +2536,59 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A20Z&sr=b&sp=r&sig=9jknCba8Pho%2FIhz2M7izgT7ni%2FG2sCCHZ%2BWKGvLr2%2F0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:20.4046945","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A20Z&sr=b&sp=r&sig=OAVDBkGJ0IJ262DOu1jEEN2I%2FRB4APfT18%2B0hrEdsac%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:20.4046006","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A20Z&sr=b&sp=r&sig=w4Dt0xo7hBknCNgRaSSmVyhIHxTSxggsifM3wJ2kr04%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:20.4047155","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T16:17:39.476Z","endDateTime":"2023-10-09T16:22:18.272Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:22:20.392Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A51Z&sr=b&sp=r&sig=c5hhjA4ZaagNt4QOxHRbHnbOiD%2F5ek5aPNio5xks6Gg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:51.4422151","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A51Z&sr=b&sp=r&sig=%2FxMInh9hTcaFplzEYuNiB6xRZ7JfS7WNl97nSY%2B2d14%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:51.4421019","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A51Z&sr=b&sp=r&sig=z4E88N14%2BFl6DBEWBitK8V4LKWubdI24xY4zpiFCNEA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:51.4422355","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3242'
+      - '3201'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:20 GMT
+      - Mon, 09 Oct 2023 19:28:51 GMT
       mise-correlation-id:
-      - 4791ba79-f507-43d4-ab29-9fac3f00fdbb
+      - 03759821-df93-4751-b33a-d9f6693bc795
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A56Z&sr=b&sp=r&sig=R0K4g28ovxfvl4xaALnh5ijPCKDUPDQ%2B8kLkebZ9FZ8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:56.7221789","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A56Z&sr=b&sp=r&sig=XDUAVDM3LiurFXr1sLWNrRVwWk%2FZlDKeuyT44Aqo32o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:56.722091","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A56Z&sr=b&sp=r&sig=ohiWuPLBnH2AAOT6JnPWdMSMGEDqTeLjOASUJmEs0n8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:56.722201","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T19:24:15.132Z","endDateTime":"2023-10-09T19:28:53.521Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:54.749Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:28:56 GMT
+      mise-correlation-id:
+      - cf477da9-c827-4651-8372-a5f12c37e2c7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2647,18 +2611,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:41.884927Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:41.884927Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:17.0295091Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:17.0295091Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:21 GMT
+      - Mon, 09 Oct 2023 19:28:57 GMT
       etag:
-      - '"9201fed9-0000-0100-0000-6524276b0000"'
+      - '"560052a6-0000-0100-0000-652453270000"'
       expires:
       - '-1'
       pragma:
@@ -2688,10 +2652,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=metric-test-case&api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=metric-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A22Z&sr=b&sp=r&sig=NvzfGxA3F5Udl8xEnfFo%2BPgUsuXbRu2zq2IkICElG%2FM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:22.6394154","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A22Z&sr=b&sp=r&sig=%2FVB1EpHCkpB0wj%2BSaRZcE4U8x5em9GRQ%2BXFPG8B3xsg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:22.6393063","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A22Z&sr=b&sp=r&sig=IZtNeOOHdwMIngc6%2FAKm90R81KQb1OMCNOl1p5Jgnp8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:22.6394467","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T16:17:39.476Z","endDateTime":"2023-10-09T16:22:18.272Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:22:20.392Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A59Z&sr=b&sp=r&sig=XI2lc1Yed07xkQPAex0%2FvTodUsBgULtMldSgL%2BviTh4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:59.2925174","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A59Z&sr=b&sp=r&sig=BN13wXj09O%2BUktvPlGrvoCaMbMqoH%2B8RLk5VXoHFwiA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:59.2924298","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A59Z&sr=b&sp=r&sig=FfOmSNpVgLieMooQt9W37xEX%2BR%2BKA7evSM4QemYr6sY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:59.2925376","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T19:24:15.132Z","endDateTime":"2023-10-09T19:28:53.521Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:54.749Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2702,9 +2666,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:22 GMT
+      - Mon, 09 Oct 2023 19:28:59 GMT
       mise-correlation-id:
-      - 1d0c8d6b-b798-4e78-8b9e-83ca445f3a1a
+      - fe675b03-80f7-44c2-b49b-a9dadb40627a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2727,18 +2691,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:41.884927Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:41.884927Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:17.0295091Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:17.0295091Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:23 GMT
+      - Mon, 09 Oct 2023 19:28:59 GMT
       etag:
-      - '"9201fed9-0000-0100-0000-6524276b0000"'
+      - '"560052a6-0000-0100-0000-652453270000"'
       expires:
       - '-1'
       pragma:
@@ -2768,23 +2732,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A24Z&sr=b&sp=r&sig=62ab%2F2SHIu%2Bo4lBoHbdPcGt%2F4FedaHhNxlYzUNor7vk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:24.9084954","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A24Z&sr=b&sp=r&sig=6GLJytAwH2oYnEjCT4hhL9ok2y9ITESZ7BvZwf%2FGR1g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:24.9084271","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A24Z&sr=b&sp=r&sig=mE1KuubTkGPTKMw2mDgTGNRu8YrOZ2R3Zd5vB2YFmCE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:24.9085103","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T16:17:39.476Z","endDateTime":"2023-10-09T16:22:18.272Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:22:20.392Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A03Z&sr=b&sp=r&sig=ktAI6rtbiN6qruMT0ghhHaLc58cxQGPhqXUtq8T1Q54%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:03.9821177","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A03Z&sr=b&sp=r&sig=awzYsHKztfCbsQlCLciYK7X18IbQzrTKQ15APRg%2FCvQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:03.9775924","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A03Z&sr=b&sp=r&sig=ALIMtrKBalttGMH%2BbEfiJMtnzd8iOzQGkiQgACycBKk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:03.9821473","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A03Z&sr=b&sp=r&sig=O3GkHmsZsQdSNVfXH4kI94mWkpJBjRluK6Mk0BFzme0%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:03.9821757","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A03Z&sr=b&sp=r&sig=g6v4gTnAVfRIGLB%2Be63vOKy%2B8pqouQZcm0PTLNUsCT4%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:03.9822079","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T19:24:15.132Z","endDateTime":"2023-10-09T19:28:53.521Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:29:00.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3238'
+      - '4396'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:24 GMT
+      - Mon, 09 Oct 2023 19:29:03 GMT
       mise-correlation-id:
-      - b2baaeda-bbf2-46e3-931d-76a4f8573a2f
+      - 34259086-2cc7-47ce-bf41-ddd33e46682b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2804,7 +2768,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"dimensions":[{"description":"Request Name","name":"RequestName"}],"description":"No
@@ -2823,9 +2787,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:25 GMT
+      - Mon, 09 Oct 2023 19:29:04 GMT
       mise-correlation-id:
-      - d3f8a586-08d5-483c-b996-827db4da2342
+      - ac795eeb-300e-4658-b83e-2a091034affb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2849,23 +2813,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-09T16:18:00.000Z","value":1.0},{"timestamp":"2023-10-09T16:19:00.000Z","value":1.0},{"timestamp":"2023-10-09T16:20:00.000Z","value":1.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-09T19:25:00.000Z","value":1.0},{"timestamp":"2023-10-09T19:26:00.000Z","value":1.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '181'
+      - '128'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:25 GMT
+      - Mon, 09 Oct 2023 19:29:04 GMT
       mise-correlation-id:
-      - 1843fb11-94b6-4faf-ac89-a901504a4046
+      - 631a3e5c-1b3e-4894-b6a9-4600f1e4c530
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2889,50 +2853,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=ResponseTime&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=ResponseTime&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-09T16:18:00.000Z","value":39.0},{"timestamp":"2023-10-09T16:19:00.000Z","value":16.0},{"timestamp":"2023-10-09T16:20:00.000Z","value":16.0}]}]}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '184'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:22:25 GMT
-      mise-correlation-id:
-      - 558924c2-dd76-4588-97b7-d362a3afa34f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: POST
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=TotalRequests&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
-  response:
-    body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-09T16:18:00.000Z","value":30.0},{"timestamp":"2023-10-09T16:19:00.000Z","value":61.0},{"timestamp":"2023-10-09T16:20:00.000Z","value":29.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-09T19:25:00.000Z","value":50.0},{"timestamp":"2023-10-09T19:26:00.000Z","value":16.0},{"timestamp":"2023-10-09T19:27:00.000Z","value":15.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2943,9 +2867,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:26 GMT
+      - Mon, 09 Oct 2023 19:29:04 GMT
       mise-correlation-id:
-      - 49a687a6-220e-4a52-9106-f7cc9910f81a
+      - 8c4ddb5c-15d6-4345-ad0b-706c4b8dde67
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2969,7 +2893,47 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=Errors&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=TotalRequests&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
+  response:
+    body:
+      string: '{"value":[{"data":[{"timestamp":"2023-10-09T19:25:00.000Z","value":52.0},{"timestamp":"2023-10-09T19:26:00.000Z","value":67.0},{"timestamp":"2023-10-09T19:27:00.000Z","value":1.0}]}]}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '183'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:05 GMT
+      mise-correlation-id:
+      - 112d80d6-d2ea-4ece-9f4c-b53fdeede53a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=Errors&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"data":[]}]}'
@@ -2983,9 +2947,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:26 GMT
+      - Mon, 09 Oct 2023 19:29:05 GMT
       mise-correlation-id:
-      - 77726590-0ca6-4077-92ed-79fbd6844e55
+      - cda6e190-9607-407f-8693-07ac8c69e876
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3008,18 +2972,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:41.884927Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:41.884927Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:17.0295091Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:17.0295091Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:27 GMT
+      - Mon, 09 Oct 2023 19:29:06 GMT
       etag:
-      - '"9201fed9-0000-0100-0000-6524276b0000"'
+      - '"560052a6-0000-0100-0000-652453270000"'
       expires:
       - '-1'
       pragma:
@@ -3049,23 +3013,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A28Z&sr=b&sp=r&sig=Mqv46DeO4P4t1glntj1lavuS8cGJNfG5SNT3ttVbGiU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:28.5572378","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A28Z&sr=b&sp=r&sig=K8gbtk3HehJUR0YN%2BqGAz2uo7WgniW3sNKvNNsXKJZw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:28.5571527","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A28Z&sr=b&sp=r&sig=uvlQx2Ff4HQIN7yiEt%2F4kHHenj5SvDKVfSuZPUOc0nw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:28.5572598","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/18473b95-bb20-4261-8d9b-d3bb3bec57e1_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A28Z&sr=b&sp=r&sig=eVRmH5guLfkiBVbMKVzzhQw9sV3pArULgycshCyrMl8%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:28.5572815","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/18473b95-bb20-4261-8d9b-d3bb3bec57e1_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A28Z&sr=b&sp=r&sig=IgKbWM42042OXccwycMEfZDLqKbt7cTqspxuimqmAKA%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:28.557296","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T16:17:39.476Z","endDateTime":"2023-10-09T16:22:18.272Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:22:27.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A08Z&sr=b&sp=r&sig=sipG36jVQot3uaXeTa1dtV4Xq%2BwSEHIejpT0q5e4JP0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:08.193785","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A08Z&sr=b&sp=r&sig=0ra3422lcuOiK75rlvZvJWJ9nJ4Sdg4yugI8giczqiU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:08.1937009","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A08Z&sr=b&sp=r&sig=y3z2jCreF8A1S2aBmILAsBOOigxvEC3oEahr4gY%2BJrs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:08.1938068","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A08Z&sr=b&sp=r&sig=%2FDelLbENQvWgdC%2FOIIqwM7Jx78lkGxCpHa%2FX1nqwHJU%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:08.1938273","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A08Z&sr=b&sp=r&sig=YPpuaDZCDvZ0uGKkVcjM%2FlW2sWw5ZJlRvlZzKgEHpTc%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:08.1938509","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T19:24:15.132Z","endDateTime":"2023-10-09T19:28:53.521Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:29:00.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4392'
+      - '4399'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:28 GMT
+      - Mon, 09 Oct 2023 19:29:08 GMT
       mise-correlation-id:
-      - 7ae37074-9356-4777-bf19-8f4d1a666ec9
+      - cd41ef30-e29c-40df-960d-2e8dfbc60302
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3089,23 +3053,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-09T16:18:00.000Z","value":1.0},{"timestamp":"2023-10-09T16:19:00.000Z","value":1.0},{"timestamp":"2023-10-09T16:20:00.000Z","value":1.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-09T19:25:00.000Z","value":1.0},{"timestamp":"2023-10-09T19:26:00.000Z","value":1.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '181'
+      - '128'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:30 GMT
+      - Mon, 09 Oct 2023 19:29:08 GMT
       mise-correlation-id:
-      - 13163314-dc0d-417e-9bbf-7b92810d085c
+      - 352cb2a9-fab3-453b-9670-dd0e4f93a5e0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3128,18 +3092,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:41.884927Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:41.884927Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:17.0295091Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:17.0295091Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:31 GMT
+      - Mon, 09 Oct 2023 19:29:09 GMT
       etag:
-      - '"9201fed9-0000-0100-0000-6524276b0000"'
+      - '"560052a6-0000-0100-0000-652453270000"'
       expires:
       - '-1'
       pragma:
@@ -3169,23 +3133,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A32Z&sr=b&sp=r&sig=ZKVToviB%2FAddERkrhe%2F94cIlQaKfjMXkLN9VKkse6YM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:32.6233928","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A32Z&sr=b&sp=r&sig=XwolY%2FLp3TEkdRG2rptD3h5fX9Ye0BPz2XoJJ9hEdLo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:32.6233215","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A32Z&sr=b&sp=r&sig=jRPv09kRl0VysgNeV5GlQ6k19i30B90T0%2B17eG9h7Bk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:32.6234091","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/18473b95-bb20-4261-8d9b-d3bb3bec57e1_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A32Z&sr=b&sp=r&sig=8JmqDnRgXWfQ%2FjsAAEzyFIvNfXIQBuYUO2Ajzj%2FSWCw%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:32.6234237","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/18473b95-bb20-4261-8d9b-d3bb3bec57e1_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A32Z&sr=b&sp=r&sig=1EWolMB7FbMwMB5ipPaApOBf6RpbqeZLDveVpeq%2FLKY%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:32.6234376","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T16:17:39.476Z","endDateTime":"2023-10-09T16:22:18.272Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:22:27.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A11Z&sr=b&sp=r&sig=ZMa4XgJyJsPnoAy5PUDUKZkAQgFwqlRuTs5KNTMvC%2FE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:11.167629","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A11Z&sr=b&sp=r&sig=SjuAGFfUb3dEpfdm7HzORREJmI9jw7GJdRxJTqEQH3w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:11.1675581","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A11Z&sr=b&sp=r&sig=%2BpOdA7hvxbS7Ia%2BdOdMf2%2BZ6cBTJ2oFK9KH%2F4bjPV00%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:11.167644","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A11Z&sr=b&sp=r&sig=9OI4WLk%2F4JF3MGt%2BcDz%2BoO3MbzUrrjYnt6bGneu2eZE%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:11.1676584","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A11Z&sr=b&sp=r&sig=u1NLG5iUEWqWPgZJLPoSjsTGVVftC1Y63%2FhXFTektKk%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:11.1676731","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T19:24:15.132Z","endDateTime":"2023-10-09T19:28:53.521Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:29:00.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4403'
+      - '4404'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:32 GMT
+      - Mon, 09 Oct 2023 19:29:11 GMT
       mise-correlation-id:
-      - d1d85d94-ad5c-4e94-acfc-03af23998b8c
+      - c928619f-bf20-4021-8266-e6bb3206279b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3205,7 +3169,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"dimensions":[{"description":"Request Name","name":"RequestName"}],"description":"No
@@ -3224,9 +3188,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:32 GMT
+      - Mon, 09 Oct 2023 19:29:11 GMT
       mise-correlation-id:
-      - 6436a8a8-70b9-4be2-b75f-01269dc1930f
+      - c9beff9a-ba16-420b-8a23-a8c6603aa8be
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3246,7 +3210,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":["HTTP Request"]}'
@@ -3260,9 +3224,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:33 GMT
+      - Mon, 09 Oct 2023 19:29:11 GMT
       mise-correlation-id:
-      - 847bf1a9-1e86-4d91-96b9-00230215d590
+      - 9f8e0cd4-9ae1-49d2-acaa-19f3921152b8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3286,10 +3250,288 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-09T16:18:00.000Z","value":1.0},{"timestamp":"2023-10-09T16:19:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+      string: '{"value":[{"data":[{"timestamp":"2023-10-09T19:25:00.000Z","value":1.0},{"timestamp":"2023-10-09T19:26:00.000Z","value":1.0},{"timestamp":"2023-10-09T19:27:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+        Request"}]}]}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '247'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:12 GMT
+      mise-correlation-id:
+      - 413b67df-4007-4cb0-8f34-860ee8873b9b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:17.0295091Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:17.0295091Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:12 GMT
+      etag:
+      - '"560052a6-0000-0100-0000-652453270000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A15Z&sr=b&sp=r&sig=wgtXkcW1WTdjbrmXB1tKgJm5%2BpI2AJJYVFE2ygIqxkc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:15.0162859","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A15Z&sr=b&sp=r&sig=SZnRHiIEhlw%2BTJQJScr2Jz40BYCmYGlyJ8YYxddckNg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:15.0162147","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A15Z&sr=b&sp=r&sig=%2Fl8K%2FmpzTx8r%2FcfVqkX4c7Xz9l%2FHsLplxahIpMKLGyM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:15.0163013","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A15Z&sr=b&sp=r&sig=h%2FHvs6EEX4tc8T9F4f5s7Y6Mn0Z5Pb6if8JHykY%2Bt7Y%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:15.016315","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A15Z&sr=b&sp=r&sig=wF6Pisnqgn7NuaiCWbHbsqI8lA34vCJwoCIMJKLCgrs%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:15.0163291","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T19:24:15.132Z","endDateTime":"2023-10-09T19:28:53.521Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:29:00.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '4403'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:15 GMT
+      mise-correlation-id:
+      - d4853830-76a5-4494-8348-0f12ab4381ec
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
+  response:
+    body:
+      string: '{"value":["HTTP Request"]}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '26'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:15 GMT
+      mise-correlation-id:
+      - 0774b5e1-c59b-4efc-8c43-0a4f5eeddaaa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filters": [{"name": "RequestName", "values": ["HTTP Request"]}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
+  response:
+    body:
+      string: '{"value":[{"data":[{"timestamp":"2023-10-09T19:25:00.000Z","value":1.0},{"timestamp":"2023-10-09T19:26:00.000Z","value":1.0},{"timestamp":"2023-10-09T19:27:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+        Request"}]}]}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '247'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:15 GMT
+      mise-correlation-id:
+      - 34ba9e74-8054-4ff0-997e-84accc68fb31
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:17.0295091Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:17.0295091Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:16 GMT
+      etag:
+      - '"560052a6-0000-0100-0000-652453270000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A18Z&sr=b&sp=r&sig=kmPfJ1NQ0ob0bvIDl%2B%2FZA6s9ByNG7pZsJ%2F99E1UgeUk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:18.1774795","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A18Z&sr=b&sp=r&sig=kJGr%2BlYzoSYsg%2F4W9iZCBoQctAYZNcbLv0X7vxLy7gc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:18.1774096","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A18Z&sr=b&sp=r&sig=4OeYKzdQz61FJeApTneOoPPROq7YfL24NXJ%2FgzJLKZc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:18.1774968","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A18Z&sr=b&sp=r&sig=9zLXaejEDly6hMJq5jDTxhBK1aoDaALdj7XfdKkret4%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:18.1775121","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A18Z&sr=b&sp=r&sig=1Kh0uWSnUk5ChQkKmNPbdnsaQffnq5ur4Ru80ndKKKg%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:18.1775286","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T19:24:15.132Z","endDateTime":"2023-10-09T19:28:53.521Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:29:00.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '4400'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:18 GMT
+      mise-correlation-id:
+      - f74f5688-14e6-4ed6-95d0-31183e9dfa57
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filters": [{"name": "RequestName", "values": ["HTTP Request"]}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
+  response:
+    body:
+      string: '{"value":[{"data":[{"timestamp":"2023-10-09T19:25:00.000Z","value":1.0},{"timestamp":"2023-10-09T19:26:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
         Request"}]}]}'
     headers:
       api-supported-versions:
@@ -3301,287 +3543,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:22:33 GMT
+      - Mon, 09 Oct 2023 19:29:18 GMT
       mise-correlation-id:
-      - 2446076a-c47c-4896-949f-94174b5529c2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:41.884927Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:41.884927Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '688'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:22:33 GMT
-      etag:
-      - '"9201fed9-0000-0100-0000-6524276b0000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A34Z&sr=b&sp=r&sig=NodJQNurZ1tLqYdxEIdU%2BbElCCRsU6Ra1Ga2b8F7%2BOU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:34.9947931","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A34Z&sr=b&sp=r&sig=UGVjwfT2N9xVXXM85LVztMnSebxw0Q9%2BU%2F5Otj3Ryso%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:34.9947284","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A34Z&sr=b&sp=r&sig=0EaMI5tkD3%2FfmRt6KEVrxYjWKtGWkC4eZASzjMtigoY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:34.9948098","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/18473b95-bb20-4261-8d9b-d3bb3bec57e1_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A34Z&sr=b&sp=r&sig=u0U3Zv%2FCRfLMdLKkrtoAVM4pgADN0FkPCLZqm%2FH490w%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:34.9948254","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/18473b95-bb20-4261-8d9b-d3bb3bec57e1_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A34Z&sr=b&sp=r&sig=Xlzm80V%2Ful9T6kUEjDgpC8oamkk36pAzfKh2mwah7eI%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:34.994842","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T16:17:39.476Z","endDateTime":"2023-10-09T16:22:18.272Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:22:27.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '4404'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:22:34 GMT
-      mise-correlation-id:
-      - c593f3a9-75c1-4332-802f-f7c77af0358b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
-  response:
-    body:
-      string: '{"value":["HTTP Request"]}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '26'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:22:37 GMT
-      mise-correlation-id:
-      - 9a465071-cc16-4c84-a192-422262cd2ba6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"filters": [{"name": "RequestName", "values": ["HTTP Request"]}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '66'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: POST
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
-  response:
-    body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-09T16:18:00.000Z","value":1.0},{"timestamp":"2023-10-09T16:19:00.000Z","value":1.0},{"timestamp":"2023-10-09T16:20:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
-        Request"}]}]}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '247'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:22:37 GMT
-      mise-correlation-id:
-      - be4eb540-acbc-4854-b528-6cefb7699c2f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:41.884927Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:41.884927Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '688'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:22:38 GMT
-      etag:
-      - '"9201fed9-0000-0100-0000-6524276b0000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A39Z&sr=b&sp=r&sig=2U%2BeLQYv08LeXCrvNa6kMykGO7Uqw%2FRRBgNrG6xa9WY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:39.8062729","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A39Z&sr=b&sp=r&sig=W2m8Z%2FFmM89qXh6GNAoSwLPdIN3cL3XRqegxKeXQPqY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:39.8062027","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A39Z&sr=b&sp=r&sig=9FnsW%2B2K%2BYc8DC9L8K2zVE0DZj%2F2v%2FWvA%2BZINALLolI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:39.8062889","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/18473b95-bb20-4261-8d9b-d3bb3bec57e1_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A39Z&sr=b&sp=r&sig=XUuTjnXtLdnJnLeEzMueAT90dtd4tk%2BZGooxQSLU9xI%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:39.8063042","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/18473b95-bb20-4261-8d9b-d3bb3bec57e1_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A39Z&sr=b&sp=r&sig=Mvt6M7TufLumIj9Ilqk0mJpq5EttMX6N7y%2FhLQ48ufM%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:39.80632","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T16:17:39.476Z","endDateTime":"2023-10-09T16:22:18.272Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:22:27.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '4407'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:22:39 GMT
-      mise-correlation-id:
-      - aa52ee39-ad03-4063-b023-420c8b952bdf
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"filters": [{"name": "RequestName", "values": ["HTTP Request"]}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '66'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: POST
-    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
-  response:
-    body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-09T16:18:00.000Z","value":1.0},{"timestamp":"2023-10-09T16:19:00.000Z","value":1.0},{"timestamp":"2023-10-09T16:20:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
-        Request"}]}]}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '247'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:22:40 GMT
-      mise-correlation-id:
-      - 77f0d224-7335-46b0-bd59-b3d8d181618b
+      - 1e14b1d5-3a5f-4e6d-9cce-1c468086299e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_metrics.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_metrics.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:58.3819547Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:58.3819547Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:41.884927Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:41.884927Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:34 GMT
+      - Mon, 09 Oct 2023 16:17:14 GMT
       etag:
-      - '"1a0a48db-0000-0100-0000-64af09c40000"'
+      - '"9201fed9-0000-0100-0000-6524276b0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:15:35 GMT
+      - Mon, 09 Oct 2023 16:17:15 GMT
       mise-correlation-id:
-      - 8deb6e3a-7cc9-45ff-9a32-17f68d5b9fcc
+      - 3f5c8ffc-8b50-4219-afd8-f53e5a30b359
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -85,12 +85,12 @@ interactions:
 - request:
     body: '{"displayName": "CLI-Test", "description": "Test created from az load test
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
-      {"rps": 1, "duration_in_sec": "120"}, "secrets": {}, "loadTestConfiguration":
+      {"rps": 1, "duration_in_sec": "120"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "654dc03e-090a-4426-8398-d529d622cafd":
+      {"passFailMetrics": {"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "3054a5c7-383c-4ada-9127-e46acdc034ea":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "4f690ff5-0b64-4b91-8d72-ed4c21637f3c": {"aggregate": "avg", "clientMetric":
+      "50"}, "ec52f15d-73f0-4c6d-a57a-8b871c34f623": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -100,32 +100,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '770'
+      - '791'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:15:36.249Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:15:36.249Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:17:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:16.089Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1064'
+      - '1010'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:36 GMT
+      - Mon, 09 Oct 2023 16:17:16 GMT
       location:
-      - https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+      - https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 50309312-7e53-4902-95b5-72702cd7aa94
+      - c5a9c96f-3723-493a-8634-65b89c445136
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:36 GMT
+      - Mon, 09 Oct 2023 16:17:16 GMT
       mise-correlation-id:
-      - a6277e82-ed8a-45f4-9713-cfb36d3358bd
+      - ba6eeb88-9569-4ab4-a05d-ad1f42696a46
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A25%3A37Z&sr=b&sp=r&sig=cVOIZcHKT3MWnsk9J5uC9xpyZQhx0XVO%2BiV%2Bpsr63Go%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:25:37.143481","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A16Z&sr=b&sp=r&sig=kJf2j8v%2BSowkKCfX4c2nqjNE6Q5VRf472Ni3%2FmBAS2o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:16.9722446","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '552'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:37 GMT
+      - Mon, 09 Oct 2023 16:17:16 GMT
       location:
-      - https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - f06f780a-bc72-44a3-bd71-17481e0d084b
+      - 4b78f012-a63f-4218-8eba-191465470b3a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A25%3A37Z&sr=b&sp=r&sig=P8QvshgUK7G7IlikAEgekHTxvZ247FMo%2FGQTNRanV0s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:25:37.4530386","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A17Z&sr=b&sp=r&sig=awdVltFu01ZFy8C5gBuo2l7pHi6iILVHenc8doXVNcY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:17.2349183","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:37 GMT
+      - Mon, 09 Oct 2023 16:17:17 GMT
       mise-correlation-id:
-      - bcfa0f71-ad6d-475b-ae4a-9b604dbe75aa
+      - 9495a150-4e37-44e9-af02-c0857244c83b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,10 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A25%3A42Z&sr=b&sp=r&sig=LCz9OVs5zFMC%2ByQbM0s66KE48qawTHsNhULZxCbw7%2F8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:25:42.7736843","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A22Z&sr=b&sp=r&sig=ZuWiKLAElMM6lDAGbUX%2F%2FiKOzifDWpW31A0pQod2FG0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:22.5188694","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:42 GMT
+      - Mon, 09 Oct 2023 16:17:22 GMT
       mise-correlation-id:
-      - a2612831-45a3-4391-8676-2e9ab1a7aef9
+      - d46feefd-0d36-4163-b20d-26ef81f0bef3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A25%3A48Z&sr=b&sp=r&sig=K%2BHOJ9%2BRFnlG29gOajC2K1ymuZR9G1OqPwZw72ilfZ0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:25:48.5964785","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A27Z&sr=b&sp=r&sig=dcxqK%2BFDr8BHrg2FwsV%2BcI5s4w91jl3CZcLgKmn%2Fqac%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:27.9184944","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:48 GMT
+      - Mon, 09 Oct 2023 16:17:27 GMT
       mise-correlation-id:
-      - e4b8c9aa-3fb9-44c1-bb55-14bd0a5f58f6
+      - 209e2442-4381-4755-89ad-891ee7ee7661
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A25%3A53Z&sr=b&sp=r&sig=J5mVmbXaXhoGNBPX5b8ENY8Fbn9AS5sUpvCIE7jHm1M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:25:53.9663341","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A33Z&sr=b&sp=r&sig=oUrrOzHWIyuQWxbd5c%2FpwUO7lANLpCAB8sEJNwV6Cfo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:33.1965542","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:53 GMT
+      - Mon, 09 Oct 2023 16:17:33 GMT
       mise-correlation-id:
-      - 4572aff7-83ff-4997-802f-fd540eea37b9
+      - 49d328e4-e0f1-42fd-9929-b9c3da6640c4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A15%3A54Z&sr=b&sp=r&sig=FWziPHzpex7QcskyHPNpDKbwKrk4ixXRY5RisHI2F7g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:15:54.2218334","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:15:36.249Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:15:50.499Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A33Z&sr=b&sp=r&sig=Y9c6YoxBzI0chfCh1JnLVK1B20fMVXfIc0e6eUYH43I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:33.4593795","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:17:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:29.913Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1633'
+      - '1579'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:54 GMT
+      - Mon, 09 Oct 2023 16:17:33 GMT
       mise-correlation-id:
-      - 44af468e-3792-42d0-a560-3ffea547dc0a
+      - 9c055795-d285-424f-9de0-fad0b1fa3834
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:58.3819547Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:58.3819547Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:41.884927Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:41.884927Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:55 GMT
+      - Mon, 09 Oct 2023 16:17:34 GMT
       etag:
-      - '"1a0a48db-0000-0100-0000-64af09c40000"'
+      - '"9201fed9-0000-0100-0000-6524276b0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A15%3A56Z&sr=b&sp=r&sig=PqnS2WCwnGAr75vzEVMDmqBK%2BZ0sIsbycnqF2u%2BBgsM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:15:56.5172568","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:15:36.249Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:15:50.499Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A35Z&sr=b&sp=r&sig=Gn3lESg%2BAl1FIf1Mkbs2sVOwJS9TsgwVFxLzkQU24pM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:35.0459691","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:17:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:29.913Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1649'
+      - '1593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:56 GMT
+      - Mon, 09 Oct 2023 16:17:35 GMT
       mise-correlation-id:
-      - b40597e6-a0f8-4173-a164-a5ba336ca386
+      - 1b6d138a-3710-47b9-99c6-acdd2b3b66f8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:58.3819547Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:58.3819547Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:41.884927Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:41.884927Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:57 GMT
+      - Mon, 09 Oct 2023 16:17:35 GMT
       etag:
-      - '"1a0a48db-0000-0100-0000-64af09c40000"'
+      - '"9201fed9-0000-0100-0000-6524276b0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:15:59 GMT
+      - Mon, 09 Oct 2023 16:17:37 GMT
       mise-correlation-id:
-      - 8df367d8-ae6b-4b2e-9f35-7e7eb987316d
+      - 972d65b0-3f47-490e-b9ed-2afce5e5d65b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A00Z&sr=b&sp=r&sig=NdwawNVE4Uqj2ZunQX9D5FqeXHsZhmxi2DS5eQaR3cs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:00.2422359","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A00Z&sr=b&sp=r&sig=imnvaQTYTARwwc%2BYzRQNV229Of22lE1UeMLK1fdkr5g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:00.2421415","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A00Z&sr=b&sp=r&sig=VulRdGUpmHVwMHV4vznkBirfWs4kARZcqHyQQhTEQVg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:00.2422635","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:00.567Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A38Z&sr=b&sp=r&sig=KDbAJq5O0XIpG8k%2FgkO5OG8hYQBmPWo8%2Frqn5dvqy5o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:38.3575591","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A38Z&sr=b&sp=r&sig=4l27ZWCb5e0P1%2Bdg0fwJfIVRsrOQNrmVoWX5Pwm1nXU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:38.3574584","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A38Z&sr=b&sp=r&sig=cjWm6m6DexAiV4qM2DvdFH5fQA9opxLYyc%2B%2B7VXtdZA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:38.3575863","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:38.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3187'
+      - '3160'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:00 GMT
+      - Mon, 09 Oct 2023 16:17:38 GMT
       location:
-      - https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+      - https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 46cbb4c2-9103-459f-ad32-c28705c18aa0
+      - 1d5c7028-62c2-48bf-a675-3f5a1f8b0a41
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A01Z&sr=b&sp=r&sig=1BLcke%2BXSjU6vExLTge07XVMWeiIDi%2FRXk4DKiTxR04%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:01.235724","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A01Z&sr=b&sp=r&sig=6W6aJRM2Zob%2BpNv6wcbw7KTl21htlEcyDLb9WPON9ps%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:01.2356616","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A01Z&sr=b&sp=r&sig=Mci2lb6NS086KKrL4MlY4Jm%2Bea%2BZPUtw3sTSS3Dkulo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:01.2357389","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:00.567Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A38Z&sr=b&sp=r&sig=JFz3Dtf3AcAyfYoCcdLBeXAov4rr85w9vZM%2F8191upQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:38.7968378","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A38Z&sr=b&sp=r&sig=I3Wa4P8mMJPMPSpoXJZvkvqDptbEosEqzIT%2F%2FpVWsWY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:38.796733","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A38Z&sr=b&sp=r&sig=lsfJAwOI0y%2B8ku1l2C6YyqWAWneFJG4Ul7UQcJi7wtg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:38.7968625","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:38.287Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3194'
+      - '3157'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:01 GMT
+      - Mon, 09 Oct 2023 16:17:38 GMT
       mise-correlation-id:
-      - 62310551-f361-48e7-bf0c-2c3d51d4ae4c
+      - 369ae9a4-9310-4d22-a0ec-b5a0b6e3602f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A06Z&sr=b&sp=r&sig=n2G4oRR83FgbfogYlkU36fBk5WRmhkYwzPvn2flQljM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:06.5176877","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A06Z&sr=b&sp=r&sig=7FXfgeap%2Bq1D3NCjhYvqxW1krbAP0ZU0xaA2sCjigEI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:06.5176115","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A06Z&sr=b&sp=r&sig=wQYGKwnk6HDse9XWyvJnMf9Z5XjCs1ZNYE0AmDkuzyo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:06.5177022","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:01.744Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A44Z&sr=b&sp=r&sig=4b74eRuWiBewi2wJqs8oDAJUeIahSE3BFsq%2B98EbqUc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:44.1403998","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A44Z&sr=b&sp=r&sig=VxVNGc%2BilT%2FyKV6f37Vww6fLJC%2B23u9iI5PrcRXa84I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:44.1402737","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A44Z&sr=b&sp=r&sig=rhhJizEIgjAb9x1sCfXhDYsgcLIVz4PNlWcJGGRn5%2Fo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:44.1404207","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:39.711Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3233'
+      - '3207'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:06 GMT
+      - Mon, 09 Oct 2023 16:17:44 GMT
       mise-correlation-id:
-      - 175c46d7-eca9-46c4-95dd-67afb56913fc
+      - 9ce7af77-a851-435b-b362-27fbd310fdd9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A11Z&sr=b&sp=r&sig=pzEMrxAsC1XPM8Y7NJKc%2BFIcwozrQmA8JdK31vcJinI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:11.8856558","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A11Z&sr=b&sp=r&sig=%2FH2N22tTAMQTvw0z%2FvyWb2rQik8ROoXHoJwhFYV3Xts%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:11.8855895","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A11Z&sr=b&sp=r&sig=XlWjtCly8NrtElDStcGoTEmjdfI8oeAsy5bSVFR46JI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:11.8856698","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:01.744Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A49Z&sr=b&sp=r&sig=X8k%2Bp%2BMyyPBuC3KXC%2B4Me6lUJcXwGLUv9mHMsiUSlp0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:49.4437127","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A49Z&sr=b&sp=r&sig=aDVv5mhGda70AWzP96QQLX3Xl3clsB6xqyf4U6kkPsY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:49.4436378","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A49Z&sr=b&sp=r&sig=Nv7YuVevQSO39UNB8FoNcYJnIsCrDfjteNDuc55cGHo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:49.4437273","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:39.711Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3237'
+      - '3203'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:11 GMT
+      - Mon, 09 Oct 2023 16:17:49 GMT
       mise-correlation-id:
-      - 8c2ffd90-8388-48c3-b68c-71312c283496
+      - 7354d7f5-c783-489d-845b-12fe43f26914
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A17Z&sr=b&sp=r&sig=VXg6V%2BPwNXoG2pmFnmcpQhecfWT%2FV6nsKnErRkvPjNs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:17.2412405","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A17Z&sr=b&sp=r&sig=yA9rdT%2BbOoK%2FKSMghuUZXlMMo%2BFFkFkc5vDH%2BF5nI5Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:17.2411656","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A17Z&sr=b&sp=r&sig=XEuwC7SYLwLUPKS7TFA490dZyMYgGt2HU64VFLH3ZNk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:17.2412545","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:01.744Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A54Z&sr=b&sp=r&sig=Tel%2BgMQLaQg%2FZV4qyOrZP4MNoLSs0DaOiKXtNmG8Oms%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:54.7248121","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A54Z&sr=b&sp=r&sig=E0B0Vdry3j4XFaA0Lo2XrkOzz%2F0kf3QtKcbvALYtlrw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:54.7247165","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A54Z&sr=b&sp=r&sig=cObD3vAxTLi1HpJ9lrIWjO7MZdYxKAQVryatqC2OA%2FU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:54.7248356","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:39.711Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3243'
+      - '3205'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:17 GMT
+      - Mon, 09 Oct 2023 16:17:54 GMT
       mise-correlation-id:
-      - 2d8bab8d-fe6e-4103-a934-314caf3b34e5
+      - e572d2a7-d4f9-430e-8634-a721a57a91f1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,10 +844,1934 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A22Z&sr=b&sp=r&sig=CqSiDYJaODcMvhIv8EHsiXyk%2ForZNJj8NGmHU8IsKtQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:22.5018282","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A22Z&sr=b&sp=r&sig=6YV0hN%2F%2FppYKLzuV%2FFjRnQPy2rvrApk9VeKEjRUcApo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:22.5017605","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A22Z&sr=b&sp=r&sig=pucxdp2pyhu3MIgQ5123YVNXyeNDBw88i3u32LfQoEk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:22.501842","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:01.744Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A00Z&sr=b&sp=r&sig=%2FHBnRkGdOCpJ2Ev7TbTKSIvHiadLzUQEUR1KsvTJgrs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:00.0450831","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A00Z&sr=b&sp=r&sig=y1TV2CDeaP6rzIgpkQGaIbiA6BOQ1RgjTEkC%2BIaWBRI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:00.0449675","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A00Z&sr=b&sp=r&sig=vDB8cOlIc8vIen%2F5Gk8BDSO59bn%2BXxrp%2Fvj2DZ7vFkg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:00.0451076","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:39.711Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3207'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:00 GMT
+      mise-correlation-id:
+      - a7dfabcf-d286-4d7f-9fa1-5354a87537d6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A05Z&sr=b&sp=r&sig=4CbL%2FkbZ4lUE8pxbLksIs8wegbuOEuUNKCRvDoN588g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:05.315546","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A05Z&sr=b&sp=r&sig=LkSLazhjIQuLhtgDNWDswkLSwba4lZaJF0bNp9%2Bo%2FYs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:05.3154443","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A05Z&sr=b&sp=r&sig=ZLu6k9BPCP4lXGrFuYG0GhEI%2Bg4UkPMiwcdd9ySco0A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:05.3155704","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:39.711Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:05 GMT
+      mise-correlation-id:
+      - 4f24968f-a66f-44a7-9b3a-43bd5174ccf9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A10Z&sr=b&sp=r&sig=dqu4CDbPk5PIIdJkD6o61K9MYG2yg4Fnf%2B9ntDkr12Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:10.6002555","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A10Z&sr=b&sp=r&sig=Mpiom4wj3Gx3hM38jBqJgh5t3PM%2BPThXY9sQS%2FVMp8E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:10.600171","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A10Z&sr=b&sp=r&sig=EgxKx6bbBPdf1J9CS6KVESGKQxt38WVrNrS07JFCPlw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:10.6002702","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:39.711Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:10 GMT
+      mise-correlation-id:
+      - 9f3dc670-802c-46af-a57a-bf2ad2e4474c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A15Z&sr=b&sp=r&sig=g0WLd90RXTWrgJvrxTpG04j%2Bu%2B11lbqET6mMLv6I9k8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:15.8847262","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A15Z&sr=b&sp=r&sig=idqF5SYoq9LnL4c7ihAb1DB1FH2WeQE8FtmVoeS3Tyw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:15.884654","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A15Z&sr=b&sp=r&sig=S1x5C3sH1bpcyZ%2BfjmvmoO4Nb1zC1EmgluivQtwCiY0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:15.884741","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:39.711Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:15 GMT
+      mise-correlation-id:
+      - bd5f3ab9-ef0d-44dd-9591-fb14839a7572
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A21Z&sr=b&sp=r&sig=f2P%2Blt0O35utrktis7IgVIJmpoxIWA97raoOfGH21jo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:21.7710054","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A21Z&sr=b&sp=r&sig=7kCka%2FLWmkYlZ8U51LSgAP5pHJhyp1PhN5SkcWamq%2Fc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:21.7709264","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A21Z&sr=b&sp=r&sig=%2FGHgvj1kMyQN0WQBhy7jUbVWRUzDWxlXvHwzMPlpBVI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:21.7710237","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:39.711Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:21 GMT
+      mise-correlation-id:
+      - d5e9fd1a-ae13-47f3-862a-b2b35f18b38c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A27Z&sr=b&sp=r&sig=lFpFHKMjdhVer5%2B3QFRDoK3pxiRkcXk4f1y2Js8erKY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:27.231192","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A27Z&sr=b&sp=r&sig=6CAQULRTPZc5Gb2vHHULql%2BOqkoRAVww%2FgII9j4VLZo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:27.2308903","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A27Z&sr=b&sp=r&sig=RP0Bs5XW8hMPCODO0y9osX9XVKaAE%2FTlVhx407%2BLjXQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:27.231227","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:23.16Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:27 GMT
+      mise-correlation-id:
+      - 7fced799-34bf-4b11-8582-e1d95f4b5e56
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A32Z&sr=b&sp=r&sig=D1HCuW76hVC3cdoCJV3ex%2B%2B8COuXA%2Be8voNJTlMT2Bw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:32.518743","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A32Z&sr=b&sp=r&sig=bqn37DEZDGo5suu1NvMaKOIqe6aClqVs0WOfT6s3wqg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:32.5186367","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A32Z&sr=b&sp=r&sig=KHN0UT5BJbx5xyLHQvG65hcnz4x%2FOWvn0BOsvwj2GS8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:32.518759","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:32 GMT
+      mise-correlation-id:
+      - dcb6aaad-9a0e-404f-9d11-94b866ffd8b6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A37Z&sr=b&sp=r&sig=bB1pbX%2B7vwV6vAno2wlMa23WsjL8EUhJzF4lT57doBc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:37.9344833","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A37Z&sr=b&sp=r&sig=DpooL%2FCM2stgZ6QYoVOh6IFY5dEG149AzRfVZUj3rKI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:37.9344031","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A37Z&sr=b&sp=r&sig=TD6DX8JAhJPcqbCJjT1mqXe7NwfPIfs2SZpZZ57eKSU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:37.9344975","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:37 GMT
+      mise-correlation-id:
+      - a53e5f20-6a85-4daa-96b1-b4ac96497c87
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A43Z&sr=b&sp=r&sig=TlHms99Pgg5wule2aQpUDD6Zp22AHW38IcqGWRzVPd0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:43.214547","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A43Z&sr=b&sp=r&sig=aFNU8UHZpYzqm6sVnDmKJw6T2UDTXVhyPPpaIWLThz0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:43.2144658","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A43Z&sr=b&sp=r&sig=EssxjOLAg%2FklkC2S%2Fj4Vh%2FfmOOgbJ2dT5TTKhwVd0Ws%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:43.2145658","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:43 GMT
+      mise-correlation-id:
+      - 29ebf87b-f4ec-4872-b3e9-cfb1b41d9028
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A48Z&sr=b&sp=r&sig=7RXuR3yWJ%2FVTHK1F%2B9FOnjq4D73%2Bw%2FDUhmbcMqcG0jY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:48.4941965","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A48Z&sr=b&sp=r&sig=bv2j%2FdLZKakN32UfcoULoCDwAnt7d8vucmnjCOFClwQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:48.4941295","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A48Z&sr=b&sp=r&sig=RrClDLD9CYzB93647b3bqkpNzz9RJg%2BpVSh%2BUXH6e98%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:48.4942121","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:48 GMT
+      mise-correlation-id:
+      - ba84a863-8a36-4940-b8f1-c85c6801ec9d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A53Z&sr=b&sp=r&sig=FLmIz4Y%2Bs4FIMAELxomK2A4PjNM0D8srfax2SQS%2FU00%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:53.7661884","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A53Z&sr=b&sp=r&sig=McnToc3X%2BMNvi8fuQPwO%2BrbS0GOwxqiFJoR%2FalaJVRk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:53.7661043","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A53Z&sr=b&sp=r&sig=pH3c7%2FmmKnkIn1iOvrMZyf%2FtAJltAq6n46YOFU%2BFgbo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:53.7662033","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:53 GMT
+      mise-correlation-id:
+      - 0e55f261-3ec9-45d8-9601-2c7852425e21
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A59Z&sr=b&sp=r&sig=6Mv5nxu39GwkXkLKxiRI%2B0Jt1dPsldrZeaZaPUR9hHM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:59.0553883","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A59Z&sr=b&sp=r&sig=UCitHk9FvYZQpXEKgrLQoUn9p4uI4XCZlWZstQ%2Fcw9Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:59.0553168","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A59Z&sr=b&sp=r&sig=7ROZsLlRqYetTqGpYWQCfQjmHeWw%2BwmHuFgiAqQowmw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:59.055404","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:59 GMT
+      mise-correlation-id:
+      - 8accb8f7-d65e-40a5-b318-bcf4507bfdb3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A04Z&sr=b&sp=r&sig=IDwbJ44672dIWh%2BXHIOIDuhfYPq9JH5o5K25EntvoMs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:04.335345","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A04Z&sr=b&sp=r&sig=X7NvM0phOHbj10WZE2mA4zr7YbqelBsHzhF2RsUurMM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:04.3352744","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A04Z&sr=b&sp=r&sig=uH%2BKh8mT8ue5kvBxPCqbKudq7xRuo%2Brau3HXsakOL8U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:04.3353612","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:04 GMT
+      mise-correlation-id:
+      - 1c0ee004-1952-4bc0-ae8c-d77044893555
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A09Z&sr=b&sp=r&sig=TJdxX%2F0PoFmh4UKJADcSxWJO1LRsOXxCSEKf0Pi8wzk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:09.6187952","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A09Z&sr=b&sp=r&sig=YTRkaZG6EUcGennR8QJlB2dU%2BxXfvCqJdXgf7lyy93g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:09.6187044","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A09Z&sr=b&sp=r&sig=bUZq6BNKiWEhpmaKF81KQt%2FILY64VcsmxOoWzmwo4RU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:09.6188118","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:09 GMT
+      mise-correlation-id:
+      - 567aff43-768b-489f-aab9-7b675fecbeb7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A14Z&sr=b&sp=r&sig=DlEKqcg%2FAqCffy46h4uquwbKFGgkub0FtXfWZ8nlN0Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:14.9470895","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A14Z&sr=b&sp=r&sig=7FuXLTPPtw0FmX5b9%2FPfgV%2FuJFxWr0TD6ISDq8%2B8haY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:14.9469728","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A14Z&sr=b&sp=r&sig=yiOibPpoGHRdVGQdr1fI%2FOkix9ZrP7NMVT4CdWCD7JY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:14.9471122","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:14 GMT
+      mise-correlation-id:
+      - c7437b97-d732-42e9-a8b5-449262af9724
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A20Z&sr=b&sp=r&sig=BDo7DRyW76Xt8Ax2Ec4wuPaZIeDrxA4k%2BqdGTmRhYVw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:20.2146526","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A20Z&sr=b&sp=r&sig=PSI4uerBGyXvNyiWx0Hyb8cVYkoejeKm2R4mBReT6gM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:20.2145688","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A20Z&sr=b&sp=r&sig=UlkkIam5vMq4PY13n5CVlcTlcCX%2BA2crTmGznwOCKaI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:20.2146728","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:20 GMT
+      mise-correlation-id:
+      - 028f1e4f-91cd-49da-ae14-c9fc1c98183b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A25Z&sr=b&sp=r&sig=pt7NVe9IAB%2FyxpcoxSTlP7J%2B1jgHZ%2BTiohJ%2FksdjAIY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:25.4912367","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A25Z&sr=b&sp=r&sig=mcBTlL%2BHEYM6tIXP0zrUHOErLhzCkrj4Jg2XbXAHHe8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:25.4911466","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A25Z&sr=b&sp=r&sig=Ayti25uKVrbwC1II3Fi36kwLUN%2FXqgr8xGE7oE1UYbI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:25.4912587","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:25 GMT
+      mise-correlation-id:
+      - 8cd8f442-b9a3-401c-894c-4aa319441234
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A30Z&sr=b&sp=r&sig=v79gKWcDzv4fu1LglgOVGLGKk8vcERCm34s7DQtIhHk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:30.7776658","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A30Z&sr=b&sp=r&sig=SAIigixbc0RT%2BH5%2Bh86gOPfYriwBhczmELaVDThT6%2BM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:30.7775932","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A30Z&sr=b&sp=r&sig=4DjB2aXEyRasbQf17Traeo9b%2BTSR%2FtxSaiji9wrUr84%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:30.7776802","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:30 GMT
+      mise-correlation-id:
+      - 897d02eb-3910-48e8-89eb-39260443fb66
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A36Z&sr=b&sp=r&sig=xhvoDFmPZi7XpjF2vHtpQ5PbUUZOXi5yxsjYGMzN7VE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:36.076175","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A36Z&sr=b&sp=r&sig=VTaT37NMoBzR5AwoLgZJogghwLob3L5qV38RuX8c%2FA8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:36.076105","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A36Z&sr=b&sp=r&sig=6KE4TQQ2k7cisEDDWsC%2B4lDFCTvuxWIyeq8uWuEG198%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:36.0761887","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:36 GMT
+      mise-correlation-id:
+      - 9aadceda-9850-4918-9b2e-21851bae5713
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A41Z&sr=b&sp=r&sig=v6RdDTC1FPMMrsvsfFSUeBnM5iQEuW5hbEBzpuJMTJE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:41.3453623","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A41Z&sr=b&sp=r&sig=KKRVQJBAWcyCcNhTQISodOD728LwKI2uhaSHNA%2Bjupg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:41.345297","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A41Z&sr=b&sp=r&sig=w4DTYcvJQTcvKYMA%2BC6%2FvLyEHNhUlZnZ%2Fpe9N5yD6gk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:41.3453771","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:41 GMT
+      mise-correlation-id:
+      - 726b0c58-9d76-42b6-8f9c-5367ea1ddd04
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A46Z&sr=b&sp=r&sig=gfV6YcZmB7VAd6lc1qlGgqJfdwsQZtd%2BPM0hWJuKKdk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:46.639","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A46Z&sr=b&sp=r&sig=VxixszjcKbFwGNYuTwbhw5SNyszGn6CkRuIY7WVM4lM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:46.6389217","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A46Z&sr=b&sp=r&sig=qqxgRHrTDYjh1ieAgbdt8LkbEm6DjPLwdb64CbDsocQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:46.6390146","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:46 GMT
+      mise-correlation-id:
+      - 744a2c28-f47e-48da-afae-d56a81e05e80
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A51Z&sr=b&sp=r&sig=fgaTR%2BwiOe5dfwXof7EAAe1snp2Wvtvkbm0WD20wM18%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:51.9297337","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A51Z&sr=b&sp=r&sig=fDZN0Iy1aszLwv7OamJMGwjgWc1EnJKjMFvBJirbX88%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:51.9296608","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A51Z&sr=b&sp=r&sig=QMT2VSVb8O1uw4jlHtBYiD4RVgYxYTj%2BC%2B8CdjdAAro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:51.9297502","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:51 GMT
+      mise-correlation-id:
+      - 649da7a5-d4b9-43fa-af0c-11da8a004324
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A57Z&sr=b&sp=r&sig=ViWpCKp3K541TU2BUwnMg6x9y6eVqirtUwH8j%2F8D0vI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:57.2042026","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A57Z&sr=b&sp=r&sig=FMNZgd%2Bgu3eIig5Tbk0VYro7kaGS39XPmWdldhsDJX4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:57.2041348","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A57Z&sr=b&sp=r&sig=F%2Fs4M%2FkBi2nTYFkMRPuFUXd0InDZSBqJFzi%2FMNN6HkA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:57.2042191","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:57 GMT
+      mise-correlation-id:
+      - e8d230aa-0206-416e-b429-773d7c247e4c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A02Z&sr=b&sp=r&sig=AYIkR4JR0WLHdHMLooxmGiuIDULDOqCQcb5ey3f1boU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:02.4830182","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A02Z&sr=b&sp=r&sig=N%2FA8kZr7lf5G4sQHCU6q10KNJINVy6s6WrvKiGLkabE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:02.4829436","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A02Z&sr=b&sp=r&sig=IiFjfHxJi5PLW3%2BfW4ApOHEBmOHlQAM3WRMbYkAw%2FDo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:02.4830324","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:02 GMT
+      mise-correlation-id:
+      - d24dbcb7-c611-4dda-b237-f71c6ee6dd4b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A07Z&sr=b&sp=r&sig=KVZtH7IaHJAILz3XcHmwclUn92viVS6TNlvd6XlneSE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:07.760896","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A07Z&sr=b&sp=r&sig=5bvIj4Xqv0txcBQoj5R%2FPjuwrGa4CkW4H9OfInQ9BfU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:07.7608231","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A07Z&sr=b&sp=r&sig=burPPoQUVZul%2BVxJK%2B7NY3g8zvswBrH2zdyTW%2Fw3K4E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:07.7609103","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:07 GMT
+      mise-correlation-id:
+      - da2fbecd-a54d-4d61-afd4-b747d2b7ba87
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A13Z&sr=b&sp=r&sig=JLt6U8P0l7PsFAnKjMxKhr17SpXVDaJaQwnUjgpIOGA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:13.0390339","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A13Z&sr=b&sp=r&sig=hjcQEp4hoUjZoevmsM2679AmpctXQoQ39yP2lQycnpI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:13.0389631","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A13Z&sr=b&sp=r&sig=C1%2BoG%2F%2BY8H3b2RVM46UZsHSzU1q8kns6JsBMOTUr1d8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:13.0390484","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:13 GMT
+      mise-correlation-id:
+      - 8e8cf27a-82b6-484c-9702-aa0d3e7b0856
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A18Z&sr=b&sp=r&sig=9X2Mq5CEtTXevXy8Y84DSs7RRoc2IQQuYweKDVAsjMY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:18.3209074","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A18Z&sr=b&sp=r&sig=GJTA22mx4CIclfMQiDehVim%2B8%2FbvTbVMDQ9TvfrtHUw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:18.320841","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A18Z&sr=b&sp=r&sig=z5PJKflitHGUitNJMVRVzAtjqILg8zkX5O%2FCP%2BYBq%2Bk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:18.3209246","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:18 GMT
+      mise-correlation-id:
+      - b6ab1c31-0faf-4041-841a-3f3fbee225e2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A23Z&sr=b&sp=r&sig=nJ%2F15o%2FGhjJQTn78mPf5%2FHyHQxU5%2BBoLYAdUUNSJCww%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:23.606757","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A23Z&sr=b&sp=r&sig=mq%2FNGK9JMJtlH1pYipbSasGdpbP0QyyYRniObcUMHV0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:23.6066986","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A23Z&sr=b&sp=r&sig=qalHg1vjxS40AxrINPjiky6FCYGVC3H6CkKitWWb2nM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:23.6067733","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:23 GMT
+      mise-correlation-id:
+      - 31ed6bcd-680c-42b7-a64d-62fb58ac09a8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A28Z&sr=b&sp=r&sig=VjrFGU5RHMGY6ufa1%2BQHAmOH7CItf6hTKLet14Vq0Mw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:28.8912996","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A28Z&sr=b&sp=r&sig=J4UFg6ox6WQV5L2QUKNOdL5bCIcdtVb760ekgGRByj8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:28.8912011","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A28Z&sr=b&sp=r&sig=V095%2BoIRAHbDAcu7DCY%2B1xBYs8ybZMPXiwNlPTGqZNI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:28.8913197","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:28 GMT
+      mise-correlation-id:
+      - 450fae28-d997-4563-8550-1bdb50cd91c5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A34Z&sr=b&sp=r&sig=z0dfk9484OVqmPQegH8PLRk50F7I2KQ%2Flb2WAF4pijE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:34.1833968","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A34Z&sr=b&sp=r&sig=AXRARpFmHjh5%2BVIyiu1xuGWaCGzOwo3C18D%2FvvJJySw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:34.1833051","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A34Z&sr=b&sp=r&sig=TqsE3ioildB37nsCLIJlAI49S3NDv2fWVhsGuM6jsiw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:34.18342","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:34 GMT
+      mise-correlation-id:
+      - 4b501b52-2ac5-45db-81db-1b5d25e58ec3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A39Z&sr=b&sp=r&sig=jJXREA0RbDDZAcymdJCXSqeN%2BNnHLqIQ9miqu4xt9ak%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:39.4661623","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A39Z&sr=b&sp=r&sig=TllehZnen%2BosumJpemgVeylJTVLfCxQ7FInCfWJX74M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:39.4660909","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A39Z&sr=b&sp=r&sig=ygq85FpksFzJvR1j%2BoFGpTLp1PbO0MUGvx9aW8LrA0g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:39.4661763","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:39 GMT
+      mise-correlation-id:
+      - eac68533-37e2-4764-b998-84cd2aa5d611
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A44Z&sr=b&sp=r&sig=LeoD8W54GaLZuBIoKdqLRV%2FiVv8qy5tWtzIlCpectmU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:44.7694373","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A44Z&sr=b&sp=r&sig=QrOhF6koK1zGok08oSoM1fpdAUGFZmcKxWJKTDxs0Uk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:44.7693424","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A44Z&sr=b&sp=r&sig=wWMr9g3mF%2FcYB5xn8w7XIe%2FwvzzOS2ig2Nqm6H%2BXObI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:44.7694597","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:44 GMT
+      mise-correlation-id:
+      - 4c99c62b-f950-484b-b6c5-662a5a586a6d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A50Z&sr=b&sp=r&sig=DGuLLk9hNDV8LFWk47rNmT2CWCuICIUCkzfA0%2BsyIEs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:50.050286","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A50Z&sr=b&sp=r&sig=Flg25ZWyHODcWYBPChO24cQUHdCXU5OMN5Nqn9sSXbw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:50.0502202","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A50Z&sr=b&sp=r&sig=JBhjKoWEiEpgQ3%2FNB4IimV1zq5Mqz5ssthtRd%2BfithI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:50.0503007","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:50 GMT
+      mise-correlation-id:
+      - 954ece6a-5f71-4e3c-8da7-098dbbef4037
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A55Z&sr=b&sp=r&sig=eqV6k2mGsX6QKQP4kJejROmuc5NtLgyZpKBGFtXcqGI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:55.3156846","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A55Z&sr=b&sp=r&sig=4ibKU6oItLWF0879gaN3f3C2vTMe4mJ1QNRjPs2oTAk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:55.3155902","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A55Z&sr=b&sp=r&sig=KZ1op9W7Km8at0XEwpunPHKiHAUiH21ovYViGgRipoQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:55.31571","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:55 GMT
+      mise-correlation-id:
+      - aa9349a5-6ce3-4a06-abd4-90745834658d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A00Z&sr=b&sp=r&sig=N0oCpJS7QcLlY%2BZfo0zR15HURaQUZSvhRaFONWKXbTM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:00.6056378","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A00Z&sr=b&sp=r&sig=%2Fcl215NgdnwJoIMn5fzVYV0GpliFC7hc9zYwJrBODrQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:00.6055691","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A00Z&sr=b&sp=r&sig=zuE4LbQ1gSOHL8sc6sA2qnkp54qTlsYjL8G5gTvuaQg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:00.6056512","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:21:00 GMT
+      mise-correlation-id:
+      - 981d795f-db73-4b7a-8461-eb6dd898f06a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A05Z&sr=b&sp=r&sig=JA5fS4i%2FLwGof8%2BKY2Cc5%2FviuKv7RNNlm7pKD6C3Llc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:05.8659761","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A05Z&sr=b&sp=r&sig=TkYWXrM2d4gYEnEcVqV%2FAJ3COkBa%2FKap1cbNrRQXKck%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:05.8659043","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A05Z&sr=b&sp=r&sig=2wfp%2FcJmo9lFCoEMEqcnhqvdjwy4mrGaJ699P4Zm9E4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:05.865995","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:21:05 GMT
+      mise-correlation-id:
+      - e7dec28b-3c44-4c14-b1b0-64e900b52159
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A11Z&sr=b&sp=r&sig=MNkVDwzwJKD5LqKfVNAPJJNdpXzwvoHhHp18kA2F8VE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:11.1325701","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A11Z&sr=b&sp=r&sig=FZul6a3TrpDRfuMV6DsUTwCo5GwVOKuF5d8qev%2FoclE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:11.1325033","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A11Z&sr=b&sp=r&sig=ytkDVscpBiQURHqhmtFhV%2FnQWuqUAc7PyaVOX7SWUUw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:11.1325857","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:21:11 GMT
+      mise-correlation-id:
+      - b77ea90d-5fa1-40cc-99cf-4fd564529ffd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A16Z&sr=b&sp=r&sig=sYygbaRfOwZLoYfx%2F6O4TWA1QQF%2B8Sn%2FSBIXF3q247c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:16.9478695","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A16Z&sr=b&sp=r&sig=qAabKp6iM7MLatLee3CCkFLMYoNaeQ2PPBPOtf4s%2Bik%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:16.9478004","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A16Z&sr=b&sp=r&sig=0B9lcylhqj3Oybn%2FE2Tzuqb7zAIbaNe2I1rKSPAESGw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:16.9478851","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:21:16 GMT
+      mise-correlation-id:
+      - cdaaba4a-6ec2-45d3-8aff-2df0ef8b2e33
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A22Z&sr=b&sp=r&sig=KZTKz4ed%2FQs0QJRZI%2BxVeD54MpUvxEwFlD2au%2BDpuAo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:22.2234619","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A22Z&sr=b&sp=r&sig=HuNz%2F9Ui2Siy%2FDQaXYMcOknOOajvG0qzbuuru5xAEfc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:22.223396","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A22Z&sr=b&sp=r&sig=oFgTkHJ34Uo9N2qUVNdTSLjm%2BwzuWAk0IoM0RPXRi0Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:22.2234777","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:21:22 GMT
+      mise-correlation-id:
+      - cecbf70b-b413-4365-aca9-1c444efbe54a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A27Z&sr=b&sp=r&sig=zaNgfJdI%2BRiV1TXnKzT5YbAYvuW4qZthptzZlR%2FFwqY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:27.5222456","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A27Z&sr=b&sp=r&sig=w1dhHesYCntLB%2BUXVFQXfbNBBug9gqqhduGFkIs9w4M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:27.5221374","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A27Z&sr=b&sp=r&sig=l7%2B4eYvVtOL84%2BP%2BfIGsQxHyG9hQW910o9rjXfY%2F41o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:27.5223203","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:21:27 GMT
+      mise-correlation-id:
+      - 12c125b0-77fd-4445-a476-b4cd4c80c1bc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A32Z&sr=b&sp=r&sig=o90rRznsAl%2B2HnyvUN0%2B1Ll3jV5BDBPAI8%2FUddYnYmE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:32.8036674","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A32Z&sr=b&sp=r&sig=Qid2ODZ2K8WwfW8XUlwHaZ4B9ligZ5IF8gGflvBQWKQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:32.8036015","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A32Z&sr=b&sp=r&sig=KvMGn0JgI1UKed0CnU8AHYA1IIaT3AI0HvBzCWRo8Xc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:32.803683","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:21:32 GMT
+      mise-correlation-id:
+      - 463a5376-3d84-44b6-a35d-66194291c83e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A38Z&sr=b&sp=r&sig=LEnNPfDfBuDn878UBhtX95JZkbdftFValBhmqd5dth0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:38.0824444","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A38Z&sr=b&sp=r&sig=hPIIjJdHcgRS7%2BgW8VUGgnjkF04KKYXLeNraOm4Qs3s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:38.0823534","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A38Z&sr=b&sp=r&sig=tsFqOg0gh5HGNLG%2BfR0sQqA%2FYXV9LOTT9YQSgOftNMc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:38.0824628","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:21:38 GMT
+      mise-correlation-id:
+      - a9a119c1-37f8-4030-b203-7b23e4aaaeae
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A43Z&sr=b&sp=r&sig=md0m8hvKeFSVmMkKPDDiZCuiRmPNVbmky0vQDvojaWs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:43.3708094","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A43Z&sr=b&sp=r&sig=5JbTvVbALpAkELE%2B4TxgEBLz6lVykJEYjwKMNGD7VuY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:43.3707405","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A43Z&sr=b&sp=r&sig=oEEKQBdjllB08qyHU%2FJQP5HgKfT6xhfiOfaTUpB9%2B9E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:43.3708232","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:21:43 GMT
+      mise-correlation-id:
+      - 4a4f85c3-fc31-42b5-ac18-749763df77b3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A48Z&sr=b&sp=r&sig=UknDD4kMHa97w1ESYoJsWMQuUNBy1CyUHw9MWYFB414%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:48.6385852","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A48Z&sr=b&sp=r&sig=QC6rjGAggMfdTMrBX8nYpwwhZn6hi2hjIuRl4OnjfWo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:48.6385152","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A48Z&sr=b&sp=r&sig=%2Bpo%2FZBt58QDWjw1VdoWnW%2FFgfXausHNH3NYJWdA1rgs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:48.6386013","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:21:48 GMT
+      mise-correlation-id:
+      - ce18b66e-09bf-4af9-b11c-594bbcace233
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A53Z&sr=b&sp=r&sig=SCaJUjVL0d6rvQ2tpS9fJgVS0OREl1vcUNGigL3yPME%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:53.9156442","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A53Z&sr=b&sp=r&sig=xK3mFADJ5XOqTzJzZbe3tDGlBBQEt9Kbi67h2%2Bw5sKg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:53.9155691","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A53Z&sr=b&sp=r&sig=5jjLvQZnVfn%2BRpOHeLyhf68Dm9OgZinZajTWr1hIcyk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:53.9156587","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:21:53 GMT
+      mise-correlation-id:
+      - 51ebf17e-b49c-410e-97ed-fa8619e95c0c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A59Z&sr=b&sp=r&sig=ZUvvhF%2B%2Bo6cf6Lw1EgDGZsMGpK5gxWmKeA%2BbdLPplbE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:59.2031999","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A59Z&sr=b&sp=r&sig=VeFeQtvF4X7%2Fo9DIFmLnBLviEZTK46f6m2KcwNx58Vc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:59.2031284","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A59Z&sr=b&sp=r&sig=sXSfWroU9%2FNOkePU6Fu4xu%2BWOCdVMPwHhgewcWjOlRw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:59.2032165","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:21:59 GMT
+      mise-correlation-id:
+      - 7cc6e6c0-568a-4136-8ab6-43dbe6423b8f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A04Z&sr=b&sp=r&sig=zh%2BWeHnnvh%2FYx%2By4jEDE7MQWxTEdiQaTuUvy%2F%2Fe%2Fvgs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:04.4699987","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A04Z&sr=b&sp=r&sig=B6q4OETXQjAh8ZU3KwaW4N6vmuC4qngaDvke1O0Slfc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:04.4699268","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A04Z&sr=b&sp=r&sig=xP8t35W5ToQoCNH%2BPb7ljtrx7WjqLpiZ%2B6d1nsD0HMw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:04.470013","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3209'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:22:04 GMT
+      mise-correlation-id:
+      - 6dbb5eee-5d30-43bb-9e60-4f11c6e2fc5a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A09Z&sr=b&sp=r&sig=iCW73su3vQtucGYiYtcH7x2fbYHYBtpnc7iA9eAUcPU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:09.8299335","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A09Z&sr=b&sp=r&sig=0RSjZV20nxRP%2Bv4Mv0FHRg2DJp3twkSL%2B80IPv%2BA%2FYw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:09.8298629","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A09Z&sr=b&sp=r&sig=wxBJGXBfS38BeoGcbIa%2FT5ZMDFweyWS2GA1e%2B5jWjGk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:09.8299496","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:22:09 GMT
+      mise-correlation-id:
+      - 6387342a-9380-4825-ae3a-e956bf96c0f8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A15Z&sr=b&sp=r&sig=ekLbbq5IooGUP9OE5Bq0zj6eJm0zG9W28RUCypB7qU8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:15.1052996","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A15Z&sr=b&sp=r&sig=vqzOVq9EE5%2Bb7IAnUfuwL4NAEoufF%2FTIbx9GxTTgMlU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:15.1052101","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A15Z&sr=b&sp=r&sig=YBsOGJGE20JX%2FUTjrKtY%2B5ScBDQ%2FIkHSMaEo%2Fm%2BT8LI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:15.1053228","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:39.476Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:27.391Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:22:15 GMT
+      mise-correlation-id:
+      - 0c5fa5be-98aa-4d84-9390-1393d7b7aa9d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A20Z&sr=b&sp=r&sig=9jknCba8Pho%2FIhz2M7izgT7ni%2FG2sCCHZ%2BWKGvLr2%2F0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:20.4046945","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A20Z&sr=b&sp=r&sig=OAVDBkGJ0IJ262DOu1jEEN2I%2FRB4APfT18%2B0hrEdsac%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:20.4046006","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A20Z&sr=b&sp=r&sig=w4Dt0xo7hBknCNgRaSSmVyhIHxTSxggsifM3wJ2kr04%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:20.4047155","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T16:17:39.476Z","endDateTime":"2023-10-09T16:22:18.272Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:22:20.392Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3242'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:22:20 GMT
+      mise-correlation-id:
+      - 4791ba79-f507-43d4-ab29-9fac3f00fdbb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:41.884927Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:41.884927Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '688'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:22:21 GMT
+      etag:
+      - '"9201fed9-0000-0100-0000-6524276b0000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=metric-test-case&api-version=2022-11-01
+  response:
+    body:
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A22Z&sr=b&sp=r&sig=NvzfGxA3F5Udl8xEnfFo%2BPgUsuXbRu2zq2IkICElG%2FM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:22.6394154","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A22Z&sr=b&sp=r&sig=%2FVB1EpHCkpB0wj%2BSaRZcE4U8x5em9GRQ%2BXFPG8B3xsg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:22.6393063","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A22Z&sr=b&sp=r&sig=IZtNeOOHdwMIngc6%2FAKm90R81KQb1OMCNOl1p5Jgnp8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:22.6394467","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T16:17:39.476Z","endDateTime":"2023-10-09T16:22:18.272Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:22:20.392Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3254'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:22:22 GMT
+      mise-correlation-id:
+      - 1d0c8d6b-b798-4e78-8b9e-83ca445f3a1a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:41.884927Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:41.884927Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '688'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:22:23 GMT
+      etag:
+      - '"9201fed9-0000-0100-0000-6524276b0000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A24Z&sr=b&sp=r&sig=62ab%2F2SHIu%2Bo4lBoHbdPcGt%2F4FedaHhNxlYzUNor7vk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:24.9084954","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A24Z&sr=b&sp=r&sig=6GLJytAwH2oYnEjCT4hhL9ok2y9ITESZ7BvZwf%2FGR1g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:24.9084271","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A24Z&sr=b&sp=r&sig=mE1KuubTkGPTKMw2mDgTGNRu8YrOZ2R3Zd5vB2YFmCE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:24.9085103","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T16:17:39.476Z","endDateTime":"2023-10-09T16:22:18.272Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:22:20.392Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -858,9 +2782,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:22 GMT
+      - Mon, 09 Oct 2023 16:22:24 GMT
       mise-correlation-id:
-      - a8c76715-042f-46e4-a1c9-78d1f3a5471c
+      - b2baaeda-bbf2-46e3-931d-76a4f8573a2f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -880,1247 +2804,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A27Z&sr=b&sp=r&sig=icBX5SY1e4Lb846BruIgxkqPjH3eu%2BRpnfIkg5q96OI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:27.8878221","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A27Z&sr=b&sp=r&sig=JlPB%2Bph%2B2TfDKXuZb%2FWMc8gKJmghI%2FSHQKN8duFt2g8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:27.8877528","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A27Z&sr=b&sp=r&sig=%2Bohknkzqts6WBjcklhvVTdj8CRmza%2FgtRLkaouQgE4Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:27.8878359","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:01.744Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3245'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:16:27 GMT
-      mise-correlation-id:
-      - 4f07e0fd-9a79-4940-a646-d0b059fce97d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A34Z&sr=b&sp=r&sig=XUyVLNcXvZN1gDYWIFXhTxfbX3bnRguQ92Jfs1XDjqU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:34.3041405","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A34Z&sr=b&sp=r&sig=jOmdL7ZCPTimlzXOU1vuK%2BU%2BYCfXMqgYFpT86hmwl4E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:34.3040707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A34Z&sr=b&sp=r&sig=h8sGTTf5tg6yC%2FIgVsG7iGC8edXMhz0rb5d1Wh7oSFg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:34.3041551","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:01.744Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:16:34 GMT
-      mise-correlation-id:
-      - e04991e0-e922-4ed2-bbeb-b60dab1b956f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A39Z&sr=b&sp=r&sig=RYPJ44Pwa5BIL9%2FHBXE9ddg0B%2Bplw0c3DMaOWLKxZgs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:39.6404485","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A39Z&sr=b&sp=r&sig=5aguTlSEcHvlSV7P5RAw%2BlBLdANQbNALBdU11fhiKLM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:39.6403809","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A39Z&sr=b&sp=r&sig=HGiMLM0NM2hmfDbfL4r2cITOA4z%2FTuI2Fqx34YYOta8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:39.6404631","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:01.744Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3239'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:16:39 GMT
-      mise-correlation-id:
-      - 73694681-6eeb-4bcf-a386-5b0fbb8af170
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A45Z&sr=b&sp=r&sig=IiNaM2uNri%2BM9ICpGjhrrtPqHEVfsOqZ8woia5%2B6Fw0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:45.2069413","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A45Z&sr=b&sp=r&sig=iOXaWXTEXyRl0sxQWFK1XAO8xCw%2FuhCExxrdjtJvXSk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:45.2068543","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A45Z&sr=b&sp=r&sig=hkDN%2FXidLvtabR%2BG0paE9ig%2FVSVFZXlXvAW5TpeaQmg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:45.2069631","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:01.744Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3243'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:16:45 GMT
-      mise-correlation-id:
-      - 94bece4f-039d-4f17-820e-8a2d43a13366
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A50Z&sr=b&sp=r&sig=xeCDHnxJZ9RDfvJSH4IjdMXaTSyU274IuFBYaBx7uCE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:50.4729235","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A50Z&sr=b&sp=r&sig=cEadlt2fwcYehchAdRmgMY5IT2tAqGfmFPRJj7YzBE4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:50.4728427","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A50Z&sr=b&sp=r&sig=PXOMeCnHvaVnjldJbXuTAW7dAwhnigN5KrZt%2Fck6w6c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:50.4729404","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3230'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:16:50 GMT
-      mise-correlation-id:
-      - 0140adf9-ab27-470e-a2de-2137fab16480
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A55Z&sr=b&sp=r&sig=a66e4RbPfxvfhoBla8REfnrbBfHOOO3VM87T0FVCJsk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:55.8133556","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A55Z&sr=b&sp=r&sig=TVGNGE8NYNPmzEIxwTbxljSjppvsc4vDlzjkS1I%2FI0E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:55.8132716","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A55Z&sr=b&sp=r&sig=rgKrPh7o0Yq92BST0qEiDGfc0F016HyCsrn3Gh1Ut0s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:55.8133729","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3230'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:16:55 GMT
-      mise-correlation-id:
-      - 80879c38-fe39-4290-9024-5ac8ab793df5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A01Z&sr=b&sp=r&sig=GJmOxNuavScLfh7rIldZ0IC6EYsMSvZ55lJHB0uPEXE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:01.1053362","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A01Z&sr=b&sp=r&sig=WTUGipoE5BP%2BFWiN3mEP%2Fehb6%2BRINOCTRez4vzzOeq4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:01.1052691","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A01Z&sr=b&sp=r&sig=Pa%2BRh%2Fr5Y1h73bU9hHG%2BOijJRoks7rEhI2K0bSRzurc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:01.1053511","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3240'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:17:01 GMT
-      mise-correlation-id:
-      - dee23135-2fac-4ccf-8f18-0cb619a961fb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A06Z&sr=b&sp=r&sig=e%2BKNHAnL4y%2BV%2Fo2zM3uNbTDqQ7SsbbLjBasEcGflHsk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:06.3710743","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A06Z&sr=b&sp=r&sig=YhsEnYIkx9B5Zbrw6MsJOc9uuoP%2FwKukeOyi70eKbBs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:06.3709928","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A06Z&sr=b&sp=r&sig=W6GjfJs1b1JbvuO9QdZLt0hy7XtUdBXvXoQOtCqY9XI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:06.371097","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:17:06 GMT
-      mise-correlation-id:
-      - f76410ad-71f7-4882-9be3-031485f75118
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A11Z&sr=b&sp=r&sig=oy3dQVDn2fWwDfvlJuv9MoezEeuqIQTadm4f7E1f63g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:11.6808645","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A11Z&sr=b&sp=r&sig=ZQdYqpZdq0ObA0O1yVQdYa1Z65RFPvjQXpURBAqZU4o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:11.6807818","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A11Z&sr=b&sp=r&sig=Ov3ojeFLMKfkmCMC%2BNTbsFaeoLK90T3a8QrTGvefvpU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:11.6808848","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3230'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:17:11 GMT
-      mise-correlation-id:
-      - a217f181-4649-4101-9e08-aab03632349a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A16Z&sr=b&sp=r&sig=qObeQSmEo%2Bai4KdAbe1fXQguF1TH6PKpqTgFqEYZxio%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:16.9493339","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A16Z&sr=b&sp=r&sig=vp8yJTs6wR82K%2FdL2apiMHwEeEP1emqRVOrpbcVFFoo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:16.9492484","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A16Z&sr=b&sp=r&sig=%2FrnHH9vaqrbIRTu6EBXLnwsOgxgbLfZzNjwfVsBu2d0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:16.9493546","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:17:16 GMT
-      mise-correlation-id:
-      - ac6588e0-b115-4887-94ab-f900f9388836
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A22Z&sr=b&sp=r&sig=TDjJG4dkIMI9NRwlWunA9cZnrdbSmfbny%2BfsLa88RDU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:22.2327408","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A22Z&sr=b&sp=r&sig=b95xv6lRv3DgVRrV9HB3TPV9x6RU9ehOzp47ISZtEsc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:22.2326731","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A22Z&sr=b&sp=r&sig=klYFJ5bU2Abju1iNUHVC3wgnJDxaFABfF%2F5fCfxnjgA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:22.2327548","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3232'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:17:22 GMT
-      mise-correlation-id:
-      - 9f8e04de-a1ec-4c79-8c18-edf4c4fad303
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A27Z&sr=b&sp=r&sig=NriUkygrRFS713ZCHbA2Fmz%2BloeN4IOllUx8PyvrQ3Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:27.4979677","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A27Z&sr=b&sp=r&sig=Mz5Z5xXG%2FhewWoPKONXOkicKzdht6k40hwJJ3h7yqdg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:27.4978715","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A27Z&sr=b&sp=r&sig=YyPEcS3A1XIoW4d8sWe4%2BndWiwTFJUvYKkcSoFen46g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:27.4979885","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:17:27 GMT
-      mise-correlation-id:
-      - 4f3f3fff-44e0-4232-91d1-c5aa8a9c6fc2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A32Z&sr=b&sp=r&sig=s6OnJAkattzpWou73qm2OIyz%2B5vu21zTfrnLo1SDDw8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:32.7715502","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A32Z&sr=b&sp=r&sig=1jWnTcT5tS5xpP7T5AVOF3mShPnGGh4VHNwT7ZlrqeA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:32.7714833","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A32Z&sr=b&sp=r&sig=yeTTPtzXv%2Bkd3wZMjhRtYOv%2BtBZW5ZwNHsDBJxYTQVo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:32.7715637","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:17:32 GMT
-      mise-correlation-id:
-      - f2d66ae8-5a53-440b-ab2c-5dacc62c6f65
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A38Z&sr=b&sp=r&sig=0S1dZq9zN4TKrwU%2BfOHwFymJU%2FEfYWP1NyV2bKdV6pE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:38.5715535","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A38Z&sr=b&sp=r&sig=uqH1AaKHyFPbhaB73UPaUf3egdtfVasj2pq147tq%2B5E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:38.5714244","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A38Z&sr=b&sp=r&sig=coruUZNCDxsZs4FVzBd1ZVnkqkQVuC2wEHK6t0t81z4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:38.5715855","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:17:38 GMT
-      mise-correlation-id:
-      - 3e18f104-1347-45cf-9516-3d221fc7e283
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A43Z&sr=b&sp=r&sig=HEu4%2F7nQj5XeuqlthVzjEx2qa2hBhItSL6iQxLGNEq4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:43.932359","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A43Z&sr=b&sp=r&sig=OQljSEuBjBR9R5wVUMUi42W3w3Y6fxI85KznujeGBMg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:43.9322945","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A43Z&sr=b&sp=r&sig=Vu7gPV8RFcjz4Scz4BbITIeWHFf%2FcQgZKFKw5ew03kY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:43.9323732","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3231'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:17:43 GMT
-      mise-correlation-id:
-      - 1c27afbd-71f6-45a9-a375-67d787accc3e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A49Z&sr=b&sp=r&sig=Lv4lLLbgtV9uo%2F8VJdZhAaUEolmPqUjQcMVKG189Vmo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:49.6630186","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A49Z&sr=b&sp=r&sig=D6mDWFWImAAAewAk1L%2FQEJgaUoiMmje%2FEqsFceXI3vs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:49.6629204","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A49Z&sr=b&sp=r&sig=GqJqPuckBVpbbqY9LPYl0RYW5qGrx01feFKuyz8ai%2Bw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:49.6630463","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3236'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:17:49 GMT
-      mise-correlation-id:
-      - 9c21df94-f1f8-4b0d-9327-86c0df6c828c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A54Z&sr=b&sp=r&sig=Org1E2SW3kAd%2FGys4GCIKGueunKHZ6UU9CLhyfMH0ZU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:54.9756362","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A54Z&sr=b&sp=r&sig=JOBNLZZ%2BBlHN1pC0MfRpcUf8p2mFEjR0hYki9s3b9GU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:54.9755584","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A54Z&sr=b&sp=r&sig=HEHGuXlwUS0yERRLlKZ4vTKTgc4iWHb6bQwfeX5dA5U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:54.9756543","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3232'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:17:54 GMT
-      mise-correlation-id:
-      - 73dedcf0-92f0-44d3-9791-f380064d3a98
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A01Z&sr=b&sp=r&sig=wsGaq0k%2B4n1S5UuLjmBnBGy19pp6evWDByUo6LCAS8w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:01.2912312","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A01Z&sr=b&sp=r&sig=F%2FN2G8LB4HmxkjA9NTytM6ruA3o2qCw7eiYZMmW921g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:01.2911363","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A01Z&sr=b&sp=r&sig=Sdk3b0rwnxfXuFj8hRhOC2PhjUxOM3O5prWloqCvZyk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:01.2912522","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3232'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:18:01 GMT
-      mise-correlation-id:
-      - 21312e91-13f6-4ca2-862c-0c131657bf4e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A06Z&sr=b&sp=r&sig=xJ5DuOyzoH3XWYqrGRrKje59x4Ii1bKBUgLOGC1dUF0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:06.6500428","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A06Z&sr=b&sp=r&sig=9WxJ1vGrJegYrLdrbnHsw4WUcm%2B8IiVOpGeItQRMHNk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:06.6499694","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A06Z&sr=b&sp=r&sig=qeB2Eyf1dRREcLgrOGnhXfPUFO6EhU42WNz4EHmhQJk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:06.6500634","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3230'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:18:06 GMT
-      mise-correlation-id:
-      - 4aded6f3-6f9b-45e9-85d6-d212c3377563
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A11Z&sr=b&sp=r&sig=xXFWnlakbChl12YOOEbEGVxbikb%2FJgIF6jVkrmObtxY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:11.9999118","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A11Z&sr=b&sp=r&sig=fuh0XVmtG0elZ1tcIj10ei4RLhQ7oMtuJJICyFSERjs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:11.9998303","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A11Z&sr=b&sp=r&sig=6auJA%2FL2s1NAdN4PZLWMagCj4HIZyzMKMgh3TS2ZqSU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:11.9999269","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3232'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:18:11 GMT
-      mise-correlation-id:
-      - dd4c6a2e-3f25-469b-aff2-2aa663eccf93
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A17Z&sr=b&sp=r&sig=FrPzjuDorr3bdwR52VoDPSxSQLDF3IAl4e8%2F3eTWbUM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:17.3761851","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A17Z&sr=b&sp=r&sig=pAT7c%2FHUfBl15%2BKo2Qwbe2iICIWhWquvayQcELm429I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:17.3761004","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A17Z&sr=b&sp=r&sig=cRB%2B61OIG5sOVx2lEBPhZNVLB1%2BCxHv%2BZVeGwqZf%2FhY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:17.376204","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3241'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:18:17 GMT
-      mise-correlation-id:
-      - 86c36290-7c46-4887-a69f-a7c158e4df9b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A22Z&sr=b&sp=r&sig=8z1e6GLTpngIK2tLsYjk1Wem%2FstxJO%2FQJ4EdfZiNG%2BY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:22.8694815","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A22Z&sr=b&sp=r&sig=BDmY%2F9vedHNuS%2BVErh1akrzht5i05Bvpr2B3dMcQJSw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:22.8694069","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A22Z&sr=b&sp=r&sig=Hw3mgObPjt6wQubGuXCOzp0hdg0Bq9Pt3%2FEDDR35kFE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:22.8694955","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3240'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:18:22 GMT
-      mise-correlation-id:
-      - b8a11bb3-d32f-4126-80f7-83a3fdd362ad
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A28Z&sr=b&sp=r&sig=iDcMnYa%2FCGnx2A%2BaoCB7nxjnBEoXQv3P2iGytqGIEGw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:28.1911433","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A28Z&sr=b&sp=r&sig=%2FQWBkM8Sh95%2FMkre1HF9enl2BvFlBn1wysRAh00p5GE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:28.191044","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A28Z&sr=b&sp=r&sig=bOpk3ac%2F1BkN5UMQOx4Gs3Z2I%2FrgzAx5p1lJ%2B38v%2B5A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:28.191169","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3242'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:18:28 GMT
-      mise-correlation-id:
-      - 22c25fd8-7a46-4b77-aa8b-2c1d3d207dce
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A34Z&sr=b&sp=r&sig=PmHqvD4a%2BCmz3hZtbPJUiXHcr0Mjaz61z6%2FQ90Z940A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:34.0009666","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A34Z&sr=b&sp=r&sig=wM960%2FTfLYFJYOiBunwiejGoxgJYLKwQBP%2F%2Bm%2BIP63I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:34.0008941","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A34Z&sr=b&sp=r&sig=dhHcrkH6d6368f6%2FSWf3iZVGGMVEdwukE12w3IgMul0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:34.0009807","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3242'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:18:33 GMT
-      mise-correlation-id:
-      - 800b5ad0-2557-4bc7-ae4b-6429741532d1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A39Z&sr=b&sp=r&sig=JY579%2B3L3KtPqn48IphJz8irr0MlnM4xgJf8f2EP10A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:39.277122","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A39Z&sr=b&sp=r&sig=LBV709LJO51DP%2FM90WZFMVgEQDsA0JOiO2NedZs%2BsGY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:39.2770544","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A39Z&sr=b&sp=r&sig=Zfq%2FGJ3sVaUfN%2B9nqdi%2FB8g%2B8dnNkJU7WVP08K6V3nQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:39.2771366","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3241'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:18:39 GMT
-      mise-correlation-id:
-      - 6c4d2d1a-9858-431f-b8fc-2d1043557385
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A44Z&sr=b&sp=r&sig=MV894aKpubBdAab3zD4KQkc4HNA7%2FEgJK%2BRs7Sa2qUU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:44.7050357","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A44Z&sr=b&sp=r&sig=zEonvzt73Fi%2BhCQT1JobMLwrSHmPhoL4y4iH2QRMctA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:44.7049509","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A44Z&sr=b&sp=r&sig=UykzJBwfU%2Bl%2B5IFs7wIK9n39PjbUdHHwIUHSvOBISI4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:44.705053","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:18:44 GMT
-      mise-correlation-id:
-      - c0bb1736-55b2-4dfb-ae1b-b30739d490f3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A49Z&sr=b&sp=r&sig=uUNX2f0jsyjwhO4JlZOm41fFQ2DM%2F%2FnooM%2BkjAnDrLI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:49.9756332","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A49Z&sr=b&sp=r&sig=xEr9KqASpvy4%2BhqL27P71URub2%2Flv1iVksOSxa%2FcZZg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:49.9755684","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A49Z&sr=b&sp=r&sig=QDCxGkUty86Ehg5BWCczQb871isocY%2BiS%2BH%2BWHFsu0c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:49.9756481","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3246'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:18:49 GMT
-      mise-correlation-id:
-      - c8824126-9567-404e-b63b-a0e94a17b0cd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A55Z&sr=b&sp=r&sig=arDvTI6MuPPyoIK%2B5y34OmFMcTWe00ox2JSwnJ731dc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:55.2646733","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A55Z&sr=b&sp=r&sig=4YQFA44DMAd8NKYgovbuiNFqYhA5T9xBqYZ4jzZzw%2BM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:55.2645877","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A55Z&sr=b&sp=r&sig=%2BGT%2FVhuh4bKfi23frW%2Fr%2FBqh1Ys0Y0XemqYwemarmZk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:55.2646947","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:01.54Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:49.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3240'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:18:55 GMT
-      mise-correlation-id:
-      - 95e0c281-0888-467e-aa80-22f51aedbb30
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A01Z&sr=b&sp=r&sig=QjrQnd8yyN6OiEGlPENwtBAWqnyKzl%2FA57XEPm2%2Fip0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:01.2451013","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A01Z&sr=b&sp=r&sig=JTPfWjcMlOT0CfAZC3MzV%2BZLzH8euw7rutpDlsDAN6E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:01.2450316","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A01Z&sr=b&sp=r&sig=9Z2MOJ7Wb4fHtvXs89CVrW7nmOutlF%2BKwt%2FGlQW6mLY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:01.2451154","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTED","startDateTime":"2023-07-12T20:16:01.54Z","endDateTime":"2023-07-12T20:19:00.536Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:00.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3278'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:19:01 GMT
-      mise-correlation-id:
-      - b777153d-065a-430e-86ce-3a61df19263a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A06Z&sr=b&sp=r&sig=SR3Yrw4edJi8R6%2B51xtMrpnuUzLzaQ%2F5kN6GmT4tlOc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:06.5502218","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A06Z&sr=b&sp=r&sig=O9WPlzPEL9zueYGN0CApKiTRR7I%2FC7zEIHiCQoJNcME%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:06.5501582","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A06Z&sr=b&sp=r&sig=THx7Ve3oMeXo2WmZPv8QfumMyRxfoj%2Fpjf3F5n6ujBw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:06.550237","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-07-12T20:16:01.54Z","endDateTime":"2023-07-12T20:19:00.536Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:01.846Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3271'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:19:06 GMT
-      mise-correlation-id:
-      - 0324b239-d43c-472a-8201-cf3f68127315
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:58.3819547Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:58.3819547Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:19:07 GMT
-      etag:
-      - '"1a0a48db-0000-0100-0000-64af09c40000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=metric-test-case&api-version=2022-11-01
-  response:
-    body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A08Z&sr=b&sp=r&sig=AmyoUtzU%2B2ulPKzc4lE26hTXOgUP%2F2S5RkSO0%2BxBc2k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:08.9999938","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A08Z&sr=b&sp=r&sig=7vCkjagsIJDrqZNsW7jNqKcT4ytpLS%2FQotkiPeQOgZA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:08.9999188","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A09Z&sr=b&sp=r&sig=g6bStKCzZ3jAyTOQTX9WtBaJtJEMfr11wWEnMp3OIso%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:09.0000089","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/ce7b1e1e-e7cb-43d3-a527-3f0477cefe64_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A09Z&sr=b&sp=r&sig=ZsjH7U6d0xVykWHja9Smeup3msL1IyeZ0ZaeJMypIhQ%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:09.0000234","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/ce7b1e1e-e7cb-43d3-a527-3f0477cefe64_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A09Z&sr=b&sp=r&sig=Rgml0Ckn7h7lv25EHmqzfSkfuWx%2F%2BL3Nq7Lg1qP1tfw%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:09.0000375","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-07-12T20:16:01.54Z","endDateTime":"2023-07-12T20:19:00.536Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:08.315Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '4447'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:19:08 GMT
-      mise-correlation-id:
-      - cfd79c60-a0e0-4080-948a-53cf0b3634c3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:58.3819547Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:58.3819547Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:19:10 GMT
-      etag:
-      - '"1a0a48db-0000-0100-0000-64af09c40000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A11Z&sr=b&sp=r&sig=glnBuMbFO0LQUfvBxrU5miTFuCDyqC359ZTjjUlufTw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:11.4143104","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A11Z&sr=b&sp=r&sig=BHIzJo4T1Bnfh%2FABpzH%2B8eRDdV%2BWbBR9c133TzeIqPo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:11.4142375","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A11Z&sr=b&sp=r&sig=2gAu1vDCm72s1NR1XjAnLErhUyvNnzVLUACaBklniys%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:11.4143255","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/ce7b1e1e-e7cb-43d3-a527-3f0477cefe64_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A11Z&sr=b&sp=r&sig=dXmkjxpKOY%2FptOm4OD8%2F%2BnQC5pjs6biX0FhQnF9o8J0%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:11.4143391","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/ce7b1e1e-e7cb-43d3-a527-3f0477cefe64_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A11Z&sr=b&sp=r&sig=JcMpnEKFNP1a5zkUF4UUm6w6bHpCtvHsPXXGBFuxSz0%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:11.4143536","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-07-12T20:16:01.54Z","endDateTime":"2023-07-12T20:19:00.536Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:08.315Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '4435'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:19:11 GMT
-      mise-correlation-id:
-      - 9ec766f3-a278-48cd-8623-e1e3655d1d8e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"dimensions":[{"description":"Request Name","name":"RequestName"}],"description":"No
@@ -2139,9 +2823,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:11 GMT
+      - Mon, 09 Oct 2023 16:22:25 GMT
       mise-correlation-id:
-      - 05c4cc7d-219e-450c-973b-adeb3dd45d24
+      - d3f8a586-08d5-483c-b996-827db4da2342
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2165,10 +2849,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-07-12T20%3A16%3A01.54Z%2F2023-07-12T20%3A19%3A00.536Z&api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-07-12T20:16:00.000Z","value":1.0},{"timestamp":"2023-07-12T20:17:00.000Z","value":1.0},{"timestamp":"2023-07-12T20:18:00.000Z","value":1.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-09T16:18:00.000Z","value":1.0},{"timestamp":"2023-10-09T16:19:00.000Z","value":1.0},{"timestamp":"2023-10-09T16:20:00.000Z","value":1.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2179,9 +2863,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:12 GMT
+      - Mon, 09 Oct 2023 16:22:25 GMT
       mise-correlation-id:
-      - 05b0934a-045f-4631-831f-fe82af323384
+      - 1843fb11-94b6-4faf-ac89-a901504a4046
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2205,10 +2889,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=ResponseTime&metricNamespace=LoadTestRunMetrics&timespan=2023-07-12T20%3A16%3A01.54Z%2F2023-07-12T20%3A19%3A00.536Z&api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=ResponseTime&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-07-12T20:16:00.000Z","value":23.0},{"timestamp":"2023-07-12T20:17:00.000Z","value":16.0},{"timestamp":"2023-07-12T20:18:00.000Z","value":15.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-09T16:18:00.000Z","value":39.0},{"timestamp":"2023-10-09T16:19:00.000Z","value":16.0},{"timestamp":"2023-10-09T16:20:00.000Z","value":16.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2219,9 +2903,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:12 GMT
+      - Mon, 09 Oct 2023 16:22:25 GMT
       mise-correlation-id:
-      - 1d1bcccd-1d99-478b-9ae6-d5b1b035c8bf
+      - 558924c2-dd76-4588-97b7-d362a3afa34f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2245,10 +2929,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=TotalRequests&metricNamespace=LoadTestRunMetrics&timespan=2023-07-12T20%3A16%3A01.54Z%2F2023-07-12T20%3A19%3A00.536Z&api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=TotalRequests&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-07-12T20:16:00.000Z","value":11.0},{"timestamp":"2023-07-12T20:17:00.000Z","value":65.0},{"timestamp":"2023-07-12T20:18:00.000Z","value":44.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-09T16:18:00.000Z","value":30.0},{"timestamp":"2023-10-09T16:19:00.000Z","value":61.0},{"timestamp":"2023-10-09T16:20:00.000Z","value":29.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2259,9 +2943,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:12 GMT
+      - Mon, 09 Oct 2023 16:22:26 GMT
       mise-correlation-id:
-      - 3f3572b1-2492-4c27-bfd9-4d7e37808fd8
+      - 49a687a6-220e-4a52-9106-f7cc9910f81a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2285,7 +2969,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=Errors&metricNamespace=LoadTestRunMetrics&timespan=2023-07-12T20%3A16%3A01.54Z%2F2023-07-12T20%3A19%3A00.536Z&api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=Errors&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"data":[]}]}'
@@ -2299,9 +2983,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:13 GMT
+      - Mon, 09 Oct 2023 16:22:26 GMT
       mise-correlation-id:
-      - d139c6a7-8f51-4f03-ab86-a25f4d09735a
+      - 77726590-0ca6-4077-92ed-79fbd6844e55
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2324,18 +3008,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:58.3819547Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:58.3819547Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:41.884927Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:41.884927Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:14 GMT
+      - Mon, 09 Oct 2023 16:22:27 GMT
       etag:
-      - '"1a0a48db-0000-0100-0000-64af09c40000"'
+      - '"9201fed9-0000-0100-0000-6524276b0000"'
       expires:
       - '-1'
       pragma:
@@ -2365,23 +3049,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A15Z&sr=b&sp=r&sig=CjB5N2ZAYIQSq%2BHaV2n0ZDFapRbGpQ%2BcMGx4EzfQc8s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:15.9124475","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A15Z&sr=b&sp=r&sig=Tl4Qf3vV1ZJOM8gZpDJThe39zjGq3lKVMqNfCGXYqqc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:15.9123792","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A15Z&sr=b&sp=r&sig=6X8IojTiyZTce%2Fipoh0I4C82%2Fi3PoFtNODiX2w6TrRE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:15.9124622","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/ce7b1e1e-e7cb-43d3-a527-3f0477cefe64_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A15Z&sr=b&sp=r&sig=%2FrorC91pPIoHkwahCM0CH%2BrwiTH5wZ8sj9QEVBQjP6I%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:15.9124753","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/ce7b1e1e-e7cb-43d3-a527-3f0477cefe64_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A15Z&sr=b&sp=r&sig=ypr8uJyuehWTXDSsQti5h9rCCk7cAzqusvPyIiaHE38%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:15.9124892","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-07-12T20:16:01.54Z","endDateTime":"2023-07-12T20:19:00.536Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:08.315Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A28Z&sr=b&sp=r&sig=Mqv46DeO4P4t1glntj1lavuS8cGJNfG5SNT3ttVbGiU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:28.5572378","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A28Z&sr=b&sp=r&sig=K8gbtk3HehJUR0YN%2BqGAz2uo7WgniW3sNKvNNsXKJZw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:28.5571527","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A28Z&sr=b&sp=r&sig=uvlQx2Ff4HQIN7yiEt%2F4kHHenj5SvDKVfSuZPUOc0nw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:28.5572598","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/18473b95-bb20-4261-8d9b-d3bb3bec57e1_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A28Z&sr=b&sp=r&sig=eVRmH5guLfkiBVbMKVzzhQw9sV3pArULgycshCyrMl8%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:28.5572815","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/18473b95-bb20-4261-8d9b-d3bb3bec57e1_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A28Z&sr=b&sp=r&sig=IgKbWM42042OXccwycMEfZDLqKbt7cTqspxuimqmAKA%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:28.557296","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T16:17:39.476Z","endDateTime":"2023-10-09T16:22:18.272Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:22:27.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4435'
+      - '4392'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:15 GMT
+      - Mon, 09 Oct 2023 16:22:28 GMT
       mise-correlation-id:
-      - c3b417f8-3510-42b4-875d-6463fbf09ab7
+      - 7ae37074-9356-4777-bf19-8f4d1a666ec9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2405,10 +3089,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-07-12T20%3A16%3A01.54Z%2F2023-07-12T20%3A19%3A00.536Z&api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-07-12T20:16:00.000Z","value":1.0},{"timestamp":"2023-07-12T20:17:00.000Z","value":1.0},{"timestamp":"2023-07-12T20:18:00.000Z","value":1.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-09T16:18:00.000Z","value":1.0},{"timestamp":"2023-10-09T16:19:00.000Z","value":1.0},{"timestamp":"2023-10-09T16:20:00.000Z","value":1.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2419,9 +3103,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:16 GMT
+      - Mon, 09 Oct 2023 16:22:30 GMT
       mise-correlation-id:
-      - 24e22a22-fed5-4119-a6ed-3825adae21b8
+      - 13163314-dc0d-417e-9bbf-7b92810d085c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2444,18 +3128,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:58.3819547Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:58.3819547Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:41.884927Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:41.884927Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:17 GMT
+      - Mon, 09 Oct 2023 16:22:31 GMT
       etag:
-      - '"1a0a48db-0000-0100-0000-64af09c40000"'
+      - '"9201fed9-0000-0100-0000-6524276b0000"'
       expires:
       - '-1'
       pragma:
@@ -2485,23 +3169,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A18Z&sr=b&sp=r&sig=6KfQDYK3VwPEhu1O5FF6cSwfCKcuu3vyD%2BiVq3tqRYw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:18.8498243","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A18Z&sr=b&sp=r&sig=wD9YB2Ieo%2BsTJeSjJWsi8X6oDmRQkAcjtIXkmZg2L5U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:18.8497443","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A18Z&sr=b&sp=r&sig=vNxtyMiejJmJGEHTfdY9LPM%2ByhwJNKT9IUpVeCYrSM0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:18.8498458","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/ce7b1e1e-e7cb-43d3-a527-3f0477cefe64_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A18Z&sr=b&sp=r&sig=PngWSTfpTSl2Un2PHk%2F4LpsDbZT2r%2BclSyWWU48QeQ0%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:18.849866","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/ce7b1e1e-e7cb-43d3-a527-3f0477cefe64_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A18Z&sr=b&sp=r&sig=%2Fink5YKkTiSQ5XrGa%2BRC16JgwY1y3Bmn3C085gI8Vfo%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:18.8498883","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-07-12T20:16:01.54Z","endDateTime":"2023-07-12T20:19:00.536Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:08.315Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A32Z&sr=b&sp=r&sig=ZKVToviB%2FAddERkrhe%2F94cIlQaKfjMXkLN9VKkse6YM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:32.6233928","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A32Z&sr=b&sp=r&sig=XwolY%2FLp3TEkdRG2rptD3h5fX9Ye0BPz2XoJJ9hEdLo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:32.6233215","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A32Z&sr=b&sp=r&sig=jRPv09kRl0VysgNeV5GlQ6k19i30B90T0%2B17eG9h7Bk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:32.6234091","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/18473b95-bb20-4261-8d9b-d3bb3bec57e1_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A32Z&sr=b&sp=r&sig=8JmqDnRgXWfQ%2FjsAAEzyFIvNfXIQBuYUO2Ajzj%2FSWCw%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:32.6234237","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/18473b95-bb20-4261-8d9b-d3bb3bec57e1_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A32Z&sr=b&sp=r&sig=1EWolMB7FbMwMB5ipPaApOBf6RpbqeZLDveVpeq%2FLKY%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:32.6234376","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T16:17:39.476Z","endDateTime":"2023-10-09T16:22:18.272Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:22:27.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4436'
+      - '4403'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:18 GMT
+      - Mon, 09 Oct 2023 16:22:32 GMT
       mise-correlation-id:
-      - 625915c1-33c9-494f-a8a5-12572dab46d9
+      - d1d85d94-ad5c-4e94-acfc-03af23998b8c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2521,7 +3205,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"dimensions":[{"description":"Request Name","name":"RequestName"}],"description":"No
@@ -2540,9 +3224,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:19 GMT
+      - Mon, 09 Oct 2023 16:22:32 GMT
       mise-correlation-id:
-      - 453eff34-544b-465e-9d47-14caf8a50ab5
+      - 6436a8a8-70b9-4be2-b75f-01269dc1930f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2562,7 +3246,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-07-12T20%3A16%3A01.54Z%2F2023-07-12T20%3A19%3A00.536Z&api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":["HTTP Request"]}'
@@ -2576,9 +3260,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:19 GMT
+      - Mon, 09 Oct 2023 16:22:33 GMT
       mise-correlation-id:
-      - c0e1efb4-f0db-468d-8337-137155807a43
+      - 847bf1a9-1e86-4d91-96b9-00230215d590
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2602,10 +3286,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-07-12T20%3A16%3A01.54Z%2F2023-07-12T20%3A19%3A00.536Z&api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-07-12T20:16:00.000Z","value":1.0},{"timestamp":"2023-07-12T20:17:00.000Z","value":1.0},{"timestamp":"2023-07-12T20:18:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+      string: '{"value":[{"data":[{"timestamp":"2023-10-09T16:18:00.000Z","value":1.0},{"timestamp":"2023-10-09T16:19:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
         Request"}]}]}'
     headers:
       api-supported-versions:
@@ -2613,13 +3297,13 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '247'
+      - '194'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:20 GMT
+      - Mon, 09 Oct 2023 16:22:33 GMT
       mise-correlation-id:
-      - 00c508a4-c5af-4a23-80e8-703183df6480
+      - 2446076a-c47c-4896-949f-94174b5529c2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2642,18 +3326,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:58.3819547Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:58.3819547Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:41.884927Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:41.884927Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:21 GMT
+      - Mon, 09 Oct 2023 16:22:33 GMT
       etag:
-      - '"1a0a48db-0000-0100-0000-64af09c40000"'
+      - '"9201fed9-0000-0100-0000-6524276b0000"'
       expires:
       - '-1'
       pragma:
@@ -2683,23 +3367,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A22Z&sr=b&sp=r&sig=eP1trxkaCZOzQGJpM0u8fSNtLltTKYPG%2BiYzHRmPqd8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:22.6604545","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A22Z&sr=b&sp=r&sig=w9B1scDT0HEyIYaQeSp98lOwPAv57iBVMkh%2BSQFEkGg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:22.6603944","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A22Z&sr=b&sp=r&sig=n6FBNA7cU6emm10WARnArfa69zJpH2xFoq8165q3ws0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:22.6604689","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/ce7b1e1e-e7cb-43d3-a527-3f0477cefe64_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A22Z&sr=b&sp=r&sig=I3CNCXXxc82ahJ3LWIxVlNmE5BrF%2BpWajU98DqcQ294%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:22.6604822","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/ce7b1e1e-e7cb-43d3-a527-3f0477cefe64_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A22Z&sr=b&sp=r&sig=7jGSnI7np0GtwbzRBgnT2yNERdmAMuIp3KRzHsz2SpY%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:22.6604959","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-07-12T20:16:01.54Z","endDateTime":"2023-07-12T20:19:00.536Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:08.315Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A34Z&sr=b&sp=r&sig=NodJQNurZ1tLqYdxEIdU%2BbElCCRsU6Ra1Ga2b8F7%2BOU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:34.9947931","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A34Z&sr=b&sp=r&sig=UGVjwfT2N9xVXXM85LVztMnSebxw0Q9%2BU%2F5Otj3Ryso%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:34.9947284","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A34Z&sr=b&sp=r&sig=0EaMI5tkD3%2FfmRt6KEVrxYjWKtGWkC4eZASzjMtigoY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:34.9948098","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/18473b95-bb20-4261-8d9b-d3bb3bec57e1_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A34Z&sr=b&sp=r&sig=u0U3Zv%2FCRfLMdLKkrtoAVM4pgADN0FkPCLZqm%2FH490w%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:34.9948254","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/18473b95-bb20-4261-8d9b-d3bb3bec57e1_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A34Z&sr=b&sp=r&sig=Xlzm80V%2Ful9T6kUEjDgpC8oamkk36pAzfKh2mwah7eI%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:34.994842","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T16:17:39.476Z","endDateTime":"2023-10-09T16:22:18.272Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:22:27.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4429'
+      - '4404'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:22 GMT
+      - Mon, 09 Oct 2023 16:22:34 GMT
       mise-correlation-id:
-      - b1b994c9-b7da-45c2-987d-5779b91df816
+      - c593f3a9-75c1-4332-802f-f7c77af0358b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2719,7 +3403,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-07-12T20%3A16%3A01.54Z%2F2023-07-12T20%3A19%3A00.536Z&api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":["HTTP Request"]}'
@@ -2733,9 +3417,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:23 GMT
+      - Mon, 09 Oct 2023 16:22:37 GMT
       mise-correlation-id:
-      - 9121119d-ce1b-4944-9cc2-3450757f0d43
+      - 9a465071-cc16-4c84-a192-422262cd2ba6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2759,10 +3443,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-07-12T20%3A16%3A01.54Z%2F2023-07-12T20%3A19%3A00.536Z&api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-07-12T20:16:00.000Z","value":1.0},{"timestamp":"2023-07-12T20:17:00.000Z","value":1.0},{"timestamp":"2023-07-12T20:18:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+      string: '{"value":[{"data":[{"timestamp":"2023-10-09T16:18:00.000Z","value":1.0},{"timestamp":"2023-10-09T16:19:00.000Z","value":1.0},{"timestamp":"2023-10-09T16:20:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
         Request"}]}]}'
     headers:
       api-supported-versions:
@@ -2774,9 +3458,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:23 GMT
+      - Mon, 09 Oct 2023 16:22:37 GMT
       mise-correlation-id:
-      - c128d88a-b5a3-479a-925e-a07ca4c54c93
+      - be4eb540-acbc-4854-b528-6cefb7699c2f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2799,18 +3483,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:58.3819547Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:58.3819547Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:41.884927Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:41.884927Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:24 GMT
+      - Mon, 09 Oct 2023 16:22:38 GMT
       etag:
-      - '"1a0a48db-0000-0100-0000-64af09c40000"'
+      - '"9201fed9-0000-0100-0000-6524276b0000"'
       expires:
       - '-1'
       pragma:
@@ -2840,23 +3524,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b2b831f6-9411-4d1e-b81f-5b1ce9d8625f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"654dc03e-090a-4426-8398-d529d622cafd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f690ff5-0b64-4b91-8d72-ed4c21637f3c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/f1dae3a0-5d72-42b0-9ecd-b70871d89a2e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A25Z&sr=b&sp=r&sig=t7aa%2FRcz2rnS75JfcOr8O%2FxuuBO%2FnAgeh1%2B6cX3BwbQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:25.6328075","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/2c787eb7-2012-4e84-b8a8-5884e223c018?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A25Z&sr=b&sp=r&sig=zs%2FUs5xKWaraiJK%2FDck%2FvRiv8oY1JT%2BYK4jVxVHwpzQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:25.6327432","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/5c2a1dfb-d873-40ed-a5a4-36ece505770c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A25Z&sr=b&sp=r&sig=mlzNZu%2BhHiC%2FAM2eItKW3SkaF1SHrf%2FIUdbpUTHoYFc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:25.6328221","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/ce7b1e1e-e7cb-43d3-a527-3f0477cefe64_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A25Z&sr=b&sp=r&sig=T6v2gSYhPsDDy%2BoS5htd1f%2BHh8kL24JTA1EIMMHxL3Y%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:25.6328355","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e2cf4670-942e-4cc8-80df-9593291aeb5c/ce7b1e1e-e7cb-43d3-a527-3f0477cefe64_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A25Z&sr=b&sp=r&sig=ENg5wHZLCInXpsLlxwNtvCImtOanvJ7KDIifZBtCouk%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:25.6328494","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-07-12T20:16:01.54Z","endDateTime":"2023-07-12T20:19:00.536Z","executedDateTime":"2023-07-12T20:16:00.023Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-07-12T20:16:00.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:08.315Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0d958a88-d8bc-413a-8ff2-52a2ad9f9cc0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3054a5c7-383c-4ada-9127-e46acdc034ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec52f15d-73f0-4c6d-a57a-8b871c34f623":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/7c623dee-0e62-48a2-9d3a-f81daae2b828?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A39Z&sr=b&sp=r&sig=2U%2BeLQYv08LeXCrvNa6kMykGO7Uqw%2FRRBgNrG6xa9WY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:39.8062729","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/f3fbf1e1-ce09-472d-a6dc-5d9e879328be?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A39Z&sr=b&sp=r&sig=W2m8Z%2FFmM89qXh6GNAoSwLPdIN3cL3XRqegxKeXQPqY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:22:39.8062027","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/1392bdad-5caf-4002-b9cb-f6edf01e175f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A39Z&sr=b&sp=r&sig=9FnsW%2B2K%2BYc8DC9L8K2zVE0DZj%2F2v%2FWvA%2BZINALLolI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:39.8062889","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/18473b95-bb20-4261-8d9b-d3bb3bec57e1_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A39Z&sr=b&sp=r&sig=XUuTjnXtLdnJnLeEzMueAT90dtd4tk%2BZGooxQSLU9xI%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:39.8063042","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/053b534e-86c2-44f8-8e42-ba03b24314bb/18473b95-bb20-4261-8d9b-d3bb3bec57e1_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A22%3A39Z&sr=b&sp=r&sig=Mvt6M7TufLumIj9Ilqk0mJpq5EttMX6N7y%2FhLQ48ufM%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:22:39.80632","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T16:17:39.476Z","endDateTime":"2023-10-09T16:22:18.272Z","executedDateTime":"2023-10-09T16:17:37.971Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T16:17:38.287Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:22:27.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4449'
+      - '4407'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:25 GMT
+      - Mon, 09 Oct 2023 16:22:39 GMT
       mise-correlation-id:
-      - 14404ee1-9422-44ff-be24-4d9868d06fb0
+      - aa52ee39-ad03-4063-b023-420c8b952bdf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2880,10 +3564,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://081e3613-4ce9-4913-a255-cad86fdb6c5a.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-07-12T20%3A16%3A01.54Z%2F2023-07-12T20%3A19%3A00.536Z&api-version=2022-11-01
+    uri: https://3dbbc1c1-0206-42d3-beb7-072369aff3fa.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T16%3A17%3A39.476Z%2F2023-10-09T16%3A22%3A18.272Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-07-12T20:16:00.000Z","value":1.0},{"timestamp":"2023-07-12T20:17:00.000Z","value":1.0},{"timestamp":"2023-07-12T20:18:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+      string: '{"value":[{"data":[{"timestamp":"2023-10-09T16:18:00.000Z","value":1.0},{"timestamp":"2023-10-09T16:19:00.000Z","value":1.0},{"timestamp":"2023-10-09T16:20:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
         Request"}]}]}'
     headers:
       api-supported-versions:
@@ -2895,9 +3579,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:25 GMT
+      - Mon, 09 Oct 2023 16:22:40 GMT
       mise-correlation-id:
-      - 9026fcd8-0159-40ff-b6be-e6ec4b4bd5c1
+      - 77f0d224-7335-46b0-bd59-b3d8d181618b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_metrics.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_metrics.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:55:42.646835Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:55:42.646835Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:33.5819664Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:33.5819664Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:16 GMT
+      - Wed, 18 Oct 2023 20:56:07 GMT
       etag:
-      - '"d9016b33-0000-0100-0000-65294c600000"'
+      - '"75002f65-0000-0100-0000-653046470000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:56:17 GMT
+      - Wed, 18 Oct 2023 20:56:09 GMT
       mise-correlation-id:
-      - 51fd7da3-1306-4404-8016-b1898166b47d
+      - ca5d8877-14ec-46f4-b798-285516a7fafe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "120"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"426c8785-b3b8-4d8e-bd1f-5473b0812f43": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "546c584f-457a-4b81-9293-f42a769136e3":
+      {"passFailMetrics": {"ad6239e5-ee49-4305-88ea-6645fb367519": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "1e39773c-d505-48c8-94f0-20d1879e8a90": {"aggregate": "avg", "clientMetric":
+      "50"}, "6989712e-0ea0-425d-be3b-2e3ced72ea8a": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,26 +106,26 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:56:17.62Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:17.62Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:09.777Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:09.777Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1008'
+      - '1010'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:17 GMT
+      - Wed, 18 Oct 2023 20:56:09 GMT
       location:
-      - https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+      - https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 155a041d-f96d-4068-9cb8-0cbaaf3ca477
+      - 0b232f4d-5d0c-40d5-9072-a89933a9e6fd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:17 GMT
+      - Wed, 18 Oct 2023 20:56:10 GMT
       mise-correlation-id:
-      - a7092586-7d90-41b5-bb4f-2682d98a0a7f
+      - 3143b958-e376-4163-9430-702ab20cb8cf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A06%3A18Z&sr=b&sp=r&sig=WCd51v4OqjsTjMaqH%2BMA%2BJPtv%2FEkbx2yLuXLNrG%2FV2I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:06:18.9548606","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A11Z&sr=b&sp=r&sig=zaQ9zyGXO5sYbMh4EYTiyji2uT7RenRb972XxcaUlLY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:11.6174987","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '557'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:18 GMT
+      - Wed, 18 Oct 2023 20:56:11 GMT
       location:
-      - https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - d74aff82-a77d-4f1f-963a-06720400e4f2
+      - f0286cd6-db54-41a3-9862-0166a9a2d924
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A06%3A19Z&sr=b&sp=r&sig=%2Fa97t8WT98CslKEE9DiAjjbcZbJPbDD4QJc6UUK9eg0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:06:19.1831698","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A11Z&sr=b&sp=r&sig=gVamZ6JHswe8EDGzR5siG4c%2FJuCF6Ne%2F34mI5Ad%2BCa4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:11.8751518","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:19 GMT
+      - Wed, 18 Oct 2023 20:56:11 GMT
       mise-correlation-id:
-      - 3cee5085-3743-497c-b84b-c95755f39de1
+      - ad8dadad-1724-499d-8b4e-4cc0d4536865
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,10 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A06%3A24Z&sr=b&sp=r&sig=9S%2Fk1g4qep5NUrNBwglNmY41pPIIVKpnq0RXADN663U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:06:24.4173449","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A17Z&sr=b&sp=r&sig=%2FtyBNj5jTuuSohdTA96nFiiwYt0gTaZCspBOccjayj4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:17.2120867","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:24 GMT
+      - Wed, 18 Oct 2023 20:56:17 GMT
       mise-correlation-id:
-      - 196a38d4-7756-4be9-9890-cbd72ebce9d4
+      - 92f61685-35f2-4b07-bbf2-e9c94f34286c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A06%3A29Z&sr=b&sp=r&sig=RF4EiKS%2FAHbzM3s7g6WG9T5Ac9W5KDcehv4azw6jrZQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:06:29.7308369","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A22Z&sr=b&sp=r&sig=9vJuuoGoXFGNJiZJLwRphX1eYETW7zK8XONKDNpyrC8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:22.5394417","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:29 GMT
+      - Wed, 18 Oct 2023 20:56:22 GMT
       mise-correlation-id:
-      - 58e2a81f-aad8-4257-817d-a0748529c766
+      - e541b39c-f31e-4f8d-9fb3-4e15473d70e2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,10 +421,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A06%3A34Z&sr=b&sp=r&sig=WpUuCqrtVN93elt3rYmgLMTQ8b75nT0OnPprgG5ZjdI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:06:34.9566345","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A27Z&sr=b&sp=r&sig=VQEZEEppFwQVmrYCMff2waSjvChwo3RwrSMqP0wfyls%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:27.8833649","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:34 GMT
+      - Wed, 18 Oct 2023 20:56:27 GMT
       mise-correlation-id:
-      - 74b268e5-0170-4a1f-8478-53ae0ce25445
+      - c99695b7-df89-475e-9697-bacada542973
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A35Z&sr=b&sp=r&sig=P2PbeaGADcKncv8yVye6BiDle%2Bk3CfphRoRXOY9aQdw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:35.2654604","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:56:17.62Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:31.69Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A28Z&sr=b&sp=r&sig=yxvQNIRr3aLdtmm%2FJx7A1HVSr79cppx1CpbtHXF9TYw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:28.1485841","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:09.777Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:26.055Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1579'
+      - '1581'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:35 GMT
+      - Wed, 18 Oct 2023 20:56:28 GMT
       mise-correlation-id:
-      - e8d35dea-2277-4518-82b0-ea42491eb7cf
+      - fdab9b09-f4bd-41de-a1d5-241b30aba9b3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:55:42.646835Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:55:42.646835Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:33.5819664Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:33.5819664Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:36 GMT
+      - Wed, 18 Oct 2023 20:56:29 GMT
       etag:
-      - '"d9016b33-0000-0100-0000-65294c600000"'
+      - '"75002f65-0000-0100-0000-653046470000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A37Z&sr=b&sp=r&sig=nsM5vPsj53RP0OG12WPA%2B9xJvoPjdxEFQJx9lSkOe4M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:37.97134","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:56:17.62Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:31.69Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A30Z&sr=b&sp=r&sig=CMlRYP8jnzs24zY3w5IwqP2BQ77Z5NVF8XeTnW1qvBM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:30.6377865","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:09.777Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:26.055Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1589'
+      - '1591'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:37 GMT
+      - Wed, 18 Oct 2023 20:56:30 GMT
       mise-correlation-id:
-      - 69857e31-4a58-44b1-b17c-74ebf9fa1a74
+      - 2fdb5610-bad4-499c-ac10-7c7d7254b849
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:55:42.646835Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:55:42.646835Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:33.5819664Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:33.5819664Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:38 GMT
+      - Wed, 18 Oct 2023 20:56:32 GMT
       etag:
-      - '"d9016b33-0000-0100-0000-65294c600000"'
+      - '"75002f65-0000-0100-0000-653046470000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:56:40 GMT
+      - Wed, 18 Oct 2023 20:56:33 GMT
       mise-correlation-id:
-      - 127d1a3b-96f8-4c25-acda-6bdb07ce0574
+      - 9f028389-eb76-4f8d-9b90-3d91d08aeb1c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A40Z&sr=b&sp=r&sig=xSOaySXxTn5kSRaNmE1sIQfXTev%2BHDVZvudQQXgvWEk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:40.8950366","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A40Z&sr=b&sp=r&sig=OSorAjME%2FTw9etb13KKCDJYGe7KfJGWarF73rm4RVYk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:40.8949137","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A40Z&sr=b&sp=r&sig=PK4XOBzwidTvF3iBFY4dPe64A9wG3Uu%2Bv0dUV2Yn%2BK0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:40.8950517","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:40.829Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A34Z&sr=b&sp=r&sig=7w3Pz63mTdsYOVGykJg0Q%2BT0%2BltM%2BeEiIaWf2OLHdmU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:34.8481443","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A34Z&sr=b&sp=r&sig=MT9o6JVIpRRw4NHCaxJAOJAkJJ7Q0FxfEdeXQKZoLgQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:34.8480253","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A34Z&sr=b&sp=r&sig=mgvAdrGs032LSAjWW8rdADqL7Hnzrz2S19tGz7hEYvw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:34.8481698","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:34.775Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3158'
+      - '3156'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:56:41 GMT
+      - Wed, 18 Oct 2023 20:56:35 GMT
       location:
-      - https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+      - https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 5d26f5cb-5a9a-4765-9ab1-c4e304c2495c
+      - 71f5c8ae-7751-4dec-a453-dfa8c942fdb9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,442 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A41Z&sr=b&sp=r&sig=HBSm1SwWOVmW6cle6frg2fSlQhd9nLBRq8eOqAhYMsE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:41.3206765","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A41Z&sr=b&sp=r&sig=WuXJ%2Bv%2FcAmNsNiXy1K%2BhrjGRs3IvCt6dbJqjCK1gBA4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:41.3205889","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A41Z&sr=b&sp=r&sig=OEOUvc94fRLQ5geBKbh%2BAeSnQF18q%2BE5X%2Blh%2BZagTyo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:41.3206982","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"NOTSTARTED","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:41.186Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3209'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:56:41 GMT
-      mise-correlation-id:
-      - 5e9a22d1-420f-472b-9b93-067e43ebafee
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A46Z&sr=b&sp=r&sig=YT7R6ADMSrYZPYMfzt%2BHuawTLLVSVcXRDSnr6AXBp34%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:46.6174933","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A46Z&sr=b&sp=r&sig=nZGKj%2FK0kRpLTTYzodvwn9E1HZJqGTIFn%2Fu6hLYOxnE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:46.6174234","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A46Z&sr=b&sp=r&sig=I6Mcmf3Dx10GPfwHFi8Wf0bqCg3fUm%2BoJ%2FZtaFFcAko%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:46.6175072","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:41.346Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3207'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:56:46 GMT
-      mise-correlation-id:
-      - 3fae0e14-4c28-4fa6-9c97-489a94e98ac8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A51Z&sr=b&sp=r&sig=EuXLvooLmuUE8%2B70AGWnYCNm96DQE6zSC6eXqsS7r6Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:51.9125281","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A51Z&sr=b&sp=r&sig=YIHE1ufKyipcm42ATTJJw58VmpYDsP35BCMHr2cESsk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:51.9124463","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A51Z&sr=b&sp=r&sig=Jf7dTzJV%2F5qx%2FaXYMheorRcukzPokfvMWf8ERM7zQiA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:51.9125436","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:41.346Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:56:51 GMT
-      mise-correlation-id:
-      - 8f7bb15b-329b-4955-b7ff-c44fd0591890
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A57Z&sr=b&sp=r&sig=%2F21yVbHu6J5WWzT25t2fQUu0OIbwD9tLEbyyaXG7Itc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:57.1596598","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A57Z&sr=b&sp=r&sig=vPcEsD64n2Ayb34xaOGB2EE3Id8cu1LSfLrvK7S4u2k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:57.159587","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A57Z&sr=b&sp=r&sig=tMUe5FCcJs2k6taTtJkvrwaT44hPeEyYbI9bhrflYGQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:57.1596758","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:41.346Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:56:57 GMT
-      mise-correlation-id:
-      - a594cf91-a97c-458c-92ae-ae2ba6073f1d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A02Z&sr=b&sp=r&sig=5PZEXQ4HeOY4oHO0P4I%2FP%2BM8edgw9Ja9XmcDmH3sMqs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:02.3923808","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A02Z&sr=b&sp=r&sig=MdR4A8eATko4%2FgX0hUsvzGFHd6Y%2FfuNbMI3RTYoxeyY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:02.3922685","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A02Z&sr=b&sp=r&sig=aegXVp7RFrPuEpUBKmEzYJOzOXv7hoi6yd22I%2FGX6SY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:02.3924036","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:41.346Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3207'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:02 GMT
-      mise-correlation-id:
-      - 3427215b-40a1-420e-89e4-aef170ae2b33
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A07Z&sr=b&sp=r&sig=af1tEb50yYEf29beE19m0gVmNltKfSaQHdAfkFR7%2BGk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:07.6470765","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A07Z&sr=b&sp=r&sig=oPo8AGZfkyXM0xBbKHIfdqcEru6nqP1UQibJhF55Ti4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:07.6469122","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A07Z&sr=b&sp=r&sig=EUGBH3yw%2FTGmdy6FzON7JG8HVZ3nH4iV4Y65%2FqOUVTk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:07.6471058","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:41.346Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:07 GMT
-      mise-correlation-id:
-      - 864c29c3-ffd0-46d9-b971-3e4a2f56a8b3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A12Z&sr=b&sp=r&sig=rjj9hEYyu1sqx8fC5Oe4PYZUnHo%2F%2FR3B1G4LYIivxCQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:12.8829528","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A12Z&sr=b&sp=r&sig=rr9wgr0KDX4s8XP5oDvgYdpFqRfwAZ64zlrTD4gUtQI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:12.8828707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A12Z&sr=b&sp=r&sig=41w1MvlGZBoawe%2FB8ohAQLdCJLaCaSATn%2B9oJCCKfUg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:12.8829685","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:41.346Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:12 GMT
-      mise-correlation-id:
-      - a3fc4efa-2a3b-4217-bfa7-afcbea5cfa82
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A18Z&sr=b&sp=r&sig=4dE%2BCilqAlpISK4zGYza%2FT1bPcdzB1L27bNBqrTE87E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:18.1275703","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A18Z&sr=b&sp=r&sig=jaBgnyng1ZlRvcdOOfnA5CCAlOFHqNbFO1d6Lvs%2Fo7s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:18.1274705","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A18Z&sr=b&sp=r&sig=DTaCV24hd2Jd33ZQwAlv7CaX7NImJ5FWOmVO19Mx9IY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:18.1275947","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:41.346Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:18 GMT
-      mise-correlation-id:
-      - ca929144-fbad-4d31-9761-7552f0115c32
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A23Z&sr=b&sp=r&sig=a47s7bqLR8lgiFdrnhZw969jKGErTiqXJyalMAJZVtE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:23.4101704","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A23Z&sr=b&sp=r&sig=2OlSxLRSmaNqC4n%2Bv8x8J744Q9hJDZYhs39MLDbf3b0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:23.410063","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A23Z&sr=b&sp=r&sig=bnGk9ntOJODofvnzHT03Nm0C8%2FeJNlcQLd0t2YXezGw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:23.4101947","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:41.346Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:23 GMT
-      mise-correlation-id:
-      - 8f250853-b815-4e5b-8c9f-3158e6ead97e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A28Z&sr=b&sp=r&sig=ooM0cRuozpkE7dfr9DHd6Jo3WzhJRRnQEnrFKBSZE0M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:28.6832607","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A28Z&sr=b&sp=r&sig=e3FuJwEBQa24ixJOy7ic1FYRl5I68iADYMX6kba9CJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:28.6831988","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A28Z&sr=b&sp=r&sig=tJAhvzMfKUJSSZfUNAkcL12VyznvNmeZCC6CzgWf69I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:28.6832758","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:28.032Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:28 GMT
-      mise-correlation-id:
-      - 46b735ed-68f7-43a4-9614-0dc02417699f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A33Z&sr=b&sp=r&sig=Abe2cyKMPNe49RMpu05%2FNIiygNTYCpmAXx5WyzFBdvg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:33.9509252","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A33Z&sr=b&sp=r&sig=qb%2BRnA7vog3a2BDZEdvfLd9qYnZFG2m5y40l9wqOiFw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:33.9508639","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A33Z&sr=b&sp=r&sig=0LBNpNwFbq4UGtLS3fpnh72M8Xymm6cct4Nv1PK1HZ8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:33.9509409","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:33 GMT
-      mise-correlation-id:
-      - fc03d135-2e81-430b-8e4e-ff18195ef9b3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A39Z&sr=b&sp=r&sig=4%2FIB1snOoMUiBsV4rAwQe8c%2BWQcK3c2eOeNmv1v7738%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:39.2331734","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A39Z&sr=b&sp=r&sig=U4aU44Xc%2BKLp9YlZItF07GA8ZIOHe2TidcQOu%2BCKccI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:39.2330824","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A39Z&sr=b&sp=r&sig=vFX3PhxRUL181vf7K3QhwdSZh8A5gCm9J5vYX8adsAM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:39.2331978","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:39 GMT
-      mise-correlation-id:
-      - fa726099-5272-48c2-9491-f7ab2df17fd9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A44Z&sr=b&sp=r&sig=kpsQX%2B1U%2FORdN4G1rmrR3H0WFKkJpVlkI%2F%2Fsczd3PYI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:44.4775185","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A44Z&sr=b&sp=r&sig=ZccqbsdU0gFCLZG2i4rNBH3tq25VqD%2BL3CQyXLtxfYg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:44.4774425","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A44Z&sr=b&sp=r&sig=Om0A6T3LNg5EMPzNCOdCt0RyGndPIjlQIgs2lA0Doek%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:44.4775327","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A35Z&sr=b&sp=r&sig=%2Fz2r9rp2Irhi7haMP9%2BED%2BsqySlzUIyKLLF9z4teCJU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:35.3541301","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A35Z&sr=b&sp=r&sig=3nSpJqblgqSK4vYHVpaUEh7nFq4W%2FCQ%2FQG8AY3lqIVk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:35.350744","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A35Z&sr=b&sp=r&sig=z697IfPyYmVVLYo8FsIgdrnGxe3Oa2CZUZbE8WwWBnU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:35.3541585","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"NOTSTARTED","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:35.199Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1146,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:44 GMT
+      - Wed, 18 Oct 2023 20:56:35 GMT
       mise-correlation-id:
-      - 60b2b24e-ad53-43c6-ad6b-fba7ded33fd6
+      - ddf32ff9-a172-4460-b882-e8bffb1dbc99
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1168,1018 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A49Z&sr=b&sp=r&sig=FjFwb0Dr4u%2BGAjmAQNKOhrMbCt479htOmiAUxlmhHZQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:49.7384906","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A49Z&sr=b&sp=r&sig=xU5N3yfr2XI36h12roXLG09ais6YIIpRc9mSY1Lr0us%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:49.7383853","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A49Z&sr=b&sp=r&sig=MFFK7AAw7Hq6qnv0gLG6JHlrx51LK2OkEmEYBNLvL4A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:49.7385156","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:49 GMT
-      mise-correlation-id:
-      - e56403cf-d64f-4cc8-aab6-a54d7bed5be8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A54Z&sr=b&sp=r&sig=e8AdULAUugrR9DXKkzOOtcwVg3gdBsTlzxs8h%2Fc0BF0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:54.9854455","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A54Z&sr=b&sp=r&sig=CGh3iCjwoH2qZ7Pkw4iDDgtm7DqZpcPf2RVRYVQy6Q4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:54.9853596","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A54Z&sr=b&sp=r&sig=V2V07DNGu6yiKQy8VIjSxjJm7syL%2FoaguEvsDgbMN2Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:54.9854658","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:54 GMT
-      mise-correlation-id:
-      - 4f197258-08d1-48fe-b163-c49357ceca95
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A00Z&sr=b&sp=r&sig=K8LVPW%2FoKyyRa1eEUeofsWKrXkG6QVMLi700w5jxwlo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:00.2278774","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A00Z&sr=b&sp=r&sig=9GWKYxv0v9ogEnFN7TkXzFQLYU104i0MKVuw8cqb1LE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:00.2277908","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A00Z&sr=b&sp=r&sig=zRUsPIAAQyUO%2FMX0Z6p3GeHW7kM%2BbQAog7NCDYJg%2Bls%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:00.2278997","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:00 GMT
-      mise-correlation-id:
-      - e98867d1-5cfe-4245-9b22-02f140cdf6ee
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A05Z&sr=b&sp=r&sig=8lEpDps1XnRfsrVtIRyFtqPv9a71kYK%2Bvwe5K5pguwQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:05.5145725","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A05Z&sr=b&sp=r&sig=jyUPZq5t2tlHUY1BS9EW%2FVbuKCaGt%2FYUvUcvy8OdIN8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:05.5144263","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A05Z&sr=b&sp=r&sig=aU6aylksRU4SAiRlKuEMK9e4%2FgkQfShxTdzscgQ4aGY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:05.5145934","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:05 GMT
-      mise-correlation-id:
-      - 52a9d868-d86e-4a84-b1ba-41db7199fd6f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A10Z&sr=b&sp=r&sig=m0HzEMRztO1YBSB06PkT9x7eLpbAHNBmTJDDcV1%2B7Kw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:10.8304144","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A10Z&sr=b&sp=r&sig=p00lTYNgwF4b9c6jbYlFZhICiLkEvj%2FnQgXHbcfvgeQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:10.8303291","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A10Z&sr=b&sp=r&sig=WzglcOqDwXzJ7gG2uwGcPEp6cGPnbzBD0MwG4fYGk%2Fw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:10.8304372","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:10 GMT
-      mise-correlation-id:
-      - d3535aa3-7973-40c3-b58d-4797e5108b71
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A16Z&sr=b&sp=r&sig=bjhSP4UVzYuMKU3yIfqXfjAcjDCApbHoi%2BXLsGBJQ8g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:16.1382146","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A16Z&sr=b&sp=r&sig=3l0EWyF6lA06fm%2FYIVIgXJcGm1QLpnxKryBW0s8qyik%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:16.1381339","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A16Z&sr=b&sp=r&sig=1xN5Ee2DqhCrCc6Enw0k5JCfV17hdcX64fX554Q3YyY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:16.1382349","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:16 GMT
-      mise-correlation-id:
-      - 2b07c513-1491-4a52-ad1d-f8514760a255
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A21Z&sr=b&sp=r&sig=gL9EV130eANvSLGz0RbU%2BQsE3wAV6mxybzgr8%2Fugyxw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:21.4812824","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A21Z&sr=b&sp=r&sig=DufXa%2Fm2zPveesft1zok5WSpT8Kcb0WWYrqAM6bR1fY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:21.4811967","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A21Z&sr=b&sp=r&sig=v5LCQeYZj8D2KHJzfsfLxFlHVRn02RF2S9Jkca9stGQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:21.4813008","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:21 GMT
-      mise-correlation-id:
-      - 52005ea9-4f8a-4506-a068-8f29dd81146b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A26Z&sr=b&sp=r&sig=Up2gdOCz9nh47mSEexblzOUh%2FMqJsxS0D0hgRi1eGTU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:26.7401049","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A26Z&sr=b&sp=r&sig=w56z82Gz4KjrEMJX8fod1QiAgagADQTtz2bsa9QENCE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:26.7400369","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A26Z&sr=b&sp=r&sig=QksKJqOXAayXEMIG%2BiI61cVmH%2BhyyZP6OQGa5MDEV6U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:26.7401187","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:26 GMT
-      mise-correlation-id:
-      - 9997dc7f-72a5-4fe2-853a-cbf14a79dcce
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A31Z&sr=b&sp=r&sig=mnXZ%2Bi3GgmP3gpnZO4k3yb8CR5XtHl5MNoc%2BL3uFy4o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:31.9701998","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A31Z&sr=b&sp=r&sig=p42oUdO%2Fov%2BCdgXSn524ZaqvS7vW6ZpthJQqxWw3N9c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:31.9701303","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A31Z&sr=b&sp=r&sig=9jDejpZxB7lfA4fDZml4nxL6ncZVRWtaLWst1kMlnvc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:31.9702152","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:31 GMT
-      mise-correlation-id:
-      - adfd92a5-c7b4-4802-8c8e-cc5553dea243
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A37Z&sr=b&sp=r&sig=EBowrTR9h6PPDjzcTH0jHwFifNjoR9R2deQdb%2Fv%2FtL8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:37.2536372","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A37Z&sr=b&sp=r&sig=rB3pgtcMf1BveigTO%2BTnEZWnqMMjkXoCKdYiefCHkIQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:37.25355","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A37Z&sr=b&sp=r&sig=g5bZHSLki9QwPR%2FLx5LDlzaH9%2FuxwzUOgOkXivcUn4Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:37.2536529","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:37 GMT
-      mise-correlation-id:
-      - 798e3096-18cc-43a0-9101-b0c21bf736d2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A42Z&sr=b&sp=r&sig=AKlWdpD1LH0E7J148QYa2snfCTsfm%2Bek0V4MkfkpUL0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:42.5871751","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A42Z&sr=b&sp=r&sig=dxJR0%2F4yeAbBQcXKTo3Pm4IQJqX2VnrzmVxR7T36w2c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:42.5870885","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A42Z&sr=b&sp=r&sig=dH5y9W4mDaLRyuHOk0cbVhDnuJ3iVT%2BdCKnC1CS54MY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:42.5871905","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:42 GMT
-      mise-correlation-id:
-      - 59a21bb5-444d-4d0c-81a8-8c049c83d604
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A47Z&sr=b&sp=r&sig=OFhwx%2FU6QRl9%2BH%2Bz%2FZXK9okLyxtWtzoKPo2pvwYpphk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:47.807748","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A47Z&sr=b&sp=r&sig=6BgOPRy83tCys9OHCogX1QQSmb7frX29osH0H3jXVPg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:47.8076819","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A47Z&sr=b&sp=r&sig=iXRSKK%2FZFg1aDVodGdXK8%2BAhRkbDYPNeMz6lyAYWad8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:47.8077634","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:47 GMT
-      mise-correlation-id:
-      - 959cb413-f26e-43c7-8e19-f91ea40a3ccf
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A53Z&sr=b&sp=r&sig=HWKnV16l0vZyczraJn3cub0uYDMpw5khk8dK82Kwm3E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:53.1223449","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A53Z&sr=b&sp=r&sig=F9DjHE3O55D5KjG%2FSCxSfAU8Bzmq3oUF4orZ7jqsdLw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:53.1222491","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A53Z&sr=b&sp=r&sig=wHj6fmH9CXT7NYeEUqxXuKxosy%2FORVtlW1K3ENVVmaI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:53.1223616","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:53 GMT
-      mise-correlation-id:
-      - 33f69503-5970-4d40-8e10-d768106748fb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A58Z&sr=b&sp=r&sig=JNaIY4KIw2kJUhJKiGpytNzAC45C%2BXiWyvewloNCntQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:58.3818973","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A58Z&sr=b&sp=r&sig=quOTJngPMU8x9nNIA6jj3qPel1wtcjq4K5z9NoShCf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:58.3818272","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A58Z&sr=b&sp=r&sig=lmr9Lyz4el%2F80bp%2FhAmlDOaZpNqWMPuBv5cSMslWpc4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:58.3819118","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:58 GMT
-      mise-correlation-id:
-      - 9079013c-d483-43ef-8295-73f0c5cc084d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A03Z&sr=b&sp=r&sig=XxP%2FlXTvZ9s73%2B%2FThTTnKsxIFqtvrlMKSzLrDnZV6fI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:03.6749392","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A03Z&sr=b&sp=r&sig=0upg9VOuaUh6v0aGEj4AydqdcT%2FFlTvtxm1uej9NpyU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:03.6748569","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A03Z&sr=b&sp=r&sig=H5AfLQnc4MXM6PZrrhtz4n%2F5%2B2sGCW93fOB0TKrO%2Fb4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:03.6749596","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3208'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:03 GMT
-      mise-correlation-id:
-      - f1a6a343-a1ce-4ad6-b8bc-88000aafee37
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A09Z&sr=b&sp=r&sig=lxTmvaYfyA2yoqjBCc1wJ0jIKzJ5X3UkPQtv%2BbXb9sc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:09.0025893","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A09Z&sr=b&sp=r&sig=0fAjUV%2FA9yvr3Tmje8gChjX61NHG%2BTchsUekV2ODg1Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:09.0024637","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A09Z&sr=b&sp=r&sig=84RnK%2F0MBLyjURNCKfXdB8mVqIEDYg3VA3b1xU52COk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:09.0026124","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:09 GMT
-      mise-correlation-id:
-      - e252cabf-9567-42fc-b18b-97ebac1736f8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A14Z&sr=b&sp=r&sig=Sh%2FEFbgURVRdorjO8KbvpEnI95NM%2FboupOd7ij9It8Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:14.2706966","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A14Z&sr=b&sp=r&sig=6lvmWky9XIZeT83JlJab7bhpfkqpN670N1xpZu%2Bxxgw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:14.2706073","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A14Z&sr=b&sp=r&sig=QjW4GwYE%2FAeaZx3LfBX41i8HG4ztCetfajixO85DdgU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:14.2707169","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:14 GMT
-      mise-correlation-id:
-      - c368757f-81f4-486e-b249-b7ed7f05be59
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A19Z&sr=b&sp=r&sig=aRICdPEzbpTcNPlpcR2u3RwqeuRULjnFoJoNE7M7mNs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:19.5701196","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A19Z&sr=b&sp=r&sig=tq6HMsAA4Etz0VVwM0RCbQ12rs9zU%2BEwKfy83LJ%2Bwuw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:19.5700335","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A19Z&sr=b&sp=r&sig=hja0jbnTiwl3x%2FzN0QC2FK46zRZfkX086Nrj50R22IQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:19.5701411","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:19 GMT
-      mise-correlation-id:
-      - 3e7c09e7-696e-41fd-b174-9eab16bc651e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A25Z&sr=b&sp=r&sig=Hwf0QB%2FIG4pKg42jLMPTCybHIUYm1I%2B5KwsWq0s04qY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:25.0642107","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A25Z&sr=b&sp=r&sig=AKE7SvZ5jvNBORCXQgHjBgeVjur2Vb6YqYXmUv9zGUM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:25.0641318","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A25Z&sr=b&sp=r&sig=pGe3MnFK8BqLbDNN%2FV9bXUFi4f0%2B0mBPqC8eOVUDzYU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:25.0642281","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:25 GMT
-      mise-correlation-id:
-      - 92054842-42e7-42d4-9c0a-40f658aefd90
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A30Z&sr=b&sp=r&sig=ppFY%2BkFzV4m8gzyPijDq3cBcagEV%2BERfJzExjbc3Qk0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:30.3270064","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A30Z&sr=b&sp=r&sig=Ik2wMhm22JpSL8zoVHCw80XLgZ6uj1gcP747fsY9Yf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:30.3269031","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A30Z&sr=b&sp=r&sig=WBcTM2cvE7ELzr3uA%2B5I%2FRasZNPPiAVPHapdow5cXZ8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:30.3270323","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:30 GMT
-      mise-correlation-id:
-      - 93ca2d2e-3be0-406f-b256-ec48d4f00166
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A35Z&sr=b&sp=r&sig=G1D1PX9taNNnCqGBpvn4AZuS4Iuw1CN%2B0L%2FHG2%2FKW%2Bg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:35.6319396","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A35Z&sr=b&sp=r&sig=UQ17%2FQtH7%2BCSJaoYdwaD%2BCtJRhIyVpFquUEBCRx3N4E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:35.6318436","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A35Z&sr=b&sp=r&sig=T%2BmztF0aoHy%2BgbUhoxJN%2FIzo4aY%2FVj7uMcN3zR6iypM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:35.6319613","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3216'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:35 GMT
-      mise-correlation-id:
-      - c27fdbad-4804-4f2a-8151-058108399e11
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A40Z&sr=b&sp=r&sig=2ESVjQ0O1CRG5pf%2F4k%2B2My8IpGC4MMemxqolHlfA7DQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:40.9701698","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A40Z&sr=b&sp=r&sig=WpQNDfTtXHhELHQVQbzgfXRpZ3xxN5L8kxrtjd66ADM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:40.9700455","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A40Z&sr=b&sp=r&sig=E0kQrGph8TXoju%2FvHHPplzuLMZo8%2FTe30%2F1ZiSnXjLg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:40.9701965","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:40 GMT
-      mise-correlation-id:
-      - 6094f5e9-58d4-4696-94a4-baddf09724aa
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A46Z&sr=b&sp=r&sig=E7pGCG44G%2F8xq%2FQziv4gTVw8xbBZs1v2uVvCIOKa%2BXY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:46.2269506","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A46Z&sr=b&sp=r&sig=U0kV9ZrJb4ogT5Mfu8BGgwpumIKeMKmg%2B3nd7wK62Lo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:46.2268618","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A46Z&sr=b&sp=r&sig=y5SCQ8yCSW7ni0ChpwOaWoDl0mDmc8fDOyxTd2GjM3g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:46.2269721","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:46 GMT
-      mise-correlation-id:
-      - 9c9cafdc-865c-4a7f-82f5-7d62041d469a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A51Z&sr=b&sp=r&sig=D4Ni%2FYLRojq4aqgWT%2FoJLAEcjPQXXHPObq0evEeFkPg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:51.4960761","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A51Z&sr=b&sp=r&sig=7mkHQtGNao2tmy91S2viQ2FEmuM4xf9YHhoPFn28ABw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:51.4960136","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A51Z&sr=b&sp=r&sig=XlKekaSZh3VhdPntSJrlDYHmLXK3dmatbsXVVqCyQEw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:51.4960917","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:51 GMT
-      mise-correlation-id:
-      - 3fc134ae-9678-482b-8145-b037335c2943
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A56Z&sr=b&sp=r&sig=ZC%2BcHuIseLtzP48VdQog5unmciQILQz23oqZe6LV6T8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:56.7550612","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A56Z&sr=b&sp=r&sig=3gjX9hsg9cpEpqbcBcrXjiWv3D8K8uOHegRviH7s9JM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:56.7549789","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A56Z&sr=b&sp=r&sig=3Xs1vRWu%2FFO2p%2B6gEhwlRHFNygUr5YHScUkBiJhrR8k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:56.7550811","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:56 GMT
-      mise-correlation-id:
-      - ac60c410-44b6-4bbe-aeb1-8a87affee45f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A02Z&sr=b&sp=r&sig=zliegyk%2BSU8wy4R6WjEsDk%2FEW0CUHI10vowCBxy6eQs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:02.0122828","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A02Z&sr=b&sp=r&sig=bDmReOVYIlN2X%2BtS6w3VHGILnwBoa2sfqvNqxbmlbZE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:02.0121887","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A02Z&sr=b&sp=r&sig=tAcBwWn0bHb6pTY3LmJYs8X8hbLZAmE5udUag%2B8%2B7Xc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:02.0123204","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:00:02 GMT
-      mise-correlation-id:
-      - eb649699-a6b1-4f67-9b49-e80f1d1aae02
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A07Z&sr=b&sp=r&sig=xt%2Fa3G36oODqwZuIVqL73WkG7K6EuTz5DbZo5WY8LZ8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:07.229832","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A07Z&sr=b&sp=r&sig=A8rR95xiJsr3ldmcvx%2BjJArsSwEUsbu4RbWqA8bTyk0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:07.2296121","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A07Z&sr=b&sp=r&sig=5mhbR0J38Xi2qhfJtQJN4ImWfxkFnYIn4WOLPXAegoM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:07.229847","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:00:07 GMT
-      mise-correlation-id:
-      - de5b4793-85f9-4386-ade7-7eb8c4cee62c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A12Z&sr=b&sp=r&sig=9GQsHwrJN28RJ%2Fmw9zBV%2FBZJYNKSW%2Bde2ck4e%2B78m1M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:12.5855037","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A12Z&sr=b&sp=r&sig=MqWfGCZtKn1Thp5oJEyQSkaT8k0bk88V2eJkV2FXlSs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:12.58542","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A12Z&sr=b&sp=r&sig=v4O1AaJkC%2BA4JVUR8kiDSARec87wDw%2B%2FemizSdCXiVs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:12.585521","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:00:12 GMT
-      mise-correlation-id:
-      - 23194057-b046-4fe2-817a-bd956ff5d002
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A17Z&sr=b&sp=r&sig=fF2ApXCFqhiOKcQE4B%2FrGuGoPP%2BwPpeIZIPRiSP4NXA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:17.836501","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A17Z&sr=b&sp=r&sig=lIg6Hk6iFFnxsXFmZ0WQxJ0ziLqWrongdbFG1NrsIh4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:17.8363889","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A17Z&sr=b&sp=r&sig=WMviWe6Zj5SNThvvtk0J%2FE%2BQZN5dRswoZeLGiL5iHt4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:17.8365195","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A40Z&sr=b&sp=r&sig=rpUjLvn0byxJj54EPffjzTIlM7tH8d1hioZ5J3M7SuM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:40.6106448","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A40Z&sr=b&sp=r&sig=J5Cnw7KiipFrj7zMYEbYtM6Zlm%2FTypOFzxW3Kjw9Wxs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:40.6105499","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A40Z&sr=b&sp=r&sig=YY9NAs7Qvrxe4s%2BuUmeYgUYSonScbyppR2TxGvilILw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:40.6106655","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:35.374Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2190,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:17 GMT
+      - Wed, 18 Oct 2023 20:56:40 GMT
       mise-correlation-id:
-      - 1cfa051d-b1d3-4e7c-bac2-7aa3ab447144
+      - 2c2c2fa4-d043-4228-9b14-2aabf2b81a71
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2212,10 +772,334 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A23Z&sr=b&sp=r&sig=3igtrSVIIxKNU%2F4PNEmbgvb6tDLuIKcx0ToAkkv1dXY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:23.0777418","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A23Z&sr=b&sp=r&sig=1aWhy6a0jLg1E4afdBhMZ2q5C778Nh4kiJZH2HbwpTs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:23.0776427","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A23Z&sr=b&sp=r&sig=pt72t5lRI1bLgJhTvmvwZiJeXwxlSdO7iI82qOihNdA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:23.0777646","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A46Z&sr=b&sp=r&sig=X45E2kZmgKofL8Os5yxqTdXa5%2BRV8UlhgVZ8zDNoFTg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:46.0718124","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A46Z&sr=b&sp=r&sig=zySXV4zzW6vuDVeNsbNZMpNHd8iRuxluHpRc1mZht8Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:46.071745","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A46Z&sr=b&sp=r&sig=8iQghm%2FK12S8a5RCE3PJ6AH%2BAhyrnS%2FeKqGFccw3cxg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:46.0718264","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:35.374Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:56:46 GMT
+      mise-correlation-id:
+      - 7bc02d99-0aff-403e-8318-ee70cf914839
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A51Z&sr=b&sp=r&sig=YGgdrILZZuRTGaqImFEqbIpSINhrDxWycJT6sPUBnug%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:51.3306555","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A51Z&sr=b&sp=r&sig=sQRKz5LYOi%2BbHTJIvc%2FUnAdFw0NO0LGb3eWPMRdgiCM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:51.330559","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A51Z&sr=b&sp=r&sig=ltVylZdnf1mbpMq6dasiGrXGXsARj6Mzmfb7AZJMHOY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:51.3306706","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:35.374Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:56:51 GMT
+      mise-correlation-id:
+      - 28b2c785-c2c9-4a3c-8a13-42aac052cfb8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A56Z&sr=b&sp=r&sig=50B1Ciumn8%2FIOQbw7dX2PG91ot0%2FGhm93707ku4v%2FEM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:56.6075814","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A56Z&sr=b&sp=r&sig=RzNab5I6elUl4ppVOaBRE8dojagzflpoZDw3mDNABLI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:56.6074923","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A56Z&sr=b&sp=r&sig=t1UypXwA1gAT057f9HRWlzNVDMOG75dwBMtJ9SUq12E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:56:56.6075997","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:35.374Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:56:56 GMT
+      mise-correlation-id:
+      - 5b73e8e6-6ab4-4686-a77e-735dfb368c58
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A01Z&sr=b&sp=r&sig=BGDZVc9C0hRXRbdS69UN4QbC8UqfGF2NBqYY339eR%2Fo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:01.8787855","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A01Z&sr=b&sp=r&sig=xkPfW1esJbUucSPCschwGPkdTJRU41%2FKU%2Fa5KI0Lh2M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:01.8786876","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A01Z&sr=b&sp=r&sig=2i6ovb1qLZkByHCWJuUrZlOy6dkJbcwnr7CUkC0z%2BoY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:01.8788071","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:35.374Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:01 GMT
+      mise-correlation-id:
+      - 61e7d11d-5a55-41a6-bde3-00a82f07d374
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A07Z&sr=b&sp=r&sig=XwKE%2Fzx3lRIPd%2Fr7KlwigchorFZ%2Fd4Q3IlNC7e3s9Lk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:07.1411548","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A07Z&sr=b&sp=r&sig=j%2FZ0xUG%2BBzRkFIpYOOP2aTafP4Cy%2B3LgG7n9%2FaeCluI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:07.1410664","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A07Z&sr=b&sp=r&sig=woa%2FebwCYdkZ3wpeXkaZ%2BGK%2BI79VzyKS37uL%2BgrQ0gU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:07.1411774","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:35.374Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:07 GMT
+      mise-correlation-id:
+      - c563d222-b185-4e19-b0a2-1d41feb4d26b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A12Z&sr=b&sp=r&sig=WsOuz1F6pgqeWi%2BHALV0tydF5m2xGaUOKGAjPRDnOao%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:12.3943727","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A12Z&sr=b&sp=r&sig=9tu83NRnlaLdJ1fFG%2F2CAYRIGzCupgeqapEEEbXSU68%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:12.3943018","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A12Z&sr=b&sp=r&sig=Q64%2FaiRqqgZtZIz9C9uE3%2BtvqwCuYxcOCh6TdqKkqVs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:12.3943872","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:35.374Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:12 GMT
+      mise-correlation-id:
+      - c653e229-cc5b-4587-b311-c7f15a413ce0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A17Z&sr=b&sp=r&sig=W4OtS%2F4he%2Bx29aKo9GTNa%2BhiZ1jeeTXqW8YHqSxJOrM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:17.6819623","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A17Z&sr=b&sp=r&sig=V3YnQ6k37QMsdA6B59tyeIRRRbq%2FJ5i%2FXGW%2FLX2%2FrOM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:17.6818634","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A17Z&sr=b&sp=r&sig=e4Agi8r5fhc214NoJ4gxEvm0eRtkypXIJDxhOJ0%2Fq%2BI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:17.6819789","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:35.374Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3215'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:17 GMT
+      mise-correlation-id:
+      - 83efef63-3e3f-49ca-b2c9-7ce89b440a2c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A22Z&sr=b&sp=r&sig=%2BvlJuMCcc1w6qF%2BZl42ruqLqvfMWbwE12FlcfgUG%2FvA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:22.9685351","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A22Z&sr=b&sp=r&sig=9YlZB03Rrq0usoYhiigJtrY3tySjgqZ0mUNAC5jzsaA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:22.968469","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A22Z&sr=b&sp=r&sig=a81OvoxuUQyxdJm4RPXThEXEYOCtNgvsd%2Bl%2BagOai6Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:22.968551","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:22 GMT
+      mise-correlation-id:
+      - e431354a-2441-4057-9665-0ee469e86c35
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A28Z&sr=b&sp=r&sig=ocgRyqQhX1TB5MI%2Bp3b1dC62LZBYPGHll8f5j7cgQfM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:28.2329199","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A28Z&sr=b&sp=r&sig=KsJ9Gb5jIh%2BhRZKgzUpjHoNEvkWoMdgIjpIkE01DakM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:28.2328462","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A28Z&sr=b&sp=r&sig=6Ne8hCjR%2BPAKF23VB0v3WcMoF%2BGQPNeIGrozYiQ%2BFSc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:28.2329346","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:28 GMT
+      mise-correlation-id:
+      - c2348554-9afa-43c9-bbed-03863f5d33f8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A33Z&sr=b&sp=r&sig=HMhTHQyWHkf9U2kCKJNbeL53llBxUdBFuj184i0qE4U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:33.504429","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A33Z&sr=b&sp=r&sig=t3Grauq7MPLLG%2BgfiFwnO%2BlJtTkqgDItDFdfkyE0Qf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:33.504352","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A33Z&sr=b&sp=r&sig=WnYfYzyVmiy8FJ5PpOtCbcI2jg3JTXaPC87qy5Yb8pw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:33.5044431","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2226,9 +1110,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:23 GMT
+      - Wed, 18 Oct 2023 20:57:33 GMT
       mise-correlation-id:
-      - a20205fc-9983-42e2-b9e1-f1fa3405d3aa
+      - 1ef674de-a20c-484e-996b-27cdd0c98ddd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2248,10 +1132,622 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A28Z&sr=b&sp=r&sig=%2FVyDi5yMHuXLJL4e%2FM0ySYWpmNVmwbPJMz9dy%2B3kbK8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:28.4012369","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A28Z&sr=b&sp=r&sig=qZjao3Wfh0CPj8vOB47NkVggfJOqiLCAEG%2FRBFE%2B%2FgE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:28.4011679","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A28Z&sr=b&sp=r&sig=doB4jn7iBU9nuGivRipZOr%2Beqn5pQz8TuIR9%2FWNbN18%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:28.4012516","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A39Z&sr=b&sp=r&sig=6t0cH6OeJNTXS6sTD5QDEA9fJhmDa9rKgaTbN7NG%2FrI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:39.4050284","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A39Z&sr=b&sp=r&sig=ffEw4sy3QO36wvwKnT%2Byym5nefTuky9kbjvVBmiKy0c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:39.4049546","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A39Z&sr=b&sp=r&sig=C4DkFtMIpCUwowFf6Cu9t%2FRKgFqVjxokl14Ms239jbk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:39.4050428","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:39 GMT
+      mise-correlation-id:
+      - 887c3924-bc0e-4d2a-a715-61ba726e5ac0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A44Z&sr=b&sp=r&sig=iAj1qxteG5mHSSf3VSN6RgOkSwL%2FcTX8E2WCSt7j84E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:44.6758549","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A44Z&sr=b&sp=r&sig=2xj5V4SzI5i9EuoGz%2FpKIGsRr4gWi5A5kI77gjz83Jc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:44.6757704","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A44Z&sr=b&sp=r&sig=j1OoXPlhCU4SesmnF%2BJH75ZYlSWmKbxGAPuTz5T7MuY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:44.6758762","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:44 GMT
+      mise-correlation-id:
+      - 5114bde9-a9b4-440b-bdde-7c24cc71f36b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A50Z&sr=b&sp=r&sig=yRyAFApK0LGPquZQmgpH8nzQcCdDBTatrfaxqg2u%2B%2B4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:50.0081717","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A50Z&sr=b&sp=r&sig=xVH1U%2F9D7lBVtZp4bMkVTI8YQR%2B2dD3PaTbHEvzH2x4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:50.0080843","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A50Z&sr=b&sp=r&sig=ix6g9GkpW0RzaVyAeX1umBDkLqgY8R6T%2FqOS3qqk7lM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:50.0081862","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:50 GMT
+      mise-correlation-id:
+      - 0b1d4ad3-ec57-4073-a9cf-fa32c5421f39
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A55Z&sr=b&sp=r&sig=aIbKy05OzCDJJejefTI%2BLD35KkiBcgy4GtYVZp10Oyc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:55.3494507","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A55Z&sr=b&sp=r&sig=y%2BzGUQkZSEGupv94IIPghutpZ886DpXV4MGjEMz2H9Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:55.3493782","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A55Z&sr=b&sp=r&sig=pWcbL5Ib4aoPcYDCbFFkWV%2FMR3YugOAx7xR00mOJ6QM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:55.3494651","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:55 GMT
+      mise-correlation-id:
+      - 84dacb78-0a2d-441c-81a2-b346c3936e5f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A00Z&sr=b&sp=r&sig=ryZmJ7GvpVXKJ8j1k2pPAkXICgn%2BO4sFElSUSRJhGKM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:00.6707564","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A00Z&sr=b&sp=r&sig=pNVFgLWEnaQG0jtYkpyGrH0yUwyPRxyxeU%2FuS%2BK3ATI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:00.6706748","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A00Z&sr=b&sp=r&sig=Uqo%2BaXNbfQBThimVMxeKwSEQ3%2BLysL2Yil996NxV6A0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:00.6707762","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:00 GMT
+      mise-correlation-id:
+      - 3b39954c-d58b-418d-8f23-157d6f943fda
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A05Z&sr=b&sp=r&sig=x1l6td0MA9u3G0cU0xVAtgWfbmzTN5gEKA0NjdqPikY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:05.9881313","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A05Z&sr=b&sp=r&sig=%2FxvEQ%2BgJgrXDeHuuqXb3FGpeu6OlmOeRCq7PjDaDwf8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:05.9880354","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A05Z&sr=b&sp=r&sig=yPOC%2FhGPrXYjKm%2FUc%2FCDDrp5at3CE4gR5YALdLfCkf0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:05.9881451","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:05 GMT
+      mise-correlation-id:
+      - 78f0fc96-9de0-43c1-93e3-61aefcc7a231
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A11Z&sr=b&sp=r&sig=O8bV5yGbq2V1tQnf%2Fz3ZOKkiJ0VHYiPHD%2Fw8K08dAsI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:11.2899386","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A11Z&sr=b&sp=r&sig=Ho9Ts%2BvjPeZm1fSFhHeZ9ZU4xtQ09VGBm53sKmYqx6M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:11.2898613","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A11Z&sr=b&sp=r&sig=xXJDC6czPgbgVnRKY3aA64uvWd1LTljIPYLNns6Swj0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:11.2899524","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:11 GMT
+      mise-correlation-id:
+      - 186d3fcb-7505-4816-ac74-2f41a7ed921b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A16Z&sr=b&sp=r&sig=3oeHK3q4qf4QSkZpYfG3D5OvbxzowaCdIIHv1ZhzIbs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:16.5510985","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A16Z&sr=b&sp=r&sig=jIdR4cOI7YJvWh7J3GXw9hA556Cyf4FpfcO32ieDQf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:16.551014","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A16Z&sr=b&sp=r&sig=7aTdPrO5yfFYMdLlsQ54zEyD04fgUfh8WbhEfiFuU8E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:16.5511127","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:16 GMT
+      mise-correlation-id:
+      - c53d7186-e65c-4843-b088-fa97d2a69156
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A21Z&sr=b&sp=r&sig=4H5QXBvYngjYeR1P27MkhK26OEk10caplzJM14sVJvo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:21.8125297","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A21Z&sr=b&sp=r&sig=wNhwH5HhmFPJagGQFDQt0RrTt0NsiwBJ5OiassIvtN4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:21.8124067","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A21Z&sr=b&sp=r&sig=pnt%2F7S4RjdlUcYSiHKVyqtXsPckwW0cVtDWQAAdwS3Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:21.8125478","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:21 GMT
+      mise-correlation-id:
+      - 8a7618bc-f6ec-4c25-ae86-9cd4700bda07
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A27Z&sr=b&sp=r&sig=b04PNZCDW2CQDZwS4hDYEwdhUZkZVpBZ8qNfMwaLLWM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:27.1052861","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A27Z&sr=b&sp=r&sig=uAiMmGYU4VE2cfQ1emAE5iYffK8jMwfKOu6QLGZVkXw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:27.1051816","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A27Z&sr=b&sp=r&sig=knR3vhb3ku5Ih22QI7nrpiAkmS1HhgiDx%2BXl7wIyVos%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:27.1053095","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:27 GMT
+      mise-correlation-id:
+      - bee41383-9818-4feb-b9e9-a2da6cb21508
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A32Z&sr=b&sp=r&sig=RpjM8XsqKgQOAp4XUobvcXrJVZq6Ft%2BEvywM3gsnExo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:32.3888212","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A32Z&sr=b&sp=r&sig=2aGRlMzSp4PD%2BqzIq3Yryx%2BfreukNJRjh23oB188vUE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:32.3887518","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A32Z&sr=b&sp=r&sig=5lbacI%2FRDLSi3DvgfAPQBiNnqP%2Fxro%2Fkkas2EO44154%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:32.388835","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:32 GMT
+      mise-correlation-id:
+      - 5d515e4b-faee-40da-86a2-e59cfe99b064
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A37Z&sr=b&sp=r&sig=w6nOPUHiNk5lBQpKuZY7pjdWcZEKNuYx6y5MbBA08KU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:37.6444164","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A37Z&sr=b&sp=r&sig=3cieKIrjP1PNkiIECvBUENlOPCjqNlY%2B7XPDzOgzHkU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:37.6443461","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A37Z&sr=b&sp=r&sig=xGQyjpnnLflEHYvTGgCXW4CMQkbEz5H0Ws0tI%2BlFsSc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:37.6444299","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:37 GMT
+      mise-correlation-id:
+      - ba73a18a-5d06-4bb7-9922-cc53057a39c4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A42Z&sr=b&sp=r&sig=7zJVZ87Ktoj03Hu35mbavbKrg1O9wo7ea%2FZGCK8EiA0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:42.9640885","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A42Z&sr=b&sp=r&sig=O0ePefkiNEYOdYXKuQ6pS2FktH6ZA63MdWnXpgUstPw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:42.9640194","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A42Z&sr=b&sp=r&sig=ud7y%2B4SCYnUffmpjqbZJ41hWLwSDJkMd25bcKHwUtzY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:42.964103","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:42 GMT
+      mise-correlation-id:
+      - 65b93c27-d88c-4cc9-ac87-be48091c2cfc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A48Z&sr=b&sp=r&sig=i3vdMfWUuJDuWcaaxf%2BluytCBiDL5O4bte%2BBsBr6oG0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:48.2801476","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A48Z&sr=b&sp=r&sig=CK38SDE7%2BtUM3SOfQUYFaCzBWQQofzHzLtssnCBKDOg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:48.2800727","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A48Z&sr=b&sp=r&sig=oXGZwQa7l2Bljaz%2F%2B8hJHo27MO9NeX0q%2FzfjDC4GHl0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:48.2801627","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:48 GMT
+      mise-correlation-id:
+      - 040f9d76-07a6-4a2c-a264-4995f294fda7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A53Z&sr=b&sp=r&sig=CWNg%2BUTivG23qHglhbzgmFAtYoWAqKfh%2FrHT%2FF6vLtk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:53.5949422","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A53Z&sr=b&sp=r&sig=EdvHeZy8bPijfHgfnM9GQ3T1JWzBIHkQvqL0d9MWOAU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:53.5948674","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A53Z&sr=b&sp=r&sig=Mz501hKxHuOpowT2xU93%2BqifWlYsMuCTLhxpt2tLhvc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:53.5949565","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:53 GMT
+      mise-correlation-id:
+      - 65575ee6-d9a2-4ba6-8fff-19fac73d05d8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A58Z&sr=b&sp=r&sig=8Lo0NlX2r2sC9SpmrbsTwojnuJvNgYQBpabT0JLGST4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:58.9301931","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A58Z&sr=b&sp=r&sig=yUJ7dbrNenvZAsd8pjjJ8h5eTmQmlg%2B8c0uUWasPhxg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:58.9301257","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A58Z&sr=b&sp=r&sig=92qj69MCYNGDSJxToBxQvxarfjUeHWxrSwhfzUtz2ZM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:58.9302078","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:58 GMT
+      mise-correlation-id:
+      - 25077ab2-e933-4e9a-baed-39830e40389b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A04Z&sr=b&sp=r&sig=gxE3YER3LsFZThGF6Ig5RXvyc9mUaJAf8%2Bgr21GtPLo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:04.220941","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A04Z&sr=b&sp=r&sig=L9hFqtDNgKrii7jofE8ZjLKkk1v01UOJjvS9hF3cwSo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:04.2208707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A04Z&sr=b&sp=r&sig=beLNQHAPELEp8mxQCLicJR5uhmt5u%2FQF%2BfZFARoTMGI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:04.220957","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:04 GMT
+      mise-correlation-id:
+      - 8cbafec8-5fe9-4644-9240-4bad4cf877ea
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A09Z&sr=b&sp=r&sig=gaW6y6RSIB8sKzGHiMpazTC41EuL%2FEf4Bv4ndd%2BdpA8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:09.4796312","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A09Z&sr=b&sp=r&sig=O8lTYkIsgOVnBhvJdbuxZtVHVpmz26aNli%2F6i043a%2Bk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:09.4795598","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A09Z&sr=b&sp=r&sig=q1nE8%2F7s88ZkR%2BlBB%2Fx3LyKaXyzwTSvv3J%2Fd0V51NiQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:09.4796782","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2262,9 +1758,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:28 GMT
+      - Wed, 18 Oct 2023 20:59:09 GMT
       mise-correlation-id:
-      - 23ef412b-b13d-4df7-9332-3115fa6b2aae
+      - 087e4b35-943d-4ec7-ad11-019e3a8389c5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2284,46 +1780,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A33Z&sr=b&sp=r&sig=rCBN4waIEqESMqQcheGFDfTLXF0p8n%2Bxof2O3ocd2l0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:33.6299779","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A33Z&sr=b&sp=r&sig=4cYY1Zd3cJ7oQpCnbgT7Dw5lC9t68NMe343qMltnq3c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:33.6299127","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A33Z&sr=b&sp=r&sig=2Bng6vbAbmc1H5TIpsf4OAMqquTPn1Esht92YXfW%2FYo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:33.6299937","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:00:33 GMT
-      mise-correlation-id:
-      - 46cc7dcf-013e-448f-8c07-904cb2357e33
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A38Z&sr=b&sp=r&sig=iyZ%2F8SeKCSMDQkzJE0pWGyNLty%2FfiZZBn0NMTjPacik%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:38.8512882","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A38Z&sr=b&sp=r&sig=bNOzfocnp8WB9GYQ66HMOnEISuwC7a9dJliI%2BpNvRf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:38.8512089","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A38Z&sr=b&sp=r&sig=6Fg%2FnKT%2BeNuW1eZ2sk4KHte%2FTcuDbLh6B%2FLfC0pvAIE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:38.8513095","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A14Z&sr=b&sp=r&sig=8m6OPnKoeh4yOy2RFORRe6Yrc3%2Fc%2Bxmd9Tt9zECw8mk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:14.7884809","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A14Z&sr=b&sp=r&sig=SJGLxbDXC8x4r%2BiNnCb9vKZ%2FMlrxz2oqEs3ejN66dS4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:14.7883711","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A14Z&sr=b&sp=r&sig=0bXjFIjPurbJzpRvo4diM46b%2BQiK%2FGdq1A%2FvWv1k2kY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:14.7884956","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2334,9 +1794,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:38 GMT
+      - Wed, 18 Oct 2023 20:59:14 GMT
       mise-correlation-id:
-      - 24ecea58-f1d5-4a6e-89d3-3a61c2eef8bc
+      - ba8a67c8-6e2f-4a82-aeb7-61239b992474
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2356,23 +1816,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A44Z&sr=b&sp=r&sig=zGzLJwsqPoZDK%2BfSR893jY2Pt1UOZfM5upiNh%2FdCCaQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:44.3611263","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A44Z&sr=b&sp=r&sig=KPzSrECMSLhakJw2z3T258HkrfAW%2Bf%2FPly5bo5FCKDk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:44.36104","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A44Z&sr=b&sp=r&sig=fuRIdhuSHdotrSMQLoFhtcttD2%2BeoqUsSYnWZRd2mPM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:44.36115","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A20Z&sr=b&sp=r&sig=e1QF%2BA%2Fy%2F2bgJCVySanAkGnkSwDET93296lm8tAAxjM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:20.1238007","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A20Z&sr=b&sp=r&sig=9VUlw6SafzTWGT0X2zAWgdfPj2Mt1uDiHR0qrgBuHe8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:20.123722","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A20Z&sr=b&sp=r&sig=JbhLXg56aqSbhtszNEJOMZYGrekhXlJQ9yozAkIIJBI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:20.1238142","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3200'
+      - '3199'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:44 GMT
+      - Wed, 18 Oct 2023 20:59:20 GMT
       mise-correlation-id:
-      - a1fd84b3-59bd-4852-ab96-1968036bad9f
+      - 55fde5f2-0651-4c4c-bead-63824d925061
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2392,10 +1852,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A49Z&sr=b&sp=r&sig=IIlvQ2TfyAwZVPotuCyGqbc1jNfIue14JasjyEM3YyU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:49.6736259","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A49Z&sr=b&sp=r&sig=okOzOmXQfRNMGIVLTk4rdSL66QwQH%2BjU4HtPC2ffKgY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:49.6735414","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A49Z&sr=b&sp=r&sig=ijZgSbQl%2B780wWUApeyDt99vOEQsPfbGtlasrWATFuI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:49.6736472","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A25Z&sr=b&sp=r&sig=kMQVw3F0IygfnWvrWOI7mYTl56Nqi1cqfjxzBmMic2k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:25.4095617","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A25Z&sr=b&sp=r&sig=DYuAZL1Xa7tu2GHfnthJkYs4cNyZKe4CNK0rCN0zvl0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:25.4094818","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A25Z&sr=b&sp=r&sig=Q%2BCelCI9%2F3HeH47tuxckEkcqyVlFkiZ1Pn2ZoTkFmXY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:25.4095793","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2406,9 +1866,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:49 GMT
+      - Wed, 18 Oct 2023 20:59:25 GMT
       mise-correlation-id:
-      - 410aed3f-610c-42ca-b46e-d73aa80318d3
+      - 679e8e22-22ce-4f1c-8221-6e4d37fc51d0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2428,23 +1888,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A54Z&sr=b&sp=r&sig=IZKlEfDQtDTKP1ggROA4uEid5OtCaDkQ7%2FQmzxPu5zQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:54.9403584","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A54Z&sr=b&sp=r&sig=%2FFa7iYu%2FtaUa54U6GLeGGvx7T91JNTppYJoSYhBdv2M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:54.9402926","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A54Z&sr=b&sp=r&sig=8fpaiW3s7KTwsdf7ja4i1PL9%2BA80tUQnloYYm%2BiYCKE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:54.940374","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A30Z&sr=b&sp=r&sig=dPGz%2B4zb6iu7zPuQhx9d58w6d7HnvwiVmPpqWpp2nuE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:30.6956574","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A30Z&sr=b&sp=r&sig=gci95DmRpLI307U76GefnpvbGg9QUCfV6DeI1eBa4xs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:30.6955711","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A30Z&sr=b&sp=r&sig=MR2gxIKog4QieKTeTPK8bvQ5ByR8FvPmir1qgMODZyk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:30.6956788","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3203'
+      - '3196'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:54 GMT
+      - Wed, 18 Oct 2023 20:59:30 GMT
       mise-correlation-id:
-      - 3a6f13f2-0714-49ca-8033-88a2d257b33b
+      - 9b619d40-2a12-4432-bcb0-db40a7ad2ec5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2464,23 +1924,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A00Z&sr=b&sp=r&sig=RrY2PrgsfKJTgnIBRq7721NTUKfKxvHJQhPEdbn%2BFok%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:00.1877861","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A00Z&sr=b&sp=r&sig=J9CIiwrAt5nDVVMIxCPTTqgpxFA3QqgYAwiXb%2FpQ9J8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:00.1877134","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A00Z&sr=b&sp=r&sig=J1lVuPmCr7Z2yF%2BwR6%2BOV4GpS1F9I1yLJzlX5j%2BrHV4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:00.1878005","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A35Z&sr=b&sp=r&sig=CJeUnK7ohfUFiKXEU98sFCsYcMcrOAX%2B1tEj817jdi0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:35.9754114","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A35Z&sr=b&sp=r&sig=RuAxjqWMyTNGiGAFNWC0yyACmPOHaHZ7kBAmhZl8UFw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:35.9753328","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A35Z&sr=b&sp=r&sig=kSM%2BTX2ZtC2pdu4Cduy6NH13%2BPiUXkFazBV4%2BV7okOQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:35.9754264","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3204'
+      - '3202'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:00 GMT
+      - Wed, 18 Oct 2023 20:59:35 GMT
       mise-correlation-id:
-      - 20f4c8dc-8bf6-4473-9c2d-bb8cb6f89920
+      - c1ba0c39-7588-4149-8200-10ed60daea54
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2500,82 +1960,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A05Z&sr=b&sp=r&sig=vHmzMcR7%2BjlvcZLP5dFDaDLuPBTVIjuZ0l3%2FSpS9YCQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:05.4786732","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A05Z&sr=b&sp=r&sig=kV%2F5D7lXZdDZbyXlJc8nhdI83iLMDPg41pFd4MkObqo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:05.4785756","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A05Z&sr=b&sp=r&sig=SwjEDl22tjsbuSJY0nAyziIdtvVxSudtVsVvYGQFgbc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:05.4786952","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:01:05 GMT
-      mise-correlation-id:
-      - 5f1a0184-080b-4fbc-a1f4-749a3395fda3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A10Z&sr=b&sp=r&sig=bjQrOG2tT%2BO05Xx57YiddcEZxpdEBROkzjXeWUQMr8M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:10.8071448","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A10Z&sr=b&sp=r&sig=YFyXxGimvI9tqS%2BBO3VONvHnhEkiWnxy%2FGgLF4HPPx0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:10.8070599","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A10Z&sr=b&sp=r&sig=Qgl0w1scU%2FoE%2F6r2iULHgCg0k32acAakuA4vTr9GUCg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:10.8071656","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:01:10 GMT
-      mise-correlation-id:
-      - 07955f7e-fc22-4db4-8a39-4a35b974fad5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A16Z&sr=b&sp=r&sig=Jxdv5uXMpqr3yJBkAdSg2dveXriN%2FTa4%2BYi4DrUzbpM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:16.1241255","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A16Z&sr=b&sp=r&sig=M47TjXAZUOPU9b4qd7wAoCDJZuyo0H65549mM4XekSY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:16.124037","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A16Z&sr=b&sp=r&sig=Dvyt2ebwX0BKT%2FG4nv%2BbbrRQw7NHVShba3pmFLnUPak%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:16.1241405","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A41Z&sr=b&sp=r&sig=7ObxsgPxTSF5NUFsF55APob4LrqdUi0CdWQZpRoRZ24%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:41.2975471","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A41Z&sr=b&sp=r&sig=4ygl649gJW0XHE3G60o6Vq333I%2FTI8xoVI3Kq0HG0Z0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:41.2974739","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A41Z&sr=b&sp=r&sig=prEIRmcLfUMW1qVVYY03%2Bo2ZxE0uy%2FyFH%2FoxvOVy7Is%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:41.297561","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2586,9 +1974,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:16 GMT
+      - Wed, 18 Oct 2023 20:59:41 GMT
       mise-correlation-id:
-      - 5ccf523e-ae08-42b2-9e28-4da30d9b7d28
+      - 8bcc9eb2-5c88-41d7-a5e0-1efa51b85aab
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2608,23 +1996,635 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A21Z&sr=b&sp=r&sig=sN25hE05zGYi5HYKwWqg3npuOW0Z0LQ8CW11PtZNit4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:21.492021","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A21Z&sr=b&sp=r&sig=1QXs72T8HECpUYvjQCq%2FW7winQg9eXLVsArtd%2FH9n0Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:21.4918741","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A21Z&sr=b&sp=r&sig=xWj%2BLulPE3bFZ2G9p5KOITEl2gNHgaWEU63AxdLKOeI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:21.4920425","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-13T13:56:41.186Z","endDateTime":"2023-10-13T14:01:20.981Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:21.375Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A46Z&sr=b&sp=r&sig=8nh3zFn0oPpq7rMAb0qhGuCeQ0PNE7cS8Fqc5TDmOi0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:46.5637693","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A46Z&sr=b&sp=r&sig=ebEm0YxMWS6cyrC3%2F2llCzOFGqaBvL53j6dHVMGzN1Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:46.5637003","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A46Z&sr=b&sp=r&sig=bxBnGCT4NaZPZPme7hItd58JHBwSe0LPvIzOdlDNILY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:46.5637848","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3235'
+      - '3196'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:21 GMT
+      - Wed, 18 Oct 2023 20:59:46 GMT
       mise-correlation-id:
-      - bb782f55-c371-415c-b430-07a214971cdc
+      - 5c67afe2-e288-451e-b750-964dca53f204
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A51Z&sr=b&sp=r&sig=IDeFsxugRe0hVEDqGekUXoYjK3tz9KFijWECAhoxRG0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:51.8519044","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A51Z&sr=b&sp=r&sig=zjHAnK%2FQmtcaGUpBEkuYj%2FzTyXRy4Wp%2FJVuMy2msrZg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:51.8518289","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A51Z&sr=b&sp=r&sig=%2FkVBheVfOGzawzntKHibulZ72kGYQk3fzQ0wOS4BjJQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:51.8519188","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:51 GMT
+      mise-correlation-id:
+      - 6bf06fc9-73cf-433d-96c0-fbb1ccea4978
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A57Z&sr=b&sp=r&sig=5f%2F0nBdx%2BoI%2B2b36obt123KZQOIounPJ55tEjJecE%2Bk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:57.1732847","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A57Z&sr=b&sp=r&sig=dt7f4STbprf2IY7F1H8b8JwQ5jP9DQiRr47Gqzyye7w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:57.1732103","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A57Z&sr=b&sp=r&sig=A9DUE42FRbfAW7zKHXH08MMiJXtagoZkQkUv7NGwGqI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:57.1732993","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:57 GMT
+      mise-correlation-id:
+      - e08e26e0-c494-42f7-88e8-a834ff71cbc3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A02Z&sr=b&sp=r&sig=5y5rbQopIdt%2BK83kV9L%2B8IcIi0mKeoxywDzRfg2XrQs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:02.4593449","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A02Z&sr=b&sp=r&sig=HEO8SLq%2FKn6U7BXcfUAv4I5L8ozmU5EZsGca0IX7bnQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:02.459266","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A02Z&sr=b&sp=r&sig=3IC3O9BEaC9wUB60trSy9ocMU97VVGWdCmCh6UF7h14%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:02.4593672","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:00:02 GMT
+      mise-correlation-id:
+      - 2cdeaa69-e930-49da-9418-475ed246f3c1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A07Z&sr=b&sp=r&sig=DH5Ey%2FzGNwyMUu1ydcxhfVaVTcgTe592JVD45UruoDo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:07.7196949","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A07Z&sr=b&sp=r&sig=sUJKXRO1RlWCsMLC8%2FXpzI%2Ff1hbITx55x2DiQdVO%2FY0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:07.7196213","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A07Z&sr=b&sp=r&sig=LbkQyh5iOEw2U9X%2FoRG3hlcqgDxSXOvMsY3RLAR7oxA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:07.7197105","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:00:07 GMT
+      mise-correlation-id:
+      - c61aa0f8-5f00-4449-abf5-3f9e2b701b38
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A13Z&sr=b&sp=r&sig=3ax3Vgax6DirEIIbe13o5QlpA83mCnFomG%2F1Il960%2Fo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:13.0491737","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A13Z&sr=b&sp=r&sig=whtWNffj0OWl4Y4sRC6ISXiPdGjz9Afdm2ThcrxJE0g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:13.0490972","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A13Z&sr=b&sp=r&sig=LU%2Bw%2Bgkfv68mYNQphWis5X2F8DXupxSAa%2BSHlYpK6JE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:13.049188","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:00:13 GMT
+      mise-correlation-id:
+      - 3b9643e7-e967-4d54-b619-e119f1037d2d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A18Z&sr=b&sp=r&sig=EiMFoeGPxUVwtw0AhJr3U2K9arfUKfg6bIiHZa6X8zY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:18.3872708","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A18Z&sr=b&sp=r&sig=8o9p2%2BKBYyfjti3ooA9cy5PHih1Uvccb9O6OZY7WY20%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:18.3871977","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A18Z&sr=b&sp=r&sig=OCIRRTbN8FQ8PGw8szmzM%2BzOJsZcUY7UQ9G%2BZEABOsM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:18.3872856","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:00:18 GMT
+      mise-correlation-id:
+      - ee60e8e2-ec73-4646-80a9-a5962a7cde74
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A23Z&sr=b&sp=r&sig=ZL%2FIqGVwiwF%2BIKpAzDC8SMaFTmwUgCM7oG2n7XYqx0U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:23.7195661","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A23Z&sr=b&sp=r&sig=4x6PR1GA7J4dt%2FAyQP%2FK9BrZTpJUYsljE7lglx91yG8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:23.7194852","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A23Z&sr=b&sp=r&sig=rQVYoFMsXpRtKIrjFn1OwKNge7rRC3y%2FUTqyFVrWVck%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:23.7195846","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:00:23 GMT
+      mise-correlation-id:
+      - 7d90d3c1-b642-48e3-8e72-782575aefde8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A29Z&sr=b&sp=r&sig=HhxLYbjra52HV%2FPsGD9nT7KzV9D45AR9Lp2y4Lv3ZkU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:29.0369074","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A29Z&sr=b&sp=r&sig=7Iz59fCl%2FSD8FjPTKvT6GrQkMwXNRPXIaGTS8WRyjGk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:29.0368366","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A29Z&sr=b&sp=r&sig=aV%2BgX4BMOn%2B4uvosJ68ZypVsJ6dvxu34pZc4RsHLwck%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:29.0369217","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:00:29 GMT
+      mise-correlation-id:
+      - 754a37cc-ec5e-4a1a-b2ac-335d72455daa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A34Z&sr=b&sp=r&sig=VJ4v3XUZbAzE%2FC%2BfZJyXZdFFISFd1Lr2aNWgb4aQPVY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:34.347575","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A34Z&sr=b&sp=r&sig=73DjkaMZIZc0zAIY42h6s2GUew3gc%2Fm25mIQwWbhmwQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:34.3474719","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A34Z&sr=b&sp=r&sig=JAEDBbnA7HZur97vfsbAv4Za3U4h9g4VEWkbWUiwuhI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:34.347599","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:00:34 GMT
+      mise-correlation-id:
+      - 4bf8d6d4-4b14-40cc-982a-d915b660e34c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A39Z&sr=b&sp=r&sig=o%2Flt9RWQlEW0Ho4TkGywnLwhzWN49JuTZKSOKos6IQY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:39.6769484","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A39Z&sr=b&sp=r&sig=MTf8zGufIB5w2r5HRWEjoBuVMWC0fW45%2FQhKOXcy8gs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:39.6767772","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A39Z&sr=b&sp=r&sig=6ct5s2YHEPuTqf82zJ%2Fs7i9WRBgmI72m4izk4OsIEN8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:39.6769739","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:00:39 GMT
+      mise-correlation-id:
+      - acf5f8f7-2e69-4fbb-8615-7382824f4de8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A44Z&sr=b&sp=r&sig=2ax%2FwmGhz9mUM8WJyYrlrGYPu4eNkyp0KcXM0%2FYPr7g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:44.9921645","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A44Z&sr=b&sp=r&sig=O2LdGQqNzSTOSB6rj9R9pF7ie8X5kk2fv7rp0YMsOYA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:44.9920786","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A44Z&sr=b&sp=r&sig=LtXL61IiyW2s346mdIL%2FCMTJ6EroekcyBE47qDgIwDw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:44.9921864","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:00:44 GMT
+      mise-correlation-id:
+      - ae911aa2-176a-4f3b-b72d-e785cd32bb76
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A50Z&sr=b&sp=r&sig=7xxxdJ4WkYK4a390E9gTpSG2TNFV9VnYYZQGXeWeA%2Bg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:50.3202618","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A50Z&sr=b&sp=r&sig=VOXZ29T9g7KF4x0naUK1NSwF%2Bj3c%2BIo75aFhRqcAbAg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:50.3201841","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A50Z&sr=b&sp=r&sig=KAK9viQF3biqCzyg432kRlDKcLLH5VV49rU84%2BJaiMM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:50.3202764","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:00:50 GMT
+      mise-correlation-id:
+      - 4963f376-eb29-4e89-9011-e97a32caff5e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A55Z&sr=b&sp=r&sig=aO1t2PWKDioVqBnY7t%2F3hQsnI3ndQd3%2BxgNfRbuetBw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:55.6001152","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A55Z&sr=b&sp=r&sig=i56ZSjFtu1N4BukwM%2BMEp93Vdxjis1TH5%2FCLikFxY1A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:55.6000476","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A55Z&sr=b&sp=r&sig=Qp66Go%2FMIEsFJVZ357R1PTzLSXawrI%2FvlWl8U4CNRhE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:55.6001318","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:00:55 GMT
+      mise-correlation-id:
+      - ccc367ec-e882-47ca-a5aa-cded99fac8e2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A00Z&sr=b&sp=r&sig=XTKPkiLOeEo%2FCHelC6gjMyyfEoOk8aVbUZcF8Ly89M8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:00.8921376","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A00Z&sr=b&sp=r&sig=ajJHjt5F1ao%2BexJWBHote5kEOCLJd7tn6OT9l%2FT53qk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:00.8920247","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A00Z&sr=b&sp=r&sig=vdMnDkygBCNI7LSm4m4RoRAuTH2nHLb6Xw6fM%2Fk1X1I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:00.8921593","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:01:00 GMT
+      mise-correlation-id:
+      - 75740685-10f7-440c-83b2-85e2620fd26a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A06Z&sr=b&sp=r&sig=0WPbsLVcsZIMoIup5uGSAQuOjjkzok%2FhdlFjQ%2Fc9tCc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:06.2062351","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A06Z&sr=b&sp=r&sig=ZoJ%2FmKBMeN%2F%2BurnhdE%2FsDlftEE7uoIsDwR%2BBzJXr2dg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:06.2061502","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A06Z&sr=b&sp=r&sig=QuAlvtUstsy47f80%2B5%2BdFO0VfGJPIcbB60GSgVNm1m0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:06.206255","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3211'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:01:06 GMT
+      mise-correlation-id:
+      - 5a76fcd3-528c-4edf-95a7-cafa89163f7e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A11Z&sr=b&sp=r&sig=7L1O4SHc99KT3LcRhMfcBcocsrdtUwK1uRYht2dm3rw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:11.5180309","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A11Z&sr=b&sp=r&sig=juAc94aljs%2FA0E0AWOQEV9fdiouDR0ZYJVAzdhoDHHc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:11.5179353","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A11Z&sr=b&sp=r&sig=CfXxP9HgLRQNUPBpGjqugizvFmC4JNbgfzmVA9rtrzU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:11.5180461","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:56:35.199Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:22.748Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:01:11 GMT
+      mise-correlation-id:
+      - b296ed2d-1dc3-4036-8989-74218e27ba76
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A16Z&sr=b&sp=r&sig=5mYhiUVpgSdJVY18COwMuOuJ5J1Ez59JhF6qGC7Hpzc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:16.8470838","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A16Z&sr=b&sp=r&sig=pLl3lrJ2rm1DxGnjFsIxe%2FcgPdlVosJfKSQ%2FDuamgQw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:16.8470122","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A16Z&sr=b&sp=r&sig=sG7AFHa5J1Zpyca%2FFGsFn%2Fy%2BVBcTmRo9hQlfGwJi5lg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:16.8470981","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-18T20:56:35.199Z","endDateTime":"2023-10-18T21:01:11.605Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:12.483Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3240'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:01:16 GMT
+      mise-correlation-id:
+      - 4c962163-5267-486e-b748-28425eea352b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2647,18 +2647,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:55:42.646835Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:55:42.646835Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:33.5819664Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:33.5819664Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:22 GMT
+      - Wed, 18 Oct 2023 21:01:17 GMT
       etag:
-      - '"d9016b33-0000-0100-0000-65294c600000"'
+      - '"75002f65-0000-0100-0000-653046470000"'
       expires:
       - '-1'
       pragma:
@@ -2688,23 +2688,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=metric-test-case&api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=metric-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A23Z&sr=b&sp=r&sig=03zBNBH5yJ42Fd3gla%2BtVnFSdFC14elda8LxechJeNo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:23.6597011","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A23Z&sr=b&sp=r&sig=MeEmI0PzVzfog5s85z%2BstFntV9cWRmEdSGMmckaeOik%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:23.6596302","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A23Z&sr=b&sp=r&sig=hCjSpA5SEI2xKpGuYxnSsVHWOykTe7o2GruyvFClLpk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:23.6597153","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-13T13:56:41.186Z","endDateTime":"2023-10-13T14:01:20.981Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:23.111Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A19Z&sr=b&sp=r&sig=sz8lznxnOLdGAnBwUJ4tLZel4l7eTO7WoWyvDLrJ7Uw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:19.1234147","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A19Z&sr=b&sp=r&sig=YlBteSDUCMoYKqNHkFtPPdBorpfwFGLIcH3bUzb74%2Bs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:19.1233084","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A19Z&sr=b&sp=r&sig=W9t5H%2B8vqPGyZzFVtcleifXrWZqjTSpGInMtrZUKvbw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:19.1234391","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A19Z&sr=b&sp=r&sig=tELbZnFQNXCH6dWO%2BBFOWQpARmma4bE6vr2ejgV1sPw%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:19.1234612","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A19Z&sr=b&sp=r&sig=gbKtw4YH8yrTef4cfngxE2nCtCB6Zng8vE%2FSeuj%2Ba0I%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:19.1234847","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-18T20:56:35.199Z","endDateTime":"2023-10-18T21:01:11.605Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:19.051Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3246'
+      - '4411'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:23 GMT
+      - Wed, 18 Oct 2023 21:01:19 GMT
       mise-correlation-id:
-      - 6adb58c0-fff3-45f0-9442-c01eb0cbba35
+      - 8f7e7d2e-37e5-4cba-a678-25c4054f7ca0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2727,18 +2727,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:55:42.646835Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:55:42.646835Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:33.5819664Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:33.5819664Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:24 GMT
+      - Wed, 18 Oct 2023 21:01:19 GMT
       etag:
-      - '"d9016b33-0000-0100-0000-65294c600000"'
+      - '"75002f65-0000-0100-0000-653046470000"'
       expires:
       - '-1'
       pragma:
@@ -2768,23 +2768,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A25Z&sr=b&sp=r&sig=b2MiS09DaMXsLU4Ho4m88bz6KTfBOB1ws4X0OdG%2BmFY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:25.7503225","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A25Z&sr=b&sp=r&sig=wLF8J0aISBOzf9mnYkoQxw5e1dlWLooiRHLImOuoozk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:25.7502543","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A25Z&sr=b&sp=r&sig=GCtOolimvtNj6dkf%2FQW3FzkAAkkub4g9sSYlt6q0vgw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:25.7503383","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-13T13:56:41.186Z","endDateTime":"2023-10-13T14:01:20.981Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:23.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A21Z&sr=b&sp=r&sig=1Oadzn2ApcmhFcKG1GkgZTkfL5XJAHCNslxJwwXBFYU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:21.4907834","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A21Z&sr=b&sp=r&sig=2Ci%2Bx1pyjG5wYWp%2FsKPwmo8RN0Q%2FFhyghxSqi5Yk57E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:21.4906868","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A21Z&sr=b&sp=r&sig=S%2Fc7yV6ya64EzV5eGekuB2Zq3wVnwtGLuLqgWgxj%2BXQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:21.4908096","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A21Z&sr=b&sp=r&sig=36FG85j42kRrtvduwm%2Fz9ZpkzGUhy2W64AOXHYPIqtk%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:21.4908353","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A21Z&sr=b&sp=r&sig=Ka3t%2FYsrLty2apDXIwyErpqEtfpqIIzx%2B2IfMVbBZW8%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:21.490864","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-18T20:56:35.199Z","endDateTime":"2023-10-18T21:01:11.605Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:19.169Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3234'
+      - '4404'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:25 GMT
+      - Wed, 18 Oct 2023 21:01:21 GMT
       mise-correlation-id:
-      - dd852781-fffb-4025-95c6-076f1232e803
+      - 972745c8-9a0e-4005-af79-e89ce7971200
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2804,7 +2804,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"dimensions":[{"description":"Request Name","name":"RequestName"}],"description":"No
@@ -2823,9 +2823,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:25 GMT
+      - Wed, 18 Oct 2023 21:01:21 GMT
       mise-correlation-id:
-      - b6463755-27da-4cbf-8c22-e945bba7324c
+      - fa902514-6f13-430b-911c-976d146a8435
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2849,10 +2849,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-13T13:57:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:58:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:59:00.000Z","value":1.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-18T20:57:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:58:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:59:00.000Z","value":1.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2863,9 +2863,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:28 GMT
+      - Wed, 18 Oct 2023 21:01:22 GMT
       mise-correlation-id:
-      - f878b0f2-4f20-4f50-95a0-b5ef9d76b042
+      - 0f5eb566-5408-4bfb-a2ea-70e45db8c32c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2889,10 +2889,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=ResponseTime&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=ResponseTime&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-13T13:57:00.000Z","value":22.0},{"timestamp":"2023-10-13T13:58:00.000Z","value":15.0},{"timestamp":"2023-10-13T13:59:00.000Z","value":22.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-18T20:57:00.000Z","value":46.0},{"timestamp":"2023-10-18T20:58:00.000Z","value":16.0},{"timestamp":"2023-10-18T20:59:00.000Z","value":14.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2903,9 +2903,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:29 GMT
+      - Wed, 18 Oct 2023 21:01:22 GMT
       mise-correlation-id:
-      - d528e1dd-358c-4d7e-a7a7-b03ebc2efbe4
+      - e3bdf80e-534e-460b-8d1f-7221dbb51aa9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2929,10 +2929,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=TotalRequests&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=TotalRequests&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-13T13:57:00.000Z","value":23.0},{"timestamp":"2023-10-13T13:58:00.000Z","value":62.0},{"timestamp":"2023-10-13T13:59:00.000Z","value":28.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-18T20:57:00.000Z","value":33.0},{"timestamp":"2023-10-18T20:58:00.000Z","value":65.0},{"timestamp":"2023-10-18T20:59:00.000Z","value":22.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2943,9 +2943,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:29 GMT
+      - Wed, 18 Oct 2023 21:01:22 GMT
       mise-correlation-id:
-      - de1e3162-b3ed-4649-8590-b47eeaa70cfc
+      - 6b4be6b9-e484-4df4-a197-683cabebfc05
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2969,7 +2969,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=Errors&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=Errors&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"data":[]}]}'
@@ -2983,9 +2983,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:29 GMT
+      - Wed, 18 Oct 2023 21:01:23 GMT
       mise-correlation-id:
-      - efeb6a7e-a4a6-436e-8b88-cf266169fba1
+      - 909925b4-22e0-492a-8fb4-2788035bdf70
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3008,18 +3008,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:55:42.646835Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:55:42.646835Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:33.5819664Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:33.5819664Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:30 GMT
+      - Wed, 18 Oct 2023 21:01:25 GMT
       etag:
-      - '"d9016b33-0000-0100-0000-65294c600000"'
+      - '"75002f65-0000-0100-0000-653046470000"'
       expires:
       - '-1'
       pragma:
@@ -3049,23 +3049,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A32Z&sr=b&sp=r&sig=6k3%2BnRvtEh%2Fco9K8N56Gou99%2FfxroZW1BWWBLSSsAgk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:32.2075772","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A32Z&sr=b&sp=r&sig=L%2FcD8gFCJeQLvg4i1IogUGc5iWoPTkWz9P6CbuvxC5c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:32.2074847","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A32Z&sr=b&sp=r&sig=s6K2%2FBYmjVoMohtpYQRUhRXaZwF2bpW9Zqbn8Dq89qY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:32.2076026","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/252f1225-511a-4a14-88d0-4bde0085ed10_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A32Z&sr=b&sp=r&sig=Ot95XFEOMr%2BpMxkAubY83WIOjmBVfz931tKnNFNhvaM%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:32.2076217","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/252f1225-511a-4a14-88d0-4bde0085ed10_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A32Z&sr=b&sp=r&sig=nkPat0B%2Buf%2B9gZoIVhD%2FvohaLmttpdYGjBXM2wKa%2FyA%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:32.2076399","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-13T13:56:41.186Z","endDateTime":"2023-10-13T14:01:20.981Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:29.861Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A26Z&sr=b&sp=r&sig=wFc8FcjN%2FwcwZPF4zE5wHPKboQ8reO5iqHEb3K9Wb0s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:26.1676288","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A26Z&sr=b&sp=r&sig=QieDfN46R4UpLZmm0aa0GIzAcCWXzcdkLtWjsV7E0pw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:26.1675498","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A26Z&sr=b&sp=r&sig=oaVF1MPkPCKU9NCLNdaF9eJwYHjFkczG1NRosgwpcd8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:26.1676436","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A26Z&sr=b&sp=r&sig=OOr6MLDbhUByvc7nyhPNoyeOkkOlQMh9caHdEKDdle4%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:26.1676573","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A26Z&sr=b&sp=r&sig=VRnhApQnR0d53l%2FdhKeYHLFo055xwaz85BKY%2BBzv330%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:26.1676718","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-18T20:56:35.199Z","endDateTime":"2023-10-18T21:01:11.605Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:19.169Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4409'
+      - '4395'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:32 GMT
+      - Wed, 18 Oct 2023 21:01:26 GMT
       mise-correlation-id:
-      - bd6787c8-8670-4a53-a40c-0c8d7ba5717c
+      - 34e2071d-cd78-4c8e-b1a0-c9ad1a342da5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3089,10 +3089,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-13T13:57:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:58:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:59:00.000Z","value":1.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-18T20:57:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:58:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:59:00.000Z","value":1.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -3103,9 +3103,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:32 GMT
+      - Wed, 18 Oct 2023 21:01:26 GMT
       mise-correlation-id:
-      - 56f7ff62-b3eb-4362-bc23-8f1699642b8c
+      - 895d746f-9d43-4e6b-b88d-1fa3259eef79
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3128,18 +3128,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:55:42.646835Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:55:42.646835Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:33.5819664Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:33.5819664Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:34 GMT
+      - Wed, 18 Oct 2023 21:01:27 GMT
       etag:
-      - '"d9016b33-0000-0100-0000-65294c600000"'
+      - '"75002f65-0000-0100-0000-653046470000"'
       expires:
       - '-1'
       pragma:
@@ -3169,23 +3169,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A35Z&sr=b&sp=r&sig=etidAlXuDkHAfV%2BFzTBqK%2FgFBgqXbMkxqko%2FZS63QvY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:35.7056951","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A35Z&sr=b&sp=r&sig=JhbGiGMwVvEx3LIPbCV4008FFfu5Tkq2Ip%2FY4UmqHAE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:35.7055233","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A35Z&sr=b&sp=r&sig=n5rCm9MLi4WCmsgbw%2Ftx4lUy0S6v4APx898Y5keV4B8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:35.7057219","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/252f1225-511a-4a14-88d0-4bde0085ed10_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A35Z&sr=b&sp=r&sig=BLtMNNXqFJR5wMiv7sQqt13AcP6evT3VOGzyo5cz9fE%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:35.7057452","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/252f1225-511a-4a14-88d0-4bde0085ed10_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A35Z&sr=b&sp=r&sig=VPDutjHUNpox7GnmcazbfmHYZwix6Vi80JOKWABxx3s%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:35.7057887","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-13T13:56:41.186Z","endDateTime":"2023-10-13T14:01:20.981Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:29.861Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A29Z&sr=b&sp=r&sig=GBhGD2ufqqTbGuN%2F4jH0qRF7ZxJ05wd4YAIoS9J28uc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:29.1271958","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A29Z&sr=b&sp=r&sig=3P64OGPneYApFzmmJiIW3HteXaV%2FhCqV2dknBbxWpWc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:29.1271267","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A29Z&sr=b&sp=r&sig=gWjzV3t8gex560bNJSyPcN3XFXR%2FU%2BAW4GVyIhtMVmI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:29.1272113","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A29Z&sr=b&sp=r&sig=uAdmkttywRVPe0kSmTbXpDooeYLm6in6%2FT1zKivn7lE%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:29.1272241","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A29Z&sr=b&sp=r&sig=hM%2FkGpzMcdjelA0YLfkE%2FyszhF9fNgya9DBVYAkoGxM%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:29.1272379","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-18T20:56:35.199Z","endDateTime":"2023-10-18T21:01:11.605Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:19.169Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4399'
+      - '4403'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:35 GMT
+      - Wed, 18 Oct 2023 21:01:29 GMT
       mise-correlation-id:
-      - 9b25a7b4-1df5-4cb4-8cee-09a29fd2765a
+      - 155b4ffb-4689-4157-9d6f-631ea0a3d6b3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3205,7 +3205,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"dimensions":[{"description":"Request Name","name":"RequestName"}],"description":"No
@@ -3224,9 +3224,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:35 GMT
+      - Wed, 18 Oct 2023 21:01:29 GMT
       mise-correlation-id:
-      - a47fe928-52ca-4856-894a-dcd7f6738436
+      - 55d0dc2b-d920-450a-a569-8cf7b173fca9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3246,7 +3246,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":["HTTP Request"]}'
@@ -3260,9 +3260,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:39 GMT
+      - Wed, 18 Oct 2023 21:01:29 GMT
       mise-correlation-id:
-      - f883b6de-e739-4af1-8087-5d4f3a57bdef
+      - e8bb8484-ae00-433d-a0d8-091cfeebcaef
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3286,10 +3286,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-13T13:57:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:58:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:59:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+      string: '{"value":[{"data":[{"timestamp":"2023-10-18T20:57:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:58:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:59:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
         Request"}]}]}'
     headers:
       api-supported-versions:
@@ -3301,9 +3301,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:40 GMT
+      - Wed, 18 Oct 2023 21:01:30 GMT
       mise-correlation-id:
-      - bcbd4b8e-fe82-4e4e-9ad1-109f1e8dcab9
+      - 751dc3ef-b954-4446-9393-5cadc2df593b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3326,18 +3326,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:55:42.646835Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:55:42.646835Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:33.5819664Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:33.5819664Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:40 GMT
+      - Wed, 18 Oct 2023 21:01:31 GMT
       etag:
-      - '"d9016b33-0000-0100-0000-65294c600000"'
+      - '"75002f65-0000-0100-0000-653046470000"'
       expires:
       - '-1'
       pragma:
@@ -3367,23 +3367,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A42Z&sr=b&sp=r&sig=cemNnPeirQYwJ3DG6HWHLlYnShNbWr9cOZlnUbdaNEA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:42.3393218","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A42Z&sr=b&sp=r&sig=BuIoJB9oZKOjpHlA9Y8OC10TcjssaTJfhiAiR1sm5L0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:42.33924","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A42Z&sr=b&sp=r&sig=7KI7cJKTYSwc%2FCy6svCTto0t6Ywu0mbmhmKfuS0i49g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:42.3393379","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/252f1225-511a-4a14-88d0-4bde0085ed10_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A42Z&sr=b&sp=r&sig=wi1h9%2FkvQOJiLZjEjXvJCsouzON8PO7IgiFnSm1SpUg%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:42.3393531","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/252f1225-511a-4a14-88d0-4bde0085ed10_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A42Z&sr=b&sp=r&sig=5JuwzhJXXE7vA6WBqDUXpYHXpcViHGnMo9NmNzgZtgw%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:42.3393687","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-13T13:56:41.186Z","endDateTime":"2023-10-13T14:01:20.981Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:29.861Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A32Z&sr=b&sp=r&sig=yCEp%2FFfUDGCuW6te86vS%2F5JU%2BeR%2BFIMe4g4YRgvBO0A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:32.4187398","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A32Z&sr=b&sp=r&sig=ywwO3KyIisAZX4o%2FqWMXtYSXc%2BKgIZywKBJtp3Jjn1E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:32.4186629","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A32Z&sr=b&sp=r&sig=xA4EJJOKX56Tho%2BSPhi%2Fr3mL199D2x3jCH%2FvCc04v%2Bo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:32.4187549","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A32Z&sr=b&sp=r&sig=3IJdClSuXPajgPbCUoSmxX0GnMGxZyyaJ6RmMm4S11Y%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:32.4187689","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A32Z&sr=b&sp=r&sig=ZozHnncYVnJJ7EEkLJOhxsLOijRxmp97p1uQWwHwP8w%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:32.4187826","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-18T20:56:35.199Z","endDateTime":"2023-10-18T21:01:11.605Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:19.169Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4391'
+      - '4409'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:42 GMT
+      - Wed, 18 Oct 2023 21:01:32 GMT
       mise-correlation-id:
-      - 2a7cf860-9007-463e-9e53-ecb44495c129
+      - 50f6abae-239b-4327-a9aa-086e5e12c01a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3403,7 +3403,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":["HTTP Request"]}'
@@ -3417,9 +3417,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:43 GMT
+      - Wed, 18 Oct 2023 21:01:32 GMT
       mise-correlation-id:
-      - 8f91dfa0-b2e6-4e6b-ad3a-eba2bdb095a1
+      - 763f73e6-de50-45ff-be3f-87ebf32ebd16
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3443,10 +3443,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-13T13:57:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:58:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:59:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+      string: '{"value":[{"data":[{"timestamp":"2023-10-18T20:57:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:58:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:59:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
         Request"}]}]}'
     headers:
       api-supported-versions:
@@ -3458,9 +3458,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:43 GMT
+      - Wed, 18 Oct 2023 21:01:32 GMT
       mise-correlation-id:
-      - ac6bc155-d75f-48bf-8668-8e4d58b59df5
+      - abfd8074-cb5e-431a-84e6-b4aabe3970ed
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3483,18 +3483,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:55:42.646835Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:55:42.646835Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:33.5819664Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:33.5819664Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:44 GMT
+      - Wed, 18 Oct 2023 21:01:33 GMT
       etag:
-      - '"d9016b33-0000-0100-0000-65294c600000"'
+      - '"75002f65-0000-0100-0000-653046470000"'
       expires:
       - '-1'
       pragma:
@@ -3524,23 +3524,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A45Z&sr=b&sp=r&sig=5EkRunuNIKIQS7yGAiDJ7G9OFYi%2BLPRmUN2Fq2Cc5P0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:45.9834204","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A45Z&sr=b&sp=r&sig=A0nPi9zbpcUaKRtt7gE%2BbSCmgsrAbYMaAOWAITvDahw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:45.9833397","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A45Z&sr=b&sp=r&sig=koGeKnDWz8ewYiIGyEPxmEIj6JOK1aisxZTdZzAZ6JY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:45.9834413","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/252f1225-511a-4a14-88d0-4bde0085ed10_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A45Z&sr=b&sp=r&sig=GWeBnuzjIn8vousma0N%2B6Slagh2sJJ8GS01oykBXIBM%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:45.9834612","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/252f1225-511a-4a14-88d0-4bde0085ed10_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A45Z&sr=b&sp=r&sig=tsm7Ql9i47mllX4YtJ75CH%2FXydQbm7uZ7JVR43CAkEo%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:45.9834824","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-13T13:56:41.186Z","endDateTime":"2023-10-13T14:01:20.981Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:29.861Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ad6239e5-ee49-4305-88ea-6645fb367519":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"e7a26a4a-349e-4b8b-b3e8-84a6508e5ecd":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6989712e-0ea0-425d-be3b-2e3ced72ea8a":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/36a4d202-8039-42a1-ba21-e9fb83eef08f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A34Z&sr=b&sp=r&sig=zXqZxgoMVjLaiHm2GcT5V6hc6hWK9G57vcGbXARy7WA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:34.6968408","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/a8096ce4-58c2-42f9-bc64-cde9c9ef0a9d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A34Z&sr=b&sp=r&sig=VnnPWQUmKbOCiJW9wQvFbHNmqtZS2xafB6IU5VNHhKI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:34.6967503","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/b505d58a-4fce-49e5-9d67-c6ffce7e2408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A34Z&sr=b&sp=r&sig=TVKRLA1oUjXiI2KiB2zeZQKztkNH3TudW4L3MvTJMKA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:34.6968623","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A34Z&sr=b&sp=r&sig=fXJ7HC5CNdFBI5Pc35%2BsVrftyrUA6qVcZTKF%2B1ycn9I%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:34.6968825","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/255d75c2-9a76-426e-850b-06801b02e53c/c44da534-018d-4aa7-a502-982981d748c5_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A34Z&sr=b&sp=r&sig=B%2FtTKl5uNthv4INbH4vqDQ23sNSDuZNUeJPkOT%2BCxio%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:34.696904","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-18T20:56:35.199Z","endDateTime":"2023-10-18T21:01:11.605Z","executedDateTime":"2023-10-18T20:56:34.495Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-18T20:56:34.775Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:19.169Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4397'
+      - '4396'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:46 GMT
+      - Wed, 18 Oct 2023 21:01:34 GMT
       mise-correlation-id:
-      - 7362482e-04a8-4f1e-b768-2125826f0dca
+      - 62d8dc0a-7803-40ad-99de-2da694b20c6f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3564,10 +3564,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
+    uri: https://e00c40bc-ee7b-41c3-915e-86c335a05985.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-18T20%3A56%3A35.199Z%2F2023-10-18T21%3A01%3A11.605Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-13T13:57:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:58:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:59:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+      string: '{"value":[{"data":[{"timestamp":"2023-10-18T20:57:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:58:00.000Z","value":1.0},{"timestamp":"2023-10-18T20:59:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
         Request"}]}]}'
     headers:
       api-supported-versions:
@@ -3579,9 +3579,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:46 GMT
+      - Wed, 18 Oct 2023 21:01:35 GMT
       mise-correlation-id:
-      - cf566b26-57b8-4458-868a-22bddcf60433
+      - 8bb424ed-4f7e-4ad7-b7d1-0617dcd8dde5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_metrics.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_metrics.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:17.0295091Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:17.0295091Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:55:42.646835Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:55:42.646835Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:50 GMT
+      - Fri, 13 Oct 2023 13:56:16 GMT
       etag:
-      - '"560052a6-0000-0100-0000-652453270000"'
+      - '"d9016b33-0000-0100-0000-65294c600000"'
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:23:52 GMT
+      - Fri, 13 Oct 2023 13:56:17 GMT
       mise-correlation-id:
-      - 4830d3b1-a57f-4326-a46f-2be8fdcbf6ec
+      - 51fd7da3-1306-4404-8016-b1898166b47d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "120"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"f155be4d-d6bb-4ce7-8656-29642edd7b2c": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":
+      {"passFailMetrics": {"426c8785-b3b8-4d8e-bd1f-5473b0812f43": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "546c584f-457a-4b81-9293-f42a769136e3":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "d5f270e7-de36-494d-b217-b4803211ab9b": {"aggregate": "avg", "clientMetric":
+      "50"}, "1e39773c-d505-48c8-94f0-20d1879e8a90": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -104,28 +104,28 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:23:53.273Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:53.273Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:56:17.62Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:17.62Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1010'
+      - '1008'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:53 GMT
+      - Fri, 13 Oct 2023 13:56:17 GMT
       location:
-      - https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+      - https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - c5218776-dc0a-421c-9bef-a2ed4d7cfe52
+      - 155a041d-f96d-4068-9cb8-0cbaaf3ca477
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -143,9 +143,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:53 GMT
+      - Fri, 13 Oct 2023 13:56:17 GMT
       mise-correlation-id:
-      - f089c88e-1705-4fac-a84e-e0181ae6d0d1
+      - a7092586-7d90-41b5-bb4f-2682d98a0a7f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -273,27 +273,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A54Z&sr=b&sp=r&sig=n0NmYAKeynU69gGADZzVycrNTBIFyP8519AT6LPXaDc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:54.2953565","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A06%3A18Z&sr=b&sp=r&sig=WCd51v4OqjsTjMaqH%2BMA%2BJPtv%2FEkbx2yLuXLNrG%2FV2I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:06:18.9548606","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '557'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:54 GMT
+      - Fri, 13 Oct 2023 13:56:18 GMT
       location:
-      - https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - aeebbfc8-d672-4847-bf41-6d22e4374ef4
+      - d74aff82-a77d-4f1f-963a-06720400e4f2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -311,12 +311,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A56Z&sr=b&sp=r&sig=op1jFekj6D6%2BME5hN1xauE5drx5RjdLVyD9o8RyjbzE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:56.3556724","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A06%3A19Z&sr=b&sp=r&sig=%2Fa97t8WT98CslKEE9DiAjjbcZbJPbDD4QJc6UUK9eg0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:06:19.1831698","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:56 GMT
+      - Fri, 13 Oct 2023 13:56:19 GMT
       mise-correlation-id:
-      - 31d895b1-ff6d-4b77-b68f-1fecf567694c
+      - 3cee5085-3743-497c-b84b-c95755f39de1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -347,12 +347,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A34%3A01Z&sr=b&sp=r&sig=SgYsBZWuhfD3dSpQQhwqa%2B7A9KWyUXC5vUKbKaovHsg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:34:01.7048964","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A06%3A24Z&sr=b&sp=r&sig=9S%2Fk1g4qep5NUrNBwglNmY41pPIIVKpnq0RXADN663U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:06:24.4173449","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:01 GMT
+      - Fri, 13 Oct 2023 13:56:24 GMT
       mise-correlation-id:
-      - 23c16976-a847-4e6d-875d-3b3092d60e94
+      - 196a38d4-7756-4be9-9890-cbd72ebce9d4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -383,25 +383,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A34%3A07Z&sr=b&sp=r&sig=%2BiP79RKIXWGgsSB7yG7ZAVp0CfgbkMIirdsl0USoMNs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:34:07.8161705","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A06%3A29Z&sr=b&sp=r&sig=RF4EiKS%2FAHbzM3s7g6WG9T5Ac9W5KDcehv4azw6jrZQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:06:29.7308369","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:07 GMT
+      - Fri, 13 Oct 2023 13:56:29 GMT
       mise-correlation-id:
-      - 32e585cf-c38d-4514-80b9-ed75fc520dcb
+      - 58e2a81f-aad8-4257-817d-a0748529c766
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -419,26 +419,62 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A08Z&sr=b&sp=r&sig=O7OPVbujBeG%2BJK8gZIIHl7Ta6lmOdIl%2BJ5K1qMM4hOk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:08.0840643","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:23:53.273Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:06.52Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A06%3A34Z&sr=b&sp=r&sig=WpUuCqrtVN93elt3rYmgLMTQ8b75nT0OnPprgG5ZjdI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:06:34.9566345","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1582'
+      - '547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:08 GMT
+      - Fri, 13 Oct 2023 13:56:34 GMT
       mise-correlation-id:
-      - 8879b130-bb79-45e0-b5d9-4876b3713c00
+      - 74b268e5-0170-4a1f-8478-53ae0ce25445
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A35Z&sr=b&sp=r&sig=P2PbeaGADcKncv8yVye6BiDle%2Bk3CfphRoRXOY9aQdw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:35.2654604","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:56:17.62Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:31.69Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1579'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:56:35 GMT
+      mise-correlation-id:
+      - e8d35dea-2277-4518-82b0-ea42491eb7cf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -461,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:17.0295091Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:17.0295091Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:55:42.646835Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:55:42.646835Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:09 GMT
+      - Fri, 13 Oct 2023 13:56:36 GMT
       etag:
-      - '"560052a6-0000-0100-0000-652453270000"'
+      - '"d9016b33-0000-0100-0000-65294c600000"'
       expires:
       - '-1'
       pragma:
@@ -500,26 +536,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A10Z&sr=b&sp=r&sig=ZTCCOjvVVedWyzoZDOJVL7eut3x%2Fi22ZU2wjPfoopbc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:10.6191079","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:23:53.273Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:06.52Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A37Z&sr=b&sp=r&sig=nsM5vPsj53RP0OG12WPA%2B9xJvoPjdxEFQJx9lSkOe4M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:37.97134","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:56:17.62Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:31.69Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1592'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:10 GMT
+      - Fri, 13 Oct 2023 13:56:37 GMT
       mise-correlation-id:
-      - 2f72b568-5035-40a3-b31c-c210b6608493
+      - 69857e31-4a58-44b1-b17c-74ebf9fa1a74
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -542,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:17.0295091Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:17.0295091Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:55:42.646835Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:55:42.646835Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:12 GMT
+      - Fri, 13 Oct 2023 13:56:38 GMT
       etag:
-      - '"560052a6-0000-0100-0000-652453270000"'
+      - '"d9016b33-0000-0100-0000-65294c600000"'
       expires:
       - '-1'
       pragma:
@@ -581,9 +617,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -596,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:24:13 GMT
+      - Fri, 13 Oct 2023 13:56:40 GMT
       mise-correlation-id:
-      - 0e8e1ee2-8cbc-47e6-8fba-eb8038ba847a
+      - 127d1a3b-96f8-4c25-acda-6bdb07ce0574
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -624,27 +660,27 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A14Z&sr=b&sp=r&sig=LEUGirQYGrVx%2FKPJ7cGO%2FcvbAJs8yDy17aiaFFJXjxw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:14.7680307","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A14Z&sr=b&sp=r&sig=7t5OtJZQiVzLanoGyHyDbkzR4ZcsKrckPl5MomowBIY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:14.7678876","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A14Z&sr=b&sp=r&sig=%2FqUwP9QZ9r49yNLRzeiNANz9PEde8ICquTBtJdEpDPQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:14.768061","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:14.697Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A40Z&sr=b&sp=r&sig=xSOaySXxTn5kSRaNmE1sIQfXTev%2BHDVZvudQQXgvWEk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:40.8950366","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A40Z&sr=b&sp=r&sig=OSorAjME%2FTw9etb13KKCDJYGe7KfJGWarF73rm4RVYk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:40.8949137","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A40Z&sr=b&sp=r&sig=PK4XOBzwidTvF3iBFY4dPe64A9wG3Uu%2Bv0dUV2Yn%2BK0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:40.8950517","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:40.829Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3155'
+      - '3158'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:15 GMT
+      - Fri, 13 Oct 2023 13:56:41 GMT
       location:
-      - https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+      - https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 4b84eb9d-16d8-4827-b903-a060c555ae62
+      - 5d26f5cb-5a9a-4765-9ab1-c4e304c2495c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -662,48 +698,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A15Z&sr=b&sp=r&sig=cZk1MHpw47HJT8khydwAJHqd1ACnjjkmY2rol1Eq2Hc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:15.2902328","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A15Z&sr=b&sp=r&sig=dcT3gW%2BKZIGI%2B2aeIY1X5hgVMsD%2FZHjWcH701T6ajn4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:15.2901381","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A15Z&sr=b&sp=r&sig=wmTOyeLjZj3ndYZXxvWs%2FkQUlC2S0suZ0KNYUvdqujs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:15.2902526","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:15.132Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:15 GMT
-      mise-correlation-id:
-      - f978175e-b382-4857-959f-979951815c19
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A20Z&sr=b&sp=r&sig=DE8O%2FP5Evo7mB9i%2FMAwZvkL%2Bmumm8BmLMSFJ3w%2B0rmA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:20.6449326","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A20Z&sr=b&sp=r&sig=fMhnjp6V0NHs5OOtXfkSzJjkAPTVpOCF6efUHRmjuEo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:20.6448562","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A20Z&sr=b&sp=r&sig=h5wbeQU9lYjayLSOwMQcSNqFQAPvvfht9zWIz%2F%2FAaxE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:20.6449504","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:15.344Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A41Z&sr=b&sp=r&sig=HBSm1SwWOVmW6cle6frg2fSlQhd9nLBRq8eOqAhYMsE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:41.3206765","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A41Z&sr=b&sp=r&sig=WuXJ%2Bv%2FcAmNsNiXy1K%2BhrjGRs3IvCt6dbJqjCK1gBA4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:41.3205889","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A41Z&sr=b&sp=r&sig=OEOUvc94fRLQ5geBKbh%2BAeSnQF18q%2BE5X%2Blh%2BZagTyo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:41.3206982","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"NOTSTARTED","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:41.186Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -714,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:20 GMT
+      - Fri, 13 Oct 2023 13:56:41 GMT
       mise-correlation-id:
-      - e4ea02b1-be20-4e18-8d22-7a5b68f31a68
+      - 5e9a22d1-420f-472b-9b93-067e43ebafee
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -734,25 +734,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A25Z&sr=b&sp=r&sig=tb1zfxXPKncAObhaD9feNpNB3jgU9BVlL19puHk1Pi8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:25.9541989","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A25Z&sr=b&sp=r&sig=90KO7oaBBNF4LRnFM%2B8MpkGwZNHSPKqCpZziAycb0rQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:25.954103","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A25Z&sr=b&sp=r&sig=%2BGpVbxgPpZxfHGnIpw901UbBa3rXtso%2B8a%2Fc%2FCBhN9s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:25.9542212","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:15.344Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A46Z&sr=b&sp=r&sig=YT7R6ADMSrYZPYMfzt%2BHuawTLLVSVcXRDSnr6AXBp34%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:46.6174933","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A46Z&sr=b&sp=r&sig=nZGKj%2FK0kRpLTTYzodvwn9E1HZJqGTIFn%2Fu6hLYOxnE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:46.6174234","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A46Z&sr=b&sp=r&sig=I6Mcmf3Dx10GPfwHFi8Wf0bqCg3fUm%2BoJ%2FZtaFFcAko%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:46.6175072","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:41.346Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3206'
+      - '3207'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:25 GMT
+      - Fri, 13 Oct 2023 13:56:46 GMT
       mise-correlation-id:
-      - efd8d14a-7b4f-452f-ba55-914f4ffbc186
+      - 3fae0e14-4c28-4fa6-9c97-489a94e98ac8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -770,12 +770,156 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A31Z&sr=b&sp=r&sig=%2BW37ocKbJzgBvC04nytyTfW61G4yks%2B0RMLS9efj9wY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:31.2431876","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A31Z&sr=b&sp=r&sig=DMRkjUzU9oFbFSQGScP7lL%2B%2FAB2LOoNCLPntSqzcTF4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:31.2431214","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A31Z&sr=b&sp=r&sig=p2QY7zUCOgA4vsPJRjhydFvAXjppWOAa5fWcdolBcYg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:31.2432022","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:15.344Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A51Z&sr=b&sp=r&sig=EuXLvooLmuUE8%2B70AGWnYCNm96DQE6zSC6eXqsS7r6Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:51.9125281","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A51Z&sr=b&sp=r&sig=YIHE1ufKyipcm42ATTJJw58VmpYDsP35BCMHr2cESsk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:51.9124463","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A51Z&sr=b&sp=r&sig=Jf7dTzJV%2F5qx%2FaXYMheorRcukzPokfvMWf8ERM7zQiA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:51.9125436","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:41.346Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:56:51 GMT
+      mise-correlation-id:
+      - 8f7bb15b-329b-4955-b7ff-c44fd0591890
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A57Z&sr=b&sp=r&sig=%2F21yVbHu6J5WWzT25t2fQUu0OIbwD9tLEbyyaXG7Itc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:57.1596598","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A57Z&sr=b&sp=r&sig=vPcEsD64n2Ayb34xaOGB2EE3Id8cu1LSfLrvK7S4u2k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:56:57.159587","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A56%3A57Z&sr=b&sp=r&sig=tMUe5FCcJs2k6taTtJkvrwaT44hPeEyYbI9bhrflYGQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:56:57.1596758","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:41.346Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:56:57 GMT
+      mise-correlation-id:
+      - a594cf91-a97c-458c-92ae-ae2ba6073f1d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A02Z&sr=b&sp=r&sig=5PZEXQ4HeOY4oHO0P4I%2FP%2BM8edgw9Ja9XmcDmH3sMqs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:02.3923808","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A02Z&sr=b&sp=r&sig=MdR4A8eATko4%2FgX0hUsvzGFHd6Y%2FfuNbMI3RTYoxeyY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:02.3922685","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A02Z&sr=b&sp=r&sig=aegXVp7RFrPuEpUBKmEzYJOzOXv7hoi6yd22I%2FGX6SY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:02.3924036","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:41.346Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3207'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:57:02 GMT
+      mise-correlation-id:
+      - 3427215b-40a1-420e-89e4-aef170ae2b33
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A07Z&sr=b&sp=r&sig=af1tEb50yYEf29beE19m0gVmNltKfSaQHdAfkFR7%2BGk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:07.6470765","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A07Z&sr=b&sp=r&sig=oPo8AGZfkyXM0xBbKHIfdqcEru6nqP1UQibJhF55Ti4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:07.6469122","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A07Z&sr=b&sp=r&sig=EUGBH3yw%2FTGmdy6FzON7JG8HVZ3nH4iV4Y65%2FqOUVTk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:07.6471058","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:41.346Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:57:07 GMT
+      mise-correlation-id:
+      - 864c29c3-ffd0-46d9-b971-3e4a2f56a8b3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A12Z&sr=b&sp=r&sig=rjj9hEYyu1sqx8fC5Oe4PYZUnHo%2F%2FR3B1G4LYIivxCQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:12.8829528","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A12Z&sr=b&sp=r&sig=rr9wgr0KDX4s8XP5oDvgYdpFqRfwAZ64zlrTD4gUtQI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:12.8828707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A12Z&sr=b&sp=r&sig=41w1MvlGZBoawe%2FB8ohAQLdCJLaCaSATn%2B9oJCCKfUg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:12.8829685","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:41.346Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -786,9 +930,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:31 GMT
+      - Fri, 13 Oct 2023 13:57:12 GMT
       mise-correlation-id:
-      - 0fa6dc20-4902-478f-971b-a724bf73e75c
+      - a3fc4efa-2a3b-4217-bfa7-afcbea5cfa82
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -806,12 +950,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A36Z&sr=b&sp=r&sig=JUfy0BDWEsJ49F74oFqNY5fRmAtjCZSeVLXhyeIUPLo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:36.5545621","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A36Z&sr=b&sp=r&sig=M9gC%2F3NjRFrojC7FdzgsQykdfUEyFBJGWt0WVbf0%2BJM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:36.5544921","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A36Z&sr=b&sp=r&sig=JUasXlQ6OxfKEfe01nMvHQWjBdNFGab3vTam4%2FhcUbM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:36.5545783","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:15.344Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A18Z&sr=b&sp=r&sig=4dE%2BCilqAlpISK4zGYza%2FT1bPcdzB1L27bNBqrTE87E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:18.1275703","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A18Z&sr=b&sp=r&sig=jaBgnyng1ZlRvcdOOfnA5CCAlOFHqNbFO1d6Lvs%2Fo7s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:18.1274705","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A18Z&sr=b&sp=r&sig=DTaCV24hd2Jd33ZQwAlv7CaX7NImJ5FWOmVO19Mx9IY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:18.1275947","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:41.346Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -822,9 +966,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:36 GMT
+      - Fri, 13 Oct 2023 13:57:18 GMT
       mise-correlation-id:
-      - e705e0c8-0195-4884-96c8-f6a72adcccba
+      - ca929144-fbad-4d31-9761-7552f0115c32
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -842,84 +986,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A41Z&sr=b&sp=r&sig=wCLljhLrQy4C5ogYTzUooahyolY2Fc0RYs8u75si5nU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:41.8418063","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A41Z&sr=b&sp=r&sig=tVGyAPROFSlT%2FT6ZZKsgx5xQGL6QhQqopK%2FzVW2vyBU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:41.8417114","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A41Z&sr=b&sp=r&sig=X6XDVrGb638GiJQS1X6qJMgMlUDUgVoB%2FXh8Np8GvqE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:41.8418291","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:15.344Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:41 GMT
-      mise-correlation-id:
-      - 21d64cb4-496b-44ab-a2c2-4165606683c9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A47Z&sr=b&sp=r&sig=rGFvfq0gAZIRnvUEKp9Qg%2FIAdh8AhVjmzqm92dLqGFI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:47.127966","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A47Z&sr=b&sp=r&sig=mKO94coxreGgjwW0BoQ8%2FpiI47mpi8xg1aJL00XOS5M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:47.1278943","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A47Z&sr=b&sp=r&sig=UbyYKmuKQC%2B0UFoBBgysYujJebXQ0vB6yZ%2BoLR4%2BeeM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:47.1279797","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:15.344Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:47 GMT
-      mise-correlation-id:
-      - a679da58-780c-4960-9452-615831d6d098
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A52Z&sr=b&sp=r&sig=viq4aiGmJjyJDZyDw3GkD1TxzZeRsKJU%2FjB%2BIb87d7U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:52.411756","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A52Z&sr=b&sp=r&sig=xKUYc6zKrEWU2HimC1ciyyeivKwDpJ4ze5aZjtQm8DY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:52.4116699","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A52Z&sr=b&sp=r&sig=58OBgXw5ZJizqvYBNqwtwgZjJiNAxlxKQbsjamG1qlQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:52.4117768","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:15.344Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A23Z&sr=b&sp=r&sig=a47s7bqLR8lgiFdrnhZw969jKGErTiqXJyalMAJZVtE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:23.4101704","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A23Z&sr=b&sp=r&sig=2OlSxLRSmaNqC4n%2Bv8x8J744Q9hJDZYhs39MLDbf3b0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:23.410063","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A23Z&sr=b&sp=r&sig=bnGk9ntOJODofvnzHT03Nm0C8%2FeJNlcQLd0t2YXezGw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:23.4101947","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:56:41.346Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -930,9 +1002,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:52 GMT
+      - Fri, 13 Oct 2023 13:57:23 GMT
       mise-correlation-id:
-      - a73ebab7-2da2-4483-b34a-aaaf10d34b06
+      - 8f250853-b815-4e5b-8c9f-3158e6ead97e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -950,12 +1022,120 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A57Z&sr=b&sp=r&sig=5edLpGGa8hGjxD9OS51MAUKhXte97Kp6R1azs7RFsEk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:57.7242448","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A57Z&sr=b&sp=r&sig=Ymm6s%2FID%2F8jHoWt3ulEcnXYPxXJH4EM37gJhOhBYUiw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:57.724167","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A57Z&sr=b&sp=r&sig=qncj0wn1%2FfhKAtcdTkfvz%2FRbhzQwTkGUntQDcGuw8sw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:57.7242588","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:15.344Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A28Z&sr=b&sp=r&sig=ooM0cRuozpkE7dfr9DHd6Jo3WzhJRRnQEnrFKBSZE0M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:28.6832607","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A28Z&sr=b&sp=r&sig=e3FuJwEBQa24ixJOy7ic1FYRl5I68iADYMX6kba9CJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:28.6831988","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A28Z&sr=b&sp=r&sig=tJAhvzMfKUJSSZfUNAkcL12VyznvNmeZCC6CzgWf69I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:28.6832758","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:28.032Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:57:28 GMT
+      mise-correlation-id:
+      - 46b735ed-68f7-43a4-9614-0dc02417699f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A33Z&sr=b&sp=r&sig=Abe2cyKMPNe49RMpu05%2FNIiygNTYCpmAXx5WyzFBdvg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:33.9509252","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A33Z&sr=b&sp=r&sig=qb%2BRnA7vog3a2BDZEdvfLd9qYnZFG2m5y40l9wqOiFw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:33.9508639","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A33Z&sr=b&sp=r&sig=0LBNpNwFbq4UGtLS3fpnh72M8Xymm6cct4Nv1PK1HZ8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:33.9509409","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:57:33 GMT
+      mise-correlation-id:
+      - fc03d135-2e81-430b-8e4e-ff18195ef9b3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A39Z&sr=b&sp=r&sig=4%2FIB1snOoMUiBsV4rAwQe8c%2BWQcK3c2eOeNmv1v7738%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:39.2331734","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A39Z&sr=b&sp=r&sig=U4aU44Xc%2BKLp9YlZItF07GA8ZIOHe2TidcQOu%2BCKccI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:39.2330824","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A39Z&sr=b&sp=r&sig=vFX3PhxRUL181vf7K3QhwdSZh8A5gCm9J5vYX8adsAM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:39.2331978","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:57:39 GMT
+      mise-correlation-id:
+      - fa726099-5272-48c2-9491-f7ab2df17fd9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A44Z&sr=b&sp=r&sig=kpsQX%2B1U%2FORdN4G1rmrR3H0WFKkJpVlkI%2F%2Fsczd3PYI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:44.4775185","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A44Z&sr=b&sp=r&sig=ZccqbsdU0gFCLZG2i4rNBH3tq25VqD%2BL3CQyXLtxfYg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:44.4774425","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A44Z&sr=b&sp=r&sig=Om0A6T3LNg5EMPzNCOdCt0RyGndPIjlQIgs2lA0Doek%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:44.4775327","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -966,9 +1146,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:57 GMT
+      - Fri, 13 Oct 2023 13:57:44 GMT
       mise-correlation-id:
-      - 05c5677f-8c34-45cd-a5ff-b78e81de4d4a
+      - 60b2b24e-ad53-43c6-ad6b-fba7ded33fd6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -986,25 +1166,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A03Z&sr=b&sp=r&sig=v5GHuq6eJidFo5W5WeZuMcLxwQ6cOGfP8LLmY8xumww%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:03.0794474","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A03Z&sr=b&sp=r&sig=CZzWMeKqcgosHsq60Ku1IaGVwuI5VRHlYJ7peMELB10%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:03.0793644","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A03Z&sr=b&sp=r&sig=oK%2F0OetvDi72Wk2TNQl4EzRcQvuN%2FlzQsk9SNGudUgg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:03.0794665","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A49Z&sr=b&sp=r&sig=FjFwb0Dr4u%2BGAjmAQNKOhrMbCt479htOmiAUxlmhHZQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:49.7384906","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A49Z&sr=b&sp=r&sig=xU5N3yfr2XI36h12roXLG09ais6YIIpRc9mSY1Lr0us%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:49.7383853","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A49Z&sr=b&sp=r&sig=MFFK7AAw7Hq6qnv0gLG6JHlrx51LK2OkEmEYBNLvL4A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:49.7385156","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3197'
+      - '3196'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:03 GMT
+      - Fri, 13 Oct 2023 13:57:49 GMT
       mise-correlation-id:
-      - 53c694a2-8027-49bf-a114-e68c0e7c8157
+      - e56403cf-d64f-4cc8-aab6-a54d7bed5be8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1022,120 +1202,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A08Z&sr=b&sp=r&sig=VIpVta9TyeIKUiZPPznStfjnY7jBxWiOZatxtYH6r4w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:08.3782374","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A08Z&sr=b&sp=r&sig=fk7MHrp3Q1gEa6ZjHF1J%2BD3gzpLvj7NxFtXboPzqk6U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:08.3781557","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A08Z&sr=b&sp=r&sig=ntdzyJrr5HjHb0TJoEDEqcksgk4K0qIGbunr4dgQgsc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:08.3782576","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3195'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:08 GMT
-      mise-correlation-id:
-      - bb6a1e96-27c9-4a5a-9c9e-5b29c6e9ac18
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A13Z&sr=b&sp=r&sig=FqN1pjarQ4NuuTOb0b9%2FR4ZarSS1y%2FVLS0SvemnrzL0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:13.6921055","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A13Z&sr=b&sp=r&sig=9Yxa1LUR1phBe5Km7ijuWiiIRkHt5sPuikv1TxCrNNY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:13.6920221","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A13Z&sr=b&sp=r&sig=ol9m%2FjastVza75iPzq8qpnp72gcVY2o8liEFBsyH6sc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:13.6921229","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:13 GMT
-      mise-correlation-id:
-      - 7d6e6d09-8a93-455a-83e6-d3d4b79386fe
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A18Z&sr=b&sp=r&sig=rO14t6pWCTdrI8OzMeMR1IhpvrAiNddLvDatxTxzy3M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:18.976584","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A18Z&sr=b&sp=r&sig=F0H7ywXoyujWQF8MRE03tkhQewexM100RQuk3rcb6bk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:18.9765012","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A18Z&sr=b&sp=r&sig=miVm%2Botp5gMJtAxMaMk4kYet40SEfYNqNjx2x9iiXqU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:18.9765995","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:18 GMT
-      mise-correlation-id:
-      - 10ed8d08-9baa-4516-8386-7ef7472f5088
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A24Z&sr=b&sp=r&sig=QjOKUIdhp%2BJ%2BWbxBV9MfNnYZsVAC67fVp1A234dzOpo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:24.2544964","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A24Z&sr=b&sp=r&sig=aQyjNOUnHfFbPaVIiY%2FjvgeZc5XFpMJMTUdf6d9tnAg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:24.254404","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A24Z&sr=b&sp=r&sig=ZEaL7agu4DLeDMmemi5eGMVhstOskt2btpo7Ad4mqMo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:24.2545171","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A54Z&sr=b&sp=r&sig=e8AdULAUugrR9DXKkzOOtcwVg3gdBsTlzxs8h%2Fc0BF0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:54.9854455","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A54Z&sr=b&sp=r&sig=CGh3iCjwoH2qZ7Pkw4iDDgtm7DqZpcPf2RVRYVQy6Q4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:54.9853596","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A54Z&sr=b&sp=r&sig=V2V07DNGu6yiKQy8VIjSxjJm7syL%2FoaguEvsDgbMN2Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:54.9854658","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1146,9 +1218,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:24 GMT
+      - Fri, 13 Oct 2023 13:57:54 GMT
       mise-correlation-id:
-      - 7b79aafb-faf5-4530-8219-2b4e38c42787
+      - 4f197258-08d1-48fe-b163-c49357ceca95
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1166,948 +1238,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A29Z&sr=b&sp=r&sig=IqriW8xyN1rj%2FuTKnBhiDmAB0%2BkyI%2BX%2B8VI0N1b%2FgxM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:29.5455839","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A29Z&sr=b&sp=r&sig=qGEJSGk7YAzGWt5%2BWetHMHngZO1NwnDHXVzgHl%2Fn8us%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:29.5454922","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A29Z&sr=b&sp=r&sig=XZssaXV08jo%2BmxXGteLfNwCgYJRTwe12MqN89eHvh1k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:29.5456008","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3209'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:29 GMT
-      mise-correlation-id:
-      - 9fa5378a-6385-4399-8ad2-210796964b44
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A34Z&sr=b&sp=r&sig=tX6y78CV%2Bd9acfRpYFLE%2B41dVrhuOkfgNDUeJXdiLwU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:34.8989174","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A34Z&sr=b&sp=r&sig=nz1Qn8AiDxoklsOaseykt8qD8tTzt%2F8PQjnwwyfI9N8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:34.8988331","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A34Z&sr=b&sp=r&sig=xZzIs6sr7ts0QhtuCy0x7UyCqoBmzIKdb%2Bl1M86KheU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:34.8989377","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:34 GMT
-      mise-correlation-id:
-      - c83c73d9-e4d7-4cdb-b885-3f5bccda2023
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A40Z&sr=b&sp=r&sig=WpuE9mW%2B3%2B1EjXDqwVIfsgPUzYEVm0wvaPGUrdbihaE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:40.2179453","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A40Z&sr=b&sp=r&sig=aUnEIGZqcmfMeeNtphdq7hCsnpQGOmqUYsoGXfWzslc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:40.2178571","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A40Z&sr=b&sp=r&sig=MffAOoHBf1QHkCGCWDyJEP6VN6bdbag%2FccP5vdrm%2Fbw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:40.2179655","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:40 GMT
-      mise-correlation-id:
-      - 2231ad18-aba2-431b-be0b-71cc4c70a74a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A45Z&sr=b&sp=r&sig=%2BXT644RNTrCSryutqlL46jx%2FX198nEvAR67dTxLP300%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:45.5371862","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A45Z&sr=b&sp=r&sig=%2F01qFFz1j1VfHZGwWJ8YjtdYOkl2oPbq8QaSk1fH7xQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:45.5370881","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A45Z&sr=b&sp=r&sig=4tiAeQ3CFr%2FLAilr%2BbWLbAzjv3lwu1C0Aw1z71xDte8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:45.5372017","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:45 GMT
-      mise-correlation-id:
-      - b8a11ad8-1d2a-41a2-a6a6-1f04a308dcb0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A50Z&sr=b&sp=r&sig=mlWWeXVKReZ71lDB7NKIlKiqu%2BYKmwNcp4HG0rjKyBM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:50.8656347","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A50Z&sr=b&sp=r&sig=QqiB86GqeCxKYoNEjAx19Gwh9cMXzJiblda%2BC1nbOdE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:50.8655399","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A50Z&sr=b&sp=r&sig=7ruIKaZIRxID8s1x%2FSTOFG9gUo%2FxuXdmQIDCQsIu1vY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:50.8656568","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:50 GMT
-      mise-correlation-id:
-      - 7be1a9bf-38e2-4747-9002-90ec0582a2c8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A56Z&sr=b&sp=r&sig=OD2H1Z84bIWTiAztoRNHgLad%2FD3UXtJRpe8XyVtriK0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:56.1390214","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A56Z&sr=b&sp=r&sig=P7GN6svkakZwrxpaZhvhNtUtw0XYHzcQ3YeFuWlFBRg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:56.1389397","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A56Z&sr=b&sp=r&sig=vGy0TW6FhgbpBxArtzwIMrtqmbSUXksKaEGnyPDO8qU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:56.1390356","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3195'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:56 GMT
-      mise-correlation-id:
-      - 85e6d449-95f7-473e-a303-d7ea6e66523f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A01Z&sr=b&sp=r&sig=ax4AwONfnntCq%2Fq%2B4zHn1t%2FoHgiUvZgW%2Fu46AWs8nMk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:01.4164151","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A01Z&sr=b&sp=r&sig=02yzvKTjxX%2B8s9eNRT2MP%2B3JHjnmCfNYYm8wCo4bS0o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:01.4163231","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A01Z&sr=b&sp=r&sig=0H%2FGfLt%2FzDAss7S7mcr%2FUV%2FuU5qdjpVzuOWjvD%2B29ic%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:01.4164374","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3215'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:01 GMT
-      mise-correlation-id:
-      - 274a8def-5e5c-43de-8fcc-52d9d77fc9a5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A06Z&sr=b&sp=r&sig=1r3I6%2B7lrN6yUbLuhsfGskZSVZzNnY4ZEiULEv2%2FdTo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:06.7404738","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A06Z&sr=b&sp=r&sig=GGRouBmj5jZ9XJ7%2Fe2%2FN0%2B80coN%2B0%2F71OUcbuUw5OXM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:06.7403814","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A06Z&sr=b&sp=r&sig=x4dHIbpE6xDMVOtiecLReclGOytAPFsnsZ36lcaOdcE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:06.7404987","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3207'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:06 GMT
-      mise-correlation-id:
-      - 7624398d-cf46-4342-ba5c-dbe77b12cc74
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A12Z&sr=b&sp=r&sig=3tWlB%2B2pzpiI8DrxPgjO%2BYZhpXn9%2Bu0nOv8qMEC8KUM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:12.0653086","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A12Z&sr=b&sp=r&sig=%2Fi93secxfQV71ZRB6LJxQ4nZFHuXmYrKhlLnlWa3IgM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:12.0652265","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A12Z&sr=b&sp=r&sig=JWjOSpMaMjsZN%2BjVTzpoYD5B2LH8jHUC0HgMVZs3jfw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:12.0653255","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:12 GMT
-      mise-correlation-id:
-      - a1ef686a-2f0f-4074-9030-0687826b9928
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A17Z&sr=b&sp=r&sig=Xty33ccFAvyfkZGYvvP8TI2dYmmsBl862173yZDOD0s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:17.3830777","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A17Z&sr=b&sp=r&sig=SXoTNLcHEt8R%2Fx5rqkw%2Bjk9mzd9jStsPSVDztjbEOUA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:17.3830028","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A17Z&sr=b&sp=r&sig=x5qbR9WW%2FcIEXpD25q3K%2B7JKQLa6IPcSKVG0AofRPDA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:17.3830939","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:17 GMT
-      mise-correlation-id:
-      - 749973ac-e58c-426a-bc2f-cc193a75fb5f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A22Z&sr=b&sp=r&sig=TyUC6Z8hbiLq2VXhHo8MDFPLK90udQ98kBOwPLvwwlo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:22.7102501","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A22Z&sr=b&sp=r&sig=SSmpAYKngXz9mtJ0%2BR%2BW29FjoMDl2rD63BEpsHZPtgE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:22.710161","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A22Z&sr=b&sp=r&sig=bVsZJjlHfY50mN5pR4%2FTLaik4oVCThnwNAKQu3uUFMc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:22.7102714","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:22 GMT
-      mise-correlation-id:
-      - efaa92c3-b174-43b6-8130-079ffa51e0ae
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A28Z&sr=b&sp=r&sig=4eFBesn1hLW2Glt5JBUGII9xMP5XwNGnpRBIfVzt7a0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:28.0350979","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A28Z&sr=b&sp=r&sig=CBa4%2BS0GRRh8r6niun65hWvbw4So2jesaI5grJbVBVE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:28.0350244","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A28Z&sr=b&sp=r&sig=7jx1zKUfXO4XAASOzpg6pl%2FZNBulObTpjHdLwe4%2BDMo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:28.0351122","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:28 GMT
-      mise-correlation-id:
-      - f9955d70-69ff-4b70-bd41-b69c1e21a77a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A33Z&sr=b&sp=r&sig=KcutpUZCEAULPrWaPRZEsnj0ty%2FWmhRyshFes%2BuaAE8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:33.3610531","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A33Z&sr=b&sp=r&sig=NrPy0FKR28qpAIsEi8j90FVh7LccIsYi4i689OQpqBw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:33.3609623","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A33Z&sr=b&sp=r&sig=Y0dnFFLrowCBNVz%2FMMX6Ol2mmu0v4WaJTDyYA2LY30E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:33.361074","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:33 GMT
-      mise-correlation-id:
-      - a3e44d46-b849-4abc-8951-c77370519b84
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A38Z&sr=b&sp=r&sig=hgr1pAeLjytvtpYxjWlLj5%2F7rYI%2FVBgLsbJM9cwvcVU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:38.6415241","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A38Z&sr=b&sp=r&sig=mCsyuNTWLfyQiw3PQ3jIvMZUIRI4zt5hn6PI7B3uBmA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:38.641422","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A38Z&sr=b&sp=r&sig=pgpw68qMfwfxBsjL7DxBzq6kvJJH%2BZdCmkYM%2B3Et8ps%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:38.6415466","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:38 GMT
-      mise-correlation-id:
-      - 04f00985-13da-48af-8633-b453df817175
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A44Z&sr=b&sp=r&sig=yoQeHeLCjGUdlhPjtQitccnsvGqv3mMzjZsNFVIJptM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:44.0328785","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A44Z&sr=b&sp=r&sig=tdvTtUHglt3knpJm8Esm51GMmm1pS870qb8eLfDHOOU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:44.0328042","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A44Z&sr=b&sp=r&sig=HrQiOh337DbN7S9nuA4495Gtq0cw%2FPK4MrW7BqFbdYc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:44.0328967","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3195'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:44 GMT
-      mise-correlation-id:
-      - be91ce7a-f1fb-4741-9622-4590fabd8eab
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A49Z&sr=b&sp=r&sig=9HNHnvYmLJmKe%2BcGZJ9qh9UBJGzA%2Fbau190atS%2F73h4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:49.3250037","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A49Z&sr=b&sp=r&sig=sX53mE91%2B5vvDnZxjMjOG7nElHopRVVsHszuLInKUMs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:49.3249173","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A49Z&sr=b&sp=r&sig=eUor%2Bx6VPISZefV%2Bnlopmg8Ms%2BydUZjm59Eb6mWMIgc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:49.325025","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:49 GMT
-      mise-correlation-id:
-      - 6dd27419-2aa6-4496-a1b2-35e01efe0655
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A54Z&sr=b&sp=r&sig=gV0ZyqnrYHbnptX%2B2kLZtChxmPDOpgpJKYJd2EiTN3E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:54.6594824","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A54Z&sr=b&sp=r&sig=6Kz3XDjRBUY8HFlgBYCDy71H98cQuNLVXdt34mES4p0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:54.6594109","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A54Z&sr=b&sp=r&sig=6%2FakahXrFl3kQXKqnTtdtaNJV9yQ%2B2QUB1wcW2TulMA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:54.6594986","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:54 GMT
-      mise-correlation-id:
-      - 3cd9cd85-e4ad-43ed-880e-1d86563ed5ab
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A00Z&sr=b&sp=r&sig=%2BY3tFc9d0esRWwHmwh76VCRTuI2aMWmPGGbHFtml9rA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:00.0056742","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A00Z&sr=b&sp=r&sig=l6fm2yE%2FfMRHzk8SPgGBvr8ISHtNNOESv3M1jVVEkL8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:00.0055511","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A00Z&sr=b&sp=r&sig=DXO9V%2F71ZzqZDEWc3QGqGQoGIE2OmtH5pO6m1ICqass%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:00.0056948","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:27:00 GMT
-      mise-correlation-id:
-      - a590fb57-4309-4b60-8692-99fd5af2abae
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A05Z&sr=b&sp=r&sig=H%2FerKWHVySm41azw2rOFLjxOI3gl%2FiX4crFMiRaxcQI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:05.3066169","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A05Z&sr=b&sp=r&sig=S385OEsnHdqPIXvZs%2FSISoZPSnukcXm1Kjr5tlHzANc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:05.3065337","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A05Z&sr=b&sp=r&sig=lvgRx1LOVHZfSTjSAsq14WMLMz5ix1gnoa4WSZZbOXA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:05.3066375","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:27:05 GMT
-      mise-correlation-id:
-      - 8703bc64-60eb-473f-b108-6f0941f203c1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A10Z&sr=b&sp=r&sig=ERmkN52hcoIFKSF6jFowMqEXBxB%2BIq%2F4SUFBg129ucY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:10.6385468","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A10Z&sr=b&sp=r&sig=FM%2BeDlbQWUpsVRiCHlR9xiNtCPSzOXuguJpWMFiE23c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:10.6384539","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A10Z&sr=b&sp=r&sig=kvK3Grs%2F4b1xW93Mih1YumnN2HlZtBqo6HkWs7AF9sg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:10.6385695","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:27:10 GMT
-      mise-correlation-id:
-      - f8002582-2316-46eb-9e97-fe526f4b5efc
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A15Z&sr=b&sp=r&sig=5QiuxjZff%2FI62syOaQ1bpVxQJx9rET9jM5VdUf98LF0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:15.961066","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A15Z&sr=b&sp=r&sig=Zscy%2FXs8SCe7OCL6Jk8ZUOoXffU5FT0WEv%2B4nrMlVjM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:15.9609902","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A15Z&sr=b&sp=r&sig=2yC43wo%2FKNENb15ktOMfghuQG2KmuJHF8OnHE9zow4o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:15.9610805","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:27:15 GMT
-      mise-correlation-id:
-      - 3aedeb2c-7a56-4bbc-83d5-e12679984ce0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A21Z&sr=b&sp=r&sig=HDJQnJ2XSXt4FxUy7o1HsyWnDiwI%2Bag8eC3x7zkFFXY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:21.2836944","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A21Z&sr=b&sp=r&sig=U6APH0WeczRr373GRMrpmppukNqA7pzj3qGJ8ek2qf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:21.2836007","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A21Z&sr=b&sp=r&sig=7YjKr8FEeHO7%2B3OlpvOvPJwWPkJWu%2FMWiT9PAVpY6ME%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:21.2837189","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:27:21 GMT
-      mise-correlation-id:
-      - 05fcb2be-7d6b-44b6-83c5-bb89a95cfe37
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A26Z&sr=b&sp=r&sig=zOBeuUWTMR3pvNImxpEFKLVGehldTZhbghzuDQnM%2BW0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:26.6440849","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A26Z&sr=b&sp=r&sig=9u3bMyE2jv8E5N%2BsjVG7ngSwxpszmZqfIKvI%2BWPd39U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:26.6439992","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A26Z&sr=b&sp=r&sig=8jXSboL6yl5I%2BVW1ZIsf10dai8BbkkJdMGZtJ1OrNDA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:26.6441063","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:27:26 GMT
-      mise-correlation-id:
-      - 80408d40-ecf9-4bde-9dd9-c304a6a2cb7a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A31Z&sr=b&sp=r&sig=g7qXB4XAvmW04QWJqA%2FtOih03n8DRlABbrwYEffuc4E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:31.921939","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A31Z&sr=b&sp=r&sig=JARh7qBVuqrWFRkbNFbnPIYUAuDT9HbQolC4CVL07as%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:31.9218541","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A31Z&sr=b&sp=r&sig=jHzXLUQlV9U2wGCmfBOuUNLImaYlTpCeZsuvHoKq1tw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:31.921959","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:27:31 GMT
-      mise-correlation-id:
-      - 69766336-2ffa-44c3-a212-c6566ab7a079
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A37Z&sr=b&sp=r&sig=TXSvJapRsiVm9NNHgRNV5cZkeKQvkt1QQkNZl%2BHA%2FfE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:37.2682355","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A37Z&sr=b&sp=r&sig=uLxRkujrl29cPReKzauW1Il5vQYiBCcvDTlNQkWpRL0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:37.268139","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A37Z&sr=b&sp=r&sig=gR%2BuXzJij9W8EyK9%2Bvv%2F%2BXzDQbrO2CLtEMhhI67L%2B1g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:37.2682502","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:27:37 GMT
-      mise-correlation-id:
-      - 259f2982-5a9d-463a-8c7f-3081f7243762
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A42Z&sr=b&sp=r&sig=rLgzas86E9fsgzuQFb%2BBclgJNbIG1vV0bJl3CPsRp7k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:42.5819072","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A42Z&sr=b&sp=r&sig=dgd%2BWu4CC0h8kgo1WWYWqJQvgceZLmUlQmRqGQDjICg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:42.5817956","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A42Z&sr=b&sp=r&sig=Cm9TN1MB6z85VaAF64YFuBajxFMz7mBt%2BeXDJfTOFXE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:42.5819305","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:27:42 GMT
-      mise-correlation-id:
-      - 3d6758c4-be6f-4e59-a57c-fa7f206550da
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A47Z&sr=b&sp=r&sig=d77sBJZh%2BsrFNuShavy%2FGn8ZlYwyh0SnrKJ6KxQGR6Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:47.9112973","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A47Z&sr=b&sp=r&sig=tFwJNtgU1V5TJd4RGNMegsWEuVZEfzAdVP%2FJHOPpsxM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:47.911216","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A47Z&sr=b&sp=r&sig=TBaP%2FLWDwuMz%2BveBGoGegnpPrqtNa1nz4OoG8ZAYEFQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:47.9113125","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A00Z&sr=b&sp=r&sig=K8LVPW%2FoKyyRa1eEUeofsWKrXkG6QVMLi700w5jxwlo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:00.2278774","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A00Z&sr=b&sp=r&sig=9GWKYxv0v9ogEnFN7TkXzFQLYU104i0MKVuw8cqb1LE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:00.2277908","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A00Z&sr=b&sp=r&sig=zRUsPIAAQyUO%2FMX0Z6p3GeHW7kM%2BbQAog7NCDYJg%2Bls%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:00.2278997","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2118,9 +1254,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:47 GMT
+      - Fri, 13 Oct 2023 13:58:00 GMT
       mise-correlation-id:
-      - b8e354aa-a950-4520-9402-b13e54d68fa7
+      - e98867d1-5cfe-4245-9b22-02f140cdf6ee
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2138,156 +1274,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A53Z&sr=b&sp=r&sig=P6UWSU%2BTppyfnfB9CEgBMEGYqTTVTIPqpBLVhR6RdsY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:53.1877384","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A53Z&sr=b&sp=r&sig=pScOK4at7hkLtwVm9Mm2Xk5BZC%2FdiHYcBjqZg%2F76cUo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:53.1876681","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A53Z&sr=b&sp=r&sig=ktIbL6pTuhRSVUauUzHfjI1Ce%2BbyUBqIZYZV0%2Bhje0E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:53.1877535","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:27:53 GMT
-      mise-correlation-id:
-      - 52a351d7-e158-470b-b9da-f35fa55f54e2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A58Z&sr=b&sp=r&sig=B2o034emO1qnTn95i55NfPuTZ%2FLFxgXztqKWLF1JoEc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:58.4859815","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A58Z&sr=b&sp=r&sig=fIdPFuSopURw2c4Th0eV0xyZSoHz6WspFkBf1nk2xsA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:58.4858712","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A58Z&sr=b&sp=r&sig=0D3BZYxrOnASJ9D6UMPCwIAIrSQUFlXOiJFi6qWPx0A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:58.4860094","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3195'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:27:58 GMT
-      mise-correlation-id:
-      - fb80ffb5-1149-4f4e-a498-8af7296cd5cf
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A03Z&sr=b&sp=r&sig=PkT96l8KUF1A01bK43N2YctOhBLYfmIVYl%2F9mgjeAjE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:03.7694827","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A03Z&sr=b&sp=r&sig=dWLHH6YE5PPAk3E3bs30XM2uuTmnc8WyZnUorI%2FlpTA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:03.7693913","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A03Z&sr=b&sp=r&sig=rCiJTrujOWduP0VsfpvEkKrdYn%2BGnvuGfauGIx%2B%2Bjt4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:03.7694973","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:28:03 GMT
-      mise-correlation-id:
-      - da9d7dae-0afd-498c-872f-063a321f74a1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A09Z&sr=b&sp=r&sig=obuEGi9x%2Bv9FajEJO7%2Bq0LaPnVqrHaJzSpz1OBCTv54%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:09.0460928","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A09Z&sr=b&sp=r&sig=l8Fh%2F5xtB2xUuhEErftkWQCcD%2B%2F3Kf7DLjyN7tKibTQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:09.0460152","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A09Z&sr=b&sp=r&sig=MpyOoElOhRWeaDoGdZePvwjGgyQJCtQ60FyCCPZsJsg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:09.0461074","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:28:09 GMT
-      mise-correlation-id:
-      - 51df4eb9-4c66-4c6d-bffd-0b36989db8aa
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A14Z&sr=b&sp=r&sig=G1yXOLJzRNBoryHApDnGbIHRdVMREjMZWqi3aELBf8A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:14.3047976","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A14Z&sr=b&sp=r&sig=hnokeb%2BhrM3AkwyZnQRzKomi1m1e8%2Bunx%2Fh7phHm8oY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:14.304729","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A14Z&sr=b&sp=r&sig=Kn%2BZpeyE62GDEg9V63VeoG5sc0ZwFCqpZ0xlp4c%2ByyQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:14.3048121","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A05Z&sr=b&sp=r&sig=8lEpDps1XnRfsrVtIRyFtqPv9a71kYK%2Bvwe5K5pguwQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:05.5145725","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A05Z&sr=b&sp=r&sig=jyUPZq5t2tlHUY1BS9EW%2FVbuKCaGt%2FYUvUcvy8OdIN8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:05.5144263","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A05Z&sr=b&sp=r&sig=aU6aylksRU4SAiRlKuEMK9e4%2FgkQfShxTdzscgQ4aGY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:05.5145934","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2298,9 +1290,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:14 GMT
+      - Fri, 13 Oct 2023 13:58:05 GMT
       mise-correlation-id:
-      - 5b6d83a8-22ed-423b-bfc4-e459092b0d6c
+      - 52a9d868-d86e-4a84-b1ba-41db7199fd6f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2318,25 +1310,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A19Z&sr=b&sp=r&sig=gg0UnREdnREEku%2BE4NRnf8Md%2Fr97FcdbXRC76rPEEJ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:19.6302342","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A19Z&sr=b&sp=r&sig=fpZr2%2FWwt40NdNpQcXpVr5DNeXD4AoQIYFIE1IjcqqM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:19.6301465","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A19Z&sr=b&sp=r&sig=ftL5sp6awY%2FtXnhQlmK4judSONI%2BVQFqfYYN1te9mZ0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:19.6302543","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A10Z&sr=b&sp=r&sig=m0HzEMRztO1YBSB06PkT9x7eLpbAHNBmTJDDcV1%2B7Kw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:10.8304144","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A10Z&sr=b&sp=r&sig=p00lTYNgwF4b9c6jbYlFZhICiLkEvj%2FnQgXHbcfvgeQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:10.8303291","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A10Z&sr=b&sp=r&sig=WzglcOqDwXzJ7gG2uwGcPEp6cGPnbzBD0MwG4fYGk%2Fw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:10.8304372","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3203'
+      - '3200'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:19 GMT
+      - Fri, 13 Oct 2023 13:58:10 GMT
       mise-correlation-id:
-      - 68819f5d-b718-4fff-ac6b-6fc2fe148e68
+      - d3535aa3-7973-40c3-b58d-4797e5108b71
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2354,25 +1346,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A24Z&sr=b&sp=r&sig=TgHypqq1h2dXDsFIPsc3cGPmAHM04Cu7ClMHdlAeuCs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:24.9223111","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A24Z&sr=b&sp=r&sig=FSEQpSxQtg%2B%2F9EPgX12IQRuDhUrhrS2TNbRUs%2Fc05wk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:24.9222312","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A24Z&sr=b&sp=r&sig=E%2Bt7OiR0Eaw5yzbkDHdJCRM%2FuH4pr%2BwSKX%2Fg1d7jo0E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:24.9223275","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A16Z&sr=b&sp=r&sig=bjhSP4UVzYuMKU3yIfqXfjAcjDCApbHoi%2BXLsGBJQ8g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:16.1382146","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A16Z&sr=b&sp=r&sig=3l0EWyF6lA06fm%2FYIVIgXJcGm1QLpnxKryBW0s8qyik%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:16.1381339","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A16Z&sr=b&sp=r&sig=1xN5Ee2DqhCrCc6Enw0k5JCfV17hdcX64fX554Q3YyY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:16.1382349","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3207'
+      - '3198'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:24 GMT
+      - Fri, 13 Oct 2023 13:58:16 GMT
       mise-correlation-id:
-      - be8a4c90-f7b0-4960-95cd-78bc6c453b52
+      - 2b07c513-1491-4a52-ad1d-f8514760a255
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2390,25 +1382,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A30Z&sr=b&sp=r&sig=mEUIRibFwRo261UeQFg%2BL9yj4Sn0AEx2rSZZjoP9Zyk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:30.2025715","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A30Z&sr=b&sp=r&sig=ML9F9Ej%2F1u44SPws%2FtiwEJBtsN9vaZYcEiKE9v5Gz6I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:30.2024793","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A30Z&sr=b&sp=r&sig=ps2ZAy2fy1jCLSBKBKLN7aJfnI9dv41Cx30%2Fr3OMZOY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:30.2025916","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A21Z&sr=b&sp=r&sig=gL9EV130eANvSLGz0RbU%2BQsE3wAV6mxybzgr8%2Fugyxw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:21.4812824","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A21Z&sr=b&sp=r&sig=DufXa%2Fm2zPveesft1zok5WSpT8Kcb0WWYrqAM6bR1fY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:21.4811967","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A21Z&sr=b&sp=r&sig=v5LCQeYZj8D2KHJzfsfLxFlHVRn02RF2S9Jkca9stGQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:21.4813008","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3201'
+      - '3200'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:30 GMT
+      - Fri, 13 Oct 2023 13:58:21 GMT
       mise-correlation-id:
-      - 9bac92e0-069e-44f0-992c-e2aaaf6be9d2
+      - 52005ea9-4f8a-4506-a068-8f29dd81146b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2426,25 +1418,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A35Z&sr=b&sp=r&sig=%2BiNvMGM3BXQST%2BUJ%2Bzmc1Samya7dfuOGGDvb3r0OH5w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:35.5178791","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A35Z&sr=b&sp=r&sig=vnNaOnGXmToiu3k4gx%2F0iTHKH60%2Bww0N4UDzhdELI8A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:35.5178078","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A35Z&sr=b&sp=r&sig=d4uFpxu572Szl0m9ISw%2FfBq1gY5ZaO%2FgAlVpolJYN1c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:35.5178942","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A26Z&sr=b&sp=r&sig=Up2gdOCz9nh47mSEexblzOUh%2FMqJsxS0D0hgRi1eGTU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:26.7401049","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A26Z&sr=b&sp=r&sig=w56z82Gz4KjrEMJX8fod1QiAgagADQTtz2bsa9QENCE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:26.7400369","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A26Z&sr=b&sp=r&sig=QksKJqOXAayXEMIG%2BiI61cVmH%2BhyyZP6OQGa5MDEV6U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:26.7401187","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3207'
+      - '3200'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:35 GMT
+      - Fri, 13 Oct 2023 13:58:26 GMT
       mise-correlation-id:
-      - 7ef2030b-7a96-4832-baa2-1413b3acdcf6
+      - 9997dc7f-72a5-4fe2-853a-cbf14a79dcce
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2462,25 +1454,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A40Z&sr=b&sp=r&sig=qeLT4HHl%2FKnh2%2FhY9XtWMdwczQUeuj88j0%2BFtUmSiJM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:40.848702","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A40Z&sr=b&sp=r&sig=Sb2E8NJzH%2BAwQvGValeTP8XsDSyPfnTiB%2Fw57p8Or0s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:40.8486418","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A40Z&sr=b&sp=r&sig=x%2FyEbbnvmjmV2lR3UQV201X4yWROOfsONHqlBPjJ%2FeE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:40.8487184","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A31Z&sr=b&sp=r&sig=mnXZ%2Bi3GgmP3gpnZO4k3yb8CR5XtHl5MNoc%2BL3uFy4o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:31.9701998","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A31Z&sr=b&sp=r&sig=p42oUdO%2Fov%2BCdgXSn524ZaqvS7vW6ZpthJQqxWw3N9c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:31.9701303","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A31Z&sr=b&sp=r&sig=9jDejpZxB7lfA4fDZml4nxL6ncZVRWtaLWst1kMlnvc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:31.9702152","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3206'
+      - '3202'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:40 GMT
+      - Fri, 13 Oct 2023 13:58:31 GMT
       mise-correlation-id:
-      - 892bb9b2-5a3f-4609-9d25-5a0ca90c6f8b
+      - adfd92a5-c7b4-4802-8c8e-cc5553dea243
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2498,12 +1490,192 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A46Z&sr=b&sp=r&sig=Xk7yxfPnWLTKwPU7OCuzb%2F6P2LbOI%2BP8sPIOBf7hGj8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:46.1660819","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A46Z&sr=b&sp=r&sig=tHD%2FNdJFX7Jv1B%2BYwmNRCpU8emzKDZQcVJ%2BkCOK%2Ffgw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:46.1660131","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A46Z&sr=b&sp=r&sig=%2BiRU7Kk318QoZCtj3k8oOoLsLZe7Htoex%2Bm3CZQ0QEs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:46.166096","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A37Z&sr=b&sp=r&sig=EBowrTR9h6PPDjzcTH0jHwFifNjoR9R2deQdb%2Fv%2FtL8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:37.2536372","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A37Z&sr=b&sp=r&sig=rB3pgtcMf1BveigTO%2BTnEZWnqMMjkXoCKdYiefCHkIQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:37.25355","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A37Z&sr=b&sp=r&sig=g5bZHSLki9QwPR%2FLx5LDlzaH9%2FuxwzUOgOkXivcUn4Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:37.2536529","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:58:37 GMT
+      mise-correlation-id:
+      - 798e3096-18cc-43a0-9101-b0c21bf736d2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A42Z&sr=b&sp=r&sig=AKlWdpD1LH0E7J148QYa2snfCTsfm%2Bek0V4MkfkpUL0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:42.5871751","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A42Z&sr=b&sp=r&sig=dxJR0%2F4yeAbBQcXKTo3Pm4IQJqX2VnrzmVxR7T36w2c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:42.5870885","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A42Z&sr=b&sp=r&sig=dH5y9W4mDaLRyuHOk0cbVhDnuJ3iVT%2BdCKnC1CS54MY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:42.5871905","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:58:42 GMT
+      mise-correlation-id:
+      - 59a21bb5-444d-4d0c-81a8-8c049c83d604
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A47Z&sr=b&sp=r&sig=OFhwx%2FU6QRl9%2BH%2Bz%2FZXK9okLyxtWtzoKPo2pvwYpphk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:47.807748","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A47Z&sr=b&sp=r&sig=6BgOPRy83tCys9OHCogX1QQSmb7frX29osH0H3jXVPg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:47.8076819","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A47Z&sr=b&sp=r&sig=iXRSKK%2FZFg1aDVodGdXK8%2BAhRkbDYPNeMz6lyAYWad8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:47.8077634","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:58:47 GMT
+      mise-correlation-id:
+      - 959cb413-f26e-43c7-8e19-f91ea40a3ccf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A53Z&sr=b&sp=r&sig=HWKnV16l0vZyczraJn3cub0uYDMpw5khk8dK82Kwm3E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:53.1223449","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A53Z&sr=b&sp=r&sig=F9DjHE3O55D5KjG%2FSCxSfAU8Bzmq3oUF4orZ7jqsdLw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:53.1222491","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A53Z&sr=b&sp=r&sig=wHj6fmH9CXT7NYeEUqxXuKxosy%2FORVtlW1K3ENVVmaI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:53.1223616","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:58:53 GMT
+      mise-correlation-id:
+      - 33f69503-5970-4d40-8e10-d768106748fb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A58Z&sr=b&sp=r&sig=JNaIY4KIw2kJUhJKiGpytNzAC45C%2BXiWyvewloNCntQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:58.3818973","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A58Z&sr=b&sp=r&sig=quOTJngPMU8x9nNIA6jj3qPel1wtcjq4K5z9NoShCf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:58.3818272","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A58Z&sr=b&sp=r&sig=lmr9Lyz4el%2F80bp%2FhAmlDOaZpNqWMPuBv5cSMslWpc4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:58.3819118","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:58:58 GMT
+      mise-correlation-id:
+      - 9079013c-d483-43ef-8295-73f0c5cc084d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A03Z&sr=b&sp=r&sig=XxP%2FlXTvZ9s73%2B%2FThTTnKsxIFqtvrlMKSzLrDnZV6fI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:03.6749392","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A03Z&sr=b&sp=r&sig=0upg9VOuaUh6v0aGEj4AydqdcT%2FFlTvtxm1uej9NpyU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:03.6748569","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A03Z&sr=b&sp=r&sig=H5AfLQnc4MXM6PZrrhtz4n%2F5%2B2sGCW93fOB0TKrO%2Fb4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:03.6749596","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2514,9 +1686,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:46 GMT
+      - Fri, 13 Oct 2023 13:59:03 GMT
       mise-correlation-id:
-      - 241aadff-d5cb-4ac3-a29c-aeca744a2dbf
+      - f1a6a343-a1ce-4ad6-b8bc-88000aafee37
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2534,12 +1706,480 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A51Z&sr=b&sp=r&sig=c5hhjA4ZaagNt4QOxHRbHnbOiD%2F5ek5aPNio5xks6Gg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:51.4422151","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A51Z&sr=b&sp=r&sig=%2FxMInh9hTcaFplzEYuNiB6xRZ7JfS7WNl97nSY%2B2d14%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:51.4421019","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A51Z&sr=b&sp=r&sig=z4E88N14%2BFl6DBEWBitK8V4LKWubdI24xY4zpiFCNEA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:51.4422355","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:15.132Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:03.02Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A09Z&sr=b&sp=r&sig=lxTmvaYfyA2yoqjBCc1wJ0jIKzJ5X3UkPQtv%2BbXb9sc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:09.0025893","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A09Z&sr=b&sp=r&sig=0fAjUV%2FA9yvr3Tmje8gChjX61NHG%2BTchsUekV2ODg1Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:09.0024637","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A09Z&sr=b&sp=r&sig=84RnK%2F0MBLyjURNCKfXdB8mVqIEDYg3VA3b1xU52COk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:09.0026124","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:09 GMT
+      mise-correlation-id:
+      - e252cabf-9567-42fc-b18b-97ebac1736f8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A14Z&sr=b&sp=r&sig=Sh%2FEFbgURVRdorjO8KbvpEnI95NM%2FboupOd7ij9It8Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:14.2706966","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A14Z&sr=b&sp=r&sig=6lvmWky9XIZeT83JlJab7bhpfkqpN670N1xpZu%2Bxxgw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:14.2706073","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A14Z&sr=b&sp=r&sig=QjW4GwYE%2FAeaZx3LfBX41i8HG4ztCetfajixO85DdgU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:14.2707169","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:14 GMT
+      mise-correlation-id:
+      - c368757f-81f4-486e-b249-b7ed7f05be59
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A19Z&sr=b&sp=r&sig=aRICdPEzbpTcNPlpcR2u3RwqeuRULjnFoJoNE7M7mNs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:19.5701196","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A19Z&sr=b&sp=r&sig=tq6HMsAA4Etz0VVwM0RCbQ12rs9zU%2BEwKfy83LJ%2Bwuw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:19.5700335","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A19Z&sr=b&sp=r&sig=hja0jbnTiwl3x%2FzN0QC2FK46zRZfkX086Nrj50R22IQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:19.5701411","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:19 GMT
+      mise-correlation-id:
+      - 3e7c09e7-696e-41fd-b174-9eab16bc651e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A25Z&sr=b&sp=r&sig=Hwf0QB%2FIG4pKg42jLMPTCybHIUYm1I%2B5KwsWq0s04qY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:25.0642107","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A25Z&sr=b&sp=r&sig=AKE7SvZ5jvNBORCXQgHjBgeVjur2Vb6YqYXmUv9zGUM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:25.0641318","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A25Z&sr=b&sp=r&sig=pGe3MnFK8BqLbDNN%2FV9bXUFi4f0%2B0mBPqC8eOVUDzYU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:25.0642281","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:25 GMT
+      mise-correlation-id:
+      - 92054842-42e7-42d4-9c0a-40f658aefd90
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A30Z&sr=b&sp=r&sig=ppFY%2BkFzV4m8gzyPijDq3cBcagEV%2BERfJzExjbc3Qk0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:30.3270064","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A30Z&sr=b&sp=r&sig=Ik2wMhm22JpSL8zoVHCw80XLgZ6uj1gcP747fsY9Yf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:30.3269031","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A30Z&sr=b&sp=r&sig=WBcTM2cvE7ELzr3uA%2B5I%2FRasZNPPiAVPHapdow5cXZ8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:30.3270323","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:30 GMT
+      mise-correlation-id:
+      - 93ca2d2e-3be0-406f-b256-ec48d4f00166
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A35Z&sr=b&sp=r&sig=G1D1PX9taNNnCqGBpvn4AZuS4Iuw1CN%2B0L%2FHG2%2FKW%2Bg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:35.6319396","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A35Z&sr=b&sp=r&sig=UQ17%2FQtH7%2BCSJaoYdwaD%2BCtJRhIyVpFquUEBCRx3N4E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:35.6318436","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A35Z&sr=b&sp=r&sig=T%2BmztF0aoHy%2BgbUhoxJN%2FIzo4aY%2FVj7uMcN3zR6iypM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:35.6319613","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3216'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:35 GMT
+      mise-correlation-id:
+      - c27fdbad-4804-4f2a-8151-058108399e11
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A40Z&sr=b&sp=r&sig=2ESVjQ0O1CRG5pf%2F4k%2B2My8IpGC4MMemxqolHlfA7DQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:40.9701698","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A40Z&sr=b&sp=r&sig=WpQNDfTtXHhELHQVQbzgfXRpZ3xxN5L8kxrtjd66ADM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:40.9700455","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A40Z&sr=b&sp=r&sig=E0kQrGph8TXoju%2FvHHPplzuLMZo8%2FTe30%2F1ZiSnXjLg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:40.9701965","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:40 GMT
+      mise-correlation-id:
+      - 6094f5e9-58d4-4696-94a4-baddf09724aa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A46Z&sr=b&sp=r&sig=E7pGCG44G%2F8xq%2FQziv4gTVw8xbBZs1v2uVvCIOKa%2BXY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:46.2269506","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A46Z&sr=b&sp=r&sig=U0kV9ZrJb4ogT5Mfu8BGgwpumIKeMKmg%2B3nd7wK62Lo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:46.2268618","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A46Z&sr=b&sp=r&sig=y5SCQ8yCSW7ni0ChpwOaWoDl0mDmc8fDOyxTd2GjM3g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:46.2269721","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:46 GMT
+      mise-correlation-id:
+      - 9c9cafdc-865c-4a7f-82f5-7d62041d469a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A51Z&sr=b&sp=r&sig=D4Ni%2FYLRojq4aqgWT%2FoJLAEcjPQXXHPObq0evEeFkPg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:51.4960761","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A51Z&sr=b&sp=r&sig=7mkHQtGNao2tmy91S2viQ2FEmuM4xf9YHhoPFn28ABw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:51.4960136","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A51Z&sr=b&sp=r&sig=XlKekaSZh3VhdPntSJrlDYHmLXK3dmatbsXVVqCyQEw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:51.4960917","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:51 GMT
+      mise-correlation-id:
+      - 3fc134ae-9678-482b-8145-b037335c2943
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A56Z&sr=b&sp=r&sig=ZC%2BcHuIseLtzP48VdQog5unmciQILQz23oqZe6LV6T8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:56.7550612","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A56Z&sr=b&sp=r&sig=3gjX9hsg9cpEpqbcBcrXjiWv3D8K8uOHegRviH7s9JM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:56.7549789","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A56Z&sr=b&sp=r&sig=3Xs1vRWu%2FFO2p%2B6gEhwlRHFNygUr5YHScUkBiJhrR8k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:56.7550811","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:56 GMT
+      mise-correlation-id:
+      - ac60c410-44b6-4bbe-aeb1-8a87affee45f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A02Z&sr=b&sp=r&sig=zliegyk%2BSU8wy4R6WjEsDk%2FEW0CUHI10vowCBxy6eQs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:02.0122828","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A02Z&sr=b&sp=r&sig=bDmReOVYIlN2X%2BtS6w3VHGILnwBoa2sfqvNqxbmlbZE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:02.0121887","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A02Z&sr=b&sp=r&sig=tAcBwWn0bHb6pTY3LmJYs8X8hbLZAmE5udUag%2B8%2B7Xc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:02.0123204","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:00:02 GMT
+      mise-correlation-id:
+      - eb649699-a6b1-4f67-9b49-e80f1d1aae02
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A07Z&sr=b&sp=r&sig=xt%2Fa3G36oODqwZuIVqL73WkG7K6EuTz5DbZo5WY8LZ8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:07.229832","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A07Z&sr=b&sp=r&sig=A8rR95xiJsr3ldmcvx%2BjJArsSwEUsbu4RbWqA8bTyk0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:07.2296121","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A07Z&sr=b&sp=r&sig=5mhbR0J38Xi2qhfJtQJN4ImWfxkFnYIn4WOLPXAegoM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:07.229847","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:00:07 GMT
+      mise-correlation-id:
+      - de5b4793-85f9-4386-ade7-7eb8c4cee62c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A12Z&sr=b&sp=r&sig=9GQsHwrJN28RJ%2Fmw9zBV%2FBZJYNKSW%2Bde2ck4e%2B78m1M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:12.5855037","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A12Z&sr=b&sp=r&sig=MqWfGCZtKn1Thp5oJEyQSkaT8k0bk88V2eJkV2FXlSs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:12.58542","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A12Z&sr=b&sp=r&sig=v4O1AaJkC%2BA4JVUR8kiDSARec87wDw%2B%2FemizSdCXiVs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:12.585521","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:00:12 GMT
+      mise-correlation-id:
+      - 23194057-b046-4fe2-817a-bd956ff5d002
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A17Z&sr=b&sp=r&sig=fF2ApXCFqhiOKcQE4B%2FrGuGoPP%2BwPpeIZIPRiSP4NXA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:17.836501","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A17Z&sr=b&sp=r&sig=lIg6Hk6iFFnxsXFmZ0WQxJ0ziLqWrongdbFG1NrsIh4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:17.8363889","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A17Z&sr=b&sp=r&sig=WMviWe6Zj5SNThvvtk0J%2FE%2BQZN5dRswoZeLGiL5iHt4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:17.8365195","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2550,9 +2190,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:51 GMT
+      - Fri, 13 Oct 2023 14:00:17 GMT
       mise-correlation-id:
-      - 03759821-df93-4751-b33a-d9f6693bc795
+      - 1cfa051d-b1d3-4e7c-bac2-7aa3ab447144
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2570,25 +2210,421 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A56Z&sr=b&sp=r&sig=R0K4g28ovxfvl4xaALnh5ijPCKDUPDQ%2B8kLkebZ9FZ8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:56.7221789","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A56Z&sr=b&sp=r&sig=XDUAVDM3LiurFXr1sLWNrRVwWk%2FZlDKeuyT44Aqo32o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:56.722091","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A56Z&sr=b&sp=r&sig=ohiWuPLBnH2AAOT6JnPWdMSMGEDqTeLjOASUJmEs0n8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:56.722201","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T19:24:15.132Z","endDateTime":"2023-10-09T19:28:53.521Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:54.749Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A23Z&sr=b&sp=r&sig=3igtrSVIIxKNU%2F4PNEmbgvb6tDLuIKcx0ToAkkv1dXY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:23.0777418","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A23Z&sr=b&sp=r&sig=1aWhy6a0jLg1E4afdBhMZ2q5C778Nh4kiJZH2HbwpTs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:23.0776427","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A23Z&sr=b&sp=r&sig=pt72t5lRI1bLgJhTvmvwZiJeXwxlSdO7iI82qOihNdA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:23.0777646","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3232'
+      - '3196'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:56 GMT
+      - Fri, 13 Oct 2023 14:00:23 GMT
       mise-correlation-id:
-      - cf477da9-c827-4651-8372-a5f12c37e2c7
+      - a20205fc-9983-42e2-b9e1-f1fa3405d3aa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A28Z&sr=b&sp=r&sig=%2FVyDi5yMHuXLJL4e%2FM0ySYWpmNVmwbPJMz9dy%2B3kbK8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:28.4012369","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A28Z&sr=b&sp=r&sig=qZjao3Wfh0CPj8vOB47NkVggfJOqiLCAEG%2FRBFE%2B%2FgE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:28.4011679","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A28Z&sr=b&sp=r&sig=doB4jn7iBU9nuGivRipZOr%2Beqn5pQz8TuIR9%2FWNbN18%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:28.4012516","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:00:28 GMT
+      mise-correlation-id:
+      - 23ef412b-b13d-4df7-9332-3115fa6b2aae
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A33Z&sr=b&sp=r&sig=rCBN4waIEqESMqQcheGFDfTLXF0p8n%2Bxof2O3ocd2l0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:33.6299779","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A33Z&sr=b&sp=r&sig=4cYY1Zd3cJ7oQpCnbgT7Dw5lC9t68NMe343qMltnq3c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:33.6299127","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A33Z&sr=b&sp=r&sig=2Bng6vbAbmc1H5TIpsf4OAMqquTPn1Esht92YXfW%2FYo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:33.6299937","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:00:33 GMT
+      mise-correlation-id:
+      - 46cc7dcf-013e-448f-8c07-904cb2357e33
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A38Z&sr=b&sp=r&sig=iyZ%2F8SeKCSMDQkzJE0pWGyNLty%2FfiZZBn0NMTjPacik%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:38.8512882","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A38Z&sr=b&sp=r&sig=bNOzfocnp8WB9GYQ66HMOnEISuwC7a9dJliI%2BpNvRf0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:38.8512089","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A38Z&sr=b&sp=r&sig=6Fg%2FnKT%2BeNuW1eZ2sk4KHte%2FTcuDbLh6B%2FLfC0pvAIE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:38.8513095","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:00:38 GMT
+      mise-correlation-id:
+      - 24ecea58-f1d5-4a6e-89d3-3a61c2eef8bc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A44Z&sr=b&sp=r&sig=zGzLJwsqPoZDK%2BfSR893jY2Pt1UOZfM5upiNh%2FdCCaQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:44.3611263","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A44Z&sr=b&sp=r&sig=KPzSrECMSLhakJw2z3T258HkrfAW%2Bf%2FPly5bo5FCKDk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:44.36104","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A44Z&sr=b&sp=r&sig=fuRIdhuSHdotrSMQLoFhtcttD2%2BeoqUsSYnWZRd2mPM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:44.36115","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:00:44 GMT
+      mise-correlation-id:
+      - a1fd84b3-59bd-4852-ab96-1968036bad9f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A49Z&sr=b&sp=r&sig=IIlvQ2TfyAwZVPotuCyGqbc1jNfIue14JasjyEM3YyU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:49.6736259","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A49Z&sr=b&sp=r&sig=okOzOmXQfRNMGIVLTk4rdSL66QwQH%2BjU4HtPC2ffKgY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:49.6735414","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A49Z&sr=b&sp=r&sig=ijZgSbQl%2B780wWUApeyDt99vOEQsPfbGtlasrWATFuI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:49.6736472","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:00:49 GMT
+      mise-correlation-id:
+      - 410aed3f-610c-42ca-b46e-d73aa80318d3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A54Z&sr=b&sp=r&sig=IZKlEfDQtDTKP1ggROA4uEid5OtCaDkQ7%2FQmzxPu5zQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:54.9403584","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A54Z&sr=b&sp=r&sig=%2FFa7iYu%2FtaUa54U6GLeGGvx7T91JNTppYJoSYhBdv2M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:54.9402926","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A54Z&sr=b&sp=r&sig=8fpaiW3s7KTwsdf7ja4i1PL9%2BA80tUQnloYYm%2BiYCKE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:54.940374","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:00:54 GMT
+      mise-correlation-id:
+      - 3a6f13f2-0714-49ca-8033-88a2d257b33b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A00Z&sr=b&sp=r&sig=RrY2PrgsfKJTgnIBRq7721NTUKfKxvHJQhPEdbn%2BFok%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:00.1877861","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A00Z&sr=b&sp=r&sig=J9CIiwrAt5nDVVMIxCPTTqgpxFA3QqgYAwiXb%2FpQ9J8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:00.1877134","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A00Z&sr=b&sp=r&sig=J1lVuPmCr7Z2yF%2BwR6%2BOV4GpS1F9I1yLJzlX5j%2BrHV4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:00.1878005","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:01:00 GMT
+      mise-correlation-id:
+      - 20f4c8dc-8bf6-4473-9c2d-bb8cb6f89920
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A05Z&sr=b&sp=r&sig=vHmzMcR7%2BjlvcZLP5dFDaDLuPBTVIjuZ0l3%2FSpS9YCQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:05.4786732","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A05Z&sr=b&sp=r&sig=kV%2F5D7lXZdDZbyXlJc8nhdI83iLMDPg41pFd4MkObqo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:05.4785756","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A05Z&sr=b&sp=r&sig=SwjEDl22tjsbuSJY0nAyziIdtvVxSudtVsVvYGQFgbc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:05.4786952","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:01:05 GMT
+      mise-correlation-id:
+      - 5f1a0184-080b-4fbc-a1f4-749a3395fda3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A10Z&sr=b&sp=r&sig=bjQrOG2tT%2BO05Xx57YiddcEZxpdEBROkzjXeWUQMr8M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:10.8071448","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A10Z&sr=b&sp=r&sig=YFyXxGimvI9tqS%2BBO3VONvHnhEkiWnxy%2FGgLF4HPPx0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:10.8070599","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A10Z&sr=b&sp=r&sig=Qgl0w1scU%2FoE%2F6r2iULHgCg0k32acAakuA4vTr9GUCg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:10.8071656","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:01:10 GMT
+      mise-correlation-id:
+      - 07955f7e-fc22-4db4-8a39-4a35b974fad5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A16Z&sr=b&sp=r&sig=Jxdv5uXMpqr3yJBkAdSg2dveXriN%2FTa4%2BYi4DrUzbpM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:16.1241255","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A16Z&sr=b&sp=r&sig=M47TjXAZUOPU9b4qd7wAoCDJZuyo0H65549mM4XekSY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:16.124037","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A16Z&sr=b&sp=r&sig=Dvyt2ebwX0BKT%2FG4nv%2BbbrRQw7NHVShba3pmFLnUPak%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:16.1241405","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:56:41.186Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:32.014Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:01:16 GMT
+      mise-correlation-id:
+      - 5ccf523e-ae08-42b2-9e28-4da30d9b7d28
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A21Z&sr=b&sp=r&sig=sN25hE05zGYi5HYKwWqg3npuOW0Z0LQ8CW11PtZNit4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:21.492021","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A21Z&sr=b&sp=r&sig=1QXs72T8HECpUYvjQCq%2FW7winQg9eXLVsArtd%2FH9n0Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:21.4918741","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A21Z&sr=b&sp=r&sig=xWj%2BLulPE3bFZ2G9p5KOITEl2gNHgaWEU63AxdLKOeI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:21.4920425","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-13T13:56:41.186Z","endDateTime":"2023-10-13T14:01:20.981Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:21.375Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:01:21 GMT
+      mise-correlation-id:
+      - bb782f55-c371-415c-b430-07a214971cdc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2611,18 +2647,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:17.0295091Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:17.0295091Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:55:42.646835Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:55:42.646835Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:57 GMT
+      - Fri, 13 Oct 2023 14:01:22 GMT
       etag:
-      - '"560052a6-0000-0100-0000-652453270000"'
+      - '"d9016b33-0000-0100-0000-65294c600000"'
       expires:
       - '-1'
       pragma:
@@ -2650,25 +2686,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=metric-test-case&api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=metric-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A59Z&sr=b&sp=r&sig=XI2lc1Yed07xkQPAex0%2FvTodUsBgULtMldSgL%2BviTh4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:59.2925174","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A59Z&sr=b&sp=r&sig=BN13wXj09O%2BUktvPlGrvoCaMbMqoH%2B8RLk5VXoHFwiA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:59.2924298","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A59Z&sr=b&sp=r&sig=FfOmSNpVgLieMooQt9W37xEX%2BR%2BKA7evSM4QemYr6sY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:59.2925376","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T19:24:15.132Z","endDateTime":"2023-10-09T19:28:53.521Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:54.749Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A23Z&sr=b&sp=r&sig=03zBNBH5yJ42Fd3gla%2BtVnFSdFC14elda8LxechJeNo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:23.6597011","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A23Z&sr=b&sp=r&sig=MeEmI0PzVzfog5s85z%2BstFntV9cWRmEdSGMmckaeOik%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:23.6596302","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A23Z&sr=b&sp=r&sig=hCjSpA5SEI2xKpGuYxnSsVHWOykTe7o2GruyvFClLpk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:23.6597153","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-13T13:56:41.186Z","endDateTime":"2023-10-13T14:01:20.981Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:23.111Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3254'
+      - '3246'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:59 GMT
+      - Fri, 13 Oct 2023 14:01:23 GMT
       mise-correlation-id:
-      - fe675b03-80f7-44c2-b49b-a9dadb40627a
+      - 6adb58c0-fff3-45f0-9442-c01eb0cbba35
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2691,18 +2727,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:17.0295091Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:17.0295091Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:55:42.646835Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:55:42.646835Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:59 GMT
+      - Fri, 13 Oct 2023 14:01:24 GMT
       etag:
-      - '"560052a6-0000-0100-0000-652453270000"'
+      - '"d9016b33-0000-0100-0000-65294c600000"'
       expires:
       - '-1'
       pragma:
@@ -2730,25 +2766,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A03Z&sr=b&sp=r&sig=ktAI6rtbiN6qruMT0ghhHaLc58cxQGPhqXUtq8T1Q54%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:03.9821177","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A03Z&sr=b&sp=r&sig=awzYsHKztfCbsQlCLciYK7X18IbQzrTKQ15APRg%2FCvQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:03.9775924","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A03Z&sr=b&sp=r&sig=ALIMtrKBalttGMH%2BbEfiJMtnzd8iOzQGkiQgACycBKk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:03.9821473","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A03Z&sr=b&sp=r&sig=O3GkHmsZsQdSNVfXH4kI94mWkpJBjRluK6Mk0BFzme0%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:03.9821757","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A03Z&sr=b&sp=r&sig=g6v4gTnAVfRIGLB%2Be63vOKy%2B8pqouQZcm0PTLNUsCT4%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:03.9822079","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T19:24:15.132Z","endDateTime":"2023-10-09T19:28:53.521Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:29:00.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A25Z&sr=b&sp=r&sig=b2MiS09DaMXsLU4Ho4m88bz6KTfBOB1ws4X0OdG%2BmFY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:25.7503225","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A25Z&sr=b&sp=r&sig=wLF8J0aISBOzf9mnYkoQxw5e1dlWLooiRHLImOuoozk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:25.7502543","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A25Z&sr=b&sp=r&sig=GCtOolimvtNj6dkf%2FQW3FzkAAkkub4g9sSYlt6q0vgw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:25.7503383","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-13T13:56:41.186Z","endDateTime":"2023-10-13T14:01:20.981Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:23.111Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4396'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:03 GMT
+      - Fri, 13 Oct 2023 14:01:25 GMT
       mise-correlation-id:
-      - 34259086-2cc7-47ce-bf41-ddd33e46682b
+      - dd852781-fffb-4025-95c6-076f1232e803
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2766,9 +2802,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"dimensions":[{"description":"Request Name","name":"RequestName"}],"description":"No
@@ -2787,9 +2823,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:04 GMT
+      - Fri, 13 Oct 2023 14:01:25 GMT
       mise-correlation-id:
-      - ac795eeb-300e-4658-b83e-2a091034affb
+      - b6463755-27da-4cbf-8c22-e945bba7324c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2811,25 +2847,25 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-09T19:25:00.000Z","value":1.0},{"timestamp":"2023-10-09T19:26:00.000Z","value":1.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-13T13:57:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:58:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:59:00.000Z","value":1.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '128'
+      - '181'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:04 GMT
+      - Fri, 13 Oct 2023 14:01:28 GMT
       mise-correlation-id:
-      - 631a3e5c-1b3e-4894-b6a9-4600f1e4c530
+      - f878b0f2-4f20-4f50-95a0-b5ef9d76b042
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2851,12 +2887,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=ResponseTime&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=ResponseTime&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-09T19:25:00.000Z","value":50.0},{"timestamp":"2023-10-09T19:26:00.000Z","value":16.0},{"timestamp":"2023-10-09T19:27:00.000Z","value":15.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-13T13:57:00.000Z","value":22.0},{"timestamp":"2023-10-13T13:58:00.000Z","value":15.0},{"timestamp":"2023-10-13T13:59:00.000Z","value":22.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2867,9 +2903,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:04 GMT
+      - Fri, 13 Oct 2023 14:01:29 GMT
       mise-correlation-id:
-      - 8c4ddb5c-15d6-4345-ad0b-706c4b8dde67
+      - d528e1dd-358c-4d7e-a7a7-b03ebc2efbe4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2891,25 +2927,25 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=TotalRequests&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=TotalRequests&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-09T19:25:00.000Z","value":52.0},{"timestamp":"2023-10-09T19:26:00.000Z","value":67.0},{"timestamp":"2023-10-09T19:27:00.000Z","value":1.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-13T13:57:00.000Z","value":23.0},{"timestamp":"2023-10-13T13:58:00.000Z","value":62.0},{"timestamp":"2023-10-13T13:59:00.000Z","value":28.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '183'
+      - '184'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:05 GMT
+      - Fri, 13 Oct 2023 14:01:29 GMT
       mise-correlation-id:
-      - 112d80d6-d2ea-4ece-9f4c-b53fdeede53a
+      - de1e3162-b3ed-4649-8590-b47eeaa70cfc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2931,9 +2967,9 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=Errors&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=Errors&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"data":[]}]}'
@@ -2947,9 +2983,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:05 GMT
+      - Fri, 13 Oct 2023 14:01:29 GMT
       mise-correlation-id:
-      - cda6e190-9607-407f-8693-07ac8c69e876
+      - efeb6a7e-a4a6-436e-8b88-cf266169fba1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2972,18 +3008,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:17.0295091Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:17.0295091Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:55:42.646835Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:55:42.646835Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:06 GMT
+      - Fri, 13 Oct 2023 14:01:30 GMT
       etag:
-      - '"560052a6-0000-0100-0000-652453270000"'
+      - '"d9016b33-0000-0100-0000-65294c600000"'
       expires:
       - '-1'
       pragma:
@@ -3011,25 +3047,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A08Z&sr=b&sp=r&sig=sipG36jVQot3uaXeTa1dtV4Xq%2BwSEHIejpT0q5e4JP0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:08.193785","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A08Z&sr=b&sp=r&sig=0ra3422lcuOiK75rlvZvJWJ9nJ4Sdg4yugI8giczqiU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:08.1937009","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A08Z&sr=b&sp=r&sig=y3z2jCreF8A1S2aBmILAsBOOigxvEC3oEahr4gY%2BJrs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:08.1938068","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A08Z&sr=b&sp=r&sig=%2FDelLbENQvWgdC%2FOIIqwM7Jx78lkGxCpHa%2FX1nqwHJU%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:08.1938273","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A08Z&sr=b&sp=r&sig=YPpuaDZCDvZ0uGKkVcjM%2FlW2sWw5ZJlRvlZzKgEHpTc%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:08.1938509","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T19:24:15.132Z","endDateTime":"2023-10-09T19:28:53.521Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:29:00.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A32Z&sr=b&sp=r&sig=6k3%2BnRvtEh%2Fco9K8N56Gou99%2FfxroZW1BWWBLSSsAgk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:32.2075772","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A32Z&sr=b&sp=r&sig=L%2FcD8gFCJeQLvg4i1IogUGc5iWoPTkWz9P6CbuvxC5c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:32.2074847","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A32Z&sr=b&sp=r&sig=s6K2%2FBYmjVoMohtpYQRUhRXaZwF2bpW9Zqbn8Dq89qY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:32.2076026","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/252f1225-511a-4a14-88d0-4bde0085ed10_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A32Z&sr=b&sp=r&sig=Ot95XFEOMr%2BpMxkAubY83WIOjmBVfz931tKnNFNhvaM%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:32.2076217","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/252f1225-511a-4a14-88d0-4bde0085ed10_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A32Z&sr=b&sp=r&sig=nkPat0B%2Buf%2B9gZoIVhD%2FvohaLmttpdYGjBXM2wKa%2FyA%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:32.2076399","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-13T13:56:41.186Z","endDateTime":"2023-10-13T14:01:20.981Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:29.861Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4399'
+      - '4409'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:08 GMT
+      - Fri, 13 Oct 2023 14:01:32 GMT
       mise-correlation-id:
-      - cd41ef30-e29c-40df-960d-2e8dfbc60302
+      - bd6787c8-8670-4a53-a40c-0c8d7ba5717c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3051,25 +3087,25 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-09T19:25:00.000Z","value":1.0},{"timestamp":"2023-10-09T19:26:00.000Z","value":1.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-13T13:57:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:58:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:59:00.000Z","value":1.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '128'
+      - '181'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:08 GMT
+      - Fri, 13 Oct 2023 14:01:32 GMT
       mise-correlation-id:
-      - 352cb2a9-fab3-453b-9670-dd0e4f93a5e0
+      - 56f7ff62-b3eb-4362-bc23-8f1699642b8c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3092,18 +3128,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:17.0295091Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:17.0295091Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:55:42.646835Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:55:42.646835Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:09 GMT
+      - Fri, 13 Oct 2023 14:01:34 GMT
       etag:
-      - '"560052a6-0000-0100-0000-652453270000"'
+      - '"d9016b33-0000-0100-0000-65294c600000"'
       expires:
       - '-1'
       pragma:
@@ -3131,25 +3167,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A11Z&sr=b&sp=r&sig=ZMa4XgJyJsPnoAy5PUDUKZkAQgFwqlRuTs5KNTMvC%2FE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:11.167629","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A11Z&sr=b&sp=r&sig=SjuAGFfUb3dEpfdm7HzORREJmI9jw7GJdRxJTqEQH3w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:11.1675581","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A11Z&sr=b&sp=r&sig=%2BpOdA7hvxbS7Ia%2BdOdMf2%2BZ6cBTJ2oFK9KH%2F4bjPV00%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:11.167644","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A11Z&sr=b&sp=r&sig=9OI4WLk%2F4JF3MGt%2BcDz%2BoO3MbzUrrjYnt6bGneu2eZE%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:11.1676584","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A11Z&sr=b&sp=r&sig=u1NLG5iUEWqWPgZJLPoSjsTGVVftC1Y63%2FhXFTektKk%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:11.1676731","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T19:24:15.132Z","endDateTime":"2023-10-09T19:28:53.521Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:29:00.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A35Z&sr=b&sp=r&sig=etidAlXuDkHAfV%2BFzTBqK%2FgFBgqXbMkxqko%2FZS63QvY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:35.7056951","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A35Z&sr=b&sp=r&sig=JhbGiGMwVvEx3LIPbCV4008FFfu5Tkq2Ip%2FY4UmqHAE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:35.7055233","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A35Z&sr=b&sp=r&sig=n5rCm9MLi4WCmsgbw%2Ftx4lUy0S6v4APx898Y5keV4B8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:35.7057219","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/252f1225-511a-4a14-88d0-4bde0085ed10_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A35Z&sr=b&sp=r&sig=BLtMNNXqFJR5wMiv7sQqt13AcP6evT3VOGzyo5cz9fE%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:35.7057452","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/252f1225-511a-4a14-88d0-4bde0085ed10_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A35Z&sr=b&sp=r&sig=VPDutjHUNpox7GnmcazbfmHYZwix6Vi80JOKWABxx3s%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:35.7057887","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-13T13:56:41.186Z","endDateTime":"2023-10-13T14:01:20.981Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:29.861Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4404'
+      - '4399'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:11 GMT
+      - Fri, 13 Oct 2023 14:01:35 GMT
       mise-correlation-id:
-      - c928619f-bf20-4021-8266-e6bb3206279b
+      - 9b25a7b4-1df5-4cb4-8cee-09a29fd2765a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3167,9 +3203,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"dimensions":[{"description":"Request Name","name":"RequestName"}],"description":"No
@@ -3188,9 +3224,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:11 GMT
+      - Fri, 13 Oct 2023 14:01:35 GMT
       mise-correlation-id:
-      - c9beff9a-ba16-420b-8a23-a8c6603aa8be
+      - a47fe928-52ca-4856-894a-dcd7f6738436
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3208,9 +3244,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":["HTTP Request"]}'
@@ -3224,9 +3260,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:11 GMT
+      - Fri, 13 Oct 2023 14:01:39 GMT
       mise-correlation-id:
-      - 9f8e0cd4-9ae1-49d2-acaa-19f3921152b8
+      - f883b6de-e739-4af1-8087-5d4f3a57bdef
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3248,12 +3284,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-09T19:25:00.000Z","value":1.0},{"timestamp":"2023-10-09T19:26:00.000Z","value":1.0},{"timestamp":"2023-10-09T19:27:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+      string: '{"value":[{"data":[{"timestamp":"2023-10-13T13:57:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:58:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:59:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
         Request"}]}]}'
     headers:
       api-supported-versions:
@@ -3265,9 +3301,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:12 GMT
+      - Fri, 13 Oct 2023 14:01:40 GMT
       mise-correlation-id:
-      - 413b67df-4007-4cb0-8f34-860ee8873b9b
+      - bcbd4b8e-fe82-4e4e-9ad1-109f1e8dcab9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3290,18 +3326,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:17.0295091Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:17.0295091Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:55:42.646835Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:55:42.646835Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:12 GMT
+      - Fri, 13 Oct 2023 14:01:40 GMT
       etag:
-      - '"560052a6-0000-0100-0000-652453270000"'
+      - '"d9016b33-0000-0100-0000-65294c600000"'
       expires:
       - '-1'
       pragma:
@@ -3329,25 +3365,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A15Z&sr=b&sp=r&sig=wgtXkcW1WTdjbrmXB1tKgJm5%2BpI2AJJYVFE2ygIqxkc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:15.0162859","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A15Z&sr=b&sp=r&sig=SZnRHiIEhlw%2BTJQJScr2Jz40BYCmYGlyJ8YYxddckNg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:15.0162147","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A15Z&sr=b&sp=r&sig=%2Fl8K%2FmpzTx8r%2FcfVqkX4c7Xz9l%2FHsLplxahIpMKLGyM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:15.0163013","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A15Z&sr=b&sp=r&sig=h%2FHvs6EEX4tc8T9F4f5s7Y6Mn0Z5Pb6if8JHykY%2Bt7Y%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:15.016315","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A15Z&sr=b&sp=r&sig=wF6Pisnqgn7NuaiCWbHbsqI8lA34vCJwoCIMJKLCgrs%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:15.0163291","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T19:24:15.132Z","endDateTime":"2023-10-09T19:28:53.521Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:29:00.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A42Z&sr=b&sp=r&sig=cemNnPeirQYwJ3DG6HWHLlYnShNbWr9cOZlnUbdaNEA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:42.3393218","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A42Z&sr=b&sp=r&sig=BuIoJB9oZKOjpHlA9Y8OC10TcjssaTJfhiAiR1sm5L0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:42.33924","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A42Z&sr=b&sp=r&sig=7KI7cJKTYSwc%2FCy6svCTto0t6Ywu0mbmhmKfuS0i49g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:42.3393379","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/252f1225-511a-4a14-88d0-4bde0085ed10_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A42Z&sr=b&sp=r&sig=wi1h9%2FkvQOJiLZjEjXvJCsouzON8PO7IgiFnSm1SpUg%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:42.3393531","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/252f1225-511a-4a14-88d0-4bde0085ed10_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A42Z&sr=b&sp=r&sig=5JuwzhJXXE7vA6WBqDUXpYHXpcViHGnMo9NmNzgZtgw%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:42.3393687","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-13T13:56:41.186Z","endDateTime":"2023-10-13T14:01:20.981Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:29.861Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4403'
+      - '4391'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:15 GMT
+      - Fri, 13 Oct 2023 14:01:42 GMT
       mise-correlation-id:
-      - d4853830-76a5-4494-8348-0f12ab4381ec
+      - 2a7cf860-9007-463e-9e53-ecb44495c129
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3365,9 +3401,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":["HTTP Request"]}'
@@ -3381,9 +3417,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:15 GMT
+      - Fri, 13 Oct 2023 14:01:43 GMT
       mise-correlation-id:
-      - 0774b5e1-c59b-4efc-8c43-0a4f5eeddaaa
+      - 8f91dfa0-b2e6-4e6b-ad3a-eba2bdb095a1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3405,12 +3441,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-09T19:25:00.000Z","value":1.0},{"timestamp":"2023-10-09T19:26:00.000Z","value":1.0},{"timestamp":"2023-10-09T19:27:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+      string: '{"value":[{"data":[{"timestamp":"2023-10-13T13:57:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:58:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:59:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
         Request"}]}]}'
     headers:
       api-supported-versions:
@@ -3422,9 +3458,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:15 GMT
+      - Fri, 13 Oct 2023 14:01:43 GMT
       mise-correlation-id:
-      - 34ba9e74-8054-4ff0-997e-84accc68fb31
+      - ac6bc155-d75f-48bf-8668-8e4d58b59df5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3447,18 +3483,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:17.0295091Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:17.0295091Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:55:42.646835Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:55:42.646835Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:16 GMT
+      - Fri, 13 Oct 2023 14:01:44 GMT
       etag:
-      - '"560052a6-0000-0100-0000-652453270000"'
+      - '"d9016b33-0000-0100-0000-65294c600000"'
       expires:
       - '-1'
       pragma:
@@ -3486,25 +3522,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f155be4d-d6bb-4ce7-8656-29642edd7b2c":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"6a6bad1d-d74d-44a4-af54-cf85ed9a7a72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d5f270e7-de36-494d-b217-b4803211ab9b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/49b78d7a-fe7b-4a27-bf18-37316e3e8941?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A18Z&sr=b&sp=r&sig=kmPfJ1NQ0ob0bvIDl%2B%2FZA6s9ByNG7pZsJ%2F99E1UgeUk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:18.1774795","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/5734d1f1-ed9f-4d09-961c-d968ebb84992?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A18Z&sr=b&sp=r&sig=kJGr%2BlYzoSYsg%2F4W9iZCBoQctAYZNcbLv0X7vxLy7gc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:18.1774096","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/df8a5cb2-2bb4-43b3-ac4a-55873341101f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A18Z&sr=b&sp=r&sig=4OeYKzdQz61FJeApTneOoPPROq7YfL24NXJ%2FgzJLKZc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:18.1774968","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A18Z&sr=b&sp=r&sig=9zLXaejEDly6hMJq5jDTxhBK1aoDaALdj7XfdKkret4%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:18.1775121","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa4213fa-b7b1-49cd-ba4d-5c7c79ef6e23/c7c2bb4c-d182-4ff8-89c2-39b923b9067b_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A18Z&sr=b&sp=r&sig=1Kh0uWSnUk5ChQkKmNPbdnsaQffnq5ur4Ru80ndKKKg%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:18.1775286","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-09T19:24:15.132Z","endDateTime":"2023-10-09T19:28:53.521Z","executedDateTime":"2023-10-09T19:24:13.583Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-09T19:24:14.697Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:29:00.83Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"426c8785-b3b8-4d8e-bd1f-5473b0812f43":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"546c584f-457a-4b81-9293-f42a769136e3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1e39773c-d505-48c8-94f0-20d1879e8a90":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/94a69427-c630-48b8-bcd0-b3e07aac6724?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A45Z&sr=b&sp=r&sig=5EkRunuNIKIQS7yGAiDJ7G9OFYi%2BLPRmUN2Fq2Cc5P0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:45.9834204","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/018ac837-62b4-4821-a2e0-8ae3c59a9472?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A45Z&sr=b&sp=r&sig=A0nPi9zbpcUaKRtt7gE%2BbSCmgsrAbYMaAOWAITvDahw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:45.9833397","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/585deedf-189c-44b2-96a0-e1d3eae99e7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A45Z&sr=b&sp=r&sig=koGeKnDWz8ewYiIGyEPxmEIj6JOK1aisxZTdZzAZ6JY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:45.9834413","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/252f1225-511a-4a14-88d0-4bde0085ed10_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A45Z&sr=b&sp=r&sig=GWeBnuzjIn8vousma0N%2B6Slagh2sJJ8GS01oykBXIBM%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:45.9834612","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5bc047c1-948d-4709-b6b2-2743ab66cdac/252f1225-511a-4a14-88d0-4bde0085ed10_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A45Z&sr=b&sp=r&sig=tsm7Ql9i47mllX4YtJ75CH%2FXydQbm7uZ7JVR43CAkEo%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:45.9834824","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-13T13:56:41.186Z","endDateTime":"2023-10-13T14:01:20.981Z","executedDateTime":"2023-10-13T13:56:40.557Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-13T13:56:40.829Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:29.861Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4400'
+      - '4397'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:18 GMT
+      - Fri, 13 Oct 2023 14:01:46 GMT
       mise-correlation-id:
-      - f74f5688-14e6-4ed6-95d0-31183e9dfa57
+      - 7362482e-04a8-4f1e-b768-2125826f0dca
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3526,12 +3562,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://6b4f988d-ee88-46e4-bf0c-ce114ebbee71.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-09T19%3A24%3A15.132Z%2F2023-10-09T19%3A28%3A53.521Z&api-version=2022-11-01
+    uri: https://5dda20dd-6859-436d-8dce-9e650c85422b.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-13T13%3A56%3A41.186Z%2F2023-10-13T14%3A01%3A20.981Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-09T19:25:00.000Z","value":1.0},{"timestamp":"2023-10-09T19:26:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+      string: '{"value":[{"data":[{"timestamp":"2023-10-13T13:57:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:58:00.000Z","value":1.0},{"timestamp":"2023-10-13T13:59:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
         Request"}]}]}'
     headers:
       api-supported-versions:
@@ -3539,13 +3575,13 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '194'
+      - '247'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:18 GMT
+      - Fri, 13 Oct 2023 14:01:46 GMT
       mise-correlation-id:
-      - 1e14b1d5-3a5f-4e6d-9cce-1c468086299e
+      - cf566b26-57b8-4458-868a-22bddcf60433
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_metrics.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_metrics.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:39.7823896Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:39.7823896Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:54.1558705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:54.1558705Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:13 GMT
+      - Mon, 30 Oct 2023 07:26:27 GMT
       etag:
-      - '"3c00f92f-0000-0100-0000-653edbe50000"'
+      - '"3f002872-0000-0100-0000-653f5a840000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:26:15 GMT
+      - Mon, 30 Oct 2023 07:26:29 GMT
       mise-correlation-id:
-      - 8160cdda-26a2-4e0a-a63b-8611eaf6a7ee
+      - dc4f25e1-1a3d-4d07-a55b-d5bd4f9c2144
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "120"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"35e90d04-0264-4063-9ebe-cdb20c627cf5": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":
+      {"passFailMetrics": {"d68cc576-e7fb-4897-beae-3fe8c59391e1": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "4cfa60cd-ef20-4019-91e6-44dd3042b1f1":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "e07ff0ee-d404-41c3-a03b-07ed42ae5071": {"aggregate": "avg", "clientMetric":
+      "50"}, "c288ca27-b0ca-4e45-808e-a3679e3557f0": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:26:16.078Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:16.078Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:26:29.643Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:29.643Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:16 GMT
+      - Mon, 30 Oct 2023 07:26:29 GMT
       location:
-      - https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
+      - https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 209cc909-2e97-4025-b06d-838dedffdeab
+      - ddab4e99-f2ce-4507-b023-0bdb15cb9fc4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:16 GMT
+      - Mon, 30 Oct 2023 07:26:29 GMT
       mise-correlation-id:
-      - de49c1a2-9174-4afe-b954-0b895e1b9bfb
+      - 8fdd71b2-ea75-4ade-bb30-61d76b452b99
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A16Z&sr=b&sp=r&sig=hO58zSbz64pchPPgM9h%2FNhlIIhqT1z2JNGHTm%2Bd7d6M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:16.9231018","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A36%3A30Z&sr=b&sp=r&sig=4EwDsTP%2Fi25NKPQIoiJyhdijLfej0DOzQahCUua1QwA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:36:30.5121748","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:16 GMT
+      - Mon, 30 Oct 2023 07:26:30 GMT
       location:
-      - https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 6f3451bf-9d50-4113-bdf3-d8803206163b
+      - 58c2f23d-6e13-4e97-a042-617e0be24337
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A17Z&sr=b&sp=r&sig=lbZ5L1qlh7A62Z8s9%2BdvxPgNpmYsK5Gl6ai4K3mBFJc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:17.2032504","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A36%3A30Z&sr=b&sp=r&sig=iyPLBaapq9FPAOwfz18C67MtRDvGjgzJi0BwXn9T5VQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:36:30.7535656","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:26:30 GMT
+      mise-correlation-id:
+      - 4b2cbb03-a078-49d8-831f-9a421009de88
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A36%3A36Z&sr=b&sp=r&sig=1U5kdbw%2F9P252WowLq9orkqI6TScXgjjfX8VSkLEXAY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:36:36.0473562","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:17 GMT
+      - Mon, 30 Oct 2023 07:26:36 GMT
       mise-correlation-id:
-      - 8c5b27f7-3451-4f4a-8366-705096148b78
+      - dd8e9968-81a7-4f0c-a53a-10d5779e35bf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A22Z&sr=b&sp=r&sig=zm73njlsuzFJucUQj%2F3gSS37blN75M4nqiuHOQknpbI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:22.5812994","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A36%3A41Z&sr=b&sp=r&sig=DuxglIk0RNErlsUP5FQA46UL1AXhlhK6VEVlPX3JKbc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:36:41.3699398","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:22 GMT
+      - Mon, 30 Oct 2023 07:26:41 GMT
       mise-correlation-id:
-      - e0b411cd-d9b0-4a58-b89b-8a8a11a9afba
+      - 0b6878e6-4783-4b6a-ac94-269a7a612ac8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A28Z&sr=b&sp=r&sig=kh42dVkO9SrRI6Fq3lBuAQKyjxQFA2XwYH%2FzgK3%2BGzY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:28.2651421","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A36%3A46Z&sr=b&sp=r&sig=R3OSkPc7FNzes4Kt%2BZQMlVO7zfy4DDxo7AnkkTrj7fc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:36:46.6288983","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:28 GMT
+      - Mon, 30 Oct 2023 07:26:46 GMT
       mise-correlation-id:
-      - 9024b8ba-6712-4e8e-8dd7-4e5fac0645f9
+      - c27018d2-a0b5-4051-b09d-5b25fb320fc9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,47 +457,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A33Z&sr=b&sp=r&sig=gXISOQSIINbMaTGTM8U8P09ctBwpaDKoyVzKKTzXmg8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:33.5798842","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '547'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:26:33 GMT
-      mise-correlation-id:
-      - abf8548b-715d-452c-ab80-3e9e1a813340
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests/metric-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A33Z&sr=b&sp=r&sig=iS2lXd9KJqXMEBUWZbVAy9sGaMlYwl3lIEP3%2Fsq6DvA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:33.8318408","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:26:16.078Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:30.724Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A46Z&sr=b&sp=r&sig=mLG90GucjpzYT7IF4sQK33UlCc%2FO0Y3rcFlxpmr8464%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:46.8748512","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:26:29.643Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:43.602Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,9 +472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:33 GMT
+      - Mon, 30 Oct 2023 07:26:46 GMT
       mise-correlation-id:
-      - 354990ba-472c-422d-a0ae-1ec43172dda0
+      - bdaafce4-b4c1-46ef-93f5-3607472bcd32
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:39.7823896Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:39.7823896Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:54.1558705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:54.1558705Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:35 GMT
+      - Mon, 30 Oct 2023 07:26:47 GMT
       etag:
-      - '"3c00f92f-0000-0100-0000-653edbe50000"'
+      - '"3f002872-0000-0100-0000-653f5a840000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A36Z&sr=b&sp=r&sig=n8vK%2BTRbuHxIm8m4Qb9P%2B%2Fvj%2BJ4p2rahQ07C8K3Gzag%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:36.1515575","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:26:16.078Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:30.724Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A49Z&sr=b&sp=r&sig=47xbpXEKkhomHYGreUBE8UW114%2FDqXKi7vcytmzwSIk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:49.0307644","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:26:29.643Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:43.602Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1599'
+      - '1593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:36 GMT
+      - Mon, 30 Oct 2023 07:26:49 GMT
       mise-correlation-id:
-      - 8bde8222-f7e7-417f-b3c8-12b586ebe920
+      - 9d396702-d813-43bd-9b6a-994ae7adeb43
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:39.7823896Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:39.7823896Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:54.1558705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:54.1558705Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:37 GMT
+      - Mon, 30 Oct 2023 07:26:49 GMT
       etag:
-      - '"3c00f92f-0000-0100-0000-653edbe50000"'
+      - '"3f002872-0000-0100-0000-653f5a840000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:26:38 GMT
+      - Mon, 30 Oct 2023 07:26:51 GMT
       mise-correlation-id:
-      - 44006d41-a9ad-436d-8aac-64ef5fe6a89f
+      - a6650f59-d2bc-46e7-bb15-795800357fb9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A39Z&sr=b&sp=r&sig=butRMXfFhijdpy2OR0utLcp17nOKQF0u1rnrhlIirRo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:39.1160003","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A39Z&sr=b&sp=r&sig=B7iDQR2kejsNJesSwF7044fx%2BEtcA6BvuErKWP2yEc8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:39.115798","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A39Z&sr=b&sp=r&sig=wZZiZEySJ9CeYV%2FnCdWmOzuNtJu41gCZHwoM32eVlos%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:39.1160674","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.023Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A52Z&sr=b&sp=r&sig=3IjdEPnzd%2FNVhmJ2U3r2eHZ9jyXENwWwA4%2BizpjBCm0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:52.3759935","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A52Z&sr=b&sp=r&sig=%2FAi%2BDpWDTufcSxDAyJ7od0v%2BpU5TCpl771lnuwpIE5s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:52.3758643","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A52Z&sr=b&sp=r&sig=DUQ0Je93ZQwAARYv%2ByRmS4WF7O762rDPv%2BCpL6xP%2FsA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:52.376026","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:52.298Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3153'
+      - '3165'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:39 GMT
+      - Mon, 30 Oct 2023 07:26:52 GMT
       location:
-      - https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+      - https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 3a146cab-4492-49db-a911-bd4c9ef52425
+      - 2a9c1fa1-4d63-4a9a-87e8-1245ae051023
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A39Z&sr=b&sp=r&sig=Ld4mZBoEa0iGL%2FOgte2HB2DP78cnPQ0RIQ903cRw7IU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:39.529093","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A39Z&sr=b&sp=r&sig=96RuyUCiwuCPZmkEDLtZhP3EFJX4l837vN6IJgM1zhc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:39.529024","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A39Z&sr=b&sp=r&sig=2ehmqW01nM8CMhC9Dljixf0BXNER3iGMv%2Be%2FG9GP970%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:39.5291071","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.023Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A52Z&sr=b&sp=r&sig=Ri9hvhfzrclyxULbQoLjR%2BlD1yBqdC6xwDo2caxT0cE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:52.9367152","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A52Z&sr=b&sp=r&sig=weYBPloxJ%2BKnPd7RO4%2Fec%2B0qboylq166AWKbf9zawCE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:52.9366619","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A52Z&sr=b&sp=r&sig=VrnO%2BuBRw3maXcnrFo5sCY%2BquSpv9hF3NrLA%2FO8GcEs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:52.9367287","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:52.298Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3154'
+      - '3164'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:39 GMT
+      - Mon, 30 Oct 2023 07:26:52 GMT
       mise-correlation-id:
-      - f47f8c6e-27ef-4d09-b7f4-414eb4f9ccc3
+      - 633f7707-de07-4c7a-a4a2-7ef3623aa546
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A44Z&sr=b&sp=r&sig=iDGitHrgwzx4q%2B%2B%2FB17Mno3WrLo6xGwaOhxg6c6sihA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:44.8246189","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A44Z&sr=b&sp=r&sig=OyLZwnjYFG7cT%2BzJeV78O%2BYBsbS7mI0sGBGY9x6UCgE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:44.8245232","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A44Z&sr=b&sp=r&sig=CpyASgw4JDxUwOquFDVzeTancZovlf1%2BBQ11aor0ZBo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:44.8246418","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:40.222Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A58Z&sr=b&sp=r&sig=3iSrtM00%2FtiK9GS1U3w5Y1w7uepOQl2%2F1AbuvtfcuGY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:58.2508166","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A58Z&sr=b&sp=r&sig=x1RfY%2Fg5FnzX9EETbKx9p3OuvF3blN6l8vgdBpziHc8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:58.2507477","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A58Z&sr=b&sp=r&sig=82G%2FPNNBGyjaqABb4jrtKamLFPaV9jAotDIqAXBW87o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:58.2508314","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:53.688Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3208'
+      - '3205'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:44 GMT
+      - Mon, 30 Oct 2023 07:26:58 GMT
       mise-correlation-id:
-      - dca5a4e5-8e60-4b8a-b8cd-50b5525a92f7
+      - 3c03d2b2-01ce-4ab6-ac47-d2ca4bfe3ab3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,586 +772,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A50Z&sr=b&sp=r&sig=EjKlyo1eANrMtVVrEbhu9axpCSokirWUH%2BD9QI9ykZg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:50.1653234","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A50Z&sr=b&sp=r&sig=iGED38Pf5EA4QNoUAj7h9UEUfJEjb0uDfz0jS6U%2BThg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:50.1652542","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A50Z&sr=b&sp=r&sig=XAtHjDmoB16b14HcD8LidYHDXx77jOQbovejnfO3Afk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:50.1653371","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:40.222Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:26:50 GMT
-      mise-correlation-id:
-      - 12bb21b3-a5ff-4338-9fc3-b4cc70e84a7b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A55Z&sr=b&sp=r&sig=x0VH9Hl%2FRItANTMTddE6MBCGtnrwC9XUaJ8tvDBxC9Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:55.4943522","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A55Z&sr=b&sp=r&sig=VsPCu219zJm43PebPlCZpyf%2BrNL6r3U8NbDK2H0zy6I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:55.4942775","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A55Z&sr=b&sp=r&sig=aicGudelRyrKmR1EryCWdYZQVJ0HLElJ3bp2b%2B9WSW0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:55.4943658","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:40.222Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:26:55 GMT
-      mise-correlation-id:
-      - ec023ccd-fac5-4d8e-a83b-ac6fb7fc769d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A00Z&sr=b&sp=r&sig=3DgIxzpdt%2Bc3TcUcjrpc%2Bs4Rr7nHruj0%2FTnpQvtw16o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:00.8328586","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A00Z&sr=b&sp=r&sig=73%2FV8ObMggE%2F85rBtWD5vISDzTNLyEdfvbK58uvCp4o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:00.8327914","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A00Z&sr=b&sp=r&sig=pCAP1TwEQfaVta9rQ66pmlKtGcvw5utYoGwx0d3beKY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:00.8328731","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:40.222Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:00 GMT
-      mise-correlation-id:
-      - 88c1a9f5-d5de-4737-bb12-5926a1bb3114
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A06Z&sr=b&sp=r&sig=28S2PXbRN0mg85Ztw7QZtmlKKZw9jG%2Braus5m6QLMb0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:06.2039334","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A06Z&sr=b&sp=r&sig=S0wAkfpcHQ7jEdxzL2BUu6JFCDqlhxE4TPiHhL3pxpk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:06.2038524","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A06Z&sr=b&sp=r&sig=m5WqCGjth3Z97zRepxEeNZxuYyH266RpC8S%2FXkyGM4c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:06.2039492","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:40.222Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:06 GMT
-      mise-correlation-id:
-      - 4cc046d6-51ed-4b0b-902c-f610683b254a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A11Z&sr=b&sp=r&sig=FSl%2B0ahhbuUTpk9lQg5rdyaP1zfh%2BsdjsEoeLBVp2HA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:11.6521234","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A11Z&sr=b&sp=r&sig=17WUV23yVboHpiczfFMG3yZgjkjU3HtQCpoxFuXpkOs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:11.652025","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A11Z&sr=b&sp=r&sig=9qZ8AkhpyiA0jWl5Iwh%2Fcdp0%2Bnn0kzGOkWPNuH2c6QU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:11.6521483","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:40.222Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:11 GMT
-      mise-correlation-id:
-      - 58f28f1b-f335-4375-894b-6e8986053810
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A16Z&sr=b&sp=r&sig=KKuDbSm9PNB%2FnbJfGFhO5I0O7f76lUYDXlN7Ar%2BpnA8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:16.9364922","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A16Z&sr=b&sp=r&sig=wyKYb9IBkmTgD4Y7LrWugRlRVIKMDpe%2FWRtmeL%2B9Bsk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:16.9363949","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A16Z&sr=b&sp=r&sig=4ym1vs2xtfy5qCNcWWaHtiS5b65qyVpGcD33B3f59Ng%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:16.9365152","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:40.222Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:16 GMT
-      mise-correlation-id:
-      - ae66a448-210a-4e36-81b8-4a4425199ca2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A22Z&sr=b&sp=r&sig=fZECeSGxmq4OZbhIm0Aw8AO%2F3JZ%2B0ua9O23h7g41x2w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:22.2439874","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A22Z&sr=b&sp=r&sig=DvTkTF0N%2F31pp%2FuPJVEIvcw7yywpA%2FsFdGABP%2BBg1xI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:22.243914","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A22Z&sr=b&sp=r&sig=WeJUOSeNIOmS%2BpM6pkPZeu%2FEUsbJ989Arpjo8GYq2Vo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:22.2440017","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:40.222Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3211'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:22 GMT
-      mise-correlation-id:
-      - 5a3309e0-de4c-49ba-8818-f35fbea8db05
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A27Z&sr=b&sp=r&sig=m%2Fpg6l%2F8J96%2Bv%2F71GJS1UNXCkXRtKxWOEm8NJqm9FC4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:27.4933068","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A27Z&sr=b&sp=r&sig=SaEPpnE2VkzMAf5z4uX9hE0945nuVxpwMm6%2FRASMbXg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:27.4932379","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A27Z&sr=b&sp=r&sig=4EdRThofW%2FIKr04i9pzBToRe7nDIuzQVkXUwsSzRKSQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:27.493322","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:23.959Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:27 GMT
-      mise-correlation-id:
-      - a9299486-6090-4dfb-ba8f-ff9c2fa82504
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A32Z&sr=b&sp=r&sig=jVv39TqWaSxQLRiZ%2FVLDAVeCZw9ErDo7aQDg1RPsLSI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:32.7831702","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A32Z&sr=b&sp=r&sig=UrMChajHmAqQJwmRam46q%2BNJFckYh%2BV1QMJY6ZDVlFY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:32.7830663","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A32Z&sr=b&sp=r&sig=mHGelpT8pv8%2BuuC03y2H3KCzwddqo5WFk6TeBpZymZg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:32.7831913","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:32 GMT
-      mise-correlation-id:
-      - 286f53ae-2389-41f9-9492-97db0d474690
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A38Z&sr=b&sp=r&sig=4uhKRpT%2B8VJ0H2igYXiTWFR0BEa1pnXP%2BoBok2Pc900%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:38.103058","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A38Z&sr=b&sp=r&sig=r0w8XAgDDoD4IzrMI3FaowvKlha4TcaeY8iGat%2BEuRw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:38.1029876","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A38Z&sr=b&sp=r&sig=U%2B4Kdc06RiCYxGaGCSYtn3QqpqNm3R0p1trgTDMdt0Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:38.103072","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:38 GMT
-      mise-correlation-id:
-      - ff60e52f-29ad-4cad-ad3b-a6cd6c01fba0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A43Z&sr=b&sp=r&sig=uYsTy7%2BKE9GU7VocHYyb7MBRkOxVxZRC5pfGzSZHCBE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:43.7668784","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A43Z&sr=b&sp=r&sig=rx2bFh0UfCZreVO8HaZh7PZh7j0OSmqOzwAnmWt6FAE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:43.7667932","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A43Z&sr=b&sp=r&sig=fc9BCjHaqBExzQYJq8eOcGcHT1N2FWTeSCeGnOKG51Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:43.7668988","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3195'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:43 GMT
-      mise-correlation-id:
-      - fecc8826-8de1-46ed-815a-217ed79f9bd7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A49Z&sr=b&sp=r&sig=AmrA9wOSj%2FmW%2FQ5%2BEoFrYSRJClYfj6XL%2FqZ2GPrS7pk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:49.6662221","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A49Z&sr=b&sp=r&sig=gdSFieC94gmzWMGjolwnGymvgdngSmvj%2FvZBlARK%2B9Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:49.6661495","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A49Z&sr=b&sp=r&sig=%2FUjn69%2FQOMfLICdEf2DsXPBRkiElgBhpG9gYYH12ZDQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:49.666236","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3208'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:49 GMT
-      mise-correlation-id:
-      - 83fe4ba2-98ae-47d5-9f9c-0f540d089ea2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A55Z&sr=b&sp=r&sig=HD0dX7%2F9zmwj1MhhbERZNiFMyLVUin7AqCXoKGmhCcM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:55.3354177","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A55Z&sr=b&sp=r&sig=Vd5djop%2BSodh2Zur2qu4H5ya9otgYdvxIKK2oe%2FsTNU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:55.3353281","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A55Z&sr=b&sp=r&sig=BazVxwc4jiCeA0B40%2BMFLtaR9j8VasAghZVl4ftlmKo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:55.33544","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:55 GMT
-      mise-correlation-id:
-      - 2cf47169-cd55-40d1-9dee-7587e2b85f86
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A00Z&sr=b&sp=r&sig=qfotXr9iF55oH15sn6ij30iZbNHuqjG48yMhQAoGgUw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:00.6195477","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A00Z&sr=b&sp=r&sig=LAQ1hzBJY5ldefmZzbSjUNGQrVj%2BFaKMycmRtPExORA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:00.6194762","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A00Z&sr=b&sp=r&sig=bCC3yP1KR4Em7nudL2g%2FBQYiDi0riypUf56t68r9Tts%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:00.6195621","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:00 GMT
-      mise-correlation-id:
-      - ca20726a-650c-474d-8e0e-c24043d4e445
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A05Z&sr=b&sp=r&sig=A2Eec0wLQJxSNb7Eg%2BrB6anqrix18IqbYCuUpBSeBks%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:05.9931374","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A05Z&sr=b&sp=r&sig=5hocuIKGSux%2FAumgpRQ3rg80cxQDhWkQbIJyMOlV20g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:05.9930533","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A05Z&sr=b&sp=r&sig=ttn2TrONK7GFJiOaaXftc5yHe5uWl5tmHZWp%2FkcDDPY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:05.9931597","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:05 GMT
-      mise-correlation-id:
-      - 638c0830-7fc8-4e24-b3f9-09e0a391ec97
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A11Z&sr=b&sp=r&sig=MnMg6WJ2w%2BEDnfW3PTY22RtF7V9qsrEgE68PvC%2BImng%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:11.2866242","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A11Z&sr=b&sp=r&sig=SKv89G97yIUDXNk6kwTUl9uTnuli7Q9IGwyos%2BnZqcU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:11.2865532","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A11Z&sr=b&sp=r&sig=VWB0vCL6lHghHljcyWFj%2BvIPRry3mRJT9ykz8kuyCPM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:11.2866379","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:11 GMT
-      mise-correlation-id:
-      - 91272c71-d8fd-4549-9ffc-cb2563d16bd1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A16Z&sr=b&sp=r&sig=Y1k1LYg3CIKLccT7ZjFEubwqTAH2OxLIRKD8KX%2FZzhU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:16.6003417","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A16Z&sr=b&sp=r&sig=mmXMzWmX8q%2F%2B%2FHDIlo78JEpXzs%2Fe6icHo%2FFwQLN9%2BBY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:16.6002711","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A16Z&sr=b&sp=r&sig=XCSat01Wsy5LqH%2FNepgwPkEN7hgjlvSMH9Fb1UZzrTI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:16.6003562","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A03Z&sr=b&sp=r&sig=%2FJUN0WUbg5KN%2F4iKFlyNXh1DfYx0oXfbGiTkziW1JH4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:03.5050172","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A03Z&sr=b&sp=r&sig=0CSSKdfy8%2F1I%2FHunrP%2BL21aJE47m3e%2FgKPCYjBYpmgU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:03.5049321","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A03Z&sr=b&sp=r&sig=AbW0VsWotZ3NesrldIJEAjERlsdiSPDDmf0TdN5Etmc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:03.5050391","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:53.688Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1362,9 +786,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:28:16 GMT
+      - Mon, 30 Oct 2023 07:27:03 GMT
       mise-correlation-id:
-      - f84c9a89-38bd-493a-b869-016d0e0069f5
+      - 647e8001-23e7-46b0-ba83-b4ad2d3b7022
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1384,154 +808,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A21Z&sr=b&sp=r&sig=Cx9ga%2B4TLo31sNbXuD%2Fmz7XHwK%2BIE1oiosQKvU9IJwo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:21.9453728","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A21Z&sr=b&sp=r&sig=eKfVPSozDzpB0DIYtL59DWi6LYZEHUwAPRHqNAPDJQ8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:21.9452622","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A21Z&sr=b&sp=r&sig=FW1PRWeH1MgBEOaT%2BeVBJQTiLty5cWFyRiyPCXTPr3c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:21.9454167","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:21 GMT
-      mise-correlation-id:
-      - 1c922a18-ce43-4696-a68b-7fcab1439a8f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A27Z&sr=b&sp=r&sig=9gkFM8JrTG39iKPaYTtQpqqdcvY2xzFcHrGaBWL5Pxw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:27.2038305","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A27Z&sr=b&sp=r&sig=wN9cIo0PEZkJS2Be26pvXZqFmmxkgk8UxOL9ZPbuj%2F4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:27.2037378","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A27Z&sr=b&sp=r&sig=nNMHoDeIxetxitWLxZ%2BLsSabIxsimYWYWJR5b0PSowg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:27.2038521","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:27 GMT
-      mise-correlation-id:
-      - 0b14450a-2751-4f7b-9b8b-a013513a171d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A32Z&sr=b&sp=r&sig=RC2HEzseOBwDM54OzST8%2FY0iKDX1Ww0CNVsXH6juKHA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:32.7553691","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A32Z&sr=b&sp=r&sig=%2F8elVELfP7l88zE2KxrqgiQAgGI6ebxMVGBqEs1xBHs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:32.7552788","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A32Z&sr=b&sp=r&sig=HGKf1U9DQ138GjssuwMYos3B7e7L64zmvENcsYHTztM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:32.7553938","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:32 GMT
-      mise-correlation-id:
-      - 4cebfb95-1175-4bff-8d1d-69f6b7068b6e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A38Z&sr=b&sp=r&sig=2WbBX8bnwlIlZCPkWXH09v5en6Vx0SyfEO9REkH7KuU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:38.0206143","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A38Z&sr=b&sp=r&sig=9Ga1nR3n0bc6eV0vEj4%2BEzwsQ4fdsOmJ%2FOh%2BRACR4Zw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:38.0205443","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A38Z&sr=b&sp=r&sig=paFpSwrc1IWShtai0mYn%2FUeAFphWiJW%2FpI1mL%2B4x14k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:38.020629","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:38 GMT
-      mise-correlation-id:
-      - e44c227b-fea3-458a-a7b5-cc8b9fc3223e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A43Z&sr=b&sp=r&sig=gok4TcN%2FWLYEWhh5BGpdmtsxc3cmQiGuHhOz2MdHsno%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:43.284397","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A43Z&sr=b&sp=r&sig=m1juLUicHhDVyopn5DAgMTXp6yf5xudNXkBcYBjF%2Fv0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:43.2843227","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A43Z&sr=b&sp=r&sig=052KSZ8eSJTpXZh0%2FW%2F532Obf%2By0r1mA4KqMlw1QCLQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:43.2844127","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A08Z&sr=b&sp=r&sig=cTHU564ttlRbshMQbwL2BYzFP%2FL8yQ3M8IlLR%2FHaxjg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:08.8069558","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A08Z&sr=b&sp=r&sig=EYmriaxWytB06tosiScMuekquXdwqGs0vzc4k7%2BlzPc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:08.8068891","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A08Z&sr=b&sp=r&sig=p5Lo0JRjlkJSDb5nBnWS2Adt1Lluys9LKWzjGQbhbQg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:08.806971","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:53.688Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1542,9 +822,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:28:43 GMT
+      - Mon, 30 Oct 2023 07:27:08 GMT
       mise-correlation-id:
-      - b4f46dc4-c04c-4ccb-a104-e34a488c9857
+      - b805f36d-acef-44c8-9d95-ab20ae170921
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A48Z&sr=b&sp=r&sig=ZgEIElOehClRjg1uixz1VTiSSh8i9JsIHfqe05990i4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:48.5492392","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A48Z&sr=b&sp=r&sig=VkNCvo%2F3yh76EDkaNxO7Fo3EX6TVhA4eF7rxj3FH5Ks%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:48.5491651","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A48Z&sr=b&sp=r&sig=4ndT1LE8dg%2BSuIsIgD3NSHFQWRBgck5L1FXBH7bdB6g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:48.5492529","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A14Z&sr=b&sp=r&sig=F%2FUKsge4SiDh4Qr227C1pQ2a7%2FsRp8AMasYaaHFwaIM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:14.1375378","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A14Z&sr=b&sp=r&sig=AFLlSOtwZxQzYyNQEJDzCWTUMYuXo%2FtNc%2ByOuHsFK78%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:14.1374658","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A14Z&sr=b&sp=r&sig=b6IwzDmtfa5x24b%2FHGeOjNn3dQ0QOM7%2BpL29MEj0r%2FQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:14.1375516","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:53.688Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3197'
+      - '3211'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:28:48 GMT
+      - Mon, 30 Oct 2023 07:27:14 GMT
       mise-correlation-id:
-      - 933a133a-97b6-4e67-a62b-26f36ef87e84
+      - f9b3915d-6fc0-4eab-8bab-3ae09535d55a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,23 +880,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A53Z&sr=b&sp=r&sig=LnyvPRIVT%2FyONrCrHDMTASHhRjOpLIR7%2BhTo4v7Sh1U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:53.8660645","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A53Z&sr=b&sp=r&sig=7gthD3MF%2FHzFEpdBtxrhdRBQZEEPDqqvdDGMnm96Bho%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:53.8659959","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A53Z&sr=b&sp=r&sig=uVlX1zf1%2BPPHSGWjsAdREWmlb%2FahXHnLV87tfLmbbuc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:53.8660791","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A19Z&sr=b&sp=r&sig=pWR1J4vMXfD%2BWVcuuAWHhlIdBAIzM8FuPHOn3IHhA7Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:19.4621093","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A19Z&sr=b&sp=r&sig=UqP41sPH28g6xbU1xuzR5vpynUd5GGWVIADWDoUGwtU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:19.4620188","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A19Z&sr=b&sp=r&sig=oN%2FUEQdHJwef2vo%2FcOAOauDpa8N4h1ePr01L%2FIWzNEg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:19.462136","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:53.688Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3203'
+      - '3204'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:28:53 GMT
+      - Mon, 30 Oct 2023 07:27:19 GMT
       mise-correlation-id:
-      - 2950ea0b-09af-4d78-900a-c9abee49c430
+      - 6040b32e-a6a5-4232-90b3-d6f869480e72
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,10 +916,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A59Z&sr=b&sp=r&sig=FbpD1qoWPXFzkJ8DstnRuITt1sbB8MJ8c%2B4ux9wvQeA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:59.3216313","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A59Z&sr=b&sp=r&sig=1ohr4zLWe3fWL499hGvIP8YhTDv%2FTdiGp%2BHiiDsYx%2B8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:59.3215606","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A59Z&sr=b&sp=r&sig=2AInaxobwGgnCRn%2F2%2FhHQfzwET45J3QvjFbe5RghY%2Bk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:59.3216461","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A24Z&sr=b&sp=r&sig=ZFHee9izCr1%2BW%2BWbSJ4GS4W3CY9fd48QCUhxFTKRs%2Fs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:24.7789217","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A24Z&sr=b&sp=r&sig=atg97kMjvXNKATutpsRtLUZD0WOZbIFD2Q%2BwZRVZ080%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:24.7788318","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A24Z&sr=b&sp=r&sig=mydMoZaKGXleKlToUvezwP6spOnzhuJ2ucbHh8%2BjSco%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:24.7789435","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:53.688Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1650,9 +930,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:28:59 GMT
+      - Mon, 30 Oct 2023 07:27:24 GMT
       mise-correlation-id:
-      - ea2a3b9a-a20e-4b5f-958e-03c3896803e9
+      - 7279d1b4-d5a3-43db-8e05-17ca3800dbfc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,118 +952,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A04Z&sr=b&sp=r&sig=H3jKgKcQEtcMv4H9F%2BZ2yQieeVx40TPpmai2zmdEBws%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:04.6129179","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A04Z&sr=b&sp=r&sig=raIdwEcYrFiLniMu1nLibUzBvr8Yn3agplzh4hc4oRE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:04.6128492","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A04Z&sr=b&sp=r&sig=18h1rsYyiw3h6lotqn%2FLqVLa7N9p8wq%2B4uWuX%2F9LZro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:04.6129378","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:29:04 GMT
-      mise-correlation-id:
-      - 62c0e3f2-b2fa-49a7-813c-c5eb718c670c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A10Z&sr=b&sp=r&sig=NOfCWLSsUDFc9leOCu5BsRLj4Io4P3c4IU8k1Uf9l9E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:10.0199717","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A10Z&sr=b&sp=r&sig=JaJH%2B%2BLaw6ZHop7EWZgqTseICSHTKkWaNZCIR7Ku0zU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:10.019894","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A10Z&sr=b&sp=r&sig=zQMtIE6rwN3XoGZhmQZ9M1n%2F7%2BGtMzCrdw3IsKe2QE8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:10.0199863","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:29:10 GMT
-      mise-correlation-id:
-      - 8fd41ba7-52e7-4677-a7d5-27981639c47a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A15Z&sr=b&sp=r&sig=Qavw9ZBLC9EUN9FxyLvfbIPBT3nBnf1ExkLDGj5zID4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:15.2785751","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A15Z&sr=b&sp=r&sig=EUtOqT8hOmeuBV2HT0XNzEGyNEmURNGhr5HZTWfexH8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:15.2784881","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A15Z&sr=b&sp=r&sig=ADKovBXrjO8BpoSacsIujZOqgh1pPBlTFEgUucw1CMY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:15.278596","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:29:15 GMT
-      mise-correlation-id:
-      - 835b2d98-7bdb-49ed-b087-8ed39d965e40
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A20Z&sr=b&sp=r&sig=nU3S5UDDpvxnr3Q2lMXyd2XG0GGInEhMeiC%2B5UABpFE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:20.5817404","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A20Z&sr=b&sp=r&sig=ZHKFBX45WPmGPGz2mjN4D4UoQBTXemIdy7PP7OJV%2FZM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:20.5816691","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A20Z&sr=b&sp=r&sig=4%2Bc7pWtuo8%2F5NYsMOJMESItL0Kt4Enp3bLm7MEr1%2Buw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:20.5817641","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A30Z&sr=b&sp=r&sig=HBmdwIjB05pZRDm9bwhGB5JrF1WSMAXGIWo6vN1dT7E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:30.0484177","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A30Z&sr=b&sp=r&sig=vQVmbFv03dcshZ4pu180ppnzeOYo6i7PYBQIB%2Fhzmes%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:30.0483345","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A30Z&sr=b&sp=r&sig=oUY6gEu2XmhYYwKDrEtjzJx%2F35KMIw0Sa%2F7hm4mjkxc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:30.0484341","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:53.688Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1794,9 +966,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:20 GMT
+      - Mon, 30 Oct 2023 07:27:30 GMT
       mise-correlation-id:
-      - 4f3e754b-a54d-48ea-8bc7-2dc14e722c69
+      - e0751f53-5cb8-4e69-8894-ed340d794334
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1816,23 +988,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A25Z&sr=b&sp=r&sig=Fl8EOqbijG%2BWBSFi3PjttOGNn%2Fc%2F9XfbwmkS%2BAb%2BaN0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:25.8664788","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A25Z&sr=b&sp=r&sig=XGzbZ2mmXw6c55xmLGja2Dj%2BaHG9zYUAkylkZunpWEA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:25.8664049","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A25Z&sr=b&sp=r&sig=ZHAa3bVcBe1foCrz0ztc8Kfh1jwmcN4wg5syl4ty5o8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:25.8664934","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A35Z&sr=b&sp=r&sig=hZLhtwkDCfr%2BRKnRPPGO7R6oFllqv4kYaxVXyHl4iYc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:35.3022427","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A35Z&sr=b&sp=r&sig=0zwACl70t1Djmk3DZkdzID1QqGB7S%2BcJFqDn5Py%2B49E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:35.3020936","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A35Z&sr=b&sp=r&sig=DVyJCRacJAyBzQyK2abNWoUjAkweriwVXkPIGgbpGdk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:35.3022758","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:53.688Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3205'
+      - '3203'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:25 GMT
+      - Mon, 30 Oct 2023 07:27:35 GMT
       mise-correlation-id:
-      - 8738ea82-a4b7-4de5-8ed6-2196e8598fdc
+      - 8ec05893-ea52-4b9c-8f73-d5a8413bb1f7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1852,154 +1024,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A31Z&sr=b&sp=r&sig=TqkWep6ITPkYBVKnAhMqFlWG7VshxPCKc3ZJ3Hc%2FlF0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:31.6031363","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A31Z&sr=b&sp=r&sig=Qt280EhJVZrOUV2I2JMu8jgR5upc2aOsK8GRm8rLYqU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:31.6030687","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A31Z&sr=b&sp=r&sig=8izXpw7B9m3ylP4%2FOnFbL1zTsCbR%2BLUC33QaBAiMFrk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:31.6031512","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:29:31 GMT
-      mise-correlation-id:
-      - c263c7c3-cf27-4afc-92c9-360f6fc70a75
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A36Z&sr=b&sp=r&sig=o9vXG1byG742ptEstokGBTCg5mHBAs1ZODFLzIZFbdE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:36.8692732","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A36Z&sr=b&sp=r&sig=OsdHYNfGK5lo1iO0UiddrHXonaTkjLHgoU0ur1zIDO4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:36.8692026","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A36Z&sr=b&sp=r&sig=43pRjAknGlfjmnd7YIQ4w9nBsI8QACCwQfUDc61lHT8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:36.8692888","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:29:36 GMT
-      mise-correlation-id:
-      - 32926fd8-2d87-45e0-9765-5c7b3964993a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A42Z&sr=b&sp=r&sig=Zmb%2FxaqCcw%2B17iM7Xn2AJMVoxdxxTDTwQFc44qGhEDI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:42.1340042","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A42Z&sr=b&sp=r&sig=0km8Lsnz73I6iCxxi8hSiPL%2FSH1oZ7EgqTsExD8z548%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:42.1339202","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A42Z&sr=b&sp=r&sig=KqQSUA3xl6KGwkQj5DdTnhm%2Ff9XDUlFGfy5LbMjrp90%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:42.1340258","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:29:42 GMT
-      mise-correlation-id:
-      - 6e83b216-6cf6-48b0-80c3-0aed80363c99
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A47Z&sr=b&sp=r&sig=tUgk4uHTB2ed3c9GvTPd4ABlelj%2FitknDk36vQpGIxs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:47.3940443","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A47Z&sr=b&sp=r&sig=vvIZtdmB3zK%2FB7AcgshG4IxfX5e2HleoilUydY%2B4QqQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:47.3939785","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A47Z&sr=b&sp=r&sig=29%2Fjc2t8iI%2BMS1lUh10ZyFTEL7WSn43E%2FWSiF77clJc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:47.3940587","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:29:47 GMT
-      mise-correlation-id:
-      - 0d7ceda7-c925-452e-87e8-f10f0a0357ab
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A52Z&sr=b&sp=r&sig=mlNlWpR9igCic6RJtwMOp1dDgBzgNs0ukWr88SRKeHI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:52.650458","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A52Z&sr=b&sp=r&sig=2ds98hP5VJVwrnemjLktHGtMJB01FXdvevfgbuEIdzs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:52.6503682","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A52Z&sr=b&sp=r&sig=bqWh%2BavnjYO1T%2FnOVR6hh%2Fuq%2FEw%2B45NGsN5NsHMbcBE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:52.6504799","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A40Z&sr=b&sp=r&sig=oaBQKmJRFZ%2FKJyhnU81JPuZgv5RfRx6v9Cb3ucB41iA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:40.548749","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A40Z&sr=b&sp=r&sig=1iYo8BU5nKT5IJNU7oRLxluOJ2bpIFr2d8Mev6N7YqM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:40.5486789","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A40Z&sr=b&sp=r&sig=CwKbmw2dnhKJTsVyywF%2Fukk9KSGTcsF%2Buu7XkgdiICg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:40.5487634","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:53.688Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2010,9 +1038,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:52 GMT
+      - Mon, 30 Oct 2023 07:27:40 GMT
       mise-correlation-id:
-      - 7c3e8a8e-23b9-4a8e-ba55-7efedb4ace95
+      - a6051a34-b755-44af-879c-728e748bab7b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2032,23 +1060,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A57Z&sr=b&sp=r&sig=Y6dVprlzu3zOOEuDdvkLfNCmIINCPmeyJOc0k0tH9OA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:57.8973286","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A57Z&sr=b&sp=r&sig=ppLJD%2BeSjIqCLYtBoPHeJ9QwfFDSGoGYwXydbqe6Stg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:57.8972562","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A57Z&sr=b&sp=r&sig=Ou75Gf9YWf24JIvYNauefrw7fdWTP72ETqZBVdI5UfA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:57.8973431","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A45Z&sr=b&sp=r&sig=8oho9aYHF%2BJhBa9d8MjpfgUL9VnFWr%2FCsSO%2BCtSam54%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:45.8761193","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A45Z&sr=b&sp=r&sig=P4tLA%2BPWJKcPZhkunvU4hBXgj7m3kb2YRwQp2ihw0gA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:45.8760245","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A45Z&sr=b&sp=r&sig=92uVmeZdunRiTswdagpIucDWAOScAAPDexbwk81OIYo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:45.8761344","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3195'
+      - '3202'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:57 GMT
+      - Mon, 30 Oct 2023 07:27:45 GMT
       mise-correlation-id:
-      - 53801631-b3fe-4035-a339-697edb38ca09
+      - aa4ef39c-498e-4949-a2c9-e1c5515d99ed
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2068,154 +1096,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A03Z&sr=b&sp=r&sig=nozZF%2FgIwOKm%2FCdw6J6ZiNNBsyQGKCaJN4nq2pPpMlc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:03.1406037","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A03Z&sr=b&sp=r&sig=O6BYNFuGV5%2Bl5ulPgVCWDJRHmE%2BxUXnh0XqdcoRSYlg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:03.1405122","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A03Z&sr=b&sp=r&sig=kFgbHXCOq0Bw%2FeAlfEoybhccxxjv7%2FaPGjOPp50IVbI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:03.1406257","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:30:03 GMT
-      mise-correlation-id:
-      - 4692514e-b02e-4ac3-a701-73af176c5ded
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A08Z&sr=b&sp=r&sig=SI5lfPTLdVtzCnrOdCggF%2F9gYay9ZVheCWOUrjHwBls%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:08.4080576","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A08Z&sr=b&sp=r&sig=Ex84ee8KBvPGgGiVdmOdbIRDlGDXiH8vk%2FJZ9qjfwqo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:08.4079834","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A08Z&sr=b&sp=r&sig=xumD%2BZ8KwFd0YY4WzzEvuynO3ZXzn8lGRYoTHTeFaIM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:08.4080721","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:30:08 GMT
-      mise-correlation-id:
-      - 37f52350-2676-4d0f-905e-1337d427cd7e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A13Z&sr=b&sp=r&sig=%2B8m8HxYC665miHz%2FsGkag%2FZ%2FTQz36XzK3Tarqx0rEMc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:13.7405519","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A13Z&sr=b&sp=r&sig=cB1PTUKK9t9EEmeNqmo51IUz0TYLvROx074jw9HJtb0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:13.7404615","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A13Z&sr=b&sp=r&sig=nW4H6JnuCMZi0Sihtxi5PHy14kaSp%2BYDR6bRLAKSK%2Fs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:13.740566","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:30:13 GMT
-      mise-correlation-id:
-      - 863e09ca-566e-41e0-aa4b-dec2d7419e1b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A19Z&sr=b&sp=r&sig=RussAFh2NIFrixNLH6Ye%2FTiBZ5u2%2BIMUJU1EACAqmbU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:19.0665347","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A19Z&sr=b&sp=r&sig=Fn8a4t9Q26jpK5BIcSsCFFPyieuLTh8%2FbC0MWB1eLKc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:19.0664645","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A19Z&sr=b&sp=r&sig=avDSm8p6Ubj%2FFTcELlgFIr3Qhuv05l%2BEnW29%2B2Eg5yQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:19.0665485","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:30:19 GMT
-      mise-correlation-id:
-      - 3781284b-9c41-461f-b7bc-5509c2746560
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A24Z&sr=b&sp=r&sig=A5%2FlxCGUubnYshrtqQJkYDqiNXyBzPjIbPfqywDJZT4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:24.3208402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A24Z&sr=b&sp=r&sig=VmQLd5%2FzGwC2q4LL%2ByV4Cc9JUpDfTjApGj86D6duMiQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:24.320742","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A24Z&sr=b&sp=r&sig=HhLpzVABscVaEAbEs%2BK7ijcFaapcRObCp4NExSYhofM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:24.3208622","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A51Z&sr=b&sp=r&sig=k%2FkEkW6G4rOTt5vvUKXwR7zGZJQ7PWnKP3abLK55tXY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:51.1139303","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A51Z&sr=b&sp=r&sig=DlFDpKe1xVoOOMucOlB9tS8xcoHa2DfsSM5BV4nb3yY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:51.1138407","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A51Z&sr=b&sp=r&sig=hhqW0%2FkxcIXT9Vl%2BCdF0L92OjM4YHHbG3eVKNuS6g90%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:51.1139537","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2226,9 +1110,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:30:24 GMT
+      - Mon, 30 Oct 2023 07:27:51 GMT
       mise-correlation-id:
-      - e02aea22-cbe7-4d18-819e-d0aabe8e509b
+      - 4f55dfe4-ef07-4e19-b1fd-0748017600ac
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2248,10 +1132,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A29Z&sr=b&sp=r&sig=XqKf8si1oweDSwEgjF9Tm179gHcNSFFp06zKnB94I2o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:29.5769396","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A29Z&sr=b&sp=r&sig=OVQUNoG1p3IV0IetYbbgvKQNYyPGd%2FLCqOUhRs24TAg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:29.5768807","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A29Z&sr=b&sp=r&sig=r%2Bpz2ZwZ9wRZa2nSvakcYlndmKChX52aTy4qLWH%2FeOY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:29.5769536","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A56Z&sr=b&sp=r&sig=0Xq6GJD3%2FysM54OLFrqwrcbujIb%2BKBl4EdvZwbv2HBI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:56.3708417","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A56Z&sr=b&sp=r&sig=5zn7yHUH6N5liAXIhAC2lYcWH3Xp8oMjcuWoSf8yCL0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:56.3707597","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A56Z&sr=b&sp=r&sig=wJ2FyAn5qvZeXIJmK3qxQ513M%2BZZ88h%2BJ4AUoe8z0WM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:56.3708636","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:27:56 GMT
+      mise-correlation-id:
+      - df0d9863-6007-4b95-a2a8-2bc35519f007
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A01Z&sr=b&sp=r&sig=TzcNMidRZY%2FTri2lJ9%2FFm9rG3TlXwinR9l34bpsqCmc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:01.6662733","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A01Z&sr=b&sp=r&sig=QLQ0BzqvkmmhMysv2glcb9v3DczCIoYwdqEzdODNkkY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:01.6661596","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A01Z&sr=b&sp=r&sig=q%2Be0520PZcwJ1ItbXNsdiOD323J5S906gwVSfFN3Tu8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:01.666298","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2262,9 +1182,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:30:29 GMT
+      - Mon, 30 Oct 2023 07:28:01 GMT
       mise-correlation-id:
-      - aac04c8f-f275-4cda-b5cd-3e60fd83d8d4
+      - 34055127-3f0b-4f24-82af-54d25e635d01
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2284,10 +1204,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A34Z&sr=b&sp=r&sig=1Hwy0wqTTQEUiq4kf52HaU2iYIdjXXhqHbPjrwTXzcw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:34.9136269","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A34Z&sr=b&sp=r&sig=TrnEmLxYEyUUZ5gYwpN%2FVztd4Il82P1USELqJ2ANkjk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:34.9135339","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A34Z&sr=b&sp=r&sig=0oBsG8IYN3nXji3Ci9M3buwY7oxxYJiLcEV1%2FN4UNR4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:34.913648","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A06Z&sr=b&sp=r&sig=0b3ChL34clcfelM77wXRIURtj9KfpvMUxQvYD2nxUPs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:06.9307534","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A06Z&sr=b&sp=r&sig=oTmJZRnDl3bQPmjsbu3TvEy3V4p29lnS0AgE6oMgbMs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:06.9306697","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A06Z&sr=b&sp=r&sig=VEJRd3zk9CY2O0wICud69e6rFoMEC%2BK2iqCMDCCEJg0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:06.9307745","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2298,9 +1218,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:30:34 GMT
+      - Mon, 30 Oct 2023 07:28:06 GMT
       mise-correlation-id:
-      - 7a7e5372-57e9-4897-97ba-71a477503774
+      - a35ce43c-6f44-4027-aff1-45844faa0578
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2320,23 +1240,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A40Z&sr=b&sp=r&sig=8G4h8OpfLjXwgsv6o7Et1iR0N1OVYEbYgbxH3ZzieOM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:40.2552211","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A40Z&sr=b&sp=r&sig=tikzg2sB0o1K0cj3ihpK4zrycl%2FM0PJtdMCTsiYdLIE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:40.2551531","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A40Z&sr=b&sp=r&sig=GWSx7DnETL7nUfRlLWkr037X822cxaIend8L0FNO2jg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:40.2552364","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A12Z&sr=b&sp=r&sig=jgDPiPytfo40PDb0YvD3erKjXGeyla70r2uydxdnX2c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:12.1688942","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A12Z&sr=b&sp=r&sig=SzH2npa3kDErc2tFNsRGMkJOBY5zOt57ntPXR9MsjL4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:12.1687943","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A12Z&sr=b&sp=r&sig=1KXTuxlv%2BrgnDu6aJWTvYw2%2BMyv8sB7a2J1XNHxOv3M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:12.1689182","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3195'
+      - '3198'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:30:40 GMT
+      - Mon, 30 Oct 2023 07:28:12 GMT
       mise-correlation-id:
-      - f837add2-b266-437b-a383-43fff953d281
+      - b9343494-24bc-441f-a2ab-48150b31c84d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2356,23 +1276,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A45Z&sr=b&sp=r&sig=XF8%2BV3C6mKdJouy4Q42F4ROvXRsNKQYPnkWo0eLLXvQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:45.5334657","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A45Z&sr=b&sp=r&sig=j3YEaO5jUFaD5GGs21Zt2crUH441mH5hJxCTI63ILr0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:45.5333965","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A45Z&sr=b&sp=r&sig=b2%2BLUb4N%2FMs9tS%2B83Abw35j0j3H3ww31nn%2FFZThZGec%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:45.5334807","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A17Z&sr=b&sp=r&sig=9P513nMxVm%2F1DYivQ1rnvQsvpQn%2BTSSyA8B%2FXCHRyJA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:17.4228276","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A17Z&sr=b&sp=r&sig=sCCdtQ%2FxIFRJdcj19Hgnmz6MpDrTS5ATSHQf7uDpRmE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:17.4227428","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A17Z&sr=b&sp=r&sig=j9CDFNfRrrz0Sufx83WZJYY8ldDwvDUVCeuZFfBKGBw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:17.4228494","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3203'
+      - '3202'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:30:45 GMT
+      - Mon, 30 Oct 2023 07:28:17 GMT
       mise-correlation-id:
-      - 0483def5-dd1b-4be7-bd12-15f81ef4d29b
+      - 66513631-3867-4c8e-8dae-94ab250aea66
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2392,10 +1312,370 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A50Z&sr=b&sp=r&sig=Mo%2BkRp7ivTJ0piolvssDphkxfvUn02OkJ7jFFQWPHRA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:50.9181611","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A50Z&sr=b&sp=r&sig=JvpMM1iLZU8vcXrJEhbXrfxhmTajjvroyTOYCxz7WtE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:50.9180885","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A50Z&sr=b&sp=r&sig=aLI7U9%2BAMl0VuGFpSP0G0YnvUQLKFAqPUXK%2BIU8aMmA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:50.9181762","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A22Z&sr=b&sp=r&sig=M32aYenAyyqHmyFJuQ%2BYPhrkQ%2FcTHlYsMKyl0gKBTuo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:22.7404262","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A22Z&sr=b&sp=r&sig=0cvA8IruKuNX7AF25xekTLmstW77u2lVQtswK9Dp6Tk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:22.7403448","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A22Z&sr=b&sp=r&sig=l%2FLjgWwvVCHSqGCLqLGnCJEqIuP8VJY4xCyTtWG5HcE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:22.7404407","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:22 GMT
+      mise-correlation-id:
+      - 6e3d1369-bbd6-4702-b3d5-482d645f96a3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A28Z&sr=b&sp=r&sig=zSCB3aiBrZp3IYoS4zsmcS1QGIZRdA%2BtJsoIDo%2Bq9Is%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:28.0595354","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A28Z&sr=b&sp=r&sig=u3rEC2k846DhZsEeikK%2B1uu6QlQrlEuAQEd08YExSW8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:28.0594591","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A28Z&sr=b&sp=r&sig=5oSkanxNR2Pfth5JATBNuPBKuv9sFh9Zx%2FAabau1MtA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:28.05955","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:28 GMT
+      mise-correlation-id:
+      - 2fc7420b-45ef-4301-9731-f80caad813de
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A33Z&sr=b&sp=r&sig=yCbk78EHG7a3rgGO3TWSkXr9o%2FNMW7N0DM1H7CWHVWU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:33.3832111","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A33Z&sr=b&sp=r&sig=c3WFWuy9ZuOuyZU9plOsX6GOi9c%2FQaBnZLJ4DCcIoUQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:33.3831284","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A33Z&sr=b&sp=r&sig=gdrbTBXL%2FVpl5PL5IIeGlXv2pMXHS6bLqFHQlrEyZgA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:33.3832247","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:33 GMT
+      mise-correlation-id:
+      - fa7912ba-ce05-4cb8-b776-e6a09bf89fbc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A38Z&sr=b&sp=r&sig=ejCAR%2Flx6V8%2B53h7DyZH4KrGDs35UnbCYZdFO1AGIRU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:38.7206584","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A38Z&sr=b&sp=r&sig=sFZ9HTf6MvnLB%2BsAaXFArBWNJYj%2BX%2F%2BEEkLe4i9HomI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:38.7205696","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A38Z&sr=b&sp=r&sig=uyHNlI7RWFa6iOuAihJ5RlgPUGopf8cOE%2B5a5UlXYhQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:38.7206798","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3208'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:38 GMT
+      mise-correlation-id:
+      - cbb232c3-7916-40f9-b676-b49c415d948c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A43Z&sr=b&sp=r&sig=Sam3fb1hoQ0hfTnhnRuBHalVrBLJ2uLWl9pJILC5C1U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:43.9631924","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A43Z&sr=b&sp=r&sig=ml8NSnUdfsXOCHGl%2FRQT0jc3czNaqGB3NiOBWesP7YA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:43.963127","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A43Z&sr=b&sp=r&sig=B4trpP%2B3SkYAp9vY6aIup5v5lrDwXJGjb5F1ZIcsy2o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:43.963206","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:43 GMT
+      mise-correlation-id:
+      - 2755937e-78f6-4378-9e67-95823c7ec971
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A49Z&sr=b&sp=r&sig=vUApBs%2FKNq9YZTToOIoMATIBCYQKMSjtGvKLbzEJ8R8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:49.2053417","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A49Z&sr=b&sp=r&sig=il%2B9zx%2Ba8lzvekXtBcJ5qJf%2BgdXfcbPJM6BeQ5ig01I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:49.2052448","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A49Z&sr=b&sp=r&sig=XVeeIuA%2FUmEVY84NXlp7bGPE7Ef6ufW2WpkWlDDmNKo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:49.2053607","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:49 GMT
+      mise-correlation-id:
+      - b70809cd-9578-4b4a-9216-9a5a586c85d1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A54Z&sr=b&sp=r&sig=pIkvduLg%2BCVGUWU4vpbcmAowtdlt4rTukuMohVH60Vs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:54.4846309","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A54Z&sr=b&sp=r&sig=Tmpyp9DbYEE54SrU6Q5MmynDFI6ObPxZnGBgkRcSsYE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:54.4845487","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A54Z&sr=b&sp=r&sig=0xx0afLVyMT6WYDN2axwsqelMAaLkegB9L7QTw969HY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:54.4846449","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:54 GMT
+      mise-correlation-id:
+      - 420b627e-0aa6-41e3-9b4b-2844f935b740
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A59Z&sr=b&sp=r&sig=c1dT54Hryk2pF0DR06ZAbzTA3lXXgf2ebzi139MGE7E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:59.7376706","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A59Z&sr=b&sp=r&sig=hsmVRYAU3FbQittPbd%2BohdynjtGcLlzrUdfSQy885r0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:59.7375861","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A59Z&sr=b&sp=r&sig=mxF5uPdPoWMZptuPOqMR6flSWK5u%2Bxn8Lm94CzcbJzQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:59.7376926","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:59 GMT
+      mise-correlation-id:
+      - 32ed3c98-ef08-416a-a003-43f5fe1b2a10
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A05Z&sr=b&sp=r&sig=OuP3sYZnQ3ryWnUv7qTccBBNVzxFyGuNFu85VeVjCHw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:05.024321","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A05Z&sr=b&sp=r&sig=elBeCBmXoz2%2Fjgibqee0roU00c%2FFskKtnIh6jvXT%2BsA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:05.0242377","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A05Z&sr=b&sp=r&sig=10tSrFV3uq%2B0tlP6YVjyfO2dMzKxjKdfCE4HRmHofDc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:05.0243355","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:29:05 GMT
+      mise-correlation-id:
+      - 3c0b5202-c40b-4fee-92b4-e68726b24dfc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A10Z&sr=b&sp=r&sig=a8Zalx5MtyxP9xg8TGC6GhB5ZviTsH%2FLlTpesWL0GVs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:10.3579847","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A10Z&sr=b&sp=r&sig=5GDSwQ8ob8Mq%2FKGUFlgVklF926%2BwJsICWG4w3W7Mz3s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:10.357911","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A10Z&sr=b&sp=r&sig=qPr34ibGWZEt%2FhuKARCdk%2BmbJI%2Btf8wTbVk%2FEFSuncA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:10.358006","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:29:10 GMT
+      mise-correlation-id:
+      - db640d79-f109-49e0-8aea-924fb1da636a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A15Z&sr=b&sp=r&sig=AFKlJhNNbR37NBXcDdf21fL1Up4bBBtTvOsjSfVTlBo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:15.6167468","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A15Z&sr=b&sp=r&sig=UGY47QmzOE%2BJgPtR0TKQMxftcfM6hasAZOKY5%2FShNkU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:15.616677","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A15Z&sr=b&sp=r&sig=jFmJtgG8FvcVWflxzpFNTxKEW1bVUVdl%2BsuKv8ncJNk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:15.6167616","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2406,9 +1686,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:30:50 GMT
+      - Mon, 30 Oct 2023 07:29:15 GMT
       mise-correlation-id:
-      - 9ad6c925-cf03-420a-a5b8-204894ad03a4
+      - b7c1d41f-ea81-4f34-8c36-444f90fa1bda
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2428,23 +1708,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A56Z&sr=b&sp=r&sig=x4yA%2F56ouOvkyArJrvBmTP2HMcNxdX6Fpn%2FTOOv%2F71I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:56.2503955","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A56Z&sr=b&sp=r&sig=XDwxUDNUpk8qw0eDEwX%2BhTZOxB3l4rEdMmxxxDVgowg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:56.2503159","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A56Z&sr=b&sp=r&sig=BLyBw6%2Bqaezhz0TcL%2BtIWUA8Xu4xIwiXPtx2Ou1z2oo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:56.2504101","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A21Z&sr=b&sp=r&sig=Tbx0rJhzN8Byj63V3mskz4UrsDSnWs%2BWOMBC2U7yHgU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:21.1198569","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A21Z&sr=b&sp=r&sig=OIGBnMaf9MkV6jiORZ1DBWIhA%2Fo07hBYEbidiMXvxHk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:21.1197707","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A21Z&sr=b&sp=r&sig=NNU6tZkTQXycbYWhroVBtxF5Vr0i166uWH7y04n03yE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:21.1198787","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3205'
+      - '3198'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:30:56 GMT
+      - Mon, 30 Oct 2023 07:29:21 GMT
       mise-correlation-id:
-      - 1028bf88-e3f0-4fc7-ab64-407f4cfdb286
+      - ad1d34f0-09b3-434e-8386-17f3e51ad875
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2464,23 +1744,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A01Z&sr=b&sp=r&sig=xf%2BIKzhlX4E%2BXBgJ8MTiSosrwjjDDgeo3iHbvSGXh%2Fc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:01.5472638","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A01Z&sr=b&sp=r&sig=lMxUa8n4BmFnoQLTMxZHFOlAX%2F4xQQChKSdg0zVy7Fc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:01.5471922","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A01Z&sr=b&sp=r&sig=blCpRkstHmhTamr8kqDJbw2PYd993WXf6swQQIHy7K0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:01.5472791","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A26Z&sr=b&sp=r&sig=GuxflYodK0dq7LZGAGbjgymO4yg8FYllc2aAaHLeAwI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:26.4333328","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A26Z&sr=b&sp=r&sig=gxIr90ZlRLYK1cMjMJfc27da7zhdh70YTg%2FvXgkIwbw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:26.4332441","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A26Z&sr=b&sp=r&sig=STfGlsQaOk8yN9OaNKHjqBFufJF7FdqqUeKInWmtycc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:26.4333536","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3201'
+      - '3196'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:01 GMT
+      - Mon, 30 Oct 2023 07:29:26 GMT
       mise-correlation-id:
-      - 49a45789-41cc-4bc9-80d5-597721ee5024
+      - 4d4b66bc-fbf3-4a31-872a-9f526e711547
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2500,23 +1780,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A06Z&sr=b&sp=r&sig=rtNpJrJJYSSuLbsD08WMZ8J6qndH3LSIFU%2FzCegETMA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:06.8171742","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A06Z&sr=b&sp=r&sig=BBTNUcyC%2BpCqq%2FN%2BXTLN7jNyKW1l5BeX3XpwLWOLxdM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:06.8171047","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A06Z&sr=b&sp=r&sig=GnexckbSs4KYIgM9vcLFNyxbU0EzNKQ57XdSKeM4svE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:06.8171892","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A31Z&sr=b&sp=r&sig=kjORfyNyg7gLFBu2iezeDSbx3raFYERHZ04oSUzyYvs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:31.748584","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A31Z&sr=b&sp=r&sig=HtIYyxSA8STIZEQI5WmF3uk6jyZq4M4%2F%2Bz508hDviTg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:31.7485331","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A31Z&sr=b&sp=r&sig=9LANloRZbRtHKWhPC7I19UNTyUleuOz6HmU89Smj54I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:31.7485995","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3201'
+      - '3197'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:06 GMT
+      - Mon, 30 Oct 2023 07:29:31 GMT
       mise-correlation-id:
-      - 61705fab-5559-4214-8595-3c0bea05b092
+      - 6ace01a6-b8ca-49a7-aff1-3183e2c281a4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2536,10 +1816,154 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A12Z&sr=b&sp=r&sig=m3vnXPrkKtQYbRbOvVDXbzPtCH8kO%2BjdwPzv6j0IMrE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:12.0835409","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A12Z&sr=b&sp=r&sig=XAuGaKMxuwBYX1fj0Dhb6FWg55CRiBctXdxwC6YAOuU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:12.0834759","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A12Z&sr=b&sp=r&sig=yBatGGr%2FuB%2F7dhUbeCEZutzXiaAQ%2FzjPygbbzol93%2FI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:12.0835565","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A36Z&sr=b&sp=r&sig=sz0d4bjzG6iNgEpOSSpRhg85UouwLB3eBqW75vTTcRg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:36.9964321","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A36Z&sr=b&sp=r&sig=LRrfdbBqhDLWKHDgjnRqs592uMRTjnf%2B37w3cCcITwo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:36.9963609","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A36Z&sr=b&sp=r&sig=w4BoiymdzlV1y5Dp9552eRNFYRtYPM3aiLoS7V%2B20LE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:36.9964467","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:29:36 GMT
+      mise-correlation-id:
+      - 3f86dbcc-3820-4909-9b1d-430e88ca2abb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A42Z&sr=b&sp=r&sig=PHbNfM1L7feGULN7naREg%2B1tMYHBEKfKs0kZvT00Kdg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:42.2493776","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A42Z&sr=b&sp=r&sig=Unv9W3tQ9RJs1OQB4%2F4MoKWlYaFGR1v7PeQO7rP3nDg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:42.2492877","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A42Z&sr=b&sp=r&sig=XkxFv5O6bbnZBrQ0PsMOs8%2BNatsOb67IA%2Bcr9tspgjs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:42.2493923","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:29:42 GMT
+      mise-correlation-id:
+      - f7397ef1-64c8-408f-811d-1555904fafb6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A47Z&sr=b&sp=r&sig=y9OZzzCybFd8r2Cdxjw3G3RqXBW218TRSdwW215XNjI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:47.5264668","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A47Z&sr=b&sp=r&sig=2NRAx9bxVHp1iLE1fXqOdtY%2Fa4reixTtYXH8gMAaIng%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:47.5263994","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A47Z&sr=b&sp=r&sig=ThirQypOHWxCLY2p8%2BjtrnY2dsEfXuhRCkkVOUvKISE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:47.5264805","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:29:47 GMT
+      mise-correlation-id:
+      - e4282a89-a6fe-4b81-abd7-055552819124
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A52Z&sr=b&sp=r&sig=1Zz2aLiPpdJmJVOY8alGBOkX6uA8a5GnOEt0rK%2BOpLo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:52.8526789","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A52Z&sr=b&sp=r&sig=kbhSwRisUOTj3ghHB%2Fj7aMZ%2B0jroAWNLpPJ1Nk1wZi0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:52.8526113","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A52Z&sr=b&sp=r&sig=hErgg33ZB0z8U5CjAL2bEJvBKqG0ilTsLVjCJjQQ8A4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:52.8526933","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:29:52 GMT
+      mise-correlation-id:
+      - 2b3ab083-049c-4a98-9df9-6ec71c6bf3eb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A58Z&sr=b&sp=r&sig=8o3ioNV95P3lKSVgitgsKgCcYCvEDs3No1a%2BYzoy6lc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:58.1048122","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A58Z&sr=b&sp=r&sig=Gn185n%2FiyVNIy5u%2B6EqqfbBf%2BgNygj1Bh60dpkeT4Sg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:58.104716","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A58Z&sr=b&sp=r&sig=NPTaVHvFYea1%2Bq25YMxlmjHS641iCSMmUyAk1nDg1mY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:58.1048287","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2550,9 +1974,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:12 GMT
+      - Mon, 30 Oct 2023 07:29:58 GMT
       mise-correlation-id:
-      - bdddae97-14a6-498f-a278-a733114fae8d
+      - dafeccbb-063d-46f2-90eb-5e87ad8a4245
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2572,23 +1996,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A17Z&sr=b&sp=r&sig=dUT%2B5FqNbtwql%2F0x8vvFX4O%2FR6FR3XVc1GewogsX310%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:17.3645908","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A17Z&sr=b&sp=r&sig=9CTYSftQ6fHxX44beW7EeM%2FNulvNzrtAjF0ngYyUQpw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:17.3645254","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A17Z&sr=b&sp=r&sig=LnwBZQToxyzptWkhJG6y9TXT6JPb%2BYZCUFk%2F7KAZHi0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:17.3646063","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:40.07Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.917Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A03Z&sr=b&sp=r&sig=%2BjJhsbrH145ZACNCYYVCb03gHIy8cWgbvrnZCTr5UsM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:03.4142944","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A03Z&sr=b&sp=r&sig=TTw6bq0Ca3GPfMqPLne6p1YHvYgE6%2FiBxR9nL8%2F%2FBo0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:30:03.4142071","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A03Z&sr=b&sp=r&sig=Iagd3UsxC%2FrvOunDDyKS7pet7nbJY5ASR1N%2BgPHN5V8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:03.4143165","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3205'
+      - '3206'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:17 GMT
+      - Mon, 30 Oct 2023 07:30:03 GMT
       mise-correlation-id:
-      - ee867230-9cfd-4d60-90c6-4a202e6bf6b6
+      - fa3f0fa9-bcd1-40db-8f85-5f701213595c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2608,23 +2032,635 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A22Z&sr=b&sp=r&sig=sGwIQ87zDNrkW9nRGYdKDWl1oHrwAlQhrx2P0Yk4Rg0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:22.7566008","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A22Z&sr=b&sp=r&sig=u8IbjM6L8pAiXpFIoq8WdxMajEZIqucJCvbseHrGdRQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:22.7565019","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A22Z&sr=b&sp=r&sig=ZDv398EZRMjzEE%2FGU%2F9O27IH7Q2c1a0ptqZ7kECOO2Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:22.7566238","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-29T22:26:40.07Z","endDateTime":"2023-10-29T22:31:19.108Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:31:20.99Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A08Z&sr=b&sp=r&sig=3Nmm3eCfGEBtPs7g9C2AFG5i9oLH5gBWGeWa0A6K0b4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:08.7174578","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A08Z&sr=b&sp=r&sig=xG8Cb2WXDpweNNOxsnP4bjSlNgKEz%2FwTqRKstBH1LS8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:30:08.717391","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A08Z&sr=b&sp=r&sig=9du%2BCpzbFVumWm%2FCxvtpFJSBxJnlcpgxYVKxCQiSNXQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:08.7174719","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3232'
+      - '3199'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:22 GMT
+      - Mon, 30 Oct 2023 07:30:08 GMT
       mise-correlation-id:
-      - f7a5c6cb-6253-43eb-b484-3d2f30ba2318
+      - bf233ee8-d647-4777-9691-9c37f6584226
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A13Z&sr=b&sp=r&sig=Pwt79SlLY75DehfbYUiIHVkpUcu7qgGzCpuH5FquIxc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:13.9632916","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A13Z&sr=b&sp=r&sig=QTmxtRwCaWPxwaqdF3mtZ1XwJ0sSR6pIgCWmFeKN1vI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:30:13.9632219","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A13Z&sr=b&sp=r&sig=6RDs3IuHwvF5kSTxOSfjLlXUJ5N%2FqUUBKJY4IChZGvE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:13.9633057","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:30:13 GMT
+      mise-correlation-id:
+      - 55ea0809-4608-4566-ae2b-80061c489f00
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A19Z&sr=b&sp=r&sig=pu7C6opmW4hfUfRKAfJo%2FWTe5KWeirav3yX3Q7WygW0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:19.2162576","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A19Z&sr=b&sp=r&sig=GC07c%2FnhBIVz%2FQ1JjOtegUxBam6MqSh6VBifr1%2BxmE0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:30:19.2161736","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A19Z&sr=b&sp=r&sig=3vNssY3g%2FXFEE7CTPTUX0wLNdd3iXxUaeFYOFlrPRAI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:19.2162718","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:30:19 GMT
+      mise-correlation-id:
+      - 9fecd506-c125-4c79-92ba-e3edd7ca68fa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A24Z&sr=b&sp=r&sig=36Puh8TpZCqb6G6XA9%2BFQKl%2Fo6aOPfnBxYF4%2Fmqlp%2Bo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:24.492203","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A24Z&sr=b&sp=r&sig=rQBLojAiT%2B47So9jAzel1prBin%2BmrUWK1KrhSkRfKX4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:30:24.4921348","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A24Z&sr=b&sp=r&sig=JG66zu7St4LNAparslWL%2F1CxztU2H9gTo2AyGkzm7eA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:24.4922177","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3207'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:30:24 GMT
+      mise-correlation-id:
+      - 8bbc2f5b-d09b-4717-9ea9-ad350438aba2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A29Z&sr=b&sp=r&sig=IlwUPxJ9m23rftFrEJr6nuw5Li%2BM%2BogvIy1Hr7h9XD4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:29.8167686","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A29Z&sr=b&sp=r&sig=h%2B5BYV6x90Azc0x99OiObn3MawuKTqDyzuQ9%2Fg0oL7Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:30:29.8166854","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A29Z&sr=b&sp=r&sig=T4dJSD5dSWEgNmgWN9Dv03Utpvv4qV0oRDxZK88yU7o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:29.8167878","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:30:29 GMT
+      mise-correlation-id:
+      - e7b1e57c-ced0-42a1-aa02-f39ae021085a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A35Z&sr=b&sp=r&sig=UFniXcasjobIYqfU9q%2BdMFGZu7z2PpIroaQEcU8GtBk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:35.0552893","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A35Z&sr=b&sp=r&sig=wl3YIAVfOlfu9cokt9JV1NsR8yXYcD6g3KlCQ5CktSw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:30:35.0552235","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A35Z&sr=b&sp=r&sig=5J31HQHo61GpP2Dm5e5x1FRWl22JilsfxcL9JUL%2Fktc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:35.0553045","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:30:35 GMT
+      mise-correlation-id:
+      - 16b2d6a8-8dfb-4aee-b2bb-2a2833bdfe3f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A40Z&sr=b&sp=r&sig=g0Ez7unJUepZULOHBllq7zdp54O63VLYM%2B3utqsg8ac%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:40.3650881","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A40Z&sr=b&sp=r&sig=ooZXCT6yllejkb52NON%2FEu2GGuJvC6qYJT7f3Ft%2BWBI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:30:40.3649993","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A40Z&sr=b&sp=r&sig=d3x30i9CK7t3Gz55CGerCMREWyqyttnImcy7wWtIj%2Bo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:40.365111","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:30:40 GMT
+      mise-correlation-id:
+      - 360a8913-09ef-4bfa-9aae-06d73b13a515
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A45Z&sr=b&sp=r&sig=tfr9kBKf1EHMFtLHcQy8hu%2BVJaYPJdOl0OPJYTTlBYI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:45.6917763","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A45Z&sr=b&sp=r&sig=rsZfbljWMCA2olfkM7mzm%2FyL%2Bn0uXl5wfYvc5KwVwkA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:30:45.6916925","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A45Z&sr=b&sp=r&sig=ZjcgST1HaIEC6938Bq3fqWFNC8Z97JOjDovh5Ly755M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:45.691798","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:30:45 GMT
+      mise-correlation-id:
+      - f68826b9-a023-4256-b338-dbfd03d6527e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A50Z&sr=b&sp=r&sig=ohpN1PeArchUh6GctZ4PCmBZ3twJ9SWthjmz7Zp%2BMuM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:50.9533601","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A50Z&sr=b&sp=r&sig=73tirWjbMdnNUO6S3Mzx5th8LNux4y3hDkiCgV54LFs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:30:50.9532565","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A50Z&sr=b&sp=r&sig=8ze2guNLerdEAK9DutKWqzhsbnnTaKSie34KbDomODA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:50.9533858","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:30:50 GMT
+      mise-correlation-id:
+      - 4baf1b4d-c655-4f8d-9811-15c59659ee4d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A56Z&sr=b&sp=r&sig=sjNNwQAUcb8cEO159WZADQ84x%2FPSp5w9C15t1zlcw4o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:56.208312","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A56Z&sr=b&sp=r&sig=fM%2F7vKKyJGSmJ5vakZhFIGpO3LN4IULbVs6LWpTQPN4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:30:56.2082283","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A56Z&sr=b&sp=r&sig=qC65SLSqD1BNgtF3bfj4ntmRkT3V%2BNB6mFI1az1ju4Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:56.2083276","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:30:56 GMT
+      mise-correlation-id:
+      - 2ed96da2-94cf-4f07-ace7-12c52323791f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A01Z&sr=b&sp=r&sig=qEznmx1V5PRDUuwN5F%2BINBBgEy3N1QbO9TSJmcmrq%2F4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:01.4815977","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A01Z&sr=b&sp=r&sig=HnRasvp5VL32WBy1gf4lx89hMLJ6sjtHIRAbaXdU8%2BY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:31:01.4815141","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A01Z&sr=b&sp=r&sig=aggFDCPeN2aFcbUPdu1730v4bTLot0SY72TbogSFhw8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:01.481623","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:31:01 GMT
+      mise-correlation-id:
+      - 9bd839aa-2b9f-466b-aa16-449acb021b93
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A06Z&sr=b&sp=r&sig=k8YnVr5ju73oz04fey8oFpM5LVNLzXJZLZRJTL%2FJ5os%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:06.751319","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A06Z&sr=b&sp=r&sig=IUDo2187uHUqvu8sov8dgY0RKjx1UXZbbyKyrTwgC1Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:31:06.7512306","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A06Z&sr=b&sp=r&sig=aRUaAuddCIV8AvI7inDJy8kWgWLrxZqm%2BbP7RF%2FLI9k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:06.7513406","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:31:06 GMT
+      mise-correlation-id:
+      - 09c96fe2-bcaf-4014-a8d0-4193ff18b2f8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A12Z&sr=b&sp=r&sig=sXum8ZZq8XHwkAyUjSZvAAid0H0yFmr331MobR9VU7A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:12.0270262","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A12Z&sr=b&sp=r&sig=qCbJTAwm7pODFwkx3C1%2B71Ed5H82YJDpeAFfn%2BZQoQE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:31:12.0269512","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A12Z&sr=b&sp=r&sig=GJ0WKaA2Ei79uddPclbfLK4CuzqYb28EmEKokN8bVhM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:12.0270401","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:31:12 GMT
+      mise-correlation-id:
+      - 37bc31ad-19e5-485f-9ede-fdc0c2cd6fc7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A17Z&sr=b&sp=r&sig=nEI44cGoCTXtvo7k37Pdl3SaRAi9Aro3Qr9U3hh5Puc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:17.2917205","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A17Z&sr=b&sp=r&sig=WVyzENlMpZyGttidNgBX%2FxjzAtRZT%2FhWekmHZ8V%2FSw4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:31:17.2916119","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A17Z&sr=b&sp=r&sig=gITcK6EEF6JFyFBzBj0NIhxHbS%2BeQWWcIA2r6dvaq7k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:17.2917438","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:31:17 GMT
+      mise-correlation-id:
+      - 57b64e9d-83fb-4927-9df3-52be980ea69f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A22Z&sr=b&sp=r&sig=5%2FKWVfKGgv0AkmKodkFnTXjggw4tmnjWANE%2F307BSMM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:22.5742624","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A22Z&sr=b&sp=r&sig=vHejM7JzQS94WPFPzWozoHvU%2B3Tv6rrGv%2Br2GwaCCZ8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:31:22.5741998","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A22Z&sr=b&sp=r&sig=PQ2we7uGHRRP6XNiJkBap3vfkOb%2FieJ85ueRUVAeKac%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:22.5742762","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:31:22 GMT
+      mise-correlation-id:
+      - 6c28109e-4279-4d37-8ab6-84a4c5bb44cf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A27Z&sr=b&sp=r&sig=5X61sDNflezFugj4lyk0NiiqQfQI3Dp1MxwmQAxAjjc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:27.8963183","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A27Z&sr=b&sp=r&sig=pkHb7Lvv1NTYwgSlEVnFSKU6r1Z017%2BK%2Fq55tdHbKck%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:31:27.896232","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A27Z&sr=b&sp=r&sig=FwyJJegfqfDCvWm43WjBYZC7Tqhtvqs09bfkMcsV%2Fn8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:27.8963324","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:31:27 GMT
+      mise-correlation-id:
+      - e8e1c0ff-b5c4-48a5-81ae-0922940a892c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A33Z&sr=b&sp=r&sig=WjA70nQUmo4a5aiItepZvlvFLr2xpXSawqzxzRDbt1k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:33.2207268","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A33Z&sr=b&sp=r&sig=1zz%2F8T4vVteeVzXFptCYCEZcMnrryoCjD7bEGpbcLkg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:31:33.2206597","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A33Z&sr=b&sp=r&sig=M5YIergn4wBZeoTXkutZnnLGjWxNAZWfBJGaw4yHDOs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:33.220741","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.526Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:44.552Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:31:33 GMT
+      mise-correlation-id:
+      - fdca3d16-b75b-474b-b50d-f728c243d4a1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A38Z&sr=b&sp=r&sig=x4sJIGyolHEOCYaRJVqgRxIGR%2F1wmLPhWc8NxIrNrOg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:38.5358481","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A38Z&sr=b&sp=r&sig=kMdiZH9YqY3k0QKY84oLBzC60YbUCdvxDiZimPQxBQY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:31:38.5357822","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A38Z&sr=b&sp=r&sig=u%2Ff3R9vwRiiw2PAvDYIZLGDtD5bOxcgzqDbFlaW%2BosY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:38.535862","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-30T07:26:53.526Z","endDateTime":"2023-10-30T07:31:33.977Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:31:35.888Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:31:38 GMT
+      mise-correlation-id:
+      - 876da904-4972-4bf6-8263-6cd312cc4fd0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2647,7 +2683,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:39.7823896Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:39.7823896Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:54.1558705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:54.1558705Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2656,9 +2692,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:24 GMT
+      - Mon, 30 Oct 2023 07:31:40 GMT
       etag:
-      - '"3c00f92f-0000-0100-0000-653edbe50000"'
+      - '"3f002872-0000-0100-0000-653f5a840000"'
       expires:
       - '-1'
       pragma:
@@ -2688,23 +2724,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=metric-test-case&api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=metric-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A25Z&sr=b&sp=r&sig=CV8%2B60yS8lFbRP%2BDGpiFC5Jg4B%2F0%2FR11M4TVTykynTQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:25.4458437","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A25Z&sr=b&sp=r&sig=Q9wjkdJ2kdoWe5%2B8KG%2Ff1KGQGwzSRjWf3xgwC8hsamQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:25.4457719","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A25Z&sr=b&sp=r&sig=mk8okqxCYgXCulAQtKO2T1c8M52jJU0G3AcR97iYcb4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:25.445858","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-29T22:26:40.07Z","endDateTime":"2023-10-29T22:31:19.108Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:31:20.99Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A41Z&sr=b&sp=r&sig=0UTffyhsQAKew9BDCR1FKgdfsHj7d9QlOs5tzc%2FGg8Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:41.6306955","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A41Z&sr=b&sp=r&sig=LbVunlBQ1Er7CAheYEQYnJcqn2h0WbbpcUiH7Mbdc10%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:31:41.630612","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A41Z&sr=b&sp=r&sig=kABxSs5a%2FcchJN4xBO0OZIaiwneuGmj2zjLbDVPb8js%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:41.6307201","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/100e8a36-dda7-40f5-97ff-d9b99fed0e3f_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A41Z&sr=b&sp=r&sig=omYpsKrDRXFGLpPfVySH4ZxXYoP2ALtBoEwH0BwAR6E%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:41.6307369","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/100e8a36-dda7-40f5-97ff-d9b99fed0e3f_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A41Z&sr=b&sp=r&sig=1Iq94krDhpRhS9B8qb7Zu8HmhDLiPVK6cVsLWU26ysY%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:41.6307791","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-30T07:26:53.526Z","endDateTime":"2023-10-30T07:31:33.977Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:31:41.46Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3251'
+      - '4403'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:25 GMT
+      - Mon, 30 Oct 2023 07:31:41 GMT
       mise-correlation-id:
-      - 72647424-e851-45e2-8502-64d38f88248c
+      - 083fdabc-42f1-4be0-ab90-bce3005942bc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2727,7 +2763,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:39.7823896Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:39.7823896Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:54.1558705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:54.1558705Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2736,9 +2772,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:26 GMT
+      - Mon, 30 Oct 2023 07:31:43 GMT
       etag:
-      - '"3c00f92f-0000-0100-0000-653edbe50000"'
+      - '"3f002872-0000-0100-0000-653f5a840000"'
       expires:
       - '-1'
       pragma:
@@ -2768,23 +2804,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A27Z&sr=b&sp=r&sig=G%2BNuCAXeEZ7DIeRhuKlki6VKPtmNpfrut9sWPqIOlE8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:27.8794753","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A27Z&sr=b&sp=r&sig=Tj%2Frc4CNSQfhW32%2FoP5yo7T3mCxB%2FG30tSCmH6IBwHo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:27.8793874","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A27Z&sr=b&sp=r&sig=UfFOKle80Z8pDBlndXUpFc5wxQjvamemBzFPUI%2FoPYY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:27.8794977","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-29T22:26:40.07Z","endDateTime":"2023-10-29T22:31:19.108Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:31:20.99Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A44Z&sr=b&sp=r&sig=psZGpiR68hsmfTNUmVdnA65%2FqNgWsLsOw6nTSWym05w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:44.0826849","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A44Z&sr=b&sp=r&sig=uh5NkbYEmLWO6pPpV%2FanJm4FOnSJxprq%2BB9LiimqL%2F4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:31:44.0825747","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A44Z&sr=b&sp=r&sig=PONlATVcmmQyT3aQ4RLITu%2FUpv5UpIbyEBcWBaStouw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:44.0827112","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/100e8a36-dda7-40f5-97ff-d9b99fed0e3f_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A44Z&sr=b&sp=r&sig=S8XgNipIo53t4uP2Jz8gpLMlQKZJM0dhSnRxIYfiBDg%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:44.0827351","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/100e8a36-dda7-40f5-97ff-d9b99fed0e3f_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A44Z&sr=b&sp=r&sig=4gycbL9xN9G1O1IjcH6daEaqO2nYcsVTB3mld7PJJjU%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:44.0827602","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-30T07:26:53.526Z","endDateTime":"2023-10-30T07:31:33.977Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:31:41.46Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3238'
+      - '4398'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:27 GMT
+      - Mon, 30 Oct 2023 07:31:44 GMT
       mise-correlation-id:
-      - 9e0d29d9-c115-41aa-89e3-58f0359c4f42
+      - 64818a30-618c-4dc5-87d4-5c7cc2bdceaf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2804,7 +2840,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"dimensions":[{"description":"Request Name","name":"RequestName"}],"description":"No
@@ -2823,9 +2859,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:28 GMT
+      - Mon, 30 Oct 2023 07:31:44 GMT
       mise-correlation-id:
-      - 5775b2dd-4d45-4126-89f1-34b0a6bf038b
+      - 07151b03-9d52-4eab-ae94-2bf6c5c76a78
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2849,10 +2885,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-30T07%3A26%3A53.526Z%2F2023-10-30T07%3A31%3A33.977Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-29T22:27:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:28:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:29:00.000Z","value":1.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-30T07:27:00.000Z","value":1.0},{"timestamp":"2023-10-30T07:28:00.000Z","value":1.0},{"timestamp":"2023-10-30T07:29:00.000Z","value":1.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2863,9 +2899,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:29 GMT
+      - Mon, 30 Oct 2023 07:31:44 GMT
       mise-correlation-id:
-      - c79cfeba-4d5f-4081-8852-c0c0750d030d
+      - e4ba60d8-b1d0-4ffc-91db-5053854496a5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2889,10 +2925,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=ResponseTime&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=ResponseTime&metricNamespace=LoadTestRunMetrics&timespan=2023-10-30T07%3A26%3A53.526Z%2F2023-10-30T07%3A31%3A33.977Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-29T22:27:00.000Z","value":32.0},{"timestamp":"2023-10-29T22:28:00.000Z","value":16.0},{"timestamp":"2023-10-29T22:29:00.000Z","value":16.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-30T07:27:00.000Z","value":65.0},{"timestamp":"2023-10-30T07:28:00.000Z","value":16.0},{"timestamp":"2023-10-30T07:29:00.000Z","value":14.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2903,9 +2939,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:29 GMT
+      - Mon, 30 Oct 2023 07:31:45 GMT
       mise-correlation-id:
-      - b849fd1c-ed3e-4db3-bfe6-64f0e448a413
+      - 64c9efb4-388e-4c06-b670-1cf458408665
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2929,10 +2965,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=TotalRequests&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=TotalRequests&metricNamespace=LoadTestRunMetrics&timespan=2023-10-30T07%3A26%3A53.526Z%2F2023-10-30T07%3A31%3A33.977Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-29T22:27:00.000Z","value":44.0},{"timestamp":"2023-10-29T22:28:00.000Z","value":48.0},{"timestamp":"2023-10-29T22:29:00.000Z","value":28.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-30T07:27:00.000Z","value":20.0},{"timestamp":"2023-10-30T07:28:00.000Z","value":56.0},{"timestamp":"2023-10-30T07:29:00.000Z","value":44.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2943,9 +2979,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:29 GMT
+      - Mon, 30 Oct 2023 07:31:45 GMT
       mise-correlation-id:
-      - 2307311c-7899-4335-bb12-b7351e76fb0f
+      - 48a6c5d1-161c-478c-9d89-167867187a1e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2969,7 +3005,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=Errors&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=Errors&metricNamespace=LoadTestRunMetrics&timespan=2023-10-30T07%3A26%3A53.526Z%2F2023-10-30T07%3A31%3A33.977Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"data":[]}]}'
@@ -2983,9 +3019,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:30 GMT
+      - Mon, 30 Oct 2023 07:31:50 GMT
       mise-correlation-id:
-      - 88df0f6b-5a89-445d-bd71-2e54425aafda
+      - b27bc469-6e78-4f57-b775-cf5872dff095
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3008,7 +3044,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:39.7823896Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:39.7823896Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:54.1558705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:54.1558705Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -3017,9 +3053,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:31 GMT
+      - Mon, 30 Oct 2023 07:31:51 GMT
       etag:
-      - '"3c00f92f-0000-0100-0000-653edbe50000"'
+      - '"3f002872-0000-0100-0000-653f5a840000"'
       expires:
       - '-1'
       pragma:
@@ -3049,23 +3085,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A32Z&sr=b&sp=r&sig=7GsFDxN3SYGyttZhmwx3Ve1U7A0mQV3DSn96aUVczTU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:32.8651187","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A32Z&sr=b&sp=r&sig=V0W8KROv%2FeLndJj%2F0hgC3x7bbfuTvzquzYylI4h8Kjc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:32.8650324","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A32Z&sr=b&sp=r&sig=8H1Vb533PJl9Wqzp5qGBmXofV4CHOYH8sZomDpvcrss%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:32.86514","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/f9a26422-7c17-48cc-b9ea-b6eb1a728824_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A32Z&sr=b&sp=r&sig=PR1HaEdjDr%2Ff01WvR66L8KJT9RwWPAb2Jp0RsZUJbC8%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:32.8651603","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/f9a26422-7c17-48cc-b9ea-b6eb1a728824_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A32Z&sr=b&sp=r&sig=xftWJjuJ%2Fkw%2FW9B0Cl3lqkgydMft43JPW4CNsWJnEw4%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:32.8651813","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-29T22:26:40.07Z","endDateTime":"2023-10-29T22:31:19.108Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:31:29.961Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A53Z&sr=b&sp=r&sig=RF59kgErD8Y1cZ604IQ1K33cG3mTpp5URQQ40%2Bo9ibI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:53.0829276","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A53Z&sr=b&sp=r&sig=XfYTAtM8PY3xExNkkvwcSG5UdmVgdG%2F1TJH7YRqYHY8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:31:53.0828423","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A53Z&sr=b&sp=r&sig=ojcEyyGB%2FA9%2FC8NM530jM7OqCgTvSaHBQQm2WcQjn7A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:53.0829497","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/100e8a36-dda7-40f5-97ff-d9b99fed0e3f_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A53Z&sr=b&sp=r&sig=rPUasbxLYVUYycf1ro%2B0tqFh1l69GP4XXZZNFOgJwwc%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:53.0829711","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/100e8a36-dda7-40f5-97ff-d9b99fed0e3f_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A53Z&sr=b&sp=r&sig=TRA7e7Md2Tdv6%2Bs7B0p5S9cduwC69R3cNemfb%2FHb%2FeQ%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:53.0829948","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-30T07:26:53.526Z","endDateTime":"2023-10-30T07:31:33.977Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:31:41.46Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4396'
+      - '4404'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:32 GMT
+      - Mon, 30 Oct 2023 07:31:53 GMT
       mise-correlation-id:
-      - 2abed0e5-25c1-451b-a279-35daa0ee15d3
+      - 3e363145-f1e2-48a9-8ca8-5c46f78cd77a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3089,10 +3125,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-30T07%3A26%3A53.526Z%2F2023-10-30T07%3A31%3A33.977Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-29T22:27:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:28:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:29:00.000Z","value":1.0}]}]}'
+      string: '{"value":[{"data":[{"timestamp":"2023-10-30T07:27:00.000Z","value":1.0},{"timestamp":"2023-10-30T07:28:00.000Z","value":1.0},{"timestamp":"2023-10-30T07:29:00.000Z","value":1.0}]}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -3103,9 +3139,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:33 GMT
+      - Mon, 30 Oct 2023 07:31:53 GMT
       mise-correlation-id:
-      - cf2cb718-4285-46f8-8cb7-d4b53b23beed
+      - 620d40bf-bf75-4303-a9f9-73d92cda7a4c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3128,7 +3164,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:39.7823896Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:39.7823896Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:54.1558705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:54.1558705Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -3137,9 +3173,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:36 GMT
+      - Mon, 30 Oct 2023 07:31:54 GMT
       etag:
-      - '"3c00f92f-0000-0100-0000-653edbe50000"'
+      - '"3f002872-0000-0100-0000-653f5a840000"'
       expires:
       - '-1'
       pragma:
@@ -3169,23 +3205,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A36Z&sr=b&sp=r&sig=VLEsxKHETMtjXkLfOhIVSWHAPX3Ba9dhIogqofasi2M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:36.915669","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A36Z&sr=b&sp=r&sig=Dj6XTOAX6fs27Ewqxucefb%2BJbyeuQpeEZ%2FUxkqIhSrM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:36.9155695","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A36Z&sr=b&sp=r&sig=n53g6bTCukRFvNKL6Tx0Z0gF0n4WBu7gmVkP4l0YvHk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:36.9156942","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/f9a26422-7c17-48cc-b9ea-b6eb1a728824_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A36Z&sr=b&sp=r&sig=nSMbn3lfaYMm0jGRHWFmv41n4CNfbJ83%2BNrXSrwM4DM%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:36.9157196","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/f9a26422-7c17-48cc-b9ea-b6eb1a728824_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A36Z&sr=b&sp=r&sig=1W9B3jy8bCrEsxEa8P%2Fknnhu8XpjwgV0Pi05EwcZvO0%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:36.9157462","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-29T22:26:40.07Z","endDateTime":"2023-10-29T22:31:19.108Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:31:29.961Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A56Z&sr=b&sp=r&sig=D8DlN9DSZMGh6ndWD%2Fb6Jdk7L0OVUnoJPfLsSU1620U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:56.0612792","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A56Z&sr=b&sp=r&sig=qX%2F8d%2F1vosf0NArBYNiGS1niDtOUOrFZqj%2BmO2XHILY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:31:56.0611864","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A56Z&sr=b&sp=r&sig=a2Htus93Rn5jwg4oLMprovdoCJ0y%2BmPDAm%2F5nO6Xfkw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:56.0612939","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/100e8a36-dda7-40f5-97ff-d9b99fed0e3f_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A56Z&sr=b&sp=r&sig=aT3tZmhXRANbe90TKAclOPv9A8zvsYZuMn%2Bv1NNwlhQ%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:56.0613078","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/100e8a36-dda7-40f5-97ff-d9b99fed0e3f_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A56Z&sr=b&sp=r&sig=xwuigDUm%2BXX68bXwiJxl1dij1El6KwaZ7XzC%2F60AyV8%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:56.0613215","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-30T07:26:53.526Z","endDateTime":"2023-10-30T07:31:33.977Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:31:41.46Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4395'
+      - '4406'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:36 GMT
+      - Mon, 30 Oct 2023 07:31:56 GMT
       mise-correlation-id:
-      - d7fe4793-3ce5-4544-bc06-4c8e33472dcc
+      - 77556c52-372d-40d4-af08-81430c36c7b7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3205,7 +3241,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-definitions?metricNamespace=LoadTestRunMetrics&api-version=2022-11-01
   response:
     body:
       string: '{"value":[{"dimensions":[{"description":"Request Name","name":"RequestName"}],"description":"No
@@ -3224,9 +3260,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:37 GMT
+      - Mon, 30 Oct 2023 07:31:56 GMT
       mise-correlation-id:
-      - e6be3feb-daed-45a9-9eaf-875a109b6fec
+      - 7f65857c-446c-46e9-b190-e0d0ff5d35d8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3246,7 +3282,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-30T07%3A26%3A53.526Z%2F2023-10-30T07%3A31%3A33.977Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":["HTTP Request"]}'
@@ -3260,9 +3296,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:38 GMT
+      - Mon, 30 Oct 2023 07:31:56 GMT
       mise-correlation-id:
-      - 69772b85-ab74-4884-a7e3-564ec06e754b
+      - f953bcd3-8c32-40b9-8468-1ff5ddb51176
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3286,10 +3322,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-30T07%3A26%3A53.526Z%2F2023-10-30T07%3A31%3A33.977Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-29T22:27:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:28:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:29:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+      string: '{"value":[{"data":[{"timestamp":"2023-10-30T07:27:00.000Z","value":1.0},{"timestamp":"2023-10-30T07:28:00.000Z","value":1.0},{"timestamp":"2023-10-30T07:29:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
         Request"}]}]}'
     headers:
       api-supported-versions:
@@ -3301,9 +3337,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:38 GMT
+      - Mon, 30 Oct 2023 07:31:57 GMT
       mise-correlation-id:
-      - 88995aac-1c7d-4705-b457-8b572f3c24d4
+      - 89b81e98-0262-4a4f-b066-b00df4a88e42
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3326,7 +3362,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:39.7823896Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:39.7823896Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:54.1558705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:54.1558705Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -3335,9 +3371,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:39 GMT
+      - Mon, 30 Oct 2023 07:31:58 GMT
       etag:
-      - '"3c00f92f-0000-0100-0000-653edbe50000"'
+      - '"3f002872-0000-0100-0000-653f5a840000"'
       expires:
       - '-1'
       pragma:
@@ -3367,23 +3403,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A41Z&sr=b&sp=r&sig=2OdGqMyQy4350ZxaL6bjd2202pk%2Bz%2BmktLJabMueyO0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:41.0465598","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A41Z&sr=b&sp=r&sig=KGVZQNqtepBFAStTbmpPCWAcoO3MW17w9EP359tfDGQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:41.0464779","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A41Z&sr=b&sp=r&sig=ETIXG%2FtOydJb9RlhUmuQHy38nBoMJaiiojwx%2FfEUqiw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:41.0465778","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/f9a26422-7c17-48cc-b9ea-b6eb1a728824_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A41Z&sr=b&sp=r&sig=CnMfy4%2BMnQWqH2eGmUxTM5HTuWbOT79GAd1Yat2BKWc%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:41.0465953","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/f9a26422-7c17-48cc-b9ea-b6eb1a728824_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A41Z&sr=b&sp=r&sig=XICTdyBn6REWM5lsiWleo721CSm9by%2F77BpBRcAXMvQ%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:41.0466128","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-29T22:26:40.07Z","endDateTime":"2023-10-29T22:31:19.108Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:31:29.961Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A59Z&sr=b&sp=r&sig=2c8YUtO7g%2Fx8veoS%2F%2BDQIE8qN5LRiQaGtxS4f%2Byjio0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:59.443259","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A59Z&sr=b&sp=r&sig=sXPPpAnGP4cN%2F9zBbSusq9JOvwJkrKGBkyDtiiwbwHA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:31:59.4431586","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A59Z&sr=b&sp=r&sig=dl9sMtUR9yN7NXn%2F3%2BkLL6p3yxofrmCYlRVyjbhlCmA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:59.4432828","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/100e8a36-dda7-40f5-97ff-d9b99fed0e3f_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A59Z&sr=b&sp=r&sig=2PFsf03CtZ%2B9Q0O62ndUy5DZBCM65a8bvtrAMRbb%2Fdg%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:59.4433047","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/100e8a36-dda7-40f5-97ff-d9b99fed0e3f_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A31%3A59Z&sr=b&sp=r&sig=CjwP7n089%2B9jwmtmlep90TEAQ8UhsNPW5svz4QGbEmY%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:31:59.4433269","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-30T07:26:53.526Z","endDateTime":"2023-10-30T07:31:33.977Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:31:41.46Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4400'
+      - '4407'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:41 GMT
+      - Mon, 30 Oct 2023 07:31:59 GMT
       mise-correlation-id:
-      - 7cee22ab-38da-457d-8074-078fecf530e5
+      - 97a9abd2-9703-4e22-ba53-53137b73e632
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3403,7 +3439,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metric-dimensions/RequestName/values?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-30T07%3A26%3A53.526Z%2F2023-10-30T07%3A31%3A33.977Z&api-version=2022-11-01
   response:
     body:
       string: '{"value":["HTTP Request"]}'
@@ -3417,9 +3453,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:41 GMT
+      - Mon, 30 Oct 2023 07:31:59 GMT
       mise-correlation-id:
-      - 683d6d35-8441-4025-9fdd-cc48b7719fdf
+      - b74813cc-da6c-444f-9626-cea769255327
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3443,10 +3479,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-30T07%3A26%3A53.526Z%2F2023-10-30T07%3A31%3A33.977Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-29T22:27:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:28:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:29:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+      string: '{"value":[{"data":[{"timestamp":"2023-10-30T07:27:00.000Z","value":1.0},{"timestamp":"2023-10-30T07:28:00.000Z","value":1.0},{"timestamp":"2023-10-30T07:29:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
         Request"}]}]}'
     headers:
       api-supported-versions:
@@ -3458,9 +3494,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:41 GMT
+      - Mon, 30 Oct 2023 07:32:00 GMT
       mise-correlation-id:
-      - 7f9f18a9-87ff-40d1-903a-d76f2fd6e3ef
+      - 721a255b-a066-4340-87b4-725eb3b75988
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3483,7 +3519,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:39.7823896Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:39.7823896Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:54.1558705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:54.1558705Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -3492,9 +3528,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:43 GMT
+      - Mon, 30 Oct 2023 07:32:01 GMT
       etag:
-      - '"3c00f92f-0000-0100-0000-653edbe50000"'
+      - '"3f002872-0000-0100-0000-653f5a840000"'
       expires:
       - '-1'
       pragma:
@@ -3524,23 +3560,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"35e90d04-0264-4063-9ebe-cdb20c627cf5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8224fc5a-3ee1-46e5-9e79-6ac2081b42fc":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e07ff0ee-d404-41c3-a03b-07ed42ae5071":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/7f3af3c8-b4d0-4d8e-b8e0-80e94626b524?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A44Z&sr=b&sp=r&sig=BEC%2FqaIz0ouuTnk4TWE0YKz3LOVhJlO9mGWBykPST%2Bs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:44.40844","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/fc7c6097-452e-40d2-9c28-4bb3d57adee9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A44Z&sr=b&sp=r&sig=Lv3uO2woKoQhXAcEGUuHgO6pT2HA5atjJ7eI05E2X9M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:31:44.4083495","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/b59b8858-ab51-4ea2-a4eb-647ff2e3b9e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A44Z&sr=b&sp=r&sig=C9SYxRxBwkqAvr7HQFkMm2aRZC8do%2B7Ta4wXxebQOZ4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:44.4084637","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/f9a26422-7c17-48cc-b9ea-b6eb1a728824_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A44Z&sr=b&sp=r&sig=FedRtCWJilP7RNLwC6bQBqvNSepBZVyUsZ4wlUu4fcg%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:44.4084823","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f202d987-0fcf-4a8f-b266-b9d10ca00f0a/f9a26422-7c17-48cc-b9ea-b6eb1a728824_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A31%3A44Z&sr=b&sp=r&sig=sCeWYcn6fwvf864lKoZziXcCdfLYoXfTvFZH%2BVWMeUQ%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:31:44.4084963","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-29T22:26:40.07Z","endDateTime":"2023-10-29T22:31:19.108Z","executedDateTime":"2023-10-29T22:26:38.754Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-29T22:26:39.023Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:31:29.961Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d68cc576-e7fb-4897-beae-3fe8c59391e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"4cfa60cd-ef20-4019-91e6-44dd3042b1f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c288ca27-b0ca-4e45-808e-a3679e3557f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/e63a3e7b-417a-45aa-b343-bd15a463f5c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A32%3A02Z&sr=b&sp=r&sig=zzbxOV8DklJWzEEdKYym538QdEoPKB3%2FCZsdMbzMxiA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:32:02.6123793","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/7d398abc-e146-4c32-bdf1-05ef60892d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A32%3A02Z&sr=b&sp=r&sig=QPl%2Ft71HMxM%2FgHBUaav6z7WSl2GqdjmW9xyZFWLOh1Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:32:02.6123142","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/05586740-6777-40ef-a3b1-ded05331975f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A32%3A02Z&sr=b&sp=r&sig=iMBnPc4Jj4StUXqll%2FWcSezWHgcnUl9BYOHdLE%2FrbNM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:32:02.6123933","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/100e8a36-dda7-40f5-97ff-d9b99fed0e3f_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A32%3A02Z&sr=b&sp=r&sig=JZ%2BKMuwFfnVb6jghszw9CWtTm3tY7GNxeoYarTMMabk%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:32:02.6124076","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0ff8f90b-b674-46d0-9e57-013dd5f23b01/100e8a36-dda7-40f5-97ff-d9b99fed0e3f_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A32%3A02Z&sr=b&sp=r&sig=eCCR8t5DqSx9JWDlkhO4%2FA%2BptqM1sTol4inLCnniatc%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:32:02.6124219","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"metric-test-run-case","displayName":"metric-test-run-case","testId":"metric-test-case","status":"DONE","startDateTime":"2023-10-30T07:26:53.526Z","endDateTime":"2023-10-30T07:31:33.977Z","executedDateTime":"2023-10-30T07:26:52.069Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/metric-test-case/testRunId/metric-test-run-case","createdDateTime":"2023-10-30T07:26:52.298Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:31:41.46Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4394'
+      - '4404'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:44 GMT
+      - Mon, 30 Oct 2023 07:32:02 GMT
       mise-correlation-id:
-      - b2683d21-ffd9-4658-bfd2-4f75badfebae
+      - f2327481-6248-42ba-a0c2-1636dcb4f9d8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -3564,10 +3600,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://18c11129-0acc-4e0c-a850-1803fc6d94f7.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-29T22%3A26%3A40.07Z%2F2023-10-29T22%3A31%3A19.108Z&api-version=2022-11-01
+    uri: https://6c3207d8-af78-4a6a-baca-2d4397a331c4.eastus.cnt-prod.loadtesting.azure.com/test-runs/metric-test-run-case/metrics?metricname=VirtualUsers&metricNamespace=LoadTestRunMetrics&timespan=2023-10-30T07%3A26%3A53.526Z%2F2023-10-30T07%3A31%3A33.977Z&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"data":[{"timestamp":"2023-10-29T22:27:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:28:00.000Z","value":1.0},{"timestamp":"2023-10-29T22:29:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
+      string: '{"value":[{"data":[{"timestamp":"2023-10-30T07:27:00.000Z","value":1.0},{"timestamp":"2023-10-30T07:28:00.000Z","value":1.0},{"timestamp":"2023-10-30T07:29:00.000Z","value":1.0}],"dimensionValues":[{"name":"RequestName","value":"HTTP
         Request"}]}]}'
     headers:
       api-supported-versions:
@@ -3579,9 +3615,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:31:44 GMT
+      - Mon, 30 Oct 2023 07:32:02 GMT
       mise-correlation-id:
-      - 330b8872-27d1-476d-a876-4530aa58b680
+      - 00caf6d9-1c37-477f-8799-12371e835f68
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_server_metric.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_server_metric.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:12 GMT
+      - Wed, 18 Oct 2023 20:56:36 GMT
       etag:
-      - '"d901f03b-0000-0100-0000-65294c820000"'
+      - '"75009065-0000-0100-0000-6530464b0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:57:13 GMT
+      - Wed, 18 Oct 2023 20:56:37 GMT
       mise-correlation-id:
-      - 80023910-7335-4f10-8864-901e06354185
+      - 02bff8e8-23e5-4d23-9ebc-4c5c11b65b62
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"b87cdada-a656-4562-96ce-72772d110124": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "f92feb41-660a-412a-9cdd-1c52fe552ae1":
+      {"passFailMetrics": {"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "3c38b39b-e04b-4852-a2d2-c9e80698d5f2":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "9e894f78-529a-4c7e-b383-94e81720cf3f": {"aggregate": "avg", "clientMetric":
+      "50"}, "17095de8-4d10-43e7-ab1f-1a93c7f07e1e": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,26 +106,26 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:57:13.96Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:13.96Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:38.216Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:38.216Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1013'
+      - '1015'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:13 GMT
+      - Wed, 18 Oct 2023 20:56:38 GMT
       location:
-      - https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+      - https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - ab96e055-b084-4b13-8cd5-a8b6207a9879
+      - e39091be-0a5c-45ef-bc42-59ca659e79fa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:14 GMT
+      - Wed, 18 Oct 2023 20:56:38 GMT
       mise-correlation-id:
-      - 44e133b4-94c5-48a5-b4ec-87c94a96d080
+      - 3c9c31be-3159-497c-8ee1-7be3bcab0077
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A15Z&sr=b&sp=r&sig=MFRQrJts2r7YW3%2BqSdlD3qxq2rnUc37bah123ywxSAw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:15.9076632","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A39Z&sr=b&sp=r&sig=7uCDNh2RMgX5LNXp%2B2EGcpiQMXpHWzv4jCQ5fNOGvR0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:39.181218","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:15 GMT
+      - Wed, 18 Oct 2023 20:56:39 GMT
       location:
-      - https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - f37165ae-7376-403a-98f1-c8a537b1c286
+      - df1e35ad-7d1e-4342-b9b6-0cc13d302624
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,118 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A16Z&sr=b&sp=r&sig=2vmB%2Foaobh8P1uhEOB3DsE719C8nHpyrZ1dx60NKaBw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:16.137236","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '550'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:16 GMT
-      mise-correlation-id:
-      - d7df1491-527c-4d35-b1ad-31e80aee2511
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A21Z&sr=b&sp=r&sig=RKfCwNXse8%2FUB%2Fr7Imu6GmNBfx1gJ3JrBsSt%2BMvqCsc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:21.4018329","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:21 GMT
-      mise-correlation-id:
-      - 3ec91e69-7f32-45c1-80ed-60c03fe85333
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A26Z&sr=b&sp=r&sig=mUiIq2EpKvkkvHVHL9UBPBGxcHV%2FXMox512m2L2r9%2FI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:26.6651744","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:26 GMT
-      mise-correlation-id:
-      - cc732240-a9a8-4103-829e-463ee7c15a13
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A31Z&sr=b&sp=r&sig=8WavkEDfOYr3E4SD1b5tYmTUItfPeFzuYhlbt2z%2BmIU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:31.9744634","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A39Z&sr=b&sp=r&sig=BJl4lcb67zPtHNDbWbAWL57Ojc29ZChGVRJMOOSdb6s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:39.4474367","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:31 GMT
+      - Wed, 18 Oct 2023 20:56:39 GMT
       mise-correlation-id:
-      - f92f92b3-2c1f-4d5e-a860-5f060400f216
+      - 2531d667-69cb-4aa9-84c0-9869bee87fac
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +349,132 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A32Z&sr=b&sp=r&sig=cNjjCByxuy9fMXp5S1VzK3yb0s4nU3FfxwgG%2BVXuXE0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:32.2865908","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:57:13.96Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:28.739Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A44Z&sr=b&sp=r&sig=pFcvXKPJeEOGCVisOu%2B3psFc%2BOWajSFFnWrUcZrNMcM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:44.7753202","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1585'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:32 GMT
+      - Wed, 18 Oct 2023 20:56:44 GMT
       mise-correlation-id:
-      - 8f3441a0-1697-4337-8dbb-2e31692f8abc
+      - 5f6cad28-44f7-4a19-b3cf-726399f01e0d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A50Z&sr=b&sp=r&sig=0MZe9AAK%2BN%2Bnj%2B4dvdM3Pq8kiw8hf0%2FBK4AiDFnW4vY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:50.0837902","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '557'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:56:50 GMT
+      mise-correlation-id:
+      - e0c785de-512f-4f83-a49b-27aeb6b1cddf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A55Z&sr=b&sp=r&sig=MzBcdNSKhNbhV4YA8GxSBvvNFacgRJm5D0vmsDowARU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:55.357457","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '546'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:56:55 GMT
+      mise-correlation-id:
+      - a550ea05-5b6f-4ad8-8e4b-fbb1c2da6936
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A55Z&sr=b&sp=r&sig=I5i4IurwjEBnT43l9Es5Ygl9O1a4v9WcuYGwFNlzDbk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:55.640379","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:38.216Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:51.151Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1583'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:56:55 GMT
+      mise-correlation-id:
+      - 3dc4f4e8-e1f3-4075-8f5b-29da09730f27
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:32 GMT
+      - Wed, 18 Oct 2023 20:56:56 GMT
       etag:
-      - '"d901f03b-0000-0100-0000-65294c820000"'
+      - '"75009065-0000-0100-0000-6530464b0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A34Z&sr=b&sp=r&sig=Tl4YnEh4BsTTbxu3ZOFqD5c8YXXZxETfjro8qxXTxmY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:34.4941958","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:57:13.96Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:28.739Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A57Z&sr=b&sp=r&sig=ao1LcATwn6V3qmCCXi1jMlq0Xl3SZhXwHDrnOIShDOE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:57.3666192","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:38.216Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:51.151Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1595'
+      - '1596'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:34 GMT
+      - Wed, 18 Oct 2023 20:56:57 GMT
       mise-correlation-id:
-      - 5bf4292c-c323-4687-9ee7-ef391f30e879
+      - ae4b500a-a483-4f30-83ca-ee4eea07b580
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:35 GMT
+      - Wed, 18 Oct 2023 20:56:57 GMT
       etag:
-      - '"d901f03b-0000-0100-0000-65294c820000"'
+      - '"75009065-0000-0100-0000-6530464b0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:57:36 GMT
+      - Wed, 18 Oct 2023 20:57:00 GMT
       mise-correlation-id:
-      - 53423755-f9e9-4e1b-922d-2f916041d656
+      - 5d70d11f-4906-4d71-8fb7-ec71a2c2d1fe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A39Z&sr=b&sp=r&sig=FYRH4BnsiGuQNrnHsRETxixZPZPPkZE77Bl2iZs9Ouo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:39.3606038","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A39Z&sr=b&sp=r&sig=wF%2BixUh6NwwgD9cBmOI2PCZqg8ML4tgrPvwE6vob4kc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:39.3605202","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A39Z&sr=b&sp=r&sig=Eh7lK4V7HYhoqytU9bz0OH9Br%2FGr%2FDCA96YkncMVaUg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:39.3606251","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:39.288Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A01Z&sr=b&sp=r&sig=WCuh%2FqvM1D6PDtpP3dciOoYrRYtrHOF3Ipi0Y2Zfjt0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:01.6534549","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A01Z&sr=b&sp=r&sig=NEKz5W3Ad8Is%2FpXxUQTLBXt4%2FsTmjgfDAtO7juF8dQI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:01.6533305","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A01Z&sr=b&sp=r&sig=OJ9vI52K0JupfO8jAyWTVP%2B8WTJW4mWpk5AAqsoUWPQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:01.6534888","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:01.573Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3189'
+      - '3191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:39 GMT
+      - Wed, 18 Oct 2023 20:57:01 GMT
       location:
-      - https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+      - https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 684c7e65-5880-4405-b0ef-cad57e2b7219
+      - 55aaae67-1482-4f4a-9903-2e846dae0463
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,190 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A39Z&sr=b&sp=r&sig=1MxrRbxSXmXidMcbs5SP9tLjZNeLfQ1KiY9y2VDGRIg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:39.7986062","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A39Z&sr=b&sp=r&sig=a6J5rfGIrAF52PE9%2FQWi9q2Vt%2BYvFSDQwqFdjoQkgQI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:39.7985182","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A39Z&sr=b&sp=r&sig=EsZtkZ3v%2Fb9uwOGxLCSkEAyKw4CmrvIL84MNJkPRVdc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:39.7986274","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"NOTSTARTED","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:39.722Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:39 GMT
-      mise-correlation-id:
-      - a78e883b-21b5-4e1f-a205-577f591a9dd7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A45Z&sr=b&sp=r&sig=SiTW5e1htlYc%2BmC4phvDgdjd1L9rIqCazBbXxMpucTI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:45.0285426","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A45Z&sr=b&sp=r&sig=jl2aFC4znEC4b%2Flh6kK2va7V5KxDad%2BXAXIFYXQzRsI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:45.0284625","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A45Z&sr=b&sp=r&sig=2%2BXhrvcmylz90ufKh8cdZvcQkRsuiO09JdL05CdTZGQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:45.028563","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:39.903Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:45 GMT
-      mise-correlation-id:
-      - 97271693-ae52-4b22-80e5-b7305e34e061
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A50Z&sr=b&sp=r&sig=4k9VCVTLVRP69zEAMo7NmZAzExxUYxy9iIZmMj8SZho%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:50.300999","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A50Z&sr=b&sp=r&sig=C72mLpztcu7rSWeLsOGTfaFILY33%2BkiCUlC2ywGc6V4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:50.3009075","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A50Z&sr=b&sp=r&sig=NDrRD9koZhmsh1TAzYd6DBmdlvcUxrh%2FM7oPQ50qS%2Fw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:50.3010141","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:39.903Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:50 GMT
-      mise-correlation-id:
-      - 09508f30-5ce8-410d-bf7a-b269c7089844
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A55Z&sr=b&sp=r&sig=BIMqmf78ksbc8wtKj7upyOt%2FNWP1Hi3qhl8an2bjTLo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:55.5704432","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A55Z&sr=b&sp=r&sig=TN2ml00msT7CL61ihfNQO0izNKw7H7pbVvStTOiJ8uI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:55.5703326","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A55Z&sr=b&sp=r&sig=XaynARjiU%2FFvNEFBoELZxkZWfbHjDhKBjVssUnpLCw8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:55.5704621","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:39.903Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:55 GMT
-      mise-correlation-id:
-      - f9019530-069d-41d6-ab71-c659a238cd41
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A00Z&sr=b&sp=r&sig=HFlGcsyp3T9A15ZcoBtKT%2BQQBvdUYwIRzGC%2BFWlmEBE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:00.8238811","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A00Z&sr=b&sp=r&sig=xyC%2Fj2T3an3F8hg9kcAYFkRLeMelQ8Rww6VW1IOlxmE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:00.823778","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A00Z&sr=b&sp=r&sig=ip96uuO9CaBLUh67zMNlVYaDJooDFa34qBQmhI3R7cE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:00.823907","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:39.903Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:00 GMT
-      mise-correlation-id:
-      - b3b7f847-0d79-4412-823f-353b103f9a55
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A06Z&sr=b&sp=r&sig=C%2BvkAm%2BjjcXRqfkoJQ3A8l78IvEb8eryAD6oCmIJVqY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:06.1366955","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A06Z&sr=b&sp=r&sig=QfZxXPJaEYjc%2BT1Yrn%2FOT27pk9eqnx0npUjzzHuMeXQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:06.1365956","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A06Z&sr=b&sp=r&sig=Xv0p5zK3axVkT1iT7ddMzjtZK9lJM5E4RvK%2BuRUpf6E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:06.1367236","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:39.903Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A02Z&sr=b&sp=r&sig=MTf3yEnPDciSo0aINAdnJXu9UTDFwSnxzv5%2BVvj%2Bj1E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:02.0889093","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A02Z&sr=b&sp=r&sig=p718F8RXzykW5yEAGKF2W6dUtgONJSyzijkWTLtoHso%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:02.0887725","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A02Z&sr=b&sp=r&sig=lHcGHJnTw%2BgOO0V8q0N%2FyuRL6%2BQUtaA3Mbx21ujJOxY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:02.0889355","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -894,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:58:06 GMT
+      - Wed, 18 Oct 2023 20:57:02 GMT
       mise-correlation-id:
-      - 3891c7d9-df04-44cd-b71b-e11eb59e773b
+      - 226f35a2-2960-4e93-839a-171c9e52b057
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -916,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A11Z&sr=b&sp=r&sig=0KvFublu9zxXQGxWo8LaaGR%2F1uFNeWr7maCxwXu%2BSVI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:11.8106761","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A11Z&sr=b&sp=r&sig=TtGdVj7ykyGxvBYIE7YWYC7UMh8PLe3%2BaSxON%2BNL04A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:11.8106252","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A11Z&sr=b&sp=r&sig=vBrDFww1qrNoAQzd85dniM92A94Qszm1KOsn8m1IRFA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:11.8106909","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:39.903Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A07Z&sr=b&sp=r&sig=AqQd6lTLOqAxMnAN5qBhfkh%2FkmulSI50WegWGVNNzlU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:07.3841293","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A07Z&sr=b&sp=r&sig=iwa%2BieisFl6gRq5fPSC8XPlKyRYm8ZNpArUgGzKPPfQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:07.384059","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A07Z&sr=b&sp=r&sig=I87GG%2BqCW7CZcBbnaqjJlzQ0aTeCOeUrPz19QjSPDw0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:07.3841465","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.082Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3238'
+      - '3235'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:58:11 GMT
+      - Wed, 18 Oct 2023 20:57:07 GMT
       mise-correlation-id:
-      - fb52760e-1d86-4823-b7a3-59400faf8fc4
+      - 87fed55c-17af-4584-995a-01b8d4f2f37a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -952,10 +772,154 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A17Z&sr=b&sp=r&sig=LFCcYdu3sOREPvCggONU5nc6hfC2AyogWxqqopkfoUE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:17.0961345","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A17Z&sr=b&sp=r&sig=VK%2FDY7vvWUfmDm1uH8XEmY5K4L%2Br%2BPKs8wnebm%2FYVGE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:17.0960642","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A17Z&sr=b&sp=r&sig=M8qzC9H05Sddq6NVoeMOZLienKZ6nxAk%2FlwB6GgHKjI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:17.0961488","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:39.903Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A12Z&sr=b&sp=r&sig=c9nacudoTllMf06e%2BuvQUYPFIr8zp0I%2FuxO0Dmcz964%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:12.6517867","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A12Z&sr=b&sp=r&sig=swk%2F2juUH5KX11Mr3ovmWP%2Fiqc8rTV825s70MD%2FnGMQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:12.651715","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A12Z&sr=b&sp=r&sig=YZHQaG%2BFlwZhSOb3wOzPpPRqnli4eyDQI2fvIlNbebg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:12.6518007","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.082Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3241'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:12 GMT
+      mise-correlation-id:
+      - 5c44b257-5229-48f2-bc14-3dabd4931df0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A17Z&sr=b&sp=r&sig=sYAqXUxjVszzTp0RsYggrGw8zZKRoTOSIfrZJbG%2F4XI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:17.937777","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A17Z&sr=b&sp=r&sig=Jkltmm0otcq7uhKoznSKz5GPL%2FHn3RFWK04ZqUbL9WU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:17.9376895","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A17Z&sr=b&sp=r&sig=tFh8wahY2J%2BVM0LjjhBbw0Mtptwa0cUz8YR35JQIK4g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:17.9377993","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.082Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:17 GMT
+      mise-correlation-id:
+      - 5e002ff1-5159-4f3a-baec-241aae97a2e7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A23Z&sr=b&sp=r&sig=ri91xcOiE%2FADoFBGPk0SS5Aw1o5lcjAf3N0hP8YiO0w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:23.210675","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A23Z&sr=b&sp=r&sig=8BixzwQ7vZ%2FDupOIc6hn4iQOLg5YjHM15%2FPuyVTIxkA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:23.2105724","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A23Z&sr=b&sp=r&sig=rqSAKKroiWfOLUg3C6s2manMfJJKuIk3W8fB0lv6Z0Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:23.2106974","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.082Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:23 GMT
+      mise-correlation-id:
+      - 0587b537-387a-47dd-b903-5770ed128450
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A28Z&sr=b&sp=r&sig=0jjbQkOgrQ0iHrIy2RbwJDOQZKNfIomyS%2Big6vJD7yI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:28.4768886","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A28Z&sr=b&sp=r&sig=G%2BIOzAq4NQAC26WqqDQWgez75pP7eRg%2BPnXuMRli%2FHE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:28.4767849","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A28Z&sr=b&sp=r&sig=VoIzvR5iw8ehIkVNeqtQvAk3zaSY5F8fCU%2BNjRZ2R6g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:28.476917","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.082Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3239'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:28 GMT
+      mise-correlation-id:
+      - fc254edb-e109-4ee5-aa72-e506dbb0e630
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A33Z&sr=b&sp=r&sig=x7PkGff2fBx2NpCwTB%2FdeORFgBYYVqH1Y5d3OtTShbY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:33.7308846","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A33Z&sr=b&sp=r&sig=Xjhgs2h7Msgy613R%2B5%2F4lEYGlB1%2BqczZ5UdkFXmMVe8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:33.730796","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A33Z&sr=b&sp=r&sig=TB8T8U%2BKGH3UbM8BIp%2FHQ7UahDChmeKIkWVxRdbzplU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:33.730906","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.082Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -966,9 +930,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:58:17 GMT
+      - Wed, 18 Oct 2023 20:57:33 GMT
       mise-correlation-id:
-      - 9ed3a582-a444-48f3-b62d-5810ee09d143
+      - fc90ac8f-623d-4fbf-ba9c-182a2467bdba
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -988,23 +952,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A22Z&sr=b&sp=r&sig=DvAgL1f6soFGpi%2BDsxgYeh4yVyr2%2B55crv4hCn2ZolA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:22.4292575","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A22Z&sr=b&sp=r&sig=qDOqWtD4bQfQSgVJ9fhayEkiswTRw9xqZFW7VBhGRJs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:22.4291702","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A22Z&sr=b&sp=r&sig=xox%2Bo13aBqugT%2B%2B5gRkFvnCQZIe9RE%2F%2B9EJm4C73lCY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:22.4292788","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONED","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:22.402Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A39Z&sr=b&sp=r&sig=6aa6%2BMXyyfsjgvUiqrDknNDThXuazBkUmg%2B5A9YCyZQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:39.0343351","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A39Z&sr=b&sp=r&sig=UoXZaUM2F0bDNV8KBcxFxHEg4oIMAqF8uKcUQRNwclY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:39.0342234","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A39Z&sr=b&sp=r&sig=lqp9ziD2EISnnDbvjisS8wiKMk%2FAvVCWHiVnHqdkBZc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:39.0343603","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.082Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3243'
+      - '3236'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:58:22 GMT
+      - Wed, 18 Oct 2023 20:57:39 GMT
       mise-correlation-id:
-      - 34f30c1e-67a4-4817-abf7-0d8f4ec8ba14
+      - 31336679-f915-4aa8-8e76-91f09eb9c792
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1024,23 +988,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A28Z&sr=b&sp=r&sig=wdP7gxyrz8O17JMOmQE9431pqpRzK0hfwL%2F3%2BEercvE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:28.495939","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A28Z&sr=b&sp=r&sig=XgKTXChJ%2BQ2uIhc6kehE%2BpTzCBbRbEvPoLt11RrtZ5I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:28.4958454","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A28Z&sr=b&sp=r&sig=Kcgj5%2F87a5FRpTCfGO6mJTC0d7h2URYmISMdKEXRJj4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:28.4959622","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:22.465Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A44Z&sr=b&sp=r&sig=5yRIwR%2BRjlJuX3Q0NbqXIQKJoki0sCEzJVjr6TTm5hE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:44.3659385","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A44Z&sr=b&sp=r&sig=JNv5o5SgZnTXJ%2FRExnOrhHvWz%2B7oNYNLtmzpIM%2BtZ0U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:44.365841","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A44Z&sr=b&sp=r&sig=pylQ7li%2BU7cJlZz7TQCrOjHedi335b%2BkcK%2Br1ohnw3o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:44.3659574","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:41.749Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3238'
+      - '3242'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:58:28 GMT
+      - Wed, 18 Oct 2023 20:57:44 GMT
       mise-correlation-id:
-      - 9921ef55-6433-4613-becd-16c7a9de10ed
+      - 316c3144-0cf9-4b74-a821-c57b0b8a050a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,658 +1024,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A33Z&sr=b&sp=r&sig=Wd%2BINMFcxxDgpexHWFobQngA2%2BojAUb6mXxjbaZqWWk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:33.812921","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A33Z&sr=b&sp=r&sig=mpQIXdBOK%2Fhdtx5b9PHqJaoL3VxmXPJlB6pInDDhp%2B0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:33.8128469","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A33Z&sr=b&sp=r&sig=BxItG48DTjzhoVlc3b0wVjwV822rqUWX2H8NGUBiNQg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:33.8129353","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:33 GMT
-      mise-correlation-id:
-      - 16dcf17b-5336-4399-a6af-d4608a457377
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A39Z&sr=b&sp=r&sig=20w0ICmu9W66DhY%2BuEk%2F4AD%2B4R80fPwEtt41wUO465A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:39.0584403","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A39Z&sr=b&sp=r&sig=8JZQlwN7qgU%2B4Ek1zJxdKlTRbQILDBdVJfk8%2BhNtk%2Bs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:39.0583363","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A39Z&sr=b&sp=r&sig=krfCrrPz5wlLc3Ns2v%2B8tzfcgWztUUdznAUkVsWvOJ8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:39.0584633","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3241'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:39 GMT
-      mise-correlation-id:
-      - 901014be-383b-410b-b41e-6adb71c9690b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A44Z&sr=b&sp=r&sig=JAJmamv4IQkMrlQ5zBaLfO0dVAKEbRiECszg%2BH00SXs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:44.3031082","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A44Z&sr=b&sp=r&sig=jduqBcANYgQODbflqDslyakFqToK3AHcStir%2B83G2%2BM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:44.3030226","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A44Z&sr=b&sp=r&sig=tMXfXkV6r5pWS%2F33wSkm71oXD48KsA8QS0KzWeANvwY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:44.303131","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:44 GMT
-      mise-correlation-id:
-      - 1145bb50-733e-42ff-8834-16f10f34531b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A49Z&sr=b&sp=r&sig=L3PQKGuMcrX1j2eq8tUjPnRDMY0Dl2DeRZLuNSQWOQA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:49.573024","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A49Z&sr=b&sp=r&sig=8KoKWG93GeF7HF98lt%2F11XFldjAxRWiT4R59xvZGnkI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:49.5729533","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A49Z&sr=b&sp=r&sig=z%2B5dQjSkIuoKOXrPEJvWme7nRc3HuZacl28XBDgUqh8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:49.5730418","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3230'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:49 GMT
-      mise-correlation-id:
-      - 72d7a2fd-c7f3-4b69-a00b-3d895675de93
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A54Z&sr=b&sp=r&sig=jnfygetiDSRFbZDS7Y%2B%2Fo5ZMr5FHa8rXqEuy3g2%2BSto%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:54.8201311","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A54Z&sr=b&sp=r&sig=6Cx444sVx5IuXhWJDT43IE82N60LqYCn8da%2FohH0BbU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:54.8200467","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A54Z&sr=b&sp=r&sig=47fn8%2FE%2BZqQveboMGmdUWwsYxkc6dPrwQxcaVqTg4NI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:54.8201524","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3239'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:54 GMT
-      mise-correlation-id:
-      - d6461ac7-829c-4e3f-9bdc-4cc6ee211423
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A00Z&sr=b&sp=r&sig=%2B8WL%2BuCr3cCAThlM4ereh9Z4n2Ggchta12eQYWvXMZA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:00.0778727","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A00Z&sr=b&sp=r&sig=Q%2B%2BxPx2MuJNFaK0cULVY9xSpfO3Z9Zs62qQwhRuOJR4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:00.0777765","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A00Z&sr=b&sp=r&sig=tGF%2BMYYf%2FUVfjtsLFnXivViZiwuS3o47N4FEgH5jDYU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:00.0778955","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3239'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:00 GMT
-      mise-correlation-id:
-      - 721a2e4d-e90b-441f-8646-f8c8be0f4b36
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A05Z&sr=b&sp=r&sig=3cjCnXlMvymaIiazjizuVNctQ3%2B3sVgYZ0A5GqsGSGU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:05.3319855","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A05Z&sr=b&sp=r&sig=s7KyCYD6B6qL3AI9v3%2BRqABQjc75uYBc4ZlYpOm8LTs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:05.3319002","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A05Z&sr=b&sp=r&sig=zX5L5F9q6Ed3MZvmtz%2FICr%2BKL7bXosznbbIpJVa3HFw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:05.3320066","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:05 GMT
-      mise-correlation-id:
-      - d404fd1c-121b-46d9-afa1-3d1c23497f5a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A10Z&sr=b&sp=r&sig=0nyEajUE02isa6aqkfAkoumWshjLG5mzm51wZumJHNo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:10.5728907","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A10Z&sr=b&sp=r&sig=KbTuFicPepFm2wtoRw3pEwm3yojZM4AjsWZrk%2BHIup4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:10.5728276","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A10Z&sr=b&sp=r&sig=LQbtsw1UIYDCRNgBIAPXQN4Lk1fpgdfIX7DNGxf3k1o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:10.5729059","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3229'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:10 GMT
-      mise-correlation-id:
-      - 759f5b33-0933-4cce-a4e6-0696580a8948
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A15Z&sr=b&sp=r&sig=wnM2k3Ziv8Vh8ur5gMFbRO97r6dg1vHvr9oJLl8GaFY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:15.9150598","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A15Z&sr=b&sp=r&sig=%2F7X1j7S8dX6j4Sd82llZaJaVYuSNoHHB5AtU%2BAVsS6A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:15.9149742","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A15Z&sr=b&sp=r&sig=07BAZDDkgtJLlh%2BPOzmqrch84lM0ZgwHowTujGjFhLM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:15.9150806","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3233'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:15 GMT
-      mise-correlation-id:
-      - 6865af57-ea59-4fec-97d2-8b0aff4b9204
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A21Z&sr=b&sp=r&sig=RMpsjvXo5vn4rXEifgtcUJn3smSRbDVY6IpvGLeVkic%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:21.1790374","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A21Z&sr=b&sp=r&sig=a8zb%2BXM1cCbuf6sn35nk9sst%2BYrPZ4Vh24cUFnzhByI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:21.1789617","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A21Z&sr=b&sp=r&sig=ee614xKJUhbCFyo3y8%2BXhNSpKBJkGPDyQBzK77ai9eA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:21.1790524","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3233'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:21 GMT
-      mise-correlation-id:
-      - f4bc9998-a236-409d-8d49-6bbb1483b3eb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A26Z&sr=b&sp=r&sig=H13WvKyVMywj9nB3zib4%2FxnDXhCz1OYXKi0lK4CgnQ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:26.4618109","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A26Z&sr=b&sp=r&sig=YmB6NS%2FvlBdvJJG7WwpobOU8Q8oooHbz9VGMirgBJjY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:26.4617369","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A26Z&sr=b&sp=r&sig=EGGmY3ba%2BuGU4CqtwBwAm%2B36zqrRDnkqv3G57QzHDfU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:26.4618272","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:26 GMT
-      mise-correlation-id:
-      - 45839d9b-f06b-4002-917a-82235394faa0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A31Z&sr=b&sp=r&sig=lwNb2Fc7%2FcqtYZQ8lZY%2FT4sF2sz7uaL4QRKZk%2BBV01M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:31.7821009","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A31Z&sr=b&sp=r&sig=pSeTasyS7kEikXIwGI2jyg8h8741hrXcwL1A3kXK3EI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:31.7820327","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A31Z&sr=b&sp=r&sig=qfTOC6pKrjtbOkmdl6S1rJMbyWoc2AZt49ryRZ4mK3I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:31.7821162","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3233'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:31 GMT
-      mise-correlation-id:
-      - 630350a6-7ef7-4119-a621-af37d1b63e23
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A37Z&sr=b&sp=r&sig=3i4gVvUefGxE%2BuxJPbwunUxa9z5%2Bt0a%2FgE59BspFRow%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:37.1166401","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A37Z&sr=b&sp=r&sig=6QPMbHQrwBbhUctcxkooLsR58GxFSnSBWD0dzL%2FIkRg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:37.11656","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A37Z&sr=b&sp=r&sig=8MrfWOj2X4GmimP83UbBG2Z%2BcjVrBXYJvUxzs6r%2FBDI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:37.1166545","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:37 GMT
-      mise-correlation-id:
-      - 13b1c09e-52c6-4c61-b7d2-7167e57e3082
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A42Z&sr=b&sp=r&sig=wHf8%2FlHL4mNZd15fSCA5osZ%2FjLM9YfN6eJMlKIzhJ3I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:42.4442298","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A42Z&sr=b&sp=r&sig=w8sF%2FMt2wAlmwlRs6FFngJVwVPsApgHcfR4AqM%2FD1BI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:42.4440711","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A42Z&sr=b&sp=r&sig=HZ9Tpl8jRIlyeuW5q15WC%2FXhZJNW9Ie9MLAakHraMZs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:42.4442716","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:42 GMT
-      mise-correlation-id:
-      - 5faa38dd-681b-46b8-b395-6bbf3ca033ac
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A47Z&sr=b&sp=r&sig=k6T%2BioeJAybBuUYj9q7iSvcZ%2FDKNL9%2FBjtjFwaATyE0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:47.770592","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A47Z&sr=b&sp=r&sig=maAzyzKL1hRjolURzvG9XVuDEn2%2FQH8iHjhdI12x5wE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:47.7705253","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A47Z&sr=b&sp=r&sig=lC0bYC6VFa7lKUjKTjdQeGORsVbEUeq0Meng6upY4jw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:47.7706072","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:47 GMT
-      mise-correlation-id:
-      - 12c2bc80-1d1b-46e8-bf4f-d64263dd7d7b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A53Z&sr=b&sp=r&sig=%2Bj6NIYld5MhaTrnC%2F2X1gPYTMWLn9N7ye33xP4%2B67CY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:53.0319227","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A53Z&sr=b&sp=r&sig=xk0nVZXCap4%2BhpmvYcPwTzRecePrwX%2FSg8Uxq3B%2Bv1A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:53.0317456","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A53Z&sr=b&sp=r&sig=17NLGc5O5tTOhP%2FNm3NCgscWXz95nhKvsVOS2qXS9Ys%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:53.0319455","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3241'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:53 GMT
-      mise-correlation-id:
-      - 75508aa5-f408-4527-b3b3-41517273f1df
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A58Z&sr=b&sp=r&sig=O1C%2BvI%2BFKOKbZdHEvV6rUp4jm0s9AZDzmLhmiZCxS6I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:58.2964023","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A58Z&sr=b&sp=r&sig=GCzyU6GDqyTI3Ly6I9triicq4b5c7Qvvf1MJYCTzUFs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:58.2962899","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A58Z&sr=b&sp=r&sig=zNFA3JWu%2Bvc7%2BvC44Xxnett%2F6DCBs3dOg6VVgjTCvjY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:58.2964264","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:58 GMT
-      mise-correlation-id:
-      - 29285751-9173-414d-922c-16d7f188dbf0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A03Z&sr=b&sp=r&sig=cK%2BrpDpUcw9qD9g1LPT%2BZn5GqROR8hfanaSQwNgPi2Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:03.5117269","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A03Z&sr=b&sp=r&sig=FY5m%2FbBz1AfLAZYeaouf%2BjJwxoGWCjsNx3aUfYNL87Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:03.5116477","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A03Z&sr=b&sp=r&sig=UIqh6VZ%2F0LyD2C1OxfJy95AHrCh4yEtiaLNFVfC7YdE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:03.5117484","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:00:03 GMT
-      mise-correlation-id:
-      - d1993c76-faed-4c0b-bde1-f7075cc3932b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A08Z&sr=b&sp=r&sig=cW4hJp8LUfc1YILHKJELkwZWwDmUQEo1feNBhcHCkD4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:08.8624275","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A08Z&sr=b&sp=r&sig=ziFvbs2yDWj5xtNnK7ro%2Fj3GS8HDvkfHCgornjiaQvA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:08.8623197","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A08Z&sr=b&sp=r&sig=WhZnvq5wIpy3qEKm1OcDxoL3uAy8%2F14FBuR1umKAcqk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:08.8624479","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A49Z&sr=b&sp=r&sig=D8GEIzY7XM3CBZ2DVG4xc5hzLixcrnraTDRqQYbsEzg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:49.6502474","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A49Z&sr=b&sp=r&sig=C3xSBMujgndw7mw%2FmLHbEbhA4zQ37o1UjXaC4O9lkVw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:49.6501521","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A49Z&sr=b&sp=r&sig=cp2wEVe%2Fexq5Kuc9sLMpXScEmPQY1IZv4IZLYC520Ms%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:49.6502667","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1722,9 +1038,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:08 GMT
+      - Wed, 18 Oct 2023 20:57:49 GMT
       mise-correlation-id:
-      - 514b1e3a-aaeb-4798-ab75-a3069ebe2f63
+      - ea3bc1aa-8492-439c-8aea-61b8682592d4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,10 +1060,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A14Z&sr=b&sp=r&sig=E6aJHBwimu7bKVEQo8Jrnlfn1EKdftcCPrpX8cjnB0U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:14.1867088","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A14Z&sr=b&sp=r&sig=OanVvAw1qjByKWMT%2BUwQDBWHaoKP5d2xSpqkzP3aVTg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:14.1866209","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A14Z&sr=b&sp=r&sig=NulsV2vL%2B24E%2Ft0GJl%2B%2FiJIuvrUC2pAUwJ7sX5aj32k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:14.1867308","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A54Z&sr=b&sp=r&sig=jGyZ28ppGoqbETTluIBdVihKvCnLW9%2Br0vaBU%2FvdSCU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:54.9233521","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A54Z&sr=b&sp=r&sig=rNq%2BkplkWnRoh6%2BDno51Q0UTc25OLIeyffqIcQwuWvA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:54.9232533","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A54Z&sr=b&sp=r&sig=XD6aPeVOZV9MidLJDmw%2Fyl3UE%2BsylvYc1uW3ytVyvho%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:54.9233778","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3239'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:54 GMT
+      mise-correlation-id:
+      - cd7cfd99-a471-402c-b87d-5dce71f5a784
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A00Z&sr=b&sp=r&sig=taoDE41rjc2lC37TRWu4Zb%2Fd5cWtIRmupv7kN%2FKqO%2FU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:00.4202215","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A00Z&sr=b&sp=r&sig=%2FqEgq9mkwyxGCiuZnlsy3Ei4guWldnqJtsXvW8346n4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:00.4201541","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A00Z&sr=b&sp=r&sig=fGCxOPhDH%2B9EDGykqdkL7wBxoUogq70rwfEV5tZY9iE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:00.4202372","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +1110,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:14 GMT
+      - Wed, 18 Oct 2023 20:58:00 GMT
       mise-correlation-id:
-      - 316a00f3-49a0-4197-bf51-acce2597a7c7
+      - 6a388172-7ae2-44fa-ad5a-d9855e9788d3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,10 +1132,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A19Z&sr=b&sp=r&sig=PPtlvC20LjUL5FhWhhMj1R45Qedp4boBQNHjAJ6vEtU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:19.5291281","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A19Z&sr=b&sp=r&sig=4CR9g%2BSPVJBySxdadr9XIufwKjMAKhyJoP8nqNtkkBM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:19.5290538","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A19Z&sr=b&sp=r&sig=ZOrTxxjiAgHnfaXIimxJPfv%2FST6%2FAlK2AJv8ybkXPZo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:19.5291466","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A05Z&sr=b&sp=r&sig=GF5sLFG74pZMJjNuhEepqAIme%2FOfEaJqBelJDmd0Xz8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:05.6853456","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A05Z&sr=b&sp=r&sig=QNV0rjpZSk1fW8eiy2PNoLDaM0rhSCq52gTJEuzbZzU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:05.6852777","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A05Z&sr=b&sp=r&sig=OK%2FpZ%2Bfzm2f9uES3%2FIRxWIu1HTiSl4dNUJGx7%2BrFRtQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:05.6853619","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:05 GMT
+      mise-correlation-id:
+      - 102516c2-3fe9-4058-81e6-2d4991da9f9d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A10Z&sr=b&sp=r&sig=7dkAwEr0lfDy1M75IMfyjcwrZ9ke65wcpnGOSM%2Bg24c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:10.9805472","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A10Z&sr=b&sp=r&sig=J1UT2r%2ForqpKatEUMJRvyMo36zylQ0GRjnf0croZFpk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:10.9804784","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A10Z&sr=b&sp=r&sig=P3ajJjYAEqZgol3HpM4I2cueMs%2BuoKQkmoFflGe7Vho%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:10.9805615","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1794,9 +1182,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:19 GMT
+      - Wed, 18 Oct 2023 20:58:10 GMT
       mise-correlation-id:
-      - 30e6c491-f657-4307-baaa-166f8d87c0c9
+      - 9e7035c0-f4fb-4d5b-ae72-6f82cdacd0be
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1816,24 +1204,600 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A24Z&sr=b&sp=r&sig=o7sTEwbSAs4%2BZvbbZ9iWVJGXm3fNafc9TzoJayMe3IY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:24.8152159","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A24Z&sr=b&sp=r&sig=74RmR6VUP50a9qlvtcQAhkDdBvCVzWNk8xNzimrpbyE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:24.8151273","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A24Z&sr=b&sp=r&sig=JIX8E%2F7goKQrvmaPtSmk5F9hq%2F1yHBBAi6dRulmOnZw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:24.8152363","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-13T13:57:39.722Z","endDateTime":"2023-10-13T14:00:24.237Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:24.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A16Z&sr=b&sp=r&sig=fq%2FsVG0IW4kDXqQZTyHjVufbtRxlHyV9neirBy%2Bej6I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:16.240269","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A16Z&sr=b&sp=r&sig=mJ5xDAfyWtw05xNkPaqUFFtQceo0GQVbInwQ76Zvm5w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:16.2401927","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A16Z&sr=b&sp=r&sig=eoGvKtRpJCXhEmD68nqhlrh9CIBHeIKKLW%2B%2Fp1JWWLw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:16.2402843","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3368'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:24 GMT
+      - Wed, 18 Oct 2023 20:58:16 GMT
       mise-correlation-id:
-      - aa2d1219-321f-414a-8fc8-3bc51ca593d8
+      - 70b0be75-5d26-4192-b245-be1774e93275
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A21Z&sr=b&sp=r&sig=dgsqk3tiwJPZaAGshyKaLEjcvUANUDLyV7NAl8AcLLc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:21.5295432","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A21Z&sr=b&sp=r&sig=ahuPp7ZzDhpNPZe32bhAkk3C1WgzvXFsPPlCxtTq5%2Fg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:21.5294637","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A21Z&sr=b&sp=r&sig=i0HnhaQBjlQmq17tNLDLxBKFNSWKb7j7fWQOKQzGKc8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:21.5295575","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3229'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:21 GMT
+      mise-correlation-id:
+      - 7edfd618-53dd-44fc-963b-65f28453a0dd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A26Z&sr=b&sp=r&sig=pl%2BA%2FLtGZB2h0MFViHMqcj7jUbKIBfeXG%2F9qvmnqSTY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:26.8682882","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A26Z&sr=b&sp=r&sig=upkWkOaZEOckFH3FKbDw2xjicR2%2BACxpvz5y8xqamMs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:26.8682062","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A26Z&sr=b&sp=r&sig=r80wsD4GG36DHrm2i6d4W7vDAh7vc2ktFr1Ndo3jWsQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:26.8683029","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:26 GMT
+      mise-correlation-id:
+      - 2302eba3-44cb-44ff-8719-a9252c586336
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A32Z&sr=b&sp=r&sig=mHGMvIrx4trT%2B%2B8cDLwwzQYDXHiiQRsWXmt2nvXRLoc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:32.1521623","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A32Z&sr=b&sp=r&sig=EkrKuZE6lfXgkFPS6A51eCZ5rv3bz2nDbUMtT790qo0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:32.1520722","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A32Z&sr=b&sp=r&sig=Yaj%2Bysa%2Bj9n1bM3nniL%2F95SMaG6CXgVTvLbYEx3veJE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:32.1521831","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:32 GMT
+      mise-correlation-id:
+      - 737da416-53ed-4eda-8dec-a555170ba479
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A37Z&sr=b&sp=r&sig=CsN7YlJm7ZLrFH%2FZh7IOtkyVNbPJpGFICjADmn6akU0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:37.4075592","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A37Z&sr=b&sp=r&sig=AXLeO4avObLMyLsN30473fFmgdB2gmylvOsJFfh3Mgo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:37.4074916","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A37Z&sr=b&sp=r&sig=XJctbrlvfEQ87hvyCkOyT2ckJ7CjpclX0SfdS4wBORM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:37.407575","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3228'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:37 GMT
+      mise-correlation-id:
+      - da3b1833-b339-4524-a337-a437c206c4c2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A42Z&sr=b&sp=r&sig=eH0NPIzGEpeAeVJoPznZPXbveuR61mMWKITd8SEfqwA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:42.6923098","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A42Z&sr=b&sp=r&sig=wTro4GkCX4VFo128rPhLHGtcH2xosaIolkQaup8s3rA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:42.6922348","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A42Z&sr=b&sp=r&sig=OjbeHy5ZMAguSXmoOcZL%2FzU%2FmKqtHInWcZlZVwxdPsY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:42.6923259","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:42 GMT
+      mise-correlation-id:
+      - 0c839137-e98d-4a99-8a45-4c178a6bee64
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A47Z&sr=b&sp=r&sig=1x1yfVJQ%2B7sO6cIpZIDSiQl1TcyFK8SQRVhBTTzbvGk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:47.9705202","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A47Z&sr=b&sp=r&sig=YOfxj0OgOOYqVOA9B7KTUfc3XZCKlQNWUtBy3iwIJoM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:47.970408","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A47Z&sr=b&sp=r&sig=MfT3TMFsel053QNHVszDwyvm8gIPRK%2FsOo82fgGxACE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:47.9705381","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3230'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:47 GMT
+      mise-correlation-id:
+      - 0210955d-f193-4508-b6a8-dd90ac0a5cc5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A53Z&sr=b&sp=r&sig=oIz1wgfKVTMC04krQ09jg5F%2FP2TNOcMfmGfM4vpESlU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:53.2997333","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A53Z&sr=b&sp=r&sig=m9UNcEUAJv81Isdak%2FNHFY5D3BwNJZ1Hm34%2FLiLa5BQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:53.2996672","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A53Z&sr=b&sp=r&sig=wpRKo%2BEb3eAV0FqJwgDjKicSyI4oH7xiZT75hI9p4WY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:53.2997481","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:53 GMT
+      mise-correlation-id:
+      - 403d06a2-2a45-4b1f-abfb-9a3545a18db9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A58Z&sr=b&sp=r&sig=8hUW2WYjn%2FuDt9udCEHXSGhYLx3nUFSuGaOnbSdqSg8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:58.6014203","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A58Z&sr=b&sp=r&sig=uNZcCLjXSgDRRoLdgSQ5vulP48cuyISaMDNkCRbpzFQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:58.6013307","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A58Z&sr=b&sp=r&sig=JAh1r5nwGoxL7YCBbg5XfMLRQuDOclRKxFfBixrWI%2Bw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:58.6014418","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:58 GMT
+      mise-correlation-id:
+      - 77589208-e612-4b85-9009-224d02c09415
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A03Z&sr=b&sp=r&sig=naRgUsQTYCOWbUW9wLIYhGA9hKQvSqvpMqV2FJXFgb4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:03.9523581","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A03Z&sr=b&sp=r&sig=L2Y3ema5LwS8gkG6jZXr8J6rggLMoHjamSQpS380Th8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:03.9522577","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A03Z&sr=b&sp=r&sig=C7fwTfZ%2F7Sv%2BWIsmJaiEqlnqCaPNB0pXM%2Bbt6dJ3oJg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:03.9523731","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:03 GMT
+      mise-correlation-id:
+      - 15bcf70a-4d9e-45e5-8537-e553a869c8b9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A09Z&sr=b&sp=r&sig=OnYmRRUS5GJ7dNSevcFxSJaZRZNKxOpzowlvrcBNfqc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:09.2271221","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A09Z&sr=b&sp=r&sig=sj0ZEdMq1ik0SlRrG41Jza7YZ0i0WbcErJYEzBdW3Kk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:09.2270269","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A09Z&sr=b&sp=r&sig=Navq9Fql09UryWyyKxWqavFE38w0rf29Ark0vAYPo4A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:09.227147","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3226'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:09 GMT
+      mise-correlation-id:
+      - 145ec6de-d471-42a5-b536-593f0f412b4a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A14Z&sr=b&sp=r&sig=laa3QOFDzz7H3JknfvSvyRp9K44Ab8FKqjSQ0znAHaE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:14.4963963","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A14Z&sr=b&sp=r&sig=19uJDiTKV2tFcfw2fk%2FaaHviuLaUSMloQP46dWyKDcQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:14.4963283","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A14Z&sr=b&sp=r&sig=bEeS6XyFg0cEcwSjmNmzf2LvlekTRpHpWaGT36D33jQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:14.4964099","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3229'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:14 GMT
+      mise-correlation-id:
+      - a3e88083-2b4d-4126-9aa7-6a20db405f35
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A19Z&sr=b&sp=r&sig=zJCxA4oOnDVTaxI7msaiKPpFaFrtrjlegdB9uChqrGE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:19.8044734","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A19Z&sr=b&sp=r&sig=VOMCpPIwow10A4ES3KVcKRTK1gvfZH85oovBlmx5mas%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:19.8043854","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A19Z&sr=b&sp=r&sig=3CRoHz2od0HW5V%2Fk3rg9A6Zn7Hu1e%2F932%2FSY3t%2B9eUI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:19.8044951","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:19 GMT
+      mise-correlation-id:
+      - 76eb0e5c-a91f-48dc-9655-c47a0f797079
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A25Z&sr=b&sp=r&sig=5Wk%2Fftr2FgwMwC2badPR7i7OaGyjtV66x9S9UfykRds%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:25.0844121","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A25Z&sr=b&sp=r&sig=7hK46iQocWwqZGhC8kS8JF1IEsvObfijBcCnjw5wlsY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:25.0843238","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A25Z&sr=b&sp=r&sig=jn4F5%2Fd6xxN1BexVJsOiMMC2%2BvYQGPmVmcoy7vmaKYY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:25.0844336","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:25 GMT
+      mise-correlation-id:
+      - 8503a001-9378-4968-bdec-eb6f4cea1205
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A30Z&sr=b&sp=r&sig=9msDMILyrv%2BI7%2BRIwRdLOlxCZQfmYWx3O69l94FuwIs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:30.4736907","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A30Z&sr=b&sp=r&sig=q%2F3zazK5pQ7cb0X%2BdIAjrKOQe%2FtE275jM%2F3N%2BkcJcEE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:30.4736079","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A30Z&sr=b&sp=r&sig=AA8tfA9wHR90xRDoTU43bYsMOWXrwnFBITxs3MpHX3E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:30.4737049","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3241'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:30 GMT
+      mise-correlation-id:
+      - 53f1b2cf-47f8-4db4-ac14-81ea803f0077
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A35Z&sr=b&sp=r&sig=CKf1hy1TBJeCPXdUqa8dAVWpq44h9KfoqV0uu4BJw9g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:35.7430117","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A35Z&sr=b&sp=r&sig=Yh7U%2FdeaixqYYOBWoMjAb54lugLOqEuxY8%2B0CPJXFDg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:35.7429237","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A35Z&sr=b&sp=r&sig=a4lkKgP%2B2w1%2Bq4DrE63OoDceCScqBqBV36yvlSKz0Vc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:35.7430345","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:35 GMT
+      mise-correlation-id:
+      - dc11165a-65fd-468d-89f3-a6449359a597
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A41Z&sr=b&sp=r&sig=%2B3EGUjAtNCkmTSzIHfogrPHhbYT6mpkZ2hB2NRFJLF0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:41.0134259","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A41Z&sr=b&sp=r&sig=cr6NFRq1xGIVpNtteVwe2kzietD3cN8exd%2BbF7yPMdw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:41.0133502","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A41Z&sr=b&sp=r&sig=OKgP4csSwkaIyma75pJlnalvKOfU2BbahRIMPqhGx3U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:41.0134401","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-18T20:57:01.939Z","endDateTime":"2023-10-18T20:59:40.244Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:40.385Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3366'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:41 GMT
+      mise-correlation-id:
+      - 87432c7e-15e1-4674-98f3-233b3d7274d9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1856,7 +1820,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1865,9 +1829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:26 GMT
+      - Wed, 18 Oct 2023 20:59:42 GMT
       etag:
-      - '"d901f03b-0000-0100-0000-65294c820000"'
+      - '"75009065-0000-0100-0000-6530464b0000"'
       expires:
       - '-1'
       pragma:
@@ -1897,11 +1861,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=server-metric-test-case&api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=server-metric-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A27Z&sr=b&sp=r&sig=Iwarv5oTsisoIaF7RwWFuvlGsyjuCwIGo0BarVcjO7k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:27.1503555","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A27Z&sr=b&sp=r&sig=PJp56IlImQDjVzEh2UY2V3iAydhbV9xIN89qd2ZdcmU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:27.1502836","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A27Z&sr=b&sp=r&sig=nNFRxdlHnPGThPZn%2BMfDNNxZFvWPQaV9YJCkHfxdXDQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:27.1503718","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-13T13:57:39.722Z","endDateTime":"2023-10-13T14:00:24.237Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:24.367Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A43Z&sr=b&sp=r&sig=7NPfaXPfdMsBlbM%2BeDiBRAaIuAQVAWD8PN9WRfSQrys%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:43.37274","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A43Z&sr=b&sp=r&sig=CNBLP3U3DD1FvOMGbQ9P1VJiqoQOoAxDBXwxh1t6UN0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:43.3726633","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A43Z&sr=b&sp=r&sig=vEPyANo5y2IJVOe1337ASUNWbNmDdos7%2BplyBjAZIco%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:43.3727544","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-18T20:57:01.939Z","endDateTime":"2023-10-18T20:59:40.244Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:42.988Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1912,9 +1876,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:27 GMT
+      - Wed, 18 Oct 2023 20:59:43 GMT
       mise-correlation-id:
-      - 127d3850-5c0b-49a2-b239-6f4e00d2c4b1
+      - 85f5fff5-0b63-4447-ade1-ac3de26b5be8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1941,7 +1905,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-13T13:56:51.3228153Z","key2":"2023-10-13T13:56:51.3228153Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-13T13:56:51.3228153Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-13T13:56:51.3228153Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-13T13:56:51.1040385Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-18T20:56:13.7128984Z","key2":"2023-10-18T20:56:13.7128984Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-18T20:56:13.7285195Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-18T20:56:13.7285195Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-18T20:56:13.4785229Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -1950,7 +1914,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 14:00:27 GMT
+      - Wed, 18 Oct 2023 20:59:43 GMT
       expires:
       - '-1'
       pragma:
@@ -1983,7 +1947,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1992,9 +1956,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:29 GMT
+      - Wed, 18 Oct 2023 20:59:45 GMT
       etag:
-      - '"d901f03b-0000-0100-0000-65294c820000"'
+      - '"75009065-0000-0100-0000-6530464b0000"'
       expires:
       - '-1'
       pragma:
@@ -2013,9 +1977,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-vxzk6dtlrnyejency/providers/Microsoft.Storage/storageAccounts/clitestloadnq4tggts4":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-vxzk6dtlrnyejency/providers/Microsoft.Storage/storageAccounts/clitestloadnq4tggts4",
-      "resourceName": "clitestloadnq4tggts4", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testRunId": "server-metric-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-gprbh4fsrwftmsxhr/providers/Microsoft.Storage/storageAccounts/clitestloadydqhjzlak":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-gprbh4fsrwftmsxhr/providers/Microsoft.Storage/storageAccounts/clitestloadydqhjzlak",
+      "resourceName": "clitestloadydqhjzlak", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -2031,10 +1995,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-13T14:00:30.809Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:30.809Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-18T20:59:46.577Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:46.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2045,11 +2009,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:30 GMT
+      - Wed, 18 Oct 2023 20:59:46 GMT
       location:
-      - https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+      - https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - d1f9012f-d667-4c4a-a263-6674bc74e509
+      - 3e9d5085-362b-4d9c-ba74-b8596081d126
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2072,7 +2036,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2081,9 +2045,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:31 GMT
+      - Wed, 18 Oct 2023 20:59:47 GMT
       etag:
-      - '"d901f03b-0000-0100-0000-65294c820000"'
+      - '"75009065-0000-0100-0000-6530464b0000"'
       expires:
       - '-1'
       pragma:
@@ -2113,10 +2077,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-13T14:00:30.809Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:30.809Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-18T20:59:46.577Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:46.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2127,9 +2091,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:33 GMT
+      - Wed, 18 Oct 2023 20:59:48 GMT
       mise-correlation-id:
-      - cf7ebd69-3a4b-4a5a-948e-65cd36545239
+      - 9ebd0b15-bcd1-48b1-a556-ea8a664871eb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2152,7 +2116,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2161,9 +2125,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:35 GMT
+      - Wed, 18 Oct 2023 20:59:49 GMT
       etag:
-      - '"d901f03b-0000-0100-0000-65294c820000"'
+      - '"75009065-0000-0100-0000-6530464b0000"'
       expires:
       - '-1'
       pragma:
@@ -2182,9 +2146,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-vxzk6dtlrnyejency/providers/Microsoft.Storage/storageAccounts/clitestloadnq4tggts4/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-gprbh4fsrwftmsxhr/providers/Microsoft.Storage/storageAccounts/clitestloadydqhjzlak/providers/microsoft.insights/metricdefinitions/Availability":
       {"name": " Availability", "metricNamespace": "microsoft.storage/storageaccounts",
-      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-vxzk6dtlrnyejency/providers/Microsoft.Storage/storageAccounts/clitestloadnq4tggts4",
+      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-gprbh4fsrwftmsxhr/providers/Microsoft.Storage/storageAccounts/clitestloadydqhjzlak",
       "resourceType": "Microsoft.Storage/storageAccounts"}}}'
     headers:
       Accept:
@@ -2200,12 +2164,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-13T14:00:30.831Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:36.087Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-18T20:59:46.606Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:50.981Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2216,9 +2180,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:36 GMT
+      - Wed, 18 Oct 2023 20:59:51 GMT
       mise-correlation-id:
-      - 62d90224-9793-45e5-ae80-78995d7aeaa3
+      - 6d9d63af-775b-4222-b7b6-ed792fe9c02f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2241,7 +2205,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2250,9 +2214,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:37 GMT
+      - Wed, 18 Oct 2023 20:59:51 GMT
       etag:
-      - '"d901f03b-0000-0100-0000-65294c820000"'
+      - '"75009065-0000-0100-0000-6530464b0000"'
       expires:
       - '-1'
       pragma:
@@ -2282,12 +2246,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-13T14:00:30.831Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:36.087Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-18T20:59:46.606Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:50.981Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2298,9 +2262,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:38 GMT
+      - Wed, 18 Oct 2023 20:59:53 GMT
       mise-correlation-id:
-      - ce7bd4ad-950c-4360-a87f-93478909257c
+      - 39ef09c5-9e66-45e0-a25d-2473b822cc0a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2323,7 +2287,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2332,9 +2296,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:39 GMT
+      - Wed, 18 Oct 2023 20:59:53 GMT
       etag:
-      - '"d901f03b-0000-0100-0000-65294c820000"'
+      - '"75009065-0000-0100-0000-6530464b0000"'
       expires:
       - '-1'
       pragma:
@@ -2353,7 +2317,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-vxzk6dtlrnyejency/providers/Microsoft.Storage/storageAccounts/clitestloadnq4tggts4/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-gprbh4fsrwftmsxhr/providers/Microsoft.Storage/storageAccounts/clitestloadydqhjzlak/providers/microsoft.insights/metricdefinitions/Availability":
       null}}'
     headers:
       Accept:
@@ -2369,23 +2333,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-13T14:00:30.831Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:41.12Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-18T20:59:46.606Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:55.443Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2495'
+      - '2496'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:41 GMT
+      - Wed, 18 Oct 2023 20:59:55 GMT
       mise-correlation-id:
-      - d873fd4a-e138-44ab-8398-c6f3ed55a11a
+      - d298a7af-2b73-43cd-848b-be53c74a75a3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2408,7 +2372,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2417,9 +2381,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:42 GMT
+      - Wed, 18 Oct 2023 20:59:57 GMT
       etag:
-      - '"d901f03b-0000-0100-0000-65294c820000"'
+      - '"75009065-0000-0100-0000-6530464b0000"'
       expires:
       - '-1'
       pragma:
@@ -2449,23 +2413,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-13T14:00:30.831Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:41.12Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-18T20:59:46.606Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:55.443Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2495'
+      - '2496'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:43 GMT
+      - Wed, 18 Oct 2023 20:59:57 GMT
       mise-correlation-id:
-      - fc8d75e6-2a3d-4605-8807-25500b1bb575
+      - 7d0f234b-cf84-48d2-8478-1fea701e7f7e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_server_metric.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_server_metric.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:36 GMT
+      - Tue, 24 Oct 2023 12:33:51 GMT
       etag:
-      - '"75009065-0000-0100-0000-6530464b0000"'
+      - '"d300cf49-0000-0100-0000-6537b9780000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:56:37 GMT
+      - Tue, 24 Oct 2023 12:33:52 GMT
       mise-correlation-id:
-      - 02bff8e8-23e5-4d23-9ebc-4c5c11b65b62
+      - 15255de7-e1d1-419e-bbec-4dae8ecbbc9a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "3c38b39b-e04b-4852-a2d2-c9e80698d5f2":
+      {"passFailMetrics": {"04694ae7-22f2-4815-9972-9047a4152168": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "a194dfcb-4122-4997-ae60-04ec74401d91":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "17095de8-4d10-43e7-ab1f-1a93c7f07e1e": {"aggregate": "avg", "clientMetric":
+      "50"}, "4e9f48fe-5417-4942-8763-f143c419890d": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:38.216Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:38.216Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:33:52.811Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:52.811Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:38 GMT
+      - Tue, 24 Oct 2023 12:33:52 GMT
       location:
-      - https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+      - https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - e39091be-0a5c-45ef-bc42-59ca659e79fa
+      - 52602450-88f6-478e-a9fc-d89c0d961340
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:38 GMT
+      - Tue, 24 Oct 2023 12:33:53 GMT
       mise-correlation-id:
-      - 3c9c31be-3159-497c-8ee1-7be3bcab0077
+      - 22fc412b-15ab-423f-80f5-87e30ef76d9a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A39Z&sr=b&sp=r&sig=7uCDNh2RMgX5LNXp%2B2EGcpiQMXpHWzv4jCQ5fNOGvR0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:39.181218","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A53Z&sr=b&sp=r&sig=1f5uQiUBejJDL3I1lR4BOdj7FAha7chpcahdop5JxIw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:53.6895423","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:39 GMT
+      - Tue, 24 Oct 2023 12:33:53 GMT
       location:
-      - https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - df1e35ad-7d1e-4342-b9b6-0cc13d302624
+      - e18c20ab-6fc4-4749-91da-53cec3e421be
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A39Z&sr=b&sp=r&sig=BJl4lcb67zPtHNDbWbAWL57Ojc29ZChGVRJMOOSdb6s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:39.4474367","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A54Z&sr=b&sp=r&sig=oNPUhtdbk27GFm9B9jAc1DMNDP4pVaw0SGqi0RbbLw4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:54.0507028","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:39 GMT
+      - Tue, 24 Oct 2023 12:33:54 GMT
       mise-correlation-id:
-      - 2531d667-69cb-4aa9-84c0-9869bee87fac
+      - 8e56c766-0a39-4d25-8f9d-2c1eaeb2c024
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,46 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A44Z&sr=b&sp=r&sig=pFcvXKPJeEOGCVisOu%2B3psFc%2BOWajSFFnWrUcZrNMcM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:44.7753202","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:56:44 GMT
-      mise-correlation-id:
-      - 5f6cad28-44f7-4a19-b3cf-726399f01e0d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A50Z&sr=b&sp=r&sig=0MZe9AAK%2BN%2Bnj%2B4dvdM3Pq8kiw8hf0%2FBK4AiDFnW4vY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:50.0837902","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A59Z&sr=b&sp=r&sig=%2F%2FRu4me1RRUNhXdKMVNqHtzHdKFDqA%2FYMQX%2B6XDCkyI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:59.6519629","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:50 GMT
+      - Tue, 24 Oct 2023 12:33:59 GMT
       mise-correlation-id:
-      - e0c785de-512f-4f83-a49b-27aeb6b1cddf
+      - bbf71bd9-91e1-452d-88e8-49e0342a3f1e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A55Z&sr=b&sp=r&sig=MzBcdNSKhNbhV4YA8GxSBvvNFacgRJm5D0vmsDowARU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:55.357457","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A44%3A04Z&sr=b&sp=r&sig=rIvOunvaFjsfHxF%2B%2Bn4VxpHxJuWaKCAvZw6obwPzLnU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:44:04.9064326","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '546'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:55 GMT
+      - Tue, 24 Oct 2023 12:34:04 GMT
       mise-correlation-id:
-      - a550ea05-5b6f-4ad8-8e4b-fbb1c2da6936
+      - 16bc7dfc-dc88-4b84-a97b-41800ac16987
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +421,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A55Z&sr=b&sp=r&sig=I5i4IurwjEBnT43l9Es5Ygl9O1a4v9WcuYGwFNlzDbk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:55.640379","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:38.216Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:51.151Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A44%3A10Z&sr=b&sp=r&sig=1dMvg2EAU%2F%2FZY3XJseGisSAEVMMCmpWcdBRrrUbeKZU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:44:10.5918353","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1583'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:55 GMT
+      - Tue, 24 Oct 2023 12:34:10 GMT
       mise-correlation-id:
-      - 3dc4f4e8-e1f3-4075-8f5b-29da09730f27
+      - 41442102-3691-4070-a66f-a3476dc56a53
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A10Z&sr=b&sp=r&sig=m%2BUC0wa%2FAYZ4EAJeEmibw%2FTg%2BJha7QSSm53Ki%2FkbMBQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:10.8433265","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:33:52.811Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:05.676Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:34:10 GMT
+      mise-correlation-id:
+      - 139b720a-bab4-4925-ab57-e6b0464235c6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:56 GMT
+      - Tue, 24 Oct 2023 12:34:12 GMT
       etag:
-      - '"75009065-0000-0100-0000-6530464b0000"'
+      - '"d300cf49-0000-0100-0000-6537b9780000"'
       expires:
       - '-1'
       pragma:
@@ -538,11 +538,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A56%3A57Z&sr=b&sp=r&sig=ao1LcATwn6V3qmCCXi1jMlq0Xl3SZhXwHDrnOIShDOE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:56:57.3666192","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:38.216Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:51.151Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A13Z&sr=b&sp=r&sig=Og7u028Mr37AuDi6WK87vUuo1IIJGZQSPhVE2mUJ07Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:13.0037348","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:33:52.811Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:05.676Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:57 GMT
+      - Tue, 24 Oct 2023 12:34:13 GMT
       mise-correlation-id:
-      - ae4b500a-a483-4f30-83ca-ee4eea07b580
+      - ebabcbf4-4f85-4d47-af62-b53f8f68619f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:57 GMT
+      - Tue, 24 Oct 2023 12:34:13 GMT
       etag:
-      - '"75009065-0000-0100-0000-6530464b0000"'
+      - '"d300cf49-0000-0100-0000-6537b9780000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:57:00 GMT
+      - Tue, 24 Oct 2023 12:34:15 GMT
       mise-correlation-id:
-      - 5d70d11f-4906-4d71-8fb7-ec71a2c2d1fe
+      - d8bd6dce-c1bb-4569-ad34-7e83ea405f65
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,10 +662,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A01Z&sr=b&sp=r&sig=WCuh%2FqvM1D6PDtpP3dciOoYrRYtrHOF3Ipi0Y2Zfjt0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:01.6534549","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A01Z&sr=b&sp=r&sig=NEKz5W3Ad8Is%2FpXxUQTLBXt4%2FsTmjgfDAtO7juF8dQI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:01.6533305","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A01Z&sr=b&sp=r&sig=OJ9vI52K0JupfO8jAyWTVP%2B8WTJW4mWpk5AAqsoUWPQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:01.6534888","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:01.573Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A16Z&sr=b&sp=r&sig=68ELqoedT2dhVZGBkWB2FNw969RwG%2F1MqEzMuf6wkNs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:16.1761083","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A16Z&sr=b&sp=r&sig=FYuUHk6Xj0oYeZMfp96ZKgTClyGtK%2BOM6rPfi7YraUs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:16.1759899","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A16Z&sr=b&sp=r&sig=Ef5K0m9hT%2FQHT8qL9dLy8%2FO10SveCsg8WHb6p2TxUa0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:16.1761452","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:16.089Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -676,11 +676,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:01 GMT
+      - Tue, 24 Oct 2023 12:34:16 GMT
       location:
-      - https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+      - https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 55aaae67-1482-4f4a-9903-2e846dae0463
+      - 85ac225d-54e9-4230-b2fc-9744c67ea93f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,262 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A02Z&sr=b&sp=r&sig=MTf3yEnPDciSo0aINAdnJXu9UTDFwSnxzv5%2BVvj%2Bj1E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:02.0889093","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A02Z&sr=b&sp=r&sig=p718F8RXzykW5yEAGKF2W6dUtgONJSyzijkWTLtoHso%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:02.0887725","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A02Z&sr=b&sp=r&sig=lHcGHJnTw%2BgOO0V8q0N%2FyuRL6%2BQUtaA3Mbx21ujJOxY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:02.0889355","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.074Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3240'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:02 GMT
-      mise-correlation-id:
-      - 226f35a2-2960-4e93-839a-171c9e52b057
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A07Z&sr=b&sp=r&sig=AqQd6lTLOqAxMnAN5qBhfkh%2FkmulSI50WegWGVNNzlU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:07.3841293","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A07Z&sr=b&sp=r&sig=iwa%2BieisFl6gRq5fPSC8XPlKyRYm8ZNpArUgGzKPPfQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:07.384059","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A07Z&sr=b&sp=r&sig=I87GG%2BqCW7CZcBbnaqjJlzQ0aTeCOeUrPz19QjSPDw0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:07.3841465","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.082Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:07 GMT
-      mise-correlation-id:
-      - 87fed55c-17af-4584-995a-01b8d4f2f37a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A12Z&sr=b&sp=r&sig=c9nacudoTllMf06e%2BuvQUYPFIr8zp0I%2FuxO0Dmcz964%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:12.6517867","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A12Z&sr=b&sp=r&sig=swk%2F2juUH5KX11Mr3ovmWP%2Fiqc8rTV825s70MD%2FnGMQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:12.651715","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A12Z&sr=b&sp=r&sig=YZHQaG%2BFlwZhSOb3wOzPpPRqnli4eyDQI2fvIlNbebg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:12.6518007","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.082Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3241'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:12 GMT
-      mise-correlation-id:
-      - 5c44b257-5229-48f2-bc14-3dabd4931df0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A17Z&sr=b&sp=r&sig=sYAqXUxjVszzTp0RsYggrGw8zZKRoTOSIfrZJbG%2F4XI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:17.937777","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A17Z&sr=b&sp=r&sig=Jkltmm0otcq7uhKoznSKz5GPL%2FHn3RFWK04ZqUbL9WU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:17.9376895","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A17Z&sr=b&sp=r&sig=tFh8wahY2J%2BVM0LjjhBbw0Mtptwa0cUz8YR35JQIK4g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:17.9377993","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.082Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:17 GMT
-      mise-correlation-id:
-      - 5e002ff1-5159-4f3a-baec-241aae97a2e7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A23Z&sr=b&sp=r&sig=ri91xcOiE%2FADoFBGPk0SS5Aw1o5lcjAf3N0hP8YiO0w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:23.210675","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A23Z&sr=b&sp=r&sig=8BixzwQ7vZ%2FDupOIc6hn4iQOLg5YjHM15%2FPuyVTIxkA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:23.2105724","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A23Z&sr=b&sp=r&sig=rqSAKKroiWfOLUg3C6s2manMfJJKuIk3W8fB0lv6Z0Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:23.2106974","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.082Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:23 GMT
-      mise-correlation-id:
-      - 0587b537-387a-47dd-b903-5770ed128450
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A28Z&sr=b&sp=r&sig=0jjbQkOgrQ0iHrIy2RbwJDOQZKNfIomyS%2Big6vJD7yI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:28.4768886","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A28Z&sr=b&sp=r&sig=G%2BIOzAq4NQAC26WqqDQWgez75pP7eRg%2BPnXuMRli%2FHE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:28.4767849","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A28Z&sr=b&sp=r&sig=VoIzvR5iw8ehIkVNeqtQvAk3zaSY5F8fCU%2BNjRZ2R6g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:28.476917","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.082Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3239'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:28 GMT
-      mise-correlation-id:
-      - fc254edb-e109-4ee5-aa72-e506dbb0e630
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A33Z&sr=b&sp=r&sig=x7PkGff2fBx2NpCwTB%2FdeORFgBYYVqH1Y5d3OtTShbY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:33.7308846","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A33Z&sr=b&sp=r&sig=Xjhgs2h7Msgy613R%2B5%2F4lEYGlB1%2BqczZ5UdkFXmMVe8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:33.730796","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A33Z&sr=b&sp=r&sig=TB8T8U%2BKGH3UbM8BIp%2FHQ7UahDChmeKIkWVxRdbzplU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:33.730906","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.082Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3240'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:33 GMT
-      mise-correlation-id:
-      - fc90ac8f-623d-4fbf-ba9c-182a2467bdba
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A39Z&sr=b&sp=r&sig=6aa6%2BMXyyfsjgvUiqrDknNDThXuazBkUmg%2B5A9YCyZQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:39.0343351","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A39Z&sr=b&sp=r&sig=UoXZaUM2F0bDNV8KBcxFxHEg4oIMAqF8uKcUQRNwclY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:39.0342234","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A39Z&sr=b&sp=r&sig=lqp9ziD2EISnnDbvjisS8wiKMk%2FAvVCWHiVnHqdkBZc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:39.0343603","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.082Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A16Z&sr=b&sp=r&sig=PJ8tR5AHk4xYo2Dbxf%2FqKy8NHFRtLcNsshq%2BvW2IEyE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:16.6316387","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A16Z&sr=b&sp=r&sig=1RES%2BNcAkgslSA2mzB6YlnN9TxMYQSAZVIjzoTduTLk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:16.6315544","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A16Z&sr=b&sp=r&sig=q4QBU0Hp10Lj%2BhEqO5oqLQmvEq7IXa7aAL6MuKidU7E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:16.6316605","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"NOTSTARTED","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:16.514Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -966,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:39 GMT
+      - Tue, 24 Oct 2023 12:34:16 GMT
       mise-correlation-id:
-      - 31336679-f915-4aa8-8e76-91f09eb9c792
+      - cb0a09db-b473-4c3a-9b04-0f43bae276d6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -988,46 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A44Z&sr=b&sp=r&sig=5yRIwR%2BRjlJuX3Q0NbqXIQKJoki0sCEzJVjr6TTm5hE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:44.3659385","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A44Z&sr=b&sp=r&sig=JNv5o5SgZnTXJ%2FRExnOrhHvWz%2B7oNYNLtmzpIM%2BtZ0U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:44.365841","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A44Z&sr=b&sp=r&sig=pylQ7li%2BU7cJlZz7TQCrOjHedi335b%2BkcK%2Br1ohnw3o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:44.3659574","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:41.749Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3242'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:44 GMT
-      mise-correlation-id:
-      - 316c3144-0cf9-4b74-a821-c57b0b8a050a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A49Z&sr=b&sp=r&sig=D8GEIzY7XM3CBZ2DVG4xc5hzLixcrnraTDRqQYbsEzg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:49.6502474","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A49Z&sr=b&sp=r&sig=C3xSBMujgndw7mw%2FmLHbEbhA4zQ37o1UjXaC4O9lkVw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:49.6501521","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A49Z&sr=b&sp=r&sig=cp2wEVe%2Fexq5Kuc9sLMpXScEmPQY1IZv4IZLYC520Ms%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:49.6502667","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A21Z&sr=b&sp=r&sig=sCDwlDUfSxM56BNbDZURDlYpZmE9W8VLE4Pdx8wayzA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:21.9049889","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A21Z&sr=b&sp=r&sig=ZfsJqtAlFfQ3f0lRxOQKn9I51GjoDJo%2BzQq1B43LzS0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:21.9049167","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A21Z&sr=b&sp=r&sig=uzu1fmaaY7MzDcZglygZinYBekB1E19HtbtB2nu0U3M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:21.9050037","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:16.71Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1038,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:49 GMT
+      - Tue, 24 Oct 2023 12:34:21 GMT
       mise-correlation-id:
-      - ea3bc1aa-8492-439c-8aea-61b8682592d4
+      - 64e14720-a593-4183-84b4-0a5313d21dfd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,10 +772,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A54Z&sr=b&sp=r&sig=jGyZ28ppGoqbETTluIBdVihKvCnLW9%2Br0vaBU%2FvdSCU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:54.9233521","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A54Z&sr=b&sp=r&sig=rNq%2BkplkWnRoh6%2BDno51Q0UTc25OLIeyffqIcQwuWvA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:54.9232533","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A54Z&sr=b&sp=r&sig=XD6aPeVOZV9MidLJDmw%2Fyl3UE%2BsylvYc1uW3ytVyvho%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:54.9233778","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A27Z&sr=b&sp=r&sig=U%2FEaAHW1g82pwXlJzvQdvfUJg79o47K6CVj2XYN9HGs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:27.2343285","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A27Z&sr=b&sp=r&sig=WCnnU1u67xD9g7WHJmuEi9IdRPApcbI4mYjLC5E3vbI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:27.2342287","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A27Z&sr=b&sp=r&sig=G5jZYGqShNmlzLkxln78aWX%2Ft0kyOMZBxqH1g4r%2FEu0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:27.2343444","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:16.71Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:34:27 GMT
+      mise-correlation-id:
+      - b0e5d182-33b0-45ae-b73c-07ee80092c32
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A32Z&sr=b&sp=r&sig=KScwJSoQF3INGfF%2FsEf7hk1v9FFVKRGaow%2Fo5CywLSg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:32.5403257","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A32Z&sr=b&sp=r&sig=8OMdigwRLFa7NagwwyVY4Yjcf207Vxvo4CjMJjuWMQ0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:32.5402149","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A32Z&sr=b&sp=r&sig=PA1ygqntjUMOsXBBj0SAV6KVaFD5RVBvPEpTXgUI2XQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:32.5403549","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:16.71Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:34:32 GMT
+      mise-correlation-id:
+      - 7bb4ce7d-8c30-46fd-8d50-c7efef03405e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A38Z&sr=b&sp=r&sig=y30I4vFTNF%2BA5d6NPadmG269CHW95dyg%2B6U2WcqoIbc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:38.223304","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A38Z&sr=b&sp=r&sig=ehsBVmlcMMJIJci7iqCXYaiRyzG4MtZNXs%2Fu%2BFzwQFg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:38.2232088","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A38Z&sr=b&sp=r&sig=lY0Y3Vur%2BGeo%2BCQH6h685aYED3CidNlCaKRc7N3mPgY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:38.2233259","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:16.71Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3240'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:34:38 GMT
+      mise-correlation-id:
+      - f4fd7cbf-f1a9-4f59-945c-b400cb265829
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A43Z&sr=b&sp=r&sig=%2BYOgLuQlMh6uOlrO508jVxJGUzbJlJQCNW3SUJJWjMQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:43.4809193","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A43Z&sr=b&sp=r&sig=974GFOb4%2FHUY%2BkvV12%2Fq8SL7f8FWyQUZFSmQp9gfrlQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:43.4808398","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A43Z&sr=b&sp=r&sig=9nesRuPPJWFGA4heZm8cGCVx%2BtbLVeVKO2ehLfBaAWo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:43.4809337","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:16.71Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1074,9 +894,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:54 GMT
+      - Tue, 24 Oct 2023 12:34:43 GMT
       mise-correlation-id:
-      - cd7cfd99-a471-402c-b87d-5dce71f5a784
+      - c3859070-aaee-4c07-8803-4e2c9f7a1107
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1096,23 +916,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A00Z&sr=b&sp=r&sig=taoDE41rjc2lC37TRWu4Zb%2Fd5cWtIRmupv7kN%2FKqO%2FU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:00.4202215","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A00Z&sr=b&sp=r&sig=%2FqEgq9mkwyxGCiuZnlsy3Ei4guWldnqJtsXvW8346n4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:00.4201541","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A00Z&sr=b&sp=r&sig=fGCxOPhDH%2B9EDGykqdkL7wBxoUogq70rwfEV5tZY9iE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:00.4202372","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A48Z&sr=b&sp=r&sig=ZBNBdkaQh1iiCilZXsNf0mB8%2FibR02aH0ijKgHVizz4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:48.7300235","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A48Z&sr=b&sp=r&sig=A0ffxn%2BdbXTEbzl7OJeR8PALZRNU%2Fxe8J3vCpofnV%2Fw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:48.7299261","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A48Z&sr=b&sp=r&sig=1rxkAe0RKsD%2BomnFjZBlQVtqL23sEokpadvGdP2gpnA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:48.7300454","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:16.71Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3237'
+      - '3239'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:58:00 GMT
+      - Tue, 24 Oct 2023 12:34:48 GMT
       mise-correlation-id:
-      - 6a388172-7ae2-44fa-ad5a-d9855e9788d3
+      - ede03b95-fc92-4271-9349-92cb40ea823a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1132,586 +952,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A05Z&sr=b&sp=r&sig=GF5sLFG74pZMJjNuhEepqAIme%2FOfEaJqBelJDmd0Xz8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:05.6853456","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A05Z&sr=b&sp=r&sig=QNV0rjpZSk1fW8eiy2PNoLDaM0rhSCq52gTJEuzbZzU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:05.6852777","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A05Z&sr=b&sp=r&sig=OK%2FpZ%2Bfzm2f9uES3%2FIRxWIu1HTiSl4dNUJGx7%2BrFRtQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:05.6853619","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:05 GMT
-      mise-correlation-id:
-      - 102516c2-3fe9-4058-81e6-2d4991da9f9d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A10Z&sr=b&sp=r&sig=7dkAwEr0lfDy1M75IMfyjcwrZ9ke65wcpnGOSM%2Bg24c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:10.9805472","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A10Z&sr=b&sp=r&sig=J1UT2r%2ForqpKatEUMJRvyMo36zylQ0GRjnf0croZFpk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:10.9804784","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A10Z&sr=b&sp=r&sig=P3ajJjYAEqZgol3HpM4I2cueMs%2BuoKQkmoFflGe7Vho%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:10.9805615","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3233'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:10 GMT
-      mise-correlation-id:
-      - 9e7035c0-f4fb-4d5b-ae72-6f82cdacd0be
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A16Z&sr=b&sp=r&sig=fq%2FsVG0IW4kDXqQZTyHjVufbtRxlHyV9neirBy%2Bej6I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:16.240269","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A16Z&sr=b&sp=r&sig=mJ5xDAfyWtw05xNkPaqUFFtQceo0GQVbInwQ76Zvm5w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:16.2401927","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A16Z&sr=b&sp=r&sig=eoGvKtRpJCXhEmD68nqhlrh9CIBHeIKKLW%2B%2Fp1JWWLw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:16.2402843","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:16 GMT
-      mise-correlation-id:
-      - 70b0be75-5d26-4192-b245-be1774e93275
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A21Z&sr=b&sp=r&sig=dgsqk3tiwJPZaAGshyKaLEjcvUANUDLyV7NAl8AcLLc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:21.5295432","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A21Z&sr=b&sp=r&sig=ahuPp7ZzDhpNPZe32bhAkk3C1WgzvXFsPPlCxtTq5%2Fg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:21.5294637","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A21Z&sr=b&sp=r&sig=i0HnhaQBjlQmq17tNLDLxBKFNSWKb7j7fWQOKQzGKc8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:21.5295575","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3229'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:21 GMT
-      mise-correlation-id:
-      - 7edfd618-53dd-44fc-963b-65f28453a0dd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A26Z&sr=b&sp=r&sig=pl%2BA%2FLtGZB2h0MFViHMqcj7jUbKIBfeXG%2F9qvmnqSTY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:26.8682882","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A26Z&sr=b&sp=r&sig=upkWkOaZEOckFH3FKbDw2xjicR2%2BACxpvz5y8xqamMs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:26.8682062","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A26Z&sr=b&sp=r&sig=r80wsD4GG36DHrm2i6d4W7vDAh7vc2ktFr1Ndo3jWsQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:26.8683029","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:26 GMT
-      mise-correlation-id:
-      - 2302eba3-44cb-44ff-8719-a9252c586336
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A32Z&sr=b&sp=r&sig=mHGMvIrx4trT%2B%2B8cDLwwzQYDXHiiQRsWXmt2nvXRLoc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:32.1521623","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A32Z&sr=b&sp=r&sig=EkrKuZE6lfXgkFPS6A51eCZ5rv3bz2nDbUMtT790qo0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:32.1520722","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A32Z&sr=b&sp=r&sig=Yaj%2Bysa%2Bj9n1bM3nniL%2F95SMaG6CXgVTvLbYEx3veJE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:32.1521831","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:32 GMT
-      mise-correlation-id:
-      - 737da416-53ed-4eda-8dec-a555170ba479
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A37Z&sr=b&sp=r&sig=CsN7YlJm7ZLrFH%2FZh7IOtkyVNbPJpGFICjADmn6akU0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:37.4075592","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A37Z&sr=b&sp=r&sig=AXLeO4avObLMyLsN30473fFmgdB2gmylvOsJFfh3Mgo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:37.4074916","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A37Z&sr=b&sp=r&sig=XJctbrlvfEQ87hvyCkOyT2ckJ7CjpclX0SfdS4wBORM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:37.407575","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3228'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:37 GMT
-      mise-correlation-id:
-      - da3b1833-b339-4524-a337-a437c206c4c2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A42Z&sr=b&sp=r&sig=eH0NPIzGEpeAeVJoPznZPXbveuR61mMWKITd8SEfqwA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:42.6923098","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A42Z&sr=b&sp=r&sig=wTro4GkCX4VFo128rPhLHGtcH2xosaIolkQaup8s3rA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:42.6922348","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A42Z&sr=b&sp=r&sig=OjbeHy5ZMAguSXmoOcZL%2FzU%2FmKqtHInWcZlZVwxdPsY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:42.6923259","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3231'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:42 GMT
-      mise-correlation-id:
-      - 0c839137-e98d-4a99-8a45-4c178a6bee64
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A47Z&sr=b&sp=r&sig=1x1yfVJQ%2B7sO6cIpZIDSiQl1TcyFK8SQRVhBTTzbvGk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:47.9705202","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A47Z&sr=b&sp=r&sig=YOfxj0OgOOYqVOA9B7KTUfc3XZCKlQNWUtBy3iwIJoM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:47.970408","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A47Z&sr=b&sp=r&sig=MfT3TMFsel053QNHVszDwyvm8gIPRK%2FsOo82fgGxACE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:47.9705381","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3230'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:47 GMT
-      mise-correlation-id:
-      - 0210955d-f193-4508-b6a8-dd90ac0a5cc5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A53Z&sr=b&sp=r&sig=oIz1wgfKVTMC04krQ09jg5F%2FP2TNOcMfmGfM4vpESlU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:53.2997333","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A53Z&sr=b&sp=r&sig=m9UNcEUAJv81Isdak%2FNHFY5D3BwNJZ1Hm34%2FLiLa5BQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:53.2996672","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A53Z&sr=b&sp=r&sig=wpRKo%2BEb3eAV0FqJwgDjKicSyI4oH7xiZT75hI9p4WY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:53.2997481","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:53 GMT
-      mise-correlation-id:
-      - 403d06a2-2a45-4b1f-abfb-9a3545a18db9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A58Z&sr=b&sp=r&sig=8hUW2WYjn%2FuDt9udCEHXSGhYLx3nUFSuGaOnbSdqSg8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:58.6014203","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A58Z&sr=b&sp=r&sig=uNZcCLjXSgDRRoLdgSQ5vulP48cuyISaMDNkCRbpzFQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:58.6013307","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A58Z&sr=b&sp=r&sig=JAh1r5nwGoxL7YCBbg5XfMLRQuDOclRKxFfBixrWI%2Bw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:58.6014418","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3231'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:58 GMT
-      mise-correlation-id:
-      - 77589208-e612-4b85-9009-224d02c09415
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A03Z&sr=b&sp=r&sig=naRgUsQTYCOWbUW9wLIYhGA9hKQvSqvpMqV2FJXFgb4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:03.9523581","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A03Z&sr=b&sp=r&sig=L2Y3ema5LwS8gkG6jZXr8J6rggLMoHjamSQpS380Th8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:03.9522577","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A03Z&sr=b&sp=r&sig=C7fwTfZ%2F7Sv%2BWIsmJaiEqlnqCaPNB0pXM%2Bbt6dJ3oJg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:03.9523731","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3233'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:03 GMT
-      mise-correlation-id:
-      - 15bcf70a-4d9e-45e5-8537-e553a869c8b9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A09Z&sr=b&sp=r&sig=OnYmRRUS5GJ7dNSevcFxSJaZRZNKxOpzowlvrcBNfqc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:09.2271221","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A09Z&sr=b&sp=r&sig=sj0ZEdMq1ik0SlRrG41Jza7YZ0i0WbcErJYEzBdW3Kk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:09.2270269","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A09Z&sr=b&sp=r&sig=Navq9Fql09UryWyyKxWqavFE38w0rf29Ark0vAYPo4A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:09.227147","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3226'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:09 GMT
-      mise-correlation-id:
-      - 145ec6de-d471-42a5-b536-593f0f412b4a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A14Z&sr=b&sp=r&sig=laa3QOFDzz7H3JknfvSvyRp9K44Ab8FKqjSQ0znAHaE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:14.4963963","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A14Z&sr=b&sp=r&sig=19uJDiTKV2tFcfw2fk%2FaaHviuLaUSMloQP46dWyKDcQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:14.4963283","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A14Z&sr=b&sp=r&sig=bEeS6XyFg0cEcwSjmNmzf2LvlekTRpHpWaGT36D33jQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:14.4964099","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3229'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:14 GMT
-      mise-correlation-id:
-      - a3e88083-2b4d-4126-9aa7-6a20db405f35
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A19Z&sr=b&sp=r&sig=zJCxA4oOnDVTaxI7msaiKPpFaFrtrjlegdB9uChqrGE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:19.8044734","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A19Z&sr=b&sp=r&sig=VOMCpPIwow10A4ES3KVcKRTK1gvfZH85oovBlmx5mas%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:19.8043854","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A19Z&sr=b&sp=r&sig=3CRoHz2od0HW5V%2Fk3rg9A6Zn7Hu1e%2F932%2FSY3t%2B9eUI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:19.8044951","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:19 GMT
-      mise-correlation-id:
-      - 76eb0e5c-a91f-48dc-9655-c47a0f797079
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A25Z&sr=b&sp=r&sig=5Wk%2Fftr2FgwMwC2badPR7i7OaGyjtV66x9S9UfykRds%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:25.0844121","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A25Z&sr=b&sp=r&sig=7hK46iQocWwqZGhC8kS8JF1IEsvObfijBcCnjw5wlsY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:25.0843238","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A25Z&sr=b&sp=r&sig=jn4F5%2Fd6xxN1BexVJsOiMMC2%2BvYQGPmVmcoy7vmaKYY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:25.0844336","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3233'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:25 GMT
-      mise-correlation-id:
-      - 8503a001-9378-4968-bdec-eb6f4cea1205
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A30Z&sr=b&sp=r&sig=9msDMILyrv%2BI7%2BRIwRdLOlxCZQfmYWx3O69l94FuwIs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:30.4736907","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A30Z&sr=b&sp=r&sig=q%2F3zazK5pQ7cb0X%2BdIAjrKOQe%2FtE275jM%2F3N%2BkcJcEE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:30.4736079","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A30Z&sr=b&sp=r&sig=AA8tfA9wHR90xRDoTU43bYsMOWXrwnFBITxs3MpHX3E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:30.4737049","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A54Z&sr=b&sp=r&sig=4ag5af0Kp%2BujeY1s0QlQ9khhmPqW0E1wJLvVfv%2FzqnY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:54.011401","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A54Z&sr=b&sp=r&sig=z9yRdN%2BrIJGW4xkGP8z2tWJa06V3Nw8%2FSQzUfTHe%2FRA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:54.011317","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A54Z&sr=b&sp=r&sig=p9v8xCWyFTZ%2FEXoUfa26o%2BsWHZ0Wc8ch1lN8YLg76q4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:54.0114188","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:16.71Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1722,9 +966,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:30 GMT
+      - Tue, 24 Oct 2023 12:34:54 GMT
       mise-correlation-id:
-      - 53f1b2cf-47f8-4db4-ac14-81ea803f0077
+      - 58a5697d-459b-4f4c-8e28-f65561290340
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,10 +988,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A35Z&sr=b&sp=r&sig=CKf1hy1TBJeCPXdUqa8dAVWpq44h9KfoqV0uu4BJw9g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:35.7430117","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A35Z&sr=b&sp=r&sig=Yh7U%2FdeaixqYYOBWoMjAb54lugLOqEuxY8%2B0CPJXFDg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:35.7429237","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A35Z&sr=b&sp=r&sig=a4lkKgP%2B2w1%2Bq4DrE63OoDceCScqBqBV36yvlSKz0Vc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:35.7430345","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:01.939Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:47.056Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A59Z&sr=b&sp=r&sig=PtCXYchHQnHZohUpDFWNqNuHBNUdJT5GwfeP4%2BY1988%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:59.2870698","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A59Z&sr=b&sp=r&sig=RVBzEfYCtEMfnDGo5hTUA8d%2FXc9%2F%2BUUZQ6J7Uaxf9MY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:59.2869963","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A59Z&sr=b&sp=r&sig=vtbfI%2BP%2FvIrradkoYK05qwBszkW8qyJqb9CBUITpl4E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:59.2870843","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:57.416Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3241'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:34:59 GMT
+      mise-correlation-id:
+      - 5b1eee2a-ba2d-457b-bcf7-7add8f7cd330
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A04Z&sr=b&sp=r&sig=rNJV%2FIyzZ2rdYbYe2HkWcVL2FklQHfM3cXk2HPrPzwU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:04.5974569","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A04Z&sr=b&sp=r&sig=F0eKkApmWV0j1bcpz1%2FC4vA0pcJN00OqjddLIJrpoAg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:04.5973768","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A04Z&sr=b&sp=r&sig=GhtbXm3meQ7VnoznY3UJAm8Omx0spqZjqSxBqrBylos%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:04.5974789","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:04 GMT
+      mise-correlation-id:
+      - 5753ca69-1b2f-4221-a394-45585512dde7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A09Z&sr=b&sp=r&sig=zbOURYmZj%2BebabbVmvYQhDp3TUJxVJxY1iAnPpOjvTE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:09.9289956","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A09Z&sr=b&sp=r&sig=V3%2F2GkuIXRibV7UlhNAW6YiVaMbcYx%2BkCSq03IT9ACk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:09.9289066","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A09Z&sr=b&sp=r&sig=JnkNRFiXF1D1VRXeR7%2BdqZDjTb7naLwMtw7qW02SUgY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:09.9290179","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +1074,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:35 GMT
+      - Tue, 24 Oct 2023 12:35:09 GMT
       mise-correlation-id:
-      - dc11165a-65fd-468d-89f3-a6449359a597
+      - caf09e1d-85bc-41e4-97ab-b78d8c867a4e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,24 +1096,708 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A41Z&sr=b&sp=r&sig=%2B3EGUjAtNCkmTSzIHfogrPHhbYT6mpkZ2hB2NRFJLF0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:41.0134259","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A41Z&sr=b&sp=r&sig=cr6NFRq1xGIVpNtteVwe2kzietD3cN8exd%2BbF7yPMdw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:41.0133502","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A41Z&sr=b&sp=r&sig=OKgP4csSwkaIyma75pJlnalvKOfU2BbahRIMPqhGx3U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:41.0134401","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-18T20:57:01.939Z","endDateTime":"2023-10-18T20:59:40.244Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:40.385Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A15Z&sr=b&sp=r&sig=6ccMjj8d2vBsE%2B%2BtvuG9FlhrxfmCCHwZGHHoL8yk%2FkY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:15.2596393","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A15Z&sr=b&sp=r&sig=idXlgksU8AXgnPCFPVugmzMBFRT3Rp%2FEr3pXnmOe%2FJA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:15.2595467","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A15Z&sr=b&sp=r&sig=NVUcJpfxG6AOn7kBpmnoWsIwoLHTqUuHHc06LnhdNYE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:15.2596616","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3366'
+      - '3237'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:41 GMT
+      - Tue, 24 Oct 2023 12:35:15 GMT
       mise-correlation-id:
-      - 87432c7e-15e1-4674-98f3-233b3d7274d9
+      - f1305949-d066-47ce-800a-5e362c11a67b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A20Z&sr=b&sp=r&sig=c31eWbrZaSs0lp1XsOqGf1epAx6Uhqil%2Fuq523yJFxY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:20.5878869","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A20Z&sr=b&sp=r&sig=ADZi72NIJWJyaAHzibX4RACL%2BBHSWcqzAWBLkatwpBc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:20.5878098","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A20Z&sr=b&sp=r&sig=sOMDToFk6AHM4MMXvxe5KSsob1GKd0nXZ%2FsGczqcD5g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:20.5879009","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:20 GMT
+      mise-correlation-id:
+      - 54013f9f-4ab3-43cc-accc-50eaa400370e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A25Z&sr=b&sp=r&sig=aeOxbknWF14JvAhTHhku5DbdX2AkafprqN%2F0KF5KDa0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:25.8483654","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A25Z&sr=b&sp=r&sig=Az6bBsi5hvkGt%2FfoF2WY1LyZd%2FwOhu6RHYlKunEjkgs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:25.8482799","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A25Z&sr=b&sp=r&sig=gQM7GTLa7yUIj2shpj74jrQQtIBCcOzv4jLvH3BKL9I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:25.8483797","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:25 GMT
+      mise-correlation-id:
+      - ce94f714-b133-4b82-a41e-e9ab852a3d6b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A31Z&sr=b&sp=r&sig=J2ApEe6skYoppABg%2BuCOiPmIISxAEVCqTmYLL1OnK5Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:31.1173682","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A31Z&sr=b&sp=r&sig=g9ySuI4%2BZwRvJ07SqwFJT1hudqfwpocP%2B4ESa%2B52QhA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:31.1172824","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A31Z&sr=b&sp=r&sig=aVmT3f0gaovcAB2U7WAC6uzSg1vSutM58pfCJzuRE30%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:31.1173863","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:31 GMT
+      mise-correlation-id:
+      - 7922f80b-9897-4d6c-9ac9-1f320e78d9d2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A36Z&sr=b&sp=r&sig=9c%2Bh2lf%2B0GakJ3afjq%2FiCmGQTH%2FgRsN9d15SdNGB4mQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:36.3829281","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A36Z&sr=b&sp=r&sig=fHD%2FoCIiIPhSRyyzKWMbp%2B5v2TYmlwBQR4DpjgpkSjE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:36.3828582","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A36Z&sr=b&sp=r&sig=293Pou6PmoULa2MMZ344%2B0uSSqZvrOUZ46s7b1PJjqA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:36.3829425","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3241'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:36 GMT
+      mise-correlation-id:
+      - b8a6a805-6834-4aa7-bcf5-54c0c5ee92da
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A41Z&sr=b&sp=r&sig=dGbfyCexMFH9su%2Fn1IfkRfJjQXOywcFOWx2stoGYgd0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:41.6652124","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A41Z&sr=b&sp=r&sig=vZa%2FCanCHsylxcvvMvy2fE5ZM%2FsZfvbreNDPVXJyMiA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:41.6651319","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A41Z&sr=b&sp=r&sig=lZhzshSaKhxcnfg0Tet7D4r2UHi5NUE1CHfRuyozJ6s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:41.6652264","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:41 GMT
+      mise-correlation-id:
+      - 52af5a47-e904-4155-ba42-57a56c5a0b8e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A46Z&sr=b&sp=r&sig=EAHhIoqkRZo7wQEzTVD8%2FEnNurnNYRAmW7CD3Kg3Wlo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:46.9308219","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A46Z&sr=b&sp=r&sig=5B3k82%2BkLmzixSd6r%2F69Rz19okNGwLwvV4odogauk%2BE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:46.9307476","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A46Z&sr=b&sp=r&sig=z%2FdLnj72J%2F4AFhyO5%2BLggxfb53IzGO4oebPgjUPB6QM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:46.9308368","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3241'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:46 GMT
+      mise-correlation-id:
+      - 8151ebc6-1953-483a-8176-2db6d265c948
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A52Z&sr=b&sp=r&sig=5pB6xwhkBvxjmO5sgvYNjIeUEDE7X5lAz9OC3osQRMQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:52.1976221","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A52Z&sr=b&sp=r&sig=aBUBhbDat579fRqNwp9qV9tLJLrXo94aa3S29vtHss0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:52.1974262","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A52Z&sr=b&sp=r&sig=QUQMYTUWztgkh9FwsyFKCkdfBRd0wO0xXE4p45Z%2FAis%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:52.19764","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3227'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:52 GMT
+      mise-correlation-id:
+      - 47b2c241-127e-4168-ae44-97818018152a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A57Z&sr=b&sp=r&sig=3GQYSWeiBTzpya2WuHppCyzKfCPAc7hQADtl%2FLZNK9E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:57.5514237","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A57Z&sr=b&sp=r&sig=wNN%2F1J7u0DrxA3eBj9m7xaWooFs50otSwKzdhOuEi2Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:57.5513552","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A57Z&sr=b&sp=r&sig=5tVPcuRN96EklaDv3%2FWuMnHkNAN%2BjjE1lnJX880b62o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:57.5514383","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:57 GMT
+      mise-correlation-id:
+      - d29a7a09-92ef-4e40-a0aa-202b9d5a41f5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A02Z&sr=b&sp=r&sig=WCOJOOtFawNmCA8rKVnU0OuqRVoCEWET7pKoQ7ge0SQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:02.8286069","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A02Z&sr=b&sp=r&sig=3bsZycEZl6B8cOexjiBnQrsLVQDqwiYLTDoS5mEPFJg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:02.8285206","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A02Z&sr=b&sp=r&sig=3nSzx4wQulgVFYJ%2FWcjCkhJNKuawJlg7QVN6RMDJX0Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:02.8286234","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3229'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:02 GMT
+      mise-correlation-id:
+      - 04ebb0b7-e9aa-44e4-846a-9f773323e423
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A08Z&sr=b&sp=r&sig=4vErnSPuCsYD34W32AH9Amxb3Bhc4ya8%2F%2BJO7ETlAPA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:08.104237","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A08Z&sr=b&sp=r&sig=Th2%2FEIeb4YRjGgWgMGkkXK6Z%2FWUbXKr1Bz4B4L7hx8k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:08.1041641","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A08Z&sr=b&sp=r&sig=%2FZeSVorFyG%2B5YfOb6VMQyFVh30yw%2FY1bEeL8inwlX9s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:08.1042519","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3240'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:08 GMT
+      mise-correlation-id:
+      - 711ed377-9189-46e8-9196-03dd9e981d3b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A13Z&sr=b&sp=r&sig=F3Z8G%2B37yHbbXMllRvkt51IJXorO8NmuTS8eHMzRJ4M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:13.4131445","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A13Z&sr=b&sp=r&sig=R3JYJVqtMJ1Zgv4i4w0xR4rKcGF%2BMd1%2BtKxxJU%2FvWLk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:13.4130714","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A13Z&sr=b&sp=r&sig=boW3OErlXzv%2B7HmD%2Fj2QMQZVnFrYWNAJm06rbanBapM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:13.4131644","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3239'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:13 GMT
+      mise-correlation-id:
+      - 8312d4af-f752-4d59-9f41-8c761a08bf97
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A18Z&sr=b&sp=r&sig=UhhWXpi6oZ3fx2vhreiBmndvqauUdGw6s1wVrooRxPc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:18.7513142","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A18Z&sr=b&sp=r&sig=Bzq8sUvHBDl3EVJLt9ZQ%2BXuSqu5bXHQ8MKYOLGfSHTw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:18.7512152","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A18Z&sr=b&sp=r&sig=m0%2ByemISM7P7I7tjShAcVJDKhlVbErvcs5%2B1FWKPgpI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:18.7513384","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:18 GMT
+      mise-correlation-id:
+      - be120b46-ccfd-4387-bbb7-8fbb41577bc1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A24Z&sr=b&sp=r&sig=He55P9BdDz4ZrWi82031M7xngnJIgiIw7hgNlstgcRE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:24.632128","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A24Z&sr=b&sp=r&sig=wKrIH57BAWgesD4D6CjI3DAga5xz4yRZlzLD4LzS7uI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:24.6320374","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A24Z&sr=b&sp=r&sig=PhEPvUReMYPLs%2FGx%2BxcuJb%2F7EIPEgwvT%2Bru%2BJEG7tqI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:24.6321421","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:24 GMT
+      mise-correlation-id:
+      - 6aa90a4d-1fff-47d5-a3c3-a307aa59bf97
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A30Z&sr=b&sp=r&sig=5T7yzAAI4yse92nFmDwJ8MMExR9Lyq3%2BliMIyb23iqk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:30.3632228","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A30Z&sr=b&sp=r&sig=p87QALgpssZchfw6pqr6pD6P4yO63eRc4%2BE9xmradiw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:30.3631574","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A30Z&sr=b&sp=r&sig=C%2BaVmk0amtm%2BP%2FGf3533kHWe8OpsQ12DXE7CvX5ZCZo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:30.3632371","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:30 GMT
+      mise-correlation-id:
+      - 9996a6f6-322d-4afa-9ba8-3179eb4f1093
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A35Z&sr=b&sp=r&sig=xlyyXIA95ykRInGcEWZpJk6tuonIRNg5%2BxlRdk7GkTI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:35.6810632","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A35Z&sr=b&sp=r&sig=6xMRtJU7zmzk3qZCI0mGJZxT541syazlyVva%2BDx8q9g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:35.6809849","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A35Z&sr=b&sp=r&sig=L2zbPWTPc1KxkWo9NyNYhVRmJi9XzUWUPtYow4S%2BQOA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:35.681077","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:35 GMT
+      mise-correlation-id:
+      - 6494004d-6c2d-4ca0-9299-271728a1e1d2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A40Z&sr=b&sp=r&sig=E1ZfxFzO2juwwG33IJCJmm97qqp6Fb6dLzvaaKYd8mA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:40.985481","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A40Z&sr=b&sp=r&sig=86LghsyZwJbP2PePN6j4mVAWvClxJOC18xy%2Fu7Ko%2F2M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:40.9853949","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A40Z&sr=b&sp=r&sig=F%2BIlTqbSbnGF5lsWDeXBQZvAT5BXJQuTXj0tvYvqvvY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:40.9855032","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:40 GMT
+      mise-correlation-id:
+      - 6f5b00f6-8650-483e-8cc4-9dc88d00e513
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A46Z&sr=b&sp=r&sig=%2Fqn3tmsh8dH7VwqorPmjHaG0oG6i9n7ZjZzUxxdJ2vw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:46.2764518","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A46Z&sr=b&sp=r&sig=7pz3jkn8hpLw4pPMAd6J2YNHR1eMlRsh9zaTzc0UVAI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:46.276353","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A46Z&sr=b&sp=r&sig=YcpOj78GPXj%2BMkIU%2Bg9vlUzLGDUoq2f3X3GfmddDg1E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:46.2764712","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:46 GMT
+      mise-correlation-id:
+      - 136c29f2-eac0-4f52-a2fa-f2ca9324c507
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A51Z&sr=b&sp=r&sig=z3Xhn2%2FLdjvZObKH59lisFQJf0i1Yqf6%2FzM%2FVPT%2FHS0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:51.5721679","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A51Z&sr=b&sp=r&sig=nx%2BK8DEZv8dqc6xxdvIwjOlVSnu5k3x14GgZZ%2F3XT0o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:51.5720808","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A51Z&sr=b&sp=r&sig=38A1hGVRFFSk3TOvrw9EA%2FBuc3jO5BLYS1K8AM2ui5U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:51.5721903","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3241'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:51 GMT
+      mise-correlation-id:
+      - 93107ec7-e9a8-49c7-88c4-b3cfc846e534
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A56Z&sr=b&sp=r&sig=qjZnT7fZHopNC3OcjjMo%2BCGne5abgi1HX8x61DCgz5E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:56.8542091","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A56Z&sr=b&sp=r&sig=O410seAdoaUNDzbEigpOMhFulE7lI2n62oFvvQH3n48%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:56.8541095","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A56Z&sr=b&sp=r&sig=fbes3wtpY6OOV%2Fts4DDmyLS1H6zYkS2EA5OoI%2BgSoXY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:56.8542238","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-24T12:34:16.514Z","endDateTime":"2023-10-24T12:36:54.947Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:36:55.036Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3368'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:56 GMT
+      mise-correlation-id:
+      - 5e54a7fc-57a6-478a-a031-7b096c2a79b1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,7 +1820,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1829,9 +1829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:42 GMT
+      - Tue, 24 Oct 2023 12:36:57 GMT
       etag:
-      - '"75009065-0000-0100-0000-6530464b0000"'
+      - '"d300cf49-0000-0100-0000-6537b9780000"'
       expires:
       - '-1'
       pragma:
@@ -1861,24 +1861,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=server-metric-test-case&api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=server-metric-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"9c5e7b7b-73cd-4c0f-a2c2-2caa3ca5dd7a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c38b39b-e04b-4852-a2d2-c9e80698d5f2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"17095de8-4d10-43e7-ab1f-1a93c7f07e1e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/a49432ee-f009-4b5f-94ed-e2a7acbd48dd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A43Z&sr=b&sp=r&sig=7NPfaXPfdMsBlbM%2BeDiBRAaIuAQVAWD8PN9WRfSQrys%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:43.37274","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/5391dcab-37a3-4f4b-bcd5-544b60516153?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A43Z&sr=b&sp=r&sig=CNBLP3U3DD1FvOMGbQ9P1VJiqoQOoAxDBXwxh1t6UN0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:43.3726633","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/323e5e84-e98b-4af5-8628-b2f133f88c31/dc661c90-f3ad-488b-a199-a1e77998e493?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A43Z&sr=b&sp=r&sig=vEPyANo5y2IJVOe1337ASUNWbNmDdos7%2BplyBjAZIco%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:43.3727544","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-18T20:57:01.939Z","endDateTime":"2023-10-18T20:59:40.244Z","executedDateTime":"2023-10-18T20:57:01.241Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-18T20:57:01.573Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:42.988Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A59Z&sr=b&sp=r&sig=cd2nM%2FTWMjAH2WPYHbtYzKi2ugvfo%2Bxnqspvp5d32RU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:59.3992205","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A59Z&sr=b&sp=r&sig=Lk%2FfWqKG9pK0mgWWjNnlOqXJMqAXmVyWkJQ2KT%2BAcJ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:59.3991315","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A59Z&sr=b&sp=r&sig=25OHeMztEdBk%2FcUiw7lhs5A5Z4NXJfrftPLjHYte0TM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:59.3992427","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-24T12:34:16.514Z","endDateTime":"2023-10-24T12:36:54.947Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:36:57.591Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3376'
+      - '3384'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:43 GMT
+      - Tue, 24 Oct 2023 12:36:59 GMT
       mise-correlation-id:
-      - 85f5fff5-0b63-4447-ade1-ac3de26b5be8
+      - b4e417d3-9303-4f9d-94e8-803be3e860de
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1905,7 +1905,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-18T20:56:13.7128984Z","key2":"2023-10-18T20:56:13.7128984Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-18T20:56:13.7285195Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-18T20:56:13.7285195Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-18T20:56:13.4785229Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-24T12:33:30.3393368Z","key2":"2023-10-24T12:33:30.3393368Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-24T12:33:30.3549625Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-24T12:33:30.3549625Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-24T12:33:30.1205929Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -1914,7 +1914,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:59:43 GMT
+      - Tue, 24 Oct 2023 12:36:59 GMT
       expires:
       - '-1'
       pragma:
@@ -1947,7 +1947,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1956,9 +1956,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:45 GMT
+      - Tue, 24 Oct 2023 12:37:01 GMT
       etag:
-      - '"75009065-0000-0100-0000-6530464b0000"'
+      - '"d300cf49-0000-0100-0000-6537b9780000"'
       expires:
       - '-1'
       pragma:
@@ -1977,9 +1977,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-gprbh4fsrwftmsxhr/providers/Microsoft.Storage/storageAccounts/clitestloadydqhjzlak":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-gprbh4fsrwftmsxhr/providers/Microsoft.Storage/storageAccounts/clitestloadydqhjzlak",
-      "resourceName": "clitestloadydqhjzlak", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testRunId": "server-metric-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-egmus6nakyklp7dc4/providers/Microsoft.Storage/storageAccounts/clitestloadar6c4swry":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-egmus6nakyklp7dc4/providers/Microsoft.Storage/storageAccounts/clitestloadar6c4swry",
+      "resourceName": "clitestloadar6c4swry", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -1995,10 +1995,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-18T20:59:46.577Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:46.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-24T12:37:03.001Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:03.001Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2009,11 +2009,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:46 GMT
+      - Tue, 24 Oct 2023 12:37:03 GMT
       location:
-      - https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+      - https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - 3e9d5085-362b-4d9c-ba74-b8596081d126
+      - a76cf999-a140-4fde-a38b-1d216fc62bf0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2036,7 +2036,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2045,9 +2045,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:47 GMT
+      - Tue, 24 Oct 2023 12:37:04 GMT
       etag:
-      - '"75009065-0000-0100-0000-6530464b0000"'
+      - '"d300cf49-0000-0100-0000-6537b9780000"'
       expires:
       - '-1'
       pragma:
@@ -2077,10 +2077,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-18T20:59:46.577Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:46.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-24T12:37:03.001Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:03.001Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2091,9 +2091,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:48 GMT
+      - Tue, 24 Oct 2023 12:37:05 GMT
       mise-correlation-id:
-      - 9ebd0b15-bcd1-48b1-a556-ea8a664871eb
+      - e6b45315-ab24-4111-b05a-462b19af998c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2116,7 +2116,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2125,9 +2125,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:49 GMT
+      - Tue, 24 Oct 2023 12:37:06 GMT
       etag:
-      - '"75009065-0000-0100-0000-6530464b0000"'
+      - '"d300cf49-0000-0100-0000-6537b9780000"'
       expires:
       - '-1'
       pragma:
@@ -2146,9 +2146,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-gprbh4fsrwftmsxhr/providers/Microsoft.Storage/storageAccounts/clitestloadydqhjzlak/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-egmus6nakyklp7dc4/providers/Microsoft.Storage/storageAccounts/clitestloadar6c4swry/providers/microsoft.insights/metricdefinitions/Availability":
       {"name": " Availability", "metricNamespace": "microsoft.storage/storageaccounts",
-      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-gprbh4fsrwftmsxhr/providers/Microsoft.Storage/storageAccounts/clitestloadydqhjzlak",
+      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-egmus6nakyklp7dc4/providers/Microsoft.Storage/storageAccounts/clitestloadar6c4swry",
       "resourceType": "Microsoft.Storage/storageAccounts"}}}'
     headers:
       Accept:
@@ -2164,12 +2164,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-18T20:59:46.606Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:50.981Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-24T12:37:03.024Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:08.036Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2180,9 +2180,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:51 GMT
+      - Tue, 24 Oct 2023 12:37:08 GMT
       mise-correlation-id:
-      - 6d9d63af-775b-4222-b7b6-ed792fe9c02f
+      - 9dafe1cc-7157-4be8-ad95-eabe746216ef
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2205,7 +2205,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2214,9 +2214,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:51 GMT
+      - Tue, 24 Oct 2023 12:37:09 GMT
       etag:
-      - '"75009065-0000-0100-0000-6530464b0000"'
+      - '"d300cf49-0000-0100-0000-6537b9780000"'
       expires:
       - '-1'
       pragma:
@@ -2246,12 +2246,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-18T20:59:46.606Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:50.981Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-24T12:37:03.024Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:08.036Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2262,9 +2262,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:53 GMT
+      - Tue, 24 Oct 2023 12:37:10 GMT
       mise-correlation-id:
-      - 39ef09c5-9e66-45e0-a25d-2473b822cc0a
+      - 5206e3af-0d17-45fa-9ae3-37c90c544735
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2287,7 +2287,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2296,9 +2296,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:53 GMT
+      - Tue, 24 Oct 2023 12:37:11 GMT
       etag:
-      - '"75009065-0000-0100-0000-6530464b0000"'
+      - '"d300cf49-0000-0100-0000-6537b9780000"'
       expires:
       - '-1'
       pragma:
@@ -2317,7 +2317,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-gprbh4fsrwftmsxhr/providers/Microsoft.Storage/storageAccounts/clitestloadydqhjzlak/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-egmus6nakyklp7dc4/providers/Microsoft.Storage/storageAccounts/clitestloadar6c4swry/providers/microsoft.insights/metricdefinitions/Availability":
       null}}'
     headers:
       Accept:
@@ -2333,10 +2333,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-18T20:59:46.606Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:55.443Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-24T12:37:03.024Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:13.413Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2347,9 +2347,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:55 GMT
+      - Tue, 24 Oct 2023 12:37:13 GMT
       mise-correlation-id:
-      - d298a7af-2b73-43cd-848b-be53c74a75a3
+      - 9e04f9f4-cecb-45e3-992d-8d744c4d8722
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2372,7 +2372,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:55:37.2187751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:55:37.2187751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2381,9 +2381,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:57 GMT
+      - Tue, 24 Oct 2023 12:37:14 GMT
       etag:
-      - '"75009065-0000-0100-0000-6530464b0000"'
+      - '"d300cf49-0000-0100-0000-6537b9780000"'
       expires:
       - '-1'
       pragma:
@@ -2413,10 +2413,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4cbd52f3-7528-4b2d-aa96-9138d23921df.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-18T20:59:46.606Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:55.443Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-24T12:37:03.024Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:13.413Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2427,9 +2427,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:57 GMT
+      - Tue, 24 Oct 2023 12:37:16 GMT
       mise-correlation-id:
-      - 7d0f234b-cf84-48d2-8478-1fea701e7f7e
+      - 8ad1a590-3eb0-4288-ad66-d088c8d1d0e9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_server_metric.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_server_metric.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:59.4343003Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:59.4343003Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:08 GMT
+      - Mon, 30 Oct 2023 07:26:26 GMT
       etag:
-      - '"3c001330-0000-0100-0000-653edbe80000"'
+      - '"3f005172-0000-0100-0000-653f5a890000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:26:10 GMT
+      - Mon, 30 Oct 2023 07:26:28 GMT
       mise-correlation-id:
-      - d6b8b5bc-5ab5-4516-955b-4a66d2bbc83f
+      - d415d66b-e15f-43c4-83ea-8e98a19e31a7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"2e069b3e-5056-45bf-a355-e9bd38d8033f": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "2aa10b1b-303a-4698-881f-a2968b6b83ca":
+      {"passFailMetrics": {"f0aa0421-dd02-474f-a3cc-024193a10a67": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "1be12e1c-f3db-49a3-8415-851c0629d9da":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "c141ce4f-631c-441a-b867-0ec54c02a5f2": {"aggregate": "avg", "clientMetric":
+      "50"}, "f9358883-47d0-439f-8762-e9bca8d0041b": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:26:11.769Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:11.769Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:26:28.545Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:28.545Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:11 GMT
+      - Mon, 30 Oct 2023 07:26:28 GMT
       location:
-      - https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+      - https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - ae8495ba-7309-4bbf-98fe-8fe15a21d32e
+      - 0bfb0050-02a9-4680-99eb-a08101063e85
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:12 GMT
+      - Mon, 30 Oct 2023 07:26:28 GMT
       mise-correlation-id:
-      - cf48b9db-bb33-4d42-9231-3c2d0af48864
+      - c11b174f-8fa9-45a9-bb88-f9fc1f05a0bd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A13Z&sr=b&sp=r&sig=JcZdu3wTw%2FAkEKpLiCiUOZqqJvH%2FBSLS64EEK%2FseSFY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:13.4320231","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A36%3A29Z&sr=b&sp=r&sig=UeRKJGzKi%2FeITi9xliFFC2PjEWNubrOXWn4QxXrQM8c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:36:29.3292576","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:13 GMT
+      - Mon, 30 Oct 2023 07:26:29 GMT
       location:
-      - https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - fb000627-0532-4f0d-aedd-47d82b667784
+      - 52dc032a-9ac1-48fa-91ea-50184c2697ca
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A13Z&sr=b&sp=r&sig=KPyYzc6CLpDxQEibMKIB%2B6AkcyysZgB%2FGVZz8Gl19jQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:13.6771241","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A36%3A29Z&sr=b&sp=r&sig=%2FWPrV2Rk9JfRCIfj47CRnrSsXixLXurB%2BDyCeiolcqQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:36:29.5951771","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:13 GMT
+      - Mon, 30 Oct 2023 07:26:29 GMT
       mise-correlation-id:
-      - 7bc93675-9012-4327-9bd8-5cee54717ddc
+      - 208a5b48-3a25-4061-b437-a186e2b8e6ef
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A18Z&sr=b&sp=r&sig=%2FmHOOyC7K3THsMDdkbj2SlVof42btOOMNuV00%2FLVuGA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:18.9454134","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A36%3A34Z&sr=b&sp=r&sig=LPTDritv7G4LNSb96R5zwQFtB0vKlpZ9J9rOLStQM%2FA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:36:34.9305879","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:18 GMT
+      - Mon, 30 Oct 2023 07:26:34 GMT
       mise-correlation-id:
-      - 85b3f3bb-8507-4f93-8cbc-9ee6cf2afc7e
+      - 0748ea2d-593f-438c-89d6-9f36e63dc664
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,10 +385,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A24Z&sr=b&sp=r&sig=%2F4A8sjkori7Rdh5iDMQZzVp8FUWOJi9s%2Fwlm23n2SM8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:24.1894528","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A36%3A40Z&sr=b&sp=r&sig=E9T8ByLejKVC3lw%2F1qaD6sw7nVcMkahejXoISK3X%2FQQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:36:40.1709634","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:24 GMT
+      - Mon, 30 Oct 2023 07:26:40 GMT
       mise-correlation-id:
-      - 868c99f6-731e-49f4-8d0d-b67bc83e9b63
+      - a94f2a91-97f2-4d63-9b1a-f45a7d6a2a11
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A29Z&sr=b&sp=r&sig=%2F318g7MINQmA4MHAH7w0TQ1N%2F%2F3QbTlR601DohBUh1Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:29.4748865","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A36%3A46Z&sr=b&sp=r&sig=klEScD1A96uyvbQUdGta7zeIJFEe%2FFr12P%2F4Ksahc58%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:36:46.3570582","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:29 GMT
+      - Mon, 30 Oct 2023 07:26:46 GMT
       mise-correlation-id:
-      - ba124f36-c0a1-4964-8d72-74a5b15e02bb
+      - 0dda609d-23f5-4efa-9948-f4fd535cdfae
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A29Z&sr=b&sp=r&sig=p1qNB4z%2FqWEiUsjNo7q57uSulbsjjafKf%2FkiF4MapXg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:29.797602","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:26:11.769Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:27.642Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A46Z&sr=b&sp=r&sig=s2QbN7KGpyf1bm1FNl%2F%2FxyDC6SWmPltsF2p92anBn7g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:46.6441992","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:26:28.545Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:42.011Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1587'
+      - '1588'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:29 GMT
+      - Mon, 30 Oct 2023 07:26:46 GMT
       mise-correlation-id:
-      - fdd85d05-ac2e-47f1-aea4-de9b3c2b75d3
+      - 7b797cd3-c962-4d94-abfc-19281e8cdf13
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:59.4343003Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:59.4343003Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:31 GMT
+      - Mon, 30 Oct 2023 07:26:48 GMT
       etag:
-      - '"3c001330-0000-0100-0000-653edbe80000"'
+      - '"3f005172-0000-0100-0000-653f5a890000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A32Z&sr=b&sp=r&sig=tAq1DH0KwfGTKDFrMPvUYuxb2RHOGuwE5Ef87Rbo3k0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:32.458633","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:26:11.769Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:27.642Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A49Z&sr=b&sp=r&sig=AWP3SZYYdJOITi%2Bj4LxQS0tHiLCCZkzh5vlwEsK4JCE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:49.1353092","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:26:28.545Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:42.011Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1595'
+      - '1598'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:32 GMT
+      - Mon, 30 Oct 2023 07:26:49 GMT
       mise-correlation-id:
-      - a9b15327-aa29-4f15-afa1-d5360aff6fee
+      - ff8c9eb0-c9dc-417e-be61-eefd38156428
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:59.4343003Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:59.4343003Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:33 GMT
+      - Mon, 30 Oct 2023 07:26:49 GMT
       etag:
-      - '"3c001330-0000-0100-0000-653edbe80000"'
+      - '"3f005172-0000-0100-0000-653f5a890000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:26:34 GMT
+      - Mon, 30 Oct 2023 07:26:51 GMT
       mise-correlation-id:
-      - 6b3dbbb9-1bfe-4fa5-9d79-3556f56cf498
+      - 87208457-d702-4fff-8dec-f683c10dfcd1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,10 +662,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A37Z&sr=b&sp=r&sig=v%2BaF3R3dGUVRV2V27XXowzpOz0odU909%2BZSXr1bdXF4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:37.3623891","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A37Z&sr=b&sp=r&sig=WN2xwEJIiuZe8sD%2BmQ1FTsU9RqmmuPeTa%2Fr2j3miX3c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:37.3623059","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A37Z&sr=b&sp=r&sig=seVHBR%2FsOzY2gkaBy2xHbgDWtl1%2FjcUrWqrHQpQ%2B0ns%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:37.3624114","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:37.27Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A53Z&sr=b&sp=r&sig=4vUEPe3W4nMkmH6%2Bni6LCjoFqjugoo%2Bjq%2F5%2FSHx5BsM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:53.4217168","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A53Z&sr=b&sp=r&sig=NPAwAV2E6ZeNTukUVMSztoXj41Xh5lYLlnTrmf6JuPY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:53.4216306","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A53Z&sr=b&sp=r&sig=R93B%2BC0nH40hP%2F7WItYhghErUIr6pWpYWk66042bOPM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:53.4217388","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:53.333Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -676,11 +676,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:37 GMT
+      - Mon, 30 Oct 2023 07:26:53 GMT
       location:
-      - https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+      - https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - c3ca5b7b-b9f6-4cb2-b267-3ee3e1cea169
+      - 630d3c65-737e-42e7-8784-db60a3f84ef4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A37Z&sr=b&sp=r&sig=XOxLZYdakjz2i93ik%2BhDD5D%2FVrH2fS1dGg%2BL1uHP9AE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:37.7923781","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A37Z&sr=b&sp=r&sig=WUNwzQCsRH1UwKvszleVGteSX83hVP97SojWukKhYho%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:37.7922931","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A37Z&sr=b&sp=r&sig=kRc7sMydzr5YdbRlW%2Fn5o991ac8iImK9u4RHowFRf1w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:37.7923925","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:37.27Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A54Z&sr=b&sp=r&sig=nKwQa%2F4bClfOBuc%2BfKA7sCHp9BaBrmqRLEqpkY%2FeEGg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:54.0215772","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A54Z&sr=b&sp=r&sig=5APxt7h8Zq%2B03nFq3G8FQ8htnGNLL7PB%2F18fDHEoe4M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:54.0215109","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A54Z&sr=b&sp=r&sig=JWorVwpZdF85HY%2FQZM4rleWw%2BirZJqvLbZdgUf3D6LY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:54.0215908","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"NOTSTARTED","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:53.859Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3189'
+      - '3242'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:37 GMT
+      - Mon, 30 Oct 2023 07:26:54 GMT
       mise-correlation-id:
-      - f19d150d-e624-411c-84f2-3747ebe4038f
+      - f204c07b-168d-4ddc-94e8-f9a169b6899b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A43Z&sr=b&sp=r&sig=1FjW3zMncqaNvRtTvMZe2CG%2FdMKDU%2FKSPO4Y5Fm5PXU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:43.1172617","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A43Z&sr=b&sp=r&sig=USnR8BVVYprTsfH47i88PlhcpUAB0508BM%2Fn6pStfVY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:43.1171668","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A43Z&sr=b&sp=r&sig=IAFsM1iLiKRAtJ0GdXCXEooYr7rIx3ydI%2F1eCPT2R2o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:43.1172834","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A59Z&sr=b&sp=r&sig=f8%2FBRgSxSN4%2FgTBb9%2FvY2URfjAssArfgPkCUHoLkFMM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:59.3018698","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A59Z&sr=b&sp=r&sig=546mxf3YmtyQHFU%2BY595qVwNUBX7xnnoDP6DkSF5LJ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:59.3017772","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A59Z&sr=b&sp=r&sig=bEnpvaQhSZQvBsSRn%2BIQVLcIww0PHMLMTRYfvd%2BHBPA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:59.3018924","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.062Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3237'
+      - '3242'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:43 GMT
+      - Mon, 30 Oct 2023 07:26:59 GMT
       mise-correlation-id:
-      - 1daf2426-fd81-4715-9aa3-e298df99160b
+      - 53173195-e3c4-4ab4-99c1-79092309f312
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A48Z&sr=b&sp=r&sig=XWzmEws1a0wRVUGVHdIocGSzp7NIyJp1bBunWuO7O0s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:48.4183999","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A48Z&sr=b&sp=r&sig=prCpo84mHcutYGEi2M4YMQ8oVTZ8kn3P86fI6NhR410%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:48.4183299","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A48Z&sr=b&sp=r&sig=4%2BF%2Bko7qcxbzPAl0IEAvRaiI2F2f5gGmBfQcLigNpgQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:48.4184136","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A04Z&sr=b&sp=r&sig=Rfk50%2F9Y6y0UwiSPDFT75XKAh3o%2FDEb45e%2F9se2a1rY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:04.5703899","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A04Z&sr=b&sp=r&sig=C7ANesc7YPtwuzEqKRvc0z1DFScwDiI7YDS41BbEaeU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:04.5703235","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A04Z&sr=b&sp=r&sig=U7l8J6Rl52%2BD%2BGH0rgJaffo25jPWLBP9HbA%2B9xLmNYU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:04.5704046","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.062Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3233'
+      - '3242'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:48 GMT
+      - Mon, 30 Oct 2023 07:27:04 GMT
       mise-correlation-id:
-      - 85e92010-fa95-4571-bccb-02f5a3a9478e
+      - 6821a83c-f211-4b70-8633-3679f53c4e6e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A53Z&sr=b&sp=r&sig=kjnALWGylDQJachPx7ok2synGj%2FDI6UzoLOUBHRfNhI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:53.7056342","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A53Z&sr=b&sp=r&sig=4VdpG%2FBsRH4YbyDSZTuKiBdUQPJ4624Zto6EfQy2gVY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:53.705562","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A53Z&sr=b&sp=r&sig=s09uRrRobUGYfZ%2BPoMxJ%2BT7FLb8CzX%2BBYPDAeLt8Mmo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:53.7056498","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A09Z&sr=b&sp=r&sig=YQFYDucPNv2eKEkSD7JCKkxhomgzhlKTHSd55j%2FS%2F3M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:09.8109542","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A09Z&sr=b&sp=r&sig=3QYKKbGNceaiVHInwl5vy%2BMuvRLwAVfVLFjcQuspevY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:09.8108637","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A09Z&sr=b&sp=r&sig=ZI%2BfqxzUg%2BtMK4YenjuJ8JRoSJ4lksSLmZuuS2VYGg0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:09.8109783","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.062Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3238'
+      - '3240'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:53 GMT
+      - Mon, 30 Oct 2023 07:27:09 GMT
       mise-correlation-id:
-      - 7da07bf8-973b-4f79-8c29-dc9c8245555b
+      - cf15e083-4791-4e07-aefa-c1c1058d42fb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A58Z&sr=b&sp=r&sig=s1kPemmnq16aqHuNASdciJ9m50EvgKNqIUBeXqzT%2Fgc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:58.9844471","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A58Z&sr=b&sp=r&sig=9k0QMaANijLpLC6sHnpuy2jjiDsJ47BY6g77HEItUgw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:58.984355","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A58Z&sr=b&sp=r&sig=wUFqCn%2Bot6eqMF66YPqhBmFpMfKEZovp1WpIDWTVpKI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:58.9844685","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A15Z&sr=b&sp=r&sig=w6S5Ey%2FfDB8ooOM1v84FQFS8eZx3ALzXmB0w4sIQ9j0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:15.0495937","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A15Z&sr=b&sp=r&sig=9nzkYqldzL6IdCL5eg9HFnxr56wX3Ya1LdTAwDrVcgs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:15.0495077","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A15Z&sr=b&sp=r&sig=e5QHycP0vtAIGEWRYwxMbT3uD8lsFeHE6f%2BrvKv907M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:15.0496096","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.062Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3232'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:59 GMT
+      - Mon, 30 Oct 2023 07:27:15 GMT
       mise-correlation-id:
-      - 5205241e-73f0-4d4b-9aaf-2ce7ec14bc24
+      - 10baf860-893e-4797-828d-04b6a7dbacab
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -880,46 +880,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A04Z&sr=b&sp=r&sig=Dn6A1dYNwF5ir4vCweQUP4Rw9f9Obyla%2FQtXt9RrA7w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:04.520819","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A04Z&sr=b&sp=r&sig=hQb6%2BAz8Po1r1BIzNpC%2FBiKIVRPriPmYggHSHzy19iw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:04.520733","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A04Z&sr=b&sp=r&sig=U3AfHnI7iEI5GbPVLtpITlMpAKbjtPj%2FVuuOvwmd15o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:04.5208387","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:04 GMT
-      mise-correlation-id:
-      - 841266c8-d6b3-4a2b-8db5-22445076fbe0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A09Z&sr=b&sp=r&sig=dnsDKDLFmOsCD02YaF7faMwx%2FK3Qpp24Ml4ePHG3yDY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:09.8290522","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A09Z&sr=b&sp=r&sig=sjRyL8as8qj0cIZisVQsn1ZYu0J1eBpaJs17nXeluL8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:09.8289667","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A09Z&sr=b&sp=r&sig=B2UNKfm5Sfwjiti0TBCyBECg57sVyCO5xbRVAvC2h8Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:09.8290752","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A20Z&sr=b&sp=r&sig=aF19YIkad11HlhNy03QqbYCSDJzYNz4vPr8EfyAQ4yQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:20.307808","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A20Z&sr=b&sp=r&sig=yT57GLNFEaI1xczDT1IiLr%2BHEnPKADpQwbUxXhfj8Zw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:20.3077407","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A20Z&sr=b&sp=r&sig=RcZdAm7pMgK1iXYThVUZTxBRiryRTMsc5c2L1RilyTY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:20.3078222","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.062Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -930,9 +894,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:09 GMT
+      - Mon, 30 Oct 2023 07:27:20 GMT
       mise-correlation-id:
-      - 32300316-32e2-47fd-9d8b-3f3c841f97c6
+      - f4d5eef2-6d8f-4cba-9ba9-0640f0122514
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -952,406 +916,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A15Z&sr=b&sp=r&sig=wy5EBjnO1pFNaeGZJZSryKT5J0NCfjv3XsGKawrT1vg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:15.1504778","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A15Z&sr=b&sp=r&sig=2VtQmXZSO8Bwu2hj74GZIps4P049%2Bz4bGDTIgwMcGl8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:15.1504082","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A15Z&sr=b&sp=r&sig=yr9JCRcfk%2F7SyrjjHhzkDcVHHVn2FxfNo87nDZzkZTg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:15.1504923","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3233'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:15 GMT
-      mise-correlation-id:
-      - 6dccf5f6-7c08-4267-9ee7-84e0057f4f13
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A20Z&sr=b&sp=r&sig=N%2FGMuqZiywtqptuUGTRf%2BxdJw6y%2B2t5N1FI51m%2B3LKk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:20.7728299","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A20Z&sr=b&sp=r&sig=dWd2q2NKZDxj6diK7jtWHiP2bOxymK1yxKa4wqLZITY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:20.7727567","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A20Z&sr=b&sp=r&sig=sxhUyyGTixxYMbnHUVrmsVAm%2FB5LyGB7SHfQngih42w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:20.7728446","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3239'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:20 GMT
-      mise-correlation-id:
-      - 346a2bfb-be62-48f9-b2ab-c04101985243
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A26Z&sr=b&sp=r&sig=eeuCGECbI%2Bk9G4g1pHd6qeljPxtoA3Q097RZo5n3U6U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:26.0625114","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A26Z&sr=b&sp=r&sig=xqqB9GFyoY9ur0LpEgclb1cpwM%2Fo6fUFehmkoDiPeX0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:26.0624201","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A26Z&sr=b&sp=r&sig=4uvChTmwFAtIeLVyo4JnpQyqA4M%2BmKmOnLoQg02YwIY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:26.0625265","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:23.249Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:26 GMT
-      mise-correlation-id:
-      - c72f65e3-bdb7-4039-8aa1-b75339ed19d1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A31Z&sr=b&sp=r&sig=S%2BuiG0eBe8UbZ4TwzqJfLp%2B4A2O0ac6yPd%2B%2F%2BnWg3Rw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:31.3198484","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A31Z&sr=b&sp=r&sig=5k6hdw45qRymxPFP80fKgeq82Pni8kj4%2BjDUIlsxEVw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:31.3197825","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A31Z&sr=b&sp=r&sig=MrEWDhjsy3fwC8k9BrrTM5ClGqbV0gmPUGRAt7V%2BINA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:31.3198636","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3240'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:31 GMT
-      mise-correlation-id:
-      - 86bcfeb6-254b-4557-8103-faf4f157a71f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A36Z&sr=b&sp=r&sig=RoRoaiHym4RxTFYmGB7T04%2FzDg7Eh0%2BZfTWUsSo8XMA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:36.6565746","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A36Z&sr=b&sp=r&sig=jVgYjmctYqjNxL1%2FK3cF%2Bl0HBIltvQAhV0wTwtHqAAo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:36.6564972","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A36Z&sr=b&sp=r&sig=SF5kz9Vwv2tCrq7PtB7Wg2JAjL81GDlNjO6jMsbDEac%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:36.6565924","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:36 GMT
-      mise-correlation-id:
-      - d7650290-9978-4dcb-8c5d-3a9ba1d9e482
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A41Z&sr=b&sp=r&sig=ErFIymDT%2BqcDZilYXy8D%2BV4wwKuRogF0ktbaoZpZfgA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:41.9173875","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A41Z&sr=b&sp=r&sig=YyMB9H2ISCD14ruw%2B%2Ff%2FtYjmWK1ucXou04qCBbAmfnw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:41.9173221","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A41Z&sr=b&sp=r&sig=KLeOwJi9%2BqAtXO1gaZrvFSefuzXLheOGTMSBYbNp6J8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:41.9174032","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3238'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:41 GMT
-      mise-correlation-id:
-      - 6f911d47-190f-448b-9a24-12ac8a1588ff
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A47Z&sr=b&sp=r&sig=DnJTA%2Bw6SntsBnnAAZsZYaMJZRTRKIw0Kp6ovqYJgcg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:47.1993511","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A47Z&sr=b&sp=r&sig=irxiI34S3urrIaNYfblK%2BZkzDzrmCER5Jz4RVwARTK8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:47.199286","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A47Z&sr=b&sp=r&sig=cysjrIyFKLcdVNNc2LvV8NQ8poi%2FQSvTGX5Wx%2Bgitf4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:47.1993671","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3233'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:47 GMT
-      mise-correlation-id:
-      - df032d0a-ac38-4dc0-ad30-1d47cfda9168
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A52Z&sr=b&sp=r&sig=Q9rxjU%2F6WjwxFhHczYjuF6vNo6gi%2FL9COFpaWnvTP4U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:52.8341344","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A52Z&sr=b&sp=r&sig=IyHCNpjxqFgRog%2Bdedvjfh9TjaIgswx2J6riEge3Dj8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:52.8340457","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A52Z&sr=b&sp=r&sig=MlNXuM%2FRw6MLeUPzrObm9XmAtdW%2FdoQH%2F7VvFUktUks%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:52.8341509","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3238'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:52 GMT
-      mise-correlation-id:
-      - a504505a-68bb-4593-aa7b-ea56073aa686
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A58Z&sr=b&sp=r&sig=Q%2FbLQjn0dAvx7u6tOH6OzH4IjsMQ5zp9B0gm%2B0yyThA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:58.1796314","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A58Z&sr=b&sp=r&sig=%2FHCoQOPWcWYWsqjJ1pEipgsBCFmjEg%2BMqFGMi3doDjA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:58.1795652","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A58Z&sr=b&sp=r&sig=f9LIbTvfuMAttFzVBarRzJ7xOS8vfFj7tUYhiKZzpqU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:58.1796462","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:58 GMT
-      mise-correlation-id:
-      - 2ee1ce08-80d0-46f7-a008-e227307f9608
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A03Z&sr=b&sp=r&sig=tF%2Brl%2Br39EqD6pbNLTVLW6w49ut1ZpafMQSeSZP9WaE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:03.4957377","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A03Z&sr=b&sp=r&sig=x%2FIOASSfXu3hDqjGkd3fRkDhLD19QE%2FsxgEVkF0r5ms%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:03.4956624","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A03Z&sr=b&sp=r&sig=Yar4%2FY3P4hBM8Y0JgZNCEwd7uus87Kxh%2F2nXhBvW9UU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:03.4957523","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3238'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:03 GMT
-      mise-correlation-id:
-      - 6eaa842e-283d-425f-8ab5-e616ce40a7f8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A08Z&sr=b&sp=r&sig=gjEgL%2BA8wFhfxJEYNf6RIpL3gI%2BFLHIW0Y3ZR%2Fd3hWM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:08.8113984","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A08Z&sr=b&sp=r&sig=geQqPuvuLcANozGiNsKHI0BUgTyVNTKLg04mFhmWhLE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:08.8113268","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A08Z&sr=b&sp=r&sig=QhI9UTWxcGyJwAhYkj1SYDA%2FvZhQKdZszX%2Bhjj5lPys%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:08.8114131","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3236'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:08 GMT
-      mise-correlation-id:
-      - 8ad36318-7789-4443-9810-47ebcb9d3466
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A14Z&sr=b&sp=r&sig=ADPdRV0oYCbZQAFl5VfrwWtMiVrjH9hPqbv0SMAdafA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:14.1543559","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A14Z&sr=b&sp=r&sig=1IjOFg2Jib%2Bv%2BVa4OVsrB6JIvOZ9hXR7qAfdkjFSInM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:14.1542732","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A14Z&sr=b&sp=r&sig=4N8DfKCHUhFcnKVcPWayBQc83nVCDeMQhSu7BYTy96o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:14.154378","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A25Z&sr=b&sp=r&sig=VboaprG0u0VhZgd71eMZpIFUaoGkMs0RWoMS0UZ7ZyI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:25.597774","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A25Z&sr=b&sp=r&sig=z3xVgpORm644dDI3XX0nfMbiYs19BeO28x9N7fwYvkw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:25.5977057","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A25Z&sr=b&sp=r&sig=MzBXm9PpaOMP1PA2KMso1xxcr3NVSlxf6pyqiSsohGQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:25.5977887","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.062Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1362,9 +930,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:28:14 GMT
+      - Mon, 30 Oct 2023 07:27:25 GMT
       mise-correlation-id:
-      - b32e2103-5306-4a7b-98ee-cb7638c8c80c
+      - 15306a4c-09ad-48ac-8f2e-ae4d33ab567a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1384,23 +952,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A19Z&sr=b&sp=r&sig=cxiTVWnE%2FVB9HXBvRvPLH62XJus7gAu1KTYcABz%2Fzmk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:19.4641126","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A19Z&sr=b&sp=r&sig=Ke0BjTv59c2s51nXgEANkAJqonM8J4T1Hw2dmJXj2iY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:19.46404","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A19Z&sr=b&sp=r&sig=GT%2FVEFdSlZVpyP0I4HOAAqJpTq0mxjgajgWalmN2zEY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:19.4641291","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A30Z&sr=b&sp=r&sig=InGQzuyo0qkuaQYt3kX7ArmjPgrL3auiQDjTie1QW88%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:30.9304233","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A30Z&sr=b&sp=r&sig=JscvxSOoOVRkdvCVe5eYB1lPvcf0k8i8Qq2xZCnWNj0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:30.9303562","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A30Z&sr=b&sp=r&sig=0g6djlt8t4jUUW6%2BdiyLaHzJaRh9Vzu0VCETClVZp6M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:30.930437","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.062Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3230'
+      - '3231'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:28:19 GMT
+      - Mon, 30 Oct 2023 07:27:30 GMT
       mise-correlation-id:
-      - 3b9ba58e-cb16-4f46-a7b7-e26e67b3bacb
+      - e4d82b6e-b59f-4c52-8dd6-e4fe3dba49a1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1420,23 +988,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A24Z&sr=b&sp=r&sig=Y2oGu%2Fzn9NUeCrXNkgh9cIqoV6NjK4JqmhYmPWIpGMA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:24.7377288","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A24Z&sr=b&sp=r&sig=5FNfP%2BuwUPPKB5sfkm3W2WhHC8XydjWXNVsKrLUX9Fo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:24.7376523","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A24Z&sr=b&sp=r&sig=mutfkrDaLUhw7s%2BdHI%2BEyAOUUM4aSD05rBfAcV1rkhQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:24.7377469","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A36Z&sr=b&sp=r&sig=0YUPowDiNfdPF0xqUKss3Rcpa9aN2onVI%2F92pJLpqeI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:36.2801908","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A36Z&sr=b&sp=r&sig=8fqHcMsD0Dsn6H1XqTEfvt8lkjvYush4eGwGwyncr98%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:36.280102","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A36Z&sr=b&sp=r&sig=D67ztVlmcfPclFX36pixOQ4or75APgUgpL1THAPN4h4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:36.2802123","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:54.062Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3234'
+      - '3231'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:28:24 GMT
+      - Mon, 30 Oct 2023 07:27:36 GMT
       mise-correlation-id:
-      - 18e1f4ab-7fd4-43b4-8f3e-f8b3a2e21f5f
+      - c7260d60-64b2-44d3-9d96-21c66c3b9d7c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1456,154 +1024,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A29Z&sr=b&sp=r&sig=BnIK3E%2F%2FDBNAOICq5uzmszT%2Fg8iQmyV%2BItlWLAIYkD4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:29.9987505","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A29Z&sr=b&sp=r&sig=zRLlWKEFDyfnvBN8CzHNiQ0jQvMq7xgFucWsFit1qkE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:29.9986658","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A29Z&sr=b&sp=r&sig=YpBBXZMCyDZCTAJOLYRWzdqU7E7%2FZczW%2FewRjBWh4nc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:29.9987724","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3238'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:30 GMT
-      mise-correlation-id:
-      - 1dc46fe5-1b4f-413f-b151-1fade91b32cb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A35Z&sr=b&sp=r&sig=D2dumRZw%2BXQ8gRnAOqJbNbP68Kgus1PNUY%2BDSUXYcBI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:35.2422418","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A35Z&sr=b&sp=r&sig=sMk5xglAPyEjIE0BJzmHhYpCuNpIpENyy9ESphj8uZ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:35.2421728","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A35Z&sr=b&sp=r&sig=UzwMfmrStpy0MJO%2FbT3oFB6BWnA0qpyQU4a%2B1kv8F6s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:35.2422564","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:35 GMT
-      mise-correlation-id:
-      - 504113b8-e9c8-4a96-879a-0028be6791e9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A40Z&sr=b&sp=r&sig=aEKqEBLVooc4zGN3hvTaMP94ylI6TAHgZMgqdLdQqT4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:40.559936","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A40Z&sr=b&sp=r&sig=ksXn0oAINUci7f3UYDthJjz43G4F6zGaJZO8PXgxjRQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:40.5598529","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A40Z&sr=b&sp=r&sig=0a609gk048X9%2BvL%2BVuLeO%2B2tQxzZxob%2FDlbfN2BpK2s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:40.5599613","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3233'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:40 GMT
-      mise-correlation-id:
-      - 3d6dcca3-1c10-4d83-bc74-87ca7f791558
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A46Z&sr=b&sp=r&sig=5R%2BdtC1UJiSGk6qFuHESpODRiKFVU36sBO3HiFoBFSQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:46.0561294","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A46Z&sr=b&sp=r&sig=F8Q45s4mKHyn3x77X7YJC4PeLiwy8aoh951C0i4pttg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:46.0560269","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A46Z&sr=b&sp=r&sig=YC6AM3Xux2Rb9CF6b0Cl7hOqCckO2zi7QyO2sV2heHI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:46.0561435","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3228'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:46 GMT
-      mise-correlation-id:
-      - 6ab2f8c0-8802-4bb2-b389-0d7c7f6a7694
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A51Z&sr=b&sp=r&sig=Gdt%2BH1lY1MZ9LCuc3PEtogZA7pf2mFFIDYtmYMkDphk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:51.3056465","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A51Z&sr=b&sp=r&sig=2sqOTIwW1b%2F05r2bUoizGq76MlIy5gXGbVhpGXzJJkM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:51.3055312","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A51Z&sr=b&sp=r&sig=1m%2FllyJS%2BAWaUaWUy%2BT%2Btp22dAzrGceP5T4s%2BZgameM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:51.3056667","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A41Z&sr=b&sp=r&sig=5%2F33w8zxhOUNTOy0CP2Bxf7%2FImDePCqC7PxPzvRsK%2BE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:41.5238235","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A41Z&sr=b&sp=r&sig=i9hIjM5ZRLo1PKy9ZJfcOq%2FtbbeZNxSGt7j%2BCBkHYNM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:41.5237387","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A41Z&sr=b&sp=r&sig=A%2FDUAz9YnotG98wTdf8iQehrL36S5VdGVnTC5dRW25c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:41.5238387","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:40.96Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1614,9 +1038,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:28:51 GMT
+      - Mon, 30 Oct 2023 07:27:41 GMT
       mise-correlation-id:
-      - a795f496-5d85-44c8-a784-5794046ac5cc
+      - e1fd23f5-58f3-4fe2-8f56-ea62e726a4f7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,23 +1060,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A57Z&sr=b&sp=r&sig=QYALrolPaiolvJkG5NRWce4znc0UVBzZzgJ3sSGUlMc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:57.0417379","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A57Z&sr=b&sp=r&sig=h86grxzj%2F4uZaHHTmLC7I3qfZfzmcot45lOrwXl5r3o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:57.0416478","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A57Z&sr=b&sp=r&sig=kksMaDn%2FVeJBbUj6KnixJsfgL7z9P0D5MzUAEooZusQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:57.0417588","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A46Z&sr=b&sp=r&sig=GZssJfCq1A3gOazElD1pkNp%2B%2BIk8%2F7V5U%2BEbRHeTw9M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:46.7968482","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A46Z&sr=b&sp=r&sig=%2BQ%2FMHgIAP6ZrrircLTHu1njSWtXqlR3NcaFcscXLBF0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:46.7967834","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A46Z&sr=b&sp=r&sig=2XLb8xSkoq%2BOiRKaWEf54FU1OzZfxbkNIX8iwmjbyI4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:46.7968625","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3230'
+      - '3241'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:28:57 GMT
+      - Mon, 30 Oct 2023 07:27:46 GMT
       mise-correlation-id:
-      - 9c810139-2edc-4847-a13a-8097e92695da
+      - 1fa9ff15-8e08-4062-a12a-1145b1d8af67
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,10 +1096,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A02Z&sr=b&sp=r&sig=yOMzal%2FkEE%2B%2Fm4SJvYb8vmg0%2FDnqHVG1g2stDJecSs4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:02.283151","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A02Z&sr=b&sp=r&sig=bURF6ObCUWj8JNdJZhcfU8hGmXeipEZU8KKZXcub5bU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:02.2830618","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A02Z&sr=b&sp=r&sig=t8j3KOc4blqXwlguemQYlyckHnMohyx%2FPjBBNSYWQVM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:02.2831732","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A52Z&sr=b&sp=r&sig=mcHGTN228w%2B1CLABQS8CC9DqlQbipAtxqkDMRGZ4T7s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:52.0497114","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A52Z&sr=b&sp=r&sig=Cgy80IKfLtcYZRlA3LHGTaC36F4p2xHC6EvmCXmuNmw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:52.0496405","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A52Z&sr=b&sp=r&sig=zKdAMoQiVC8WAWg1VgI%2B9ZLt9tRwr32m%2FAtNIireKoM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:52.0497251","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:27:52 GMT
+      mise-correlation-id:
+      - e3d23afa-0dcd-4dc6-8609-d0e0070ff04e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A57Z&sr=b&sp=r&sig=rHKFwb1w3aWv0IZscOjWGpTz5z5eVxzTIHoSagDyXmM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:57.3089154","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A57Z&sr=b&sp=r&sig=YzhS3onDElDZWpRUxkglle8bjA4Qp%2FAtnTaAhGDN2W8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:57.3088452","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A57Z&sr=b&sp=r&sig=ly6RjuP3JG31cRr0Xv%2FggpnjJbnWdaNlgPkH1i56eC0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:57.3089309","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:27:57 GMT
+      mise-correlation-id:
+      - 4642e934-1a17-4f79-8950-f85fe1dcbee0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A02Z&sr=b&sp=r&sig=gTuiK8e99IoBIUNZdSZL%2F58yYXpdTqr5tvBAjbQMNrU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:02.5638653","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A02Z&sr=b&sp=r&sig=l3%2F4OhoUD%2B6FVOr4pN1R831ihKgnoHSoVQZH9KY%2FZpg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:02.5637981","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A02Z&sr=b&sp=r&sig=iTYvqlQU9jkdBAig6Hy857SwvTd9QtjMDaYr6fZ4XNo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:02.5638801","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1686,9 +1182,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:02 GMT
+      - Mon, 30 Oct 2023 07:28:02 GMT
       mise-correlation-id:
-      - 1456b862-7c94-4892-a405-8235da39f439
+      - 1fe410a9-d3c3-474a-856e-38cf0e08677b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,10 +1204,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A07Z&sr=b&sp=r&sig=a6vCUExDYOHvj5J5%2BFUqeLvqGwF7QftLwtIWkbegFa8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:07.5884526","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A07Z&sr=b&sp=r&sig=osxpTPbyS5Q42AeLBEINtEfvbbouJrW7ZJLARKtDY64%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:07.5883704","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A07Z&sr=b&sp=r&sig=nlAI2M9AJwK9abGn%2BbnYOQ2ma2CtGW9%2BLO2imGY2Rj0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:07.5884735","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A07Z&sr=b&sp=r&sig=LJrQsyAlGpbBrijEBlmF5KRla9UEktgCdFi415CJyUs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:07.9072442","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A07Z&sr=b&sp=r&sig=PofGKopKmHxseAUAy6L0dzfsepg5vRpOgPyAMFiqNus%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:07.9071579","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A07Z&sr=b&sp=r&sig=MomkkFvZBx8wGibhTD6BVjAusG%2F9SKq1hjNVpjbIt7k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:07.9072658","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3229'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:07 GMT
+      mise-correlation-id:
+      - 349087d8-4094-4c02-92fb-d7c5dc83c89e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A13Z&sr=b&sp=r&sig=IdDqwmZN3M7wUx%2FQ%2Fks3ObnBF647cy6WxDVptr0IfzU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:13.215156","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A13Z&sr=b&sp=r&sig=U2B1mBHUX4Bx%2FiEyXEEt25aqmSLJt4BRbA91drFd29k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:13.2150587","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A13Z&sr=b&sp=r&sig=P1ak7aNgKe5Aj3pBvxECBRzJfkdKo8tXc3SZwxGF12g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:13.2151817","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1722,9 +1254,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:07 GMT
+      - Mon, 30 Oct 2023 07:28:13 GMT
       mise-correlation-id:
-      - 06950e91-2dfa-435e-a7ee-1f86d9738800
+      - 8078dfeb-1a5a-4e40-8ba5-32d8fcfba10e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,10 +1276,262 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A12Z&sr=b&sp=r&sig=yhDht7Usk06P8mqlh9ZJlU8E6DuSk3cPP5oFlHObMI4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:12.8418479","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A12Z&sr=b&sp=r&sig=DYn30y8R3ZEdeskDjA%2BNQ6rINW%2Fyr1%2BgnmnefbJAeEk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:12.8417738","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A12Z&sr=b&sp=r&sig=vF6f%2FgGVN6Yi4YKmE3ZTdt%2BSLHd%2BCRtlGIouhZykTbM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:12.841862","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A18Z&sr=b&sp=r&sig=GTYWZWkiJWTOrm56rNArz8iQxJujKQ9RxsTxDwpEW2o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:18.4613231","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A18Z&sr=b&sp=r&sig=pHZe53lw2Bjib5BhmHqjsLdd7%2B5F1Y8ETd5bR7ssGsE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:18.461254","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A18Z&sr=b&sp=r&sig=mlCudOft7HKUhf4hSXyfnuNNXoMYzOF6k2FAzeAn4p8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:18.4613369","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3228'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:18 GMT
+      mise-correlation-id:
+      - b04a8dc3-d70b-464f-8bca-29aa2c05bbed
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A23Z&sr=b&sp=r&sig=yLqRHOwHLycEEyY9p7TsbqyZImTT2ZNrv9TWWokr2d4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:23.7612488","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A23Z&sr=b&sp=r&sig=xq7%2F4GKnj%2BKTSXea6Rfy%2Fx0BvsV5gKImEOhPX5x1Hcc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:23.7611616","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A23Z&sr=b&sp=r&sig=T6WKzoApho9ZVtnuOdxVN3tipK52YZFX2fRSCX%2F8vqs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:23.7612692","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:23 GMT
+      mise-correlation-id:
+      - 6d978f54-e941-4832-b0e3-8825d7cf918a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A29Z&sr=b&sp=r&sig=Rh8qvoR849EoPSvVh%2B%2BeLq%2FxpO%2FRSr%2FMMpK841j2OD8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:29.0918182","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A29Z&sr=b&sp=r&sig=nHco3lised5hrPm%2Fd6MSJnxerYAq4ifMBXPzTnMH11o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:29.0917473","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A29Z&sr=b&sp=r&sig=kyb0lYZI6c0%2BP81%2Bb1ZrgKi%2FNaCSSLPZlfN3kCkeGog%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:29.0918328","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3245'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:29 GMT
+      mise-correlation-id:
+      - e5d25bb1-fc2e-4df6-b4b1-6cf005d7202f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A34Z&sr=b&sp=r&sig=dTxVTQ9OBY1bXix%2FPWtnLV%2BGTHsiknrdz3xicFIfeQA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:34.4426706","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A34Z&sr=b&sp=r&sig=5ELPoNagzxqcYsQYGpqdYi9g6iO%2B36VyYvCujddzUGA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:34.4426018","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A34Z&sr=b&sp=r&sig=kH2vge5VYRdIK0CH2uRI2B%2F7jAq8i3adTlIiQwTprUg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:34.4426851","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:34 GMT
+      mise-correlation-id:
+      - 33ebc69e-66e6-4e38-95d2-71cf8fdcb721
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A39Z&sr=b&sp=r&sig=4I21bmaQ88gEcVmKegkAdF9cfVdGkPEncZ45BmFOJtU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:39.7481116","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A39Z&sr=b&sp=r&sig=GIm5zSuFnfonrx2XZfn1iHieoOR2453xq3ekQ3Q5%2BRg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:39.7480234","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A39Z&sr=b&sp=r&sig=ZSYhF8KssMSN2qic%2F7Z5ylw%2FmxZBJDFdvDdwVmnGVtY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:39.7481348","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:39 GMT
+      mise-correlation-id:
+      - 04d46f49-bf5e-42c2-afe0-ed2c61387cfa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A45Z&sr=b&sp=r&sig=v0vG4Dolg1VYTlCXs2E5SVQceyfLS8CKY5pH3ma%2Fw38%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:45.0780171","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A45Z&sr=b&sp=r&sig=QPdNPzeTxcSIWxao9avNuJijuc%2BEYzSQAt0BRd8VlOs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:45.0778639","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A45Z&sr=b&sp=r&sig=T%2B3ESJ3QZFVHx7aEyHlrwL70wYiZxypCrE1P4z7VCok%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:45.0780848","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:45 GMT
+      mise-correlation-id:
+      - 55ee72b9-3162-4c18-a1e9-dfd493f712ea
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A50Z&sr=b&sp=r&sig=27i6DgzOsn1ATEC8ucqo6B9acBIRFuJrZIt18if9soY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:50.4019041","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A50Z&sr=b&sp=r&sig=dE8rc7DmoRNNU8%2BgM5sn153c3td1ZgF%2F0YZduSjelLs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:50.4018357","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A50Z&sr=b&sp=r&sig=da3NXtfuA3KZAsvUBgjo3eGwIsP974YxJQ5jwXWVVfs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:50.4019177","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:50 GMT
+      mise-correlation-id:
+      - fd124bc8-4c6f-47da-9f08-27b572086590
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A55Z&sr=b&sp=r&sig=TEGWcA%2FYp8knC%2FmDhD9sE1koEYCXMIekxa%2B6HSOoeFA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:55.7033637","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A55Z&sr=b&sp=r&sig=gTkRYrIy3h3yqFxXbl4g5yLgjn9sKFzXCRfTs%2Be7WvU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:55.703277","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A55Z&sr=b&sp=r&sig=dY9A6%2B2Of0mB3BaKw5MEYbr%2BCfBMfWUOE7c0bmh8pU8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:55.703378","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +1542,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:12 GMT
+      - Mon, 30 Oct 2023 07:28:55 GMT
       mise-correlation-id:
-      - 8939b70c-8e2b-42c5-a93a-f594161d7ae2
+      - 050d2548-a9e1-43b9-ae0c-a546b000668f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,23 +1564,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A18Z&sr=b&sp=r&sig=IkyCEE9p8yYtWh4mOVzIOSkxyDJumw2RmsP3L2OEGEw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:18.1402909","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A18Z&sr=b&sp=r&sig=u6fZxR3FkOB32ALPvtK9aHOit0ktOZRTSCGpK5hHX%2FY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:18.1402232","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A18Z&sr=b&sp=r&sig=Vf4REtfv4nNLn6jTlvI2qJ63vydFDKuYwZQolwKPf%2B0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:18.1403072","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A00Z&sr=b&sp=r&sig=wnkeloklqmS2mOjnwn4KG5ma4jhCngSdzLuK81iSdNc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:00.9560865","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A00Z&sr=b&sp=r&sig=8KwotbtnuS3aa9%2Fs4yl4g7f5whHQwJWH2V7HkYMFGag%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:00.9559818","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A00Z&sr=b&sp=r&sig=jegKTnaVTJHAe06qveqa%2BLKlI9l8trZguMfLx8cxz9o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:00.9561088","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3230'
+      - '3231'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:18 GMT
+      - Mon, 30 Oct 2023 07:29:00 GMT
       mise-correlation-id:
-      - 8e4a025d-1d6f-4760-aa70-c99e57f15cff
+      - e99710d3-0799-417f-a780-4879c5261abc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1816,24 +1600,240 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A23Z&sr=b&sp=r&sig=C7ZbIQRsatXhzskNfE12doZJyJjl8WXTLDmCsiBUep4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:23.4070475","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A23Z&sr=b&sp=r&sig=T2QWqNRaZbh81DncWEU2eucyqBZ7nmqPLkktysHHX3w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:23.4069603","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A23Z&sr=b&sp=r&sig=cL7x%2BJe%2F6muvomwkL7DcwfdI4fhQehp1j82TRkumlaw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:23.4070698","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-29T22:26:39.217Z","endDateTime":"2023-10-29T22:29:20.611Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:20.798Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A06Z&sr=b&sp=r&sig=c7yEi178bGcxndSyvxbQoxB692J9gYwYB9KtUjwOuQI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:06.2663713","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A06Z&sr=b&sp=r&sig=kpYr1WQ85FIFAKuT1luDo7DE8mZ%2FlXl%2Fn%2FeSNd7kGro%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:06.2662631","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A06Z&sr=b&sp=r&sig=dMnQ4X3srsT%2Fq3pmEzq7c1GatHWpOMFDkZ%2Bh1UP6b8g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:06.2663962","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3365'
+      - '3237'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:23 GMT
+      - Mon, 30 Oct 2023 07:29:06 GMT
       mise-correlation-id:
-      - c166177e-3b94-4919-ae28-80ca9a78a91e
+      - 1eb83a4b-0b6e-41a0-9d6d-9a2fe8531d54
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A11Z&sr=b&sp=r&sig=fHK6KLRNQnpnQOywQNGH3tWuqgMdr70Rc6Rk0D49Uys%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:11.5145675","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A11Z&sr=b&sp=r&sig=zskR218UvjZai%2BTr2olLrReK%2B5lJF1B%2Ffo61XJVw5aE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:11.5144644","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A11Z&sr=b&sp=r&sig=yfhOZExm%2B8gk%2FXAFTxpCEUekeTwvjMT%2BiVsjXm4mrhc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:11.5145892","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3239'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:29:11 GMT
+      mise-correlation-id:
+      - 43f00c03-5f35-4aa4-ad00-1eb27b0e90c3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A16Z&sr=b&sp=r&sig=VgC1j6NbmcnBitd9c3%2BdwbNFizBZpFORj2kN8aUkbvY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:16.7761981","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A16Z&sr=b&sp=r&sig=tHuyoW4xO5dC3PQF54r4IXAPGP2eUJDtfAhZ%2FvDBfIY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:16.7761276","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A16Z&sr=b&sp=r&sig=MpA0QqFxy%2BEGXdrrEADEBBgsQtOL1i9yLvG4pmt523U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:16.7762132","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:29:16 GMT
+      mise-correlation-id:
+      - 8bbaf143-a374-429c-9938-0454fc39b926
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A22Z&sr=b&sp=r&sig=Q2yYrHlP46LhIKJojsdejsRX7409z60F3A5li69Ucsc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:22.0240336","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A22Z&sr=b&sp=r&sig=89jfGjE8DUFojtfkoWEvzwZ1btV4uJ7e7Sc7Tv4WaHI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:22.0239456","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A22Z&sr=b&sp=r&sig=xtZ35fbu5BP1lp%2FQlwAWYqbGCD8T6%2B6DdrWzRDkxnVQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:22.0240783","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:29:22 GMT
+      mise-correlation-id:
+      - e51d90f5-8c35-4fc2-8e3d-a324b5836188
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A27Z&sr=b&sp=r&sig=PKOeCUkRbR%2BisaOzKormbJrR3BpR39zZJFq7XJNGRB4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:27.3480283","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A27Z&sr=b&sp=r&sig=xhQXvY2DeAuf%2BRgvFcBodWhJuAi9zQDyqbDjYe1qN48%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:27.3479439","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A27Z&sr=b&sp=r&sig=cbT9fWKVATduAkc5p%2FW%2BrcftiJe61%2FWbn4DLbvjWxXI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:27.3481052","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:29:27 GMT
+      mise-correlation-id:
+      - 2f9f0be3-4c43-46e6-84c8-a7461a7bd2c4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A32Z&sr=b&sp=r&sig=GgNUkl0PBWUF1%2B7mIgDu460zDjM5XHe7Hq%2BtJd3znug%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:32.6688035","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A32Z&sr=b&sp=r&sig=fu6i6jucXl6ciI86linzSmJBAGfg0y7ZwjweQ1HKa8Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:32.6687368","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A32Z&sr=b&sp=r&sig=%2F7635oh0IpW%2FtHY4nNVpLakZhLPYGLNiPXSgb2gjj4Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:32.6688182","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:53.859Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:43.894Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:29:32 GMT
+      mise-correlation-id:
+      - 542cc554-deb5-4128-8535-c85ecfc0ea30
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A38Z&sr=b&sp=r&sig=HrP7pCzKW3ndQNmHb7r%2F196TVg%2BQBz%2FQs46SmL0ekC4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:38.4667554","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A38Z&sr=b&sp=r&sig=XHwU%2FlipIgMmr5e1Iw1wOb%2FbJnapQl9Kc82x7LUpVBs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:38.4666584","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A38Z&sr=b&sp=r&sig=JKsUbIoI687k0meOEPKCBSH5qiU%2Bl%2B5xenuyq%2FfOTvo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:38.466772","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-30T07:26:53.859Z","endDateTime":"2023-10-30T07:29:36.544Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:36.651Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:29:38 GMT
+      mise-correlation-id:
+      - abec004d-dac4-42b1-866e-e4376886ed6f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1856,7 +1856,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:59.4343003Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:59.4343003Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1865,9 +1865,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:24 GMT
+      - Mon, 30 Oct 2023 07:29:39 GMT
       etag:
-      - '"3c001330-0000-0100-0000-653edbe80000"'
+      - '"3f005172-0000-0100-0000-653f5a890000"'
       expires:
       - '-1'
       pragma:
@@ -1897,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=server-metric-test-case&api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=server-metric-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A25Z&sr=b&sp=r&sig=347jx7AZ6bUusk4jYnqp46WP1g%2F17PkDfTxAGs6D548%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:25.6604473","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A25Z&sr=b&sp=r&sig=6H3o5Jzx%2FerlaKlwwBy1iv7nhK4z%2BG1Yb2P5txHFJjY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:25.66036","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A25Z&sr=b&sp=r&sig=2TU%2BS6d76tkMC2yXULjR9hWvBEHsYYY3L5D4ETmsDcQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:25.6604718","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-29T22:26:39.217Z","endDateTime":"2023-10-29T22:29:20.611Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:20.798Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f0aa0421-dd02-474f-a3cc-024193a10a67":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1be12e1c-f3db-49a3-8415-851c0629d9da":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9358883-47d0-439f-8762-e9bca8d0041b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/39410973-1503-40ef-846a-b3b7903b3878?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A40Z&sr=b&sp=r&sig=gzCVXGsgQ0r46QrNS382SxY0SvdkT6oSZfxtXRiT6%2Bo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:40.7753271","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/7b8cf27b-e021-4e53-a7eb-96fe29cdc1c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A40Z&sr=b&sp=r&sig=6QjhheuJwRDw62WtQtN222hgA4KmNAzzADK%2F0x0dIR0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:40.7752235","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5f72fd03-dfcc-476d-8710-46e30a34576c/2d6fbf4b-6f8e-41d3-a266-7c95782a24c8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A40Z&sr=b&sp=r&sig=y59%2FBwwDSf7iBSxolBmaVgUVA8XkDFGOnUe9RtEvOKM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:40.7753491","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-30T07:26:53.859Z","endDateTime":"2023-10-30T07:29:36.544Z","executedDateTime":"2023-10-30T07:26:53.036Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-30T07:26:53.333Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:36.651Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3379'
+      - '3380'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:25 GMT
+      - Mon, 30 Oct 2023 07:29:40 GMT
       mise-correlation-id:
-      - 3c747835-ed40-425c-920b-a0e19006ea89
+      - 207f5743-c8e5-4ccf-a8d3-73836738925e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1936,21 +1936,21 @@ interactions:
       ParameterSetName:
       - --name --resource-group
       User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-azure-mgmt-storage/21.1.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2023-01-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-29T22:25:46.9113240Z","key2":"2023-10-29T22:25:46.9113240Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-29T22:25:46.9113240Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-29T22:25:46.9113240Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-29T22:25:46.6926020Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-30T07:26:05.0624719Z","key2":"2023-10-30T07:26:05.0624719Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-30T07:26:05.0781448Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-30T07:26:05.0781448Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-30T07:26:04.8593666Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1297'
+      - '1312'
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:29:26 GMT
+      - Mon, 30 Oct 2023 07:29:41 GMT
       expires:
       - '-1'
       pragma:
@@ -1983,7 +1983,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:59.4343003Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:59.4343003Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1992,9 +1992,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:28 GMT
+      - Mon, 30 Oct 2023 07:29:42 GMT
       etag:
-      - '"3c001330-0000-0100-0000-653edbe80000"'
+      - '"3f005172-0000-0100-0000-653f5a890000"'
       expires:
       - '-1'
       pragma:
@@ -2013,9 +2013,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-k6wgjmj7wz23xxlwj/providers/Microsoft.Storage/storageAccounts/clitestload6ztzaj4yi":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-k6wgjmj7wz23xxlwj/providers/Microsoft.Storage/storageAccounts/clitestload6ztzaj4yi",
-      "resourceName": "clitestload6ztzaj4yi", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testRunId": "server-metric-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ed4atfhrtrrwsqq66/providers/Microsoft.Storage/storageAccounts/clitestloadw7n74q4dp":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ed4atfhrtrrwsqq66/providers/Microsoft.Storage/storageAccounts/clitestloadw7n74q4dp",
+      "resourceName": "clitestloadw7n74q4dp", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -2031,10 +2031,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-29T22:29:29.731Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:29.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-30T07:29:44.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:44.479Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2045,11 +2045,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:29 GMT
+      - Mon, 30 Oct 2023 07:29:44 GMT
       location:
-      - https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+      - https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - 6e0cacc6-ca2d-43a6-8840-29658834ed2d
+      - 710d8f88-4679-4e6c-b5f0-46f7270e0d7e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2072,7 +2072,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:59.4343003Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:59.4343003Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2081,9 +2081,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:30 GMT
+      - Mon, 30 Oct 2023 07:29:45 GMT
       etag:
-      - '"3c001330-0000-0100-0000-653edbe80000"'
+      - '"3f005172-0000-0100-0000-653f5a890000"'
       expires:
       - '-1'
       pragma:
@@ -2113,10 +2113,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-29T22:29:29.731Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:29.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-30T07:29:44.479Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:44.479Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2127,9 +2127,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:32 GMT
+      - Mon, 30 Oct 2023 07:29:46 GMT
       mise-correlation-id:
-      - 039dcfbf-a58b-4085-b0d8-a929448cc807
+      - c6fcf8ff-55c7-4de7-aa95-79f4448cb35a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2152,7 +2152,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:59.4343003Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:59.4343003Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2161,9 +2161,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:32 GMT
+      - Mon, 30 Oct 2023 07:29:47 GMT
       etag:
-      - '"3c001330-0000-0100-0000-653edbe80000"'
+      - '"3f005172-0000-0100-0000-653f5a890000"'
       expires:
       - '-1'
       pragma:
@@ -2182,9 +2182,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-k6wgjmj7wz23xxlwj/providers/Microsoft.Storage/storageAccounts/clitestload6ztzaj4yi/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ed4atfhrtrrwsqq66/providers/Microsoft.Storage/storageAccounts/clitestloadw7n74q4dp/providers/microsoft.insights/metricdefinitions/Availability":
       {"name": " Availability", "metricNamespace": "microsoft.storage/storageaccounts",
-      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-k6wgjmj7wz23xxlwj/providers/Microsoft.Storage/storageAccounts/clitestload6ztzaj4yi",
+      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ed4atfhrtrrwsqq66/providers/Microsoft.Storage/storageAccounts/clitestloadw7n74q4dp",
       "resourceType": "Microsoft.Storage/storageAccounts"}}}'
     headers:
       Accept:
@@ -2200,12 +2200,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-29T22:29:29.801Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:34.558Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-30T07:29:44.532Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:49.225Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2216,9 +2216,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:34 GMT
+      - Mon, 30 Oct 2023 07:29:49 GMT
       mise-correlation-id:
-      - 80fe14ca-9bd9-4c84-b1fa-f32b68d909fa
+      - f22fe25c-a839-47f5-84c6-0b27ef9f174c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2241,7 +2241,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:59.4343003Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:59.4343003Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2250,9 +2250,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:35 GMT
+      - Mon, 30 Oct 2023 07:29:49 GMT
       etag:
-      - '"3c001330-0000-0100-0000-653edbe80000"'
+      - '"3f005172-0000-0100-0000-653f5a890000"'
       expires:
       - '-1'
       pragma:
@@ -2282,12 +2282,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-29T22:29:29.801Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:34.558Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-30T07:29:44.532Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:49.225Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2298,9 +2298,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:36 GMT
+      - Mon, 30 Oct 2023 07:29:50 GMT
       mise-correlation-id:
-      - 82c5d6d8-947c-415c-ba67-ac3488d12348
+      - f4578205-fa57-427d-bcce-f5a045fcb4f3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2323,7 +2323,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:59.4343003Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:59.4343003Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2332,9 +2332,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:38 GMT
+      - Mon, 30 Oct 2023 07:29:51 GMT
       etag:
-      - '"3c001330-0000-0100-0000-653edbe80000"'
+      - '"3f005172-0000-0100-0000-653f5a890000"'
       expires:
       - '-1'
       pragma:
@@ -2353,7 +2353,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-k6wgjmj7wz23xxlwj/providers/Microsoft.Storage/storageAccounts/clitestload6ztzaj4yi/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ed4atfhrtrrwsqq66/providers/Microsoft.Storage/storageAccounts/clitestloadw7n74q4dp/providers/microsoft.insights/metricdefinitions/Availability":
       null}}'
     headers:
       Accept:
@@ -2369,10 +2369,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-29T22:29:29.801Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:39.148Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-30T07:29:44.532Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:52.457Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2383,9 +2383,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:39 GMT
+      - Mon, 30 Oct 2023 07:29:52 GMT
       mise-correlation-id:
-      - b5872359-cc32-47de-a6ce-c776024f97d9
+      - d1a8adf2-a48d-49c2-8702-2b95670a9314
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2408,7 +2408,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:59.4343003Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:59.4343003Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2417,9 +2417,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:39 GMT
+      - Mon, 30 Oct 2023 07:29:53 GMT
       etag:
-      - '"3c001330-0000-0100-0000-653edbe80000"'
+      - '"3f005172-0000-0100-0000-653f5a890000"'
       expires:
       - '-1'
       pragma:
@@ -2449,10 +2449,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://740332ce-4447-49df-a1bd-853a20257a40.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-29T22:29:29.801Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:39.148Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-30T07:29:44.532Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:52.457Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2463,9 +2463,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:40 GMT
+      - Mon, 30 Oct 2023 07:29:54 GMT
       mise-correlation-id:
-      - afdf70f6-7f9a-4dfc-9003-151a0aa94d3e
+      - 4dbc7601-6e7b-4d9c-aa1e-3c4d0cbd5f31
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_server_metric.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_server_metric.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:38 GMT
+      - Mon, 09 Oct 2023 19:24:18 GMT
       etag:
-      - '"920159da-0000-0100-0000-6524276d0000"'
+      - '"560063a9-0000-0100-0000-6524532b0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:17:40 GMT
+      - Mon, 09 Oct 2023 19:24:20 GMT
       mise-correlation-id:
-      - 70732de9-d689-4871-a32d-f2a160c46c30
+      - 055e8dbb-7e27-403d-860d-89271ccc530b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"50d832d8-2525-4501-94d2-2c57e3714d76": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "3c9f9403-19b1-4078-a94b-7ec8a40e17d0":
+      {"passFailMetrics": {"63ebb138-6fec-468f-abf2-8dc64b7d33dc": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "70577b9b-e56d-4d3a-beb1-80d92b045794": {"aggregate": "avg", "clientMetric":
+      "50"}, "15256d43-3829-4e81-b76b-2db1a045776e": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:17:40.757Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:40.757Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:24:20.466Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:20.466Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:40 GMT
+      - Mon, 09 Oct 2023 19:24:20 GMT
       location:
-      - https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+      - https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 47417845-e542-4719-8ebc-7638157e6058
+      - 28ae5d29-c04f-4371-82d9-35b16c3525e5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:41 GMT
+      - Mon, 09 Oct 2023 19:24:20 GMT
       mise-correlation-id:
-      - 3cfd5bf7-5108-4e79-8279-ea50c9bf4c39
+      - 314acfe9-5013-4dc7-bdc4-28e399b1e6ec
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A42Z&sr=b&sp=r&sig=IBF96qECUB5vw9%2B%2FUZCq4VpRx1KxmjBXoO%2Bpt71uNDg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:42.2444799","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A34%3A21Z&sr=b&sp=r&sig=xhmePXoIDKGuCelc8PpbSV4llExTyiaXHR4HoBGsJk0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:34:21.2707987","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:42 GMT
+      - Mon, 09 Oct 2023 19:24:21 GMT
       location:
-      - https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - d866f6dc-8609-4452-b521-444e0cacbff5
+      - 5d6e7c45-b1b9-4644-b666-b4ca739e6e2d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A42Z&sr=b&sp=r&sig=0z8zS0RUDd6PmmbxOumaxLZmKOtsiRLWWH%2FtYWex%2Be4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:42.5065749","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A34%3A21Z&sr=b&sp=r&sig=FTFlM9v%2BlZx8no%2B%2BFvS48Mxp8JmRtcfMWdRmdEiSiw0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:34:21.536365","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '554'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:42 GMT
+      - Mon, 09 Oct 2023 19:24:21 GMT
       mise-correlation-id:
-      - d04b1140-f9f9-4a51-a711-9015d79ab687
+      - 12b69f3a-2e31-4a2b-b956-0704e06e20a9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,46 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A47Z&sr=b&sp=r&sig=2z3mMuffUkvdTTgwCDGCiWcSrZM6xf%2BaHscJC4ZhmtU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:47.783645","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '550'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:47 GMT
-      mise-correlation-id:
-      - 9adea77b-5d41-4dec-92c8-c65b4c7652e3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A53Z&sr=b&sp=r&sig=Knx5pXVzP79Wsm6KVKtlNB4gepp4zjlAU4XYr4n39Ek%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:53.0406324","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A34%3A26Z&sr=b&sp=r&sig=olJnTraEMmFi2nZq4iJlaxAa55GXy5TqaJef0A1Y32k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:34:26.8194595","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:53 GMT
+      - Mon, 09 Oct 2023 19:24:26 GMT
       mise-correlation-id:
-      - e453e551-9ef3-4d5b-a6ba-e3f1693818bd
+      - cb10ef22-f9d5-488c-80dc-e8dcab2ec91e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,10 +385,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A58Z&sr=b&sp=r&sig=obtDATBnyLxR0OOtDL2qhgqgBJPPBxfGzVI%2FGntt9J8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:58.3149849","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A34%3A32Z&sr=b&sp=r&sig=Pjl5RPIb4m8vIbibWqyy3O5Ly5223PCzSytulv%2FQzTg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:34:32.1025373","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:32 GMT
+      mise-correlation-id:
+      - 3ceff4b7-5e95-49ab-b91f-b8a8943e27fd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A34%3A37Z&sr=b&sp=r&sig=sheZYCrq2f2nhy2Z1KBfSSfBnMGzV42n5roSKH%2FXQs8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:34:37.3808096","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:58 GMT
+      - Mon, 09 Oct 2023 19:24:37 GMT
       mise-correlation-id:
-      - 7059adf0-9b92-46cb-a3c6-d557b116c2ba
+      - d2d0a8d4-db28-4b99-a355-8aec35f70c82
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A58Z&sr=b&sp=r&sig=5R482S%2BayWetpanhAGApg1FAjXWiDyaEIidW1UToYwY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:58.6629526","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:17:40.757Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:55.733Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A37Z&sr=b&sp=r&sig=a5CYGkqfnWaOQnj3lvRNuiNvl2cX%2B9lpBuI1Lk322wY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:37.658286","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:24:20.466Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:34.407Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1586'
+      - '1585'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:58 GMT
+      - Mon, 09 Oct 2023 19:24:37 GMT
       mise-correlation-id:
-      - b70a2f8a-6345-402c-8773-852752253973
+      - b64b7f7f-938f-41d4-bf2a-1f5b7f6bc134
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:00 GMT
+      - Mon, 09 Oct 2023 19:24:38 GMT
       etag:
-      - '"920159da-0000-0100-0000-6524276d0000"'
+      - '"560063a9-0000-0100-0000-6524532b0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A01Z&sr=b&sp=r&sig=P9ELFQ25T%2B1p5YuFQKZ0TiZ%2FqbQqOEkT7VUVWKfADTc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:01.2257897","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:17:40.757Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:55.733Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A40Z&sr=b&sp=r&sig=YSWWW01221ey4K660On1XCFpzJyX46LfwSXEKrEThL4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:40.1814181","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:24:20.466Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:34.407Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1600'
+      - '1596'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:01 GMT
+      - Mon, 09 Oct 2023 19:24:40 GMT
       mise-correlation-id:
-      - efec835e-4765-4807-923e-b6f21cbf6b11
+      - bb248259-f51d-4e2b-8d55-40320236dbee
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:02 GMT
+      - Mon, 09 Oct 2023 19:24:41 GMT
       etag:
-      - '"920159da-0000-0100-0000-6524276d0000"'
+      - '"560063a9-0000-0100-0000-6524532b0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:18:03 GMT
+      - Mon, 09 Oct 2023 19:24:42 GMT
       mise-correlation-id:
-      - 91415f42-95b3-454e-8dc1-db566e239dea
+      - eef73c1d-c33e-4db6-b7e9-cc1dd77f3d8f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A05Z&sr=b&sp=r&sig=cOd0D9A8WJQb1BbN9U0i3Pz9wgZMgYCplc1JNa3V1%2BI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:05.0365883","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A05Z&sr=b&sp=r&sig=ti3uTYaebSGy4I68isjXy9VIvJ2edYdMoVnEkrJMS10%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:05.036447","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A05Z&sr=b&sp=r&sig=lSykaN2QNx1nkjrAK5fEUiFfy8rwT6IXYT%2FIsHlaKWQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:05.0366097","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:04.965Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A43Z&sr=b&sp=r&sig=56OwgTuT7l0Zuafx02njUheK00Iy9BobhJ8fAeN%2F4LM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:43.6640467","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A43Z&sr=b&sp=r&sig=QeHMHTUlj%2BrzXrW2pzKl3xTy1iyvhbYIgZ%2B%2BBpgsq9Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:43.6639215","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A43Z&sr=b&sp=r&sig=80YspEgrPKh9YrgdvVcvYLAYjYrKbiF9UVSu9dkmXPo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:43.6640745","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:43.594Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3186'
+      - '3190'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:05 GMT
+      - Mon, 09 Oct 2023 19:24:43 GMT
       location:
-      - https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+      - https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - b9e35488-00a0-48df-b293-335ab0d9b873
+      - dab5024f-c043-4dc1-b47f-b9691ae1a7b4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,10 +700,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A05Z&sr=b&sp=r&sig=Kia1SxHXVRSS1uM8CYYfIM87%2F77VU8fpXmARRh8Kh%2FI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:05.5265935","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A05Z&sr=b&sp=r&sig=5N1D2gzSQVsK7fTDK2eECdllaooJ7Dm1x2ztuTTY63w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:05.5265211","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A05Z&sr=b&sp=r&sig=rY6OE0SK7ldfNVFSvXXb6LHc%2ByleGrC5uflIyHjFmK8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:05.5266096","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.406Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A44Z&sr=b&sp=r&sig=AOt1zyWWwU%2FvmQH24bYGGkEgV4chGA22AhRh7ECggUE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:44.1484293","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A44Z&sr=b&sp=r&sig=g1UTTpTy7xsyPnPVAvpTEQn2M0PLwv8%2FliBgvRIT03g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:44.1483446","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A44Z&sr=b&sp=r&sig=pd0cl%2B37VxCjkzDE%2BWzaWroZfB2z2y3fOwr0b85dcbw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:44.1484455","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:44.003Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:44 GMT
+      mise-correlation-id:
+      - ea8eb7a4-71e9-4959-ab8a-3d05bf408504
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A49Z&sr=b&sp=r&sig=9RKLAT6lL5q03AVv8rb10CnGGH24BgdpdjFCXBJaOEE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:49.4365896","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A49Z&sr=b&sp=r&sig=WynPU7rj9233Lwuzy9J17bVib9%2Fk0IVtFXxH4JMkwK8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:49.4364932","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A49Z&sr=b&sp=r&sig=tyLPNw7JuX7yMD3gZWmQkwtK59Ti%2BkEQ%2Bh9ZxkPvPNA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:49.4366098","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:44.204Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:49 GMT
+      mise-correlation-id:
+      - fb4a3b1b-4fce-47c7-9018-4e9fc0832e1e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A54Z&sr=b&sp=r&sig=3VqxPrDGjUkYrkGUfMSbvw8I2%2FsMT9eFfmGO%2F3GKj60%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:54.7514495","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A54Z&sr=b&sp=r&sig=zsRsMOoLQxQFR2ki8OsqxqeNNF1eOcpS7JkQqLc2kh0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:54.7513676","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A54Z&sr=b&sp=r&sig=Wr8YJYm%2F8AL9oEe2EdvT8LwWeWI%2BWz24WOFthfR9cJc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:54.7514676","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:44.204Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:54 GMT
+      mise-correlation-id:
+      - 25107e9c-d2b4-43fa-84a3-9429f717a56d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A00Z&sr=b&sp=r&sig=WBEJywxLpMU3UFurHkcTX6LeUqE8gFcnLyr7i4jasTU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:00.060243","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A00Z&sr=b&sp=r&sig=EsB93OmehXiLgdMAE8ZlOBokwV0Lu01R6c%2F8QI7HH58%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:00.0601417","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A00Z&sr=b&sp=r&sig=%2FjuGb76YZFNxuYmc4hggXsKJhFQYsWBgM%2BO28w9jJGI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:00.0602666","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:44.204Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -714,9 +822,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:05 GMT
+      - Mon, 09 Oct 2023 19:25:00 GMT
       mise-correlation-id:
-      - dd5a7869-6ab3-4e88-8853-4c46528b0eab
+      - 29f7d870-5ce0-421a-a0f2-a6ec1a70247a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A10Z&sr=b&sp=r&sig=4W4sCSem8WfUdSieCWSEe6Tr4dfV%2BAX1o4eFFskrZd0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:10.8151027","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A10Z&sr=b&sp=r&sig=XEJkZDpHEjl4ZO25Di16TcbFE2sUqhOt7KIiV2lh5Cg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:10.8150164","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A10Z&sr=b&sp=r&sig=Pe0BhMK5ppWhq4rP%2BHHlo24khonxg3NSV45i6hgtehs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:10.8151238","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A05Z&sr=b&sp=r&sig=2D%2F6fj%2B9qHWLKopQtRRkO6kgzTk%2BTfS%2BF4v4hZfaovs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:05.3434934","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A05Z&sr=b&sp=r&sig=ouPjRvoD2V5OuJr6KCeb05KZY3FJykCw1gn6ztSDOSc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:05.3433897","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A05Z&sr=b&sp=r&sig=v4Tywmr%2Fpt%2FIxHpFRDfQKKXQlW3%2BvmUi%2BXRn2rnFSkI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:05.3435165","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:44.204Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3234'
+      - '3245'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:10 GMT
+      - Mon, 09 Oct 2023 19:25:05 GMT
       mise-correlation-id:
-      - 0f16662d-fbab-4229-9c36-8c5399339e92
+      - 73561e84-6b28-4ce8-8180-55b85dc6329e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +880,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A16Z&sr=b&sp=r&sig=j4pgitkY%2Fvnts3D2OpnMzZZewL7uZRS64p%2B%2Fl36J1Dc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:16.086683","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A16Z&sr=b&sp=r&sig=sd%2BYP844TBqcSdMGzcyITYWlEkLVYsLFz2TG3UR62CQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:16.0865975","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A16Z&sr=b&sp=r&sig=lX6DK9Z84ygMIfvJEeAr9PICOzhs1WUqotxHkmBTkkY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:16.086704","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A10Z&sr=b&sp=r&sig=uAa5X00BWPh%2F5K%2FhZs6MYxcQ7YIukgrVrUv3xVXB9LE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:10.6268601","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A10Z&sr=b&sp=r&sig=3jBnBL5qBktm7JcUDijw4yxmDtYN%2BrgjtrLlsxZy1uQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:10.6267758","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A10Z&sr=b&sp=r&sig=skc1mtiYLc01h7SReNGUGGe7kMRnvlcj13cvGGP1JXI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:10.6268806","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:44.204Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3236'
+      - '3235'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:16 GMT
+      - Mon, 09 Oct 2023 19:25:10 GMT
       mise-correlation-id:
-      - 2e4aa907-d07c-432e-8a7e-c7ab7ebb946c
+      - e7ff620d-ce72-4ed8-ae6a-cff5108395f1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,10 +916,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A21Z&sr=b&sp=r&sig=grfPufuSn55%2BivgTUDwRYGIQ87XhyJ4UwKrr5MXaCPg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:21.3589417","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A21Z&sr=b&sp=r&sig=pGGPGExhsK8CLOlI%2Bg6uqBdH4USyo8U4Pa6KuvIrQpE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:21.3588733","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A21Z&sr=b&sp=r&sig=8RNQys8xQDy1zNs%2F3DHntV7svZfQpDjDbtMVA%2F1KTKQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:21.3589577","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A15Z&sr=b&sp=r&sig=ll5AGMgzCe7KpdTjQD24yRA1BJSAkVJbj1%2F8WKIBVd4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:15.962599","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A15Z&sr=b&sp=r&sig=GrOzVokzHCFcEZLdQbmaXKFK2O%2Bu%2FjY2095stuT6Dzw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:15.9625142","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A15Z&sr=b&sp=r&sig=NJdj%2FLFmnFRshx%2FyoP7CCghjxhn7QiVmEe5GvwVIAxY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:15.9626164","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:44.204Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -822,9 +930,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:21 GMT
+      - Mon, 09 Oct 2023 19:25:15 GMT
       mise-correlation-id:
-      - ad98228f-c025-41ed-9b4a-3498a232ab7a
+      - 37c9874f-dbfd-4820-9245-180d829e387b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,23 +952,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A26Z&sr=b&sp=r&sig=mltKTGjoLOgEBWh88dUnb4ITsU6jDSUe%2F6ZdbDrxFDQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:26.646696","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A26Z&sr=b&sp=r&sig=bCcOJWomZWP3RNczjGinaADmq9ZMD83NN%2BcHDiQqRFU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:26.646588","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A26Z&sr=b&sp=r&sig=PaLRMosfjzxdOJIfYcBap97yVnefIGM6AdPGtu6aB9k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:26.6467233","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A21Z&sr=b&sp=r&sig=DY0RCzPBXuwnWXRlRfIngyYDFJ4ZnBMZCJDiitJmEHo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:21.2467402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A21Z&sr=b&sp=r&sig=fOL2hHFzSdh1ekKyDeZ0F23jDOtnyoErLY43kaxuXVg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:21.2466581","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A21Z&sr=b&sp=r&sig=dhe3fINSChSabhwPukGs0wqsvsYEzQinAVumq0S2Vc8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:21.2467564","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:44.204Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3232'
+      - '3229'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:26 GMT
+      - Mon, 09 Oct 2023 19:25:21 GMT
       mise-correlation-id:
-      - 81b1debc-c006-4cc7-a450-5e778eff053d
+      - 3c218217-b7dc-4d31-8731-e6e3371f5c64
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -880,766 +988,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A31Z&sr=b&sp=r&sig=WnzMs23%2Bjdds1Kp0WtcGBn2AC%2BoMGQp6xlABQpSxxQc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:31.9776947","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A31Z&sr=b&sp=r&sig=8Vm4sc8w%2BTVrvfsp1%2FQ4m3pO4DoD%2FV8kYN5exLjS1bM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:31.9776115","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A31Z&sr=b&sp=r&sig=89rs1PL3tqjrHIEK5a6029BwyIyDfgy6%2FJHhFT0zK3M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:31.977713","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3241'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:31 GMT
-      mise-correlation-id:
-      - f7381d5a-46db-416d-9919-96e9baed7a59
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A37Z&sr=b&sp=r&sig=wS0I34JqKHBtXN8C6az2UcTZb7jtfTu%2BTZB5Q0waeWc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:37.4906732","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A37Z&sr=b&sp=r&sig=AQqCdpMagaev%2B7%2BqCd%2FKtgcocu00tJlKmF9vB4TJ7%2F0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:37.4905977","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A37Z&sr=b&sp=r&sig=4rDMTMsyKsnsg6x3VerPGE0JAOgCuxfwPZaLwhUGcTU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:37.4906902","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3240'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:37 GMT
-      mise-correlation-id:
-      - e9f3f7ab-84c1-4372-9df4-5bc0a5f8b4b7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A42Z&sr=b&sp=r&sig=MMyi5l8sp3lca7pwn%2F6O1JubrU2wH6xCBjHpPUzkUQQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:42.771467","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A42Z&sr=b&sp=r&sig=pN8y3sYbVSmNWJOEooKjM8wOHnwA52YoejGnlExRBKE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:42.7713774","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A42Z&sr=b&sp=r&sig=TQ6W968HVimdIbuUTafEr9N0nNZ59%2FUcedqEk3j1Rh8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:42.7714813","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3233'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:42 GMT
-      mise-correlation-id:
-      - 86bd1b5d-7032-47ad-8db5-511e4b1ee8b0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A48Z&sr=b&sp=r&sig=LrPKu7BjmDRK855tcnBE3gEH1CXJAKW0%2FvRCtQMjXVI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:48.0541866","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A48Z&sr=b&sp=r&sig=bY1tsU2%2BlMF8APr9YtegAloCVVx1kDKgAXKJelVz86Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:48.0541148","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A48Z&sr=b&sp=r&sig=UNW9KCwIBO26t0emCLAcSkrFY2mWFT3yHPI0mutvr1I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:48.0542004","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:48 GMT
-      mise-correlation-id:
-      - 53018a23-cb10-4747-be7d-7c41064f575f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A53Z&sr=b&sp=r&sig=gZRGhtrqa8dm5H4MQ9WODwAzT5nbCtuDYITgINEbj7o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:53.3289622","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A53Z&sr=b&sp=r&sig=9K%2FzpzHpnVgRMOu8k8coj7wWSYkgMLdAaRTbce%2Fy2YM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:53.3288734","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A53Z&sr=b&sp=r&sig=74x%2BJ9ZLrBrVw5f2HHcoACWAekOdNEqGEyPU%2FrVJUQc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:53.328983","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:53 GMT
-      mise-correlation-id:
-      - 5eb9e1a9-fd12-4dd6-9302-a264b1bc24aa
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A58Z&sr=b&sp=r&sig=XyqB63D2rsvg%2FBgn%2Fvs9xAPTL3ZMtLWtdkqJb%2BjbugQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:58.6122484","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A58Z&sr=b&sp=r&sig=wJN4ylg1tdK7sf3%2BkmzHqts2Md%2F6ayakb53afN%2FXldg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:58.6121753","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A58Z&sr=b&sp=r&sig=Q3OxilVPZljUWlk%2FkBme%2BANwjOxhbJedCsj%2Fuhr2GU8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:58.6122644","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3248'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:58 GMT
-      mise-correlation-id:
-      - c46c8ca5-0d43-4ee6-82e5-3c0bcad4ccb7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A03Z&sr=b&sp=r&sig=Ncz1DdDAmMRTG%2BcirGyYCV%2FPclGNfS5i38wMeJEkyZ8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:03.8807834","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A03Z&sr=b&sp=r&sig=kj7U9eSAMmWBacIl2acLv3%2BjPYCNBpiRperl%2FN6HkhQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:03.8806933","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A03Z&sr=b&sp=r&sig=Yd5ag7%2FfDStXVUMSe0VytmAUVvyqd88R34BxXg736OY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:03.8807987","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:02.484Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3239'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:03 GMT
-      mise-correlation-id:
-      - 3046feff-f032-48e2-bc6c-950a31445089
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A09Z&sr=b&sp=r&sig=s229Q0fkfEsfdr53t2fBhMK4SBZXEpSdAinpp8wGzl0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:09.1629419","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A09Z&sr=b&sp=r&sig=ryIDGxzq0ANG0Up8wUiXsacT0KPcGXwPRFzKAUqFBN4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:09.1628525","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A09Z&sr=b&sp=r&sig=U32sWZrItrzoeTZVYY%2BK82PmBMAZ1Fk0mRsTd%2BfSNDA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:09.1629628","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3231'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:09 GMT
-      mise-correlation-id:
-      - 77c37db4-086e-448a-b4bb-0f2c1c8fcef7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A14Z&sr=b&sp=r&sig=IPMqc4XAXuW%2FC%2B%2BWSSkZmX%2BjIo8iJZGpr1ZiEcC65h0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:14.4454125","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A14Z&sr=b&sp=r&sig=ShTiaj%2Fw05rSE8t5CbJut5gb4fbq80M9cwhsGqGJAIo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:14.4453199","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A14Z&sr=b&sp=r&sig=B8NwHPn%2FUYjpyB%2FL42YIEjGn6qQkoEdzr6HIloZXpe4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:14.4454348","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3241'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:14 GMT
-      mise-correlation-id:
-      - 3500a041-f37d-4db0-a0a7-e5f815f9c2d8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A19Z&sr=b&sp=r&sig=GQSGjG7JC%2B5nLnBe8JpVjLxIAPCg90ddud6ZJK9MSLQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:19.7191356","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A19Z&sr=b&sp=r&sig=IEHV4u5S6dqrS%2FMnWt8RdwwqJr4Ak5zH2YXYgKdt%2Fs0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:19.7190667","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A19Z&sr=b&sp=r&sig=%2B1LZSX%2BmzkuWSaUg7hZb5pFGklGytIyaVHimgX5fUR8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:19.7191515","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:19 GMT
-      mise-correlation-id:
-      - c601bd66-acf5-43a3-be60-ee1b88def404
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A24Z&sr=b&sp=r&sig=CesKQjy%2B1JZB6dxKU7et3cdssmwrRvMLMEJjAwiCRBg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:24.9943909","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A24Z&sr=b&sp=r&sig=qOyf3fUyFbVOM22jIKlCWeEiARe8HcqUZuXXw3s9%2FSQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:24.9943012","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A24Z&sr=b&sp=r&sig=04UhfDQa9r0XHZQUyiEkJDgNzpFQpp4cbwWyXTtECjc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:24.9944135","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3231'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:24 GMT
-      mise-correlation-id:
-      - fabe40bd-49a5-497b-b373-769479d40f82
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A30Z&sr=b&sp=r&sig=v5KQTveDO1%2Fy8s2BalhMTWHksLW28EB4TuKVuB2f%2FdQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:30.2690336","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A30Z&sr=b&sp=r&sig=yTFvdK8dRgmBHmolYqdn1lAj6B0fAdalm3ZzRhB8frk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:30.2689345","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A30Z&sr=b&sp=r&sig=UFH6%2F3xtZ13o0PaSWIDmO48geTZ3R8MvBeIA14LFtwQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:30.2690514","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3233'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:30 GMT
-      mise-correlation-id:
-      - beab3c48-cdbb-4316-b6e5-3814d2a921fa
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A35Z&sr=b&sp=r&sig=FgW2oC0n0jG6DfolA48Z2bnoz7x5CIq9ILiaMnM1iiw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:35.540172","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A35Z&sr=b&sp=r&sig=zcYU4zFmL9KBRU3heGrFZ4PeKzDCxkggPxKG29NcyNc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:35.5400777","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A35Z&sr=b&sp=r&sig=dBKms%2FQXqQWYOzIJb3S%2B7JanSPR%2BqoVpAtM1fzZKqwM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:35.5401943","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3232'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:35 GMT
-      mise-correlation-id:
-      - ba35429e-20a4-4786-8fd7-8109d90f877c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A40Z&sr=b&sp=r&sig=gS5sTvTBPDClw3T%2Fd8lMF878enx0cmybS3MaqH3F%2FSI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:40.8061572","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A40Z&sr=b&sp=r&sig=0ffM2VUMfOKEQjENAbdqcZF7TWEjL3B4IpsH9dCYRGk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:40.8060875","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A40Z&sr=b&sp=r&sig=La66F20lCo2IXXNq5L2whv05CzUu9cVOx6ld4wZBqC8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:40.8061711","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3231'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:40 GMT
-      mise-correlation-id:
-      - ee546845-8d69-40e1-a9a5-61e5652456db
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A46Z&sr=b&sp=r&sig=QWGCZavDMNFpQT5zTHIMTXVadMx8%2BHKVkDlM%2FFFILLs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:46.0846306","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A46Z&sr=b&sp=r&sig=Johzh5hORId5qkojc%2BjqyW4nslT8Gw1chzqZxvmt3Hs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:46.0845586","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A46Z&sr=b&sp=r&sig=%2Fh4EcuU%2BJ0ehFgHZ8s4qwjXl9rTRaqlqRguqFoF%2FyIA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:46.0846475","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3239'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:46 GMT
-      mise-correlation-id:
-      - 2b046c48-c558-484a-a1aa-747a09fadc38
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A51Z&sr=b&sp=r&sig=TMku%2F5tR%2F8JYBaAVQp67JeghiyoCCJ7hKhW6dvBH1xA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:51.3506298","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A51Z&sr=b&sp=r&sig=jN3DJq4n7jhWUOPCcZ1xSjVqFeC%2BkdGyL2IeaHP6Tow%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:51.3505659","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A51Z&sr=b&sp=r&sig=QFJigdUTtc5dXPJEaYj41w%2BZPjf4Dcm4%2BFxKOXTDvnc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:51.3506455","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:51 GMT
-      mise-correlation-id:
-      - 67c11e88-f8da-4de7-9ee8-31e085182e3f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A56Z&sr=b&sp=r&sig=Xwc6PHugsR%2F7lw5e8eLOQsw3SG5Fg6YPmxHepKI%2BTbo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:56.6432022","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A56Z&sr=b&sp=r&sig=4T0Jfx8SiHfH%2F8sYBzMgD4Jo8Gd4JgG%2F%2Fir5%2BroRw9w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:56.6431227","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A56Z&sr=b&sp=r&sig=%2F13PQgc25nfOZ1oDHy9JPAzkXAX95JAuUI%2FY81wbI4o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:56.6432193","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3243'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:56 GMT
-      mise-correlation-id:
-      - aa838f73-35ea-4959-bccf-243fca38a2c0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A01Z&sr=b&sp=r&sig=TlFSSurb4ioK5cwiPRYOfDHKQFhMNvclMmSe0PgGrv4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:01.9251704","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A01Z&sr=b&sp=r&sig=m1sv0%2Bzc2b40VfwV0yytm2SAg4U0GXv7TjpqBYn5YjM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:01.925067","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A01Z&sr=b&sp=r&sig=GSKvBNQcRZe27Om6i3upknz7upOnjZwW9fDKEF95ExQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:01.9251934","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3228'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:20:01 GMT
-      mise-correlation-id:
-      - 70e17bfd-a4d8-4a15-9926-8fadbc1a9d76
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A07Z&sr=b&sp=r&sig=s06QBqCSAAWMESZPWIIH5%2FBldBuVA8Agb%2BLAym9PFMo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:07.2031878","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A07Z&sr=b&sp=r&sig=MATTzW6qlvj2IhzT31ZNnK6NO7G7AwjrJnwFlXyLfus%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:07.2031226","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A07Z&sr=b&sp=r&sig=y4sLLPxQmjVzQqO52mY5tWAQFxIV4lyF4%2B4x5jH8ROA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:07.2032029","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3233'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:20:07 GMT
-      mise-correlation-id:
-      - c1d0a5f2-8519-4dc6-a4ad-f9fdf43dc8c6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A12Z&sr=b&sp=r&sig=hyWgPupcXQNszSTrJZPAMSVUUEbaFIiE7AyjtEV9%2B0c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:12.4942502","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A12Z&sr=b&sp=r&sig=1HHv7YTZo3zAP7asNY%2FkGCtIx00hJ3kXbou1fgZTxPw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:12.4941498","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A12Z&sr=b&sp=r&sig=DON1hxXyD2%2B3lFjQ%2F4MUvfxOZ125rzlEpGrnVeqS%2BG4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:12.4942776","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:20:12 GMT
-      mise-correlation-id:
-      - e51d8249-5231-47ba-beb8-5ebb4d685863
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A17Z&sr=b&sp=r&sig=wfMxJM2Iu%2FMok%2BYrlL%2BySDBX6H0nHcm7gvjTsfVApRM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:17.7705515","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A17Z&sr=b&sp=r&sig=yopfTCIlyCXaaWkbxap63%2B%2BoKrGwMASYtGfCfj6enRU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:17.770454","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A17Z&sr=b&sp=r&sig=B02D1U4TX5vOjvAsJmVqoY5iFdSthXNRT8ZLqXvqaVs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:17.770573","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:20:17 GMT
-      mise-correlation-id:
-      - 598b3d84-be7c-4c50-a727-803a66f15253
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A23Z&sr=b&sp=r&sig=WI1fCrYGvi7%2Bz8YrdRoPZ0KSjNWpPnct5kJW5Hy%2BNQ8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:23.0520483","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A23Z&sr=b&sp=r&sig=7GovyAetTOC2XQglh4hVsSv%2FV5u4MH1WDhyljEDx7yk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:23.0519708","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A23Z&sr=b&sp=r&sig=2angoIVWzvMnswSkv2zc%2FrBN6cAxxsDF0jLm5jdg%2Ft4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:23.052064","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A26Z&sr=b&sp=r&sig=jwx%2BTCxs5MRxtBDOrJUtzshaMlyifCUqIu26VF8jXCM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:26.5273015","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A26Z&sr=b&sp=r&sig=J0MLHInmHwr2cNrm7FPtd8l4k51qpNeBffEB8unOYu8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:26.5271899","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A26Z&sr=b&sp=r&sig=%2B8%2BUWBgDemyioNAr5bmleqMtJAxugzxwa4R5%2FUIT7C4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:26.5273209","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:23.687Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1650,9 +1002,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:23 GMT
+      - Mon, 09 Oct 2023 19:25:26 GMT
       mise-correlation-id:
-      - 24fd52da-fb44-4016-b9dc-3b817775bf76
+      - 3898c49f-a882-4e2d-84d1-b27261c5c6d3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,23 +1024,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A28Z&sr=b&sp=r&sig=KtlufDexmLaYPkg89Ucub%2BIevViKILV6tYZnIOiukZY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:28.340713","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A28Z&sr=b&sp=r&sig=AmaUe4MQf3q5Kq2Oit5aE7GvWvD1luBXCjYK69QpJGg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:28.3406172","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A28Z&sr=b&sp=r&sig=gF6Pq5Vd5m5oK6b0nN4HxaPyoig6ASZENuMH1JTzXIU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:28.3407349","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A31Z&sr=b&sp=r&sig=9Vg8pnua2jSxl3yiLDNzr4ScDPrYBItem8nI2V2K6%2Bk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:31.82818","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A31Z&sr=b&sp=r&sig=W3e7EsFV7%2FKfSHDC97TgT1V%2But%2BxLWFHzB4W680vHyA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:31.8280874","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A31Z&sr=b&sp=r&sig=bMEQQcNzn5T0jmwyElWAdVi6TCsC1i%2Bq0xdVY6%2FIg9E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:31.8282003","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3228'
+      - '3236'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:28 GMT
+      - Mon, 09 Oct 2023 19:25:31 GMT
       mise-correlation-id:
-      - 0509ed82-1816-48bd-8735-f063f9837e5b
+      - fabb884c-874a-403f-a58f-19f2978b4bbf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,10 +1060,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A33Z&sr=b&sp=r&sig=as2QKbjmx2tur4A491AA%2B4O%2BVinATZtvQylyBXUTMZ8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:33.6169446","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A33Z&sr=b&sp=r&sig=iOIgTJEVBuQNZMVIIte7%2BzlA5n7zEbcdWuCV6dnOqvc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:33.6168681","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A33Z&sr=b&sp=r&sig=47tXfUHfIpTTe1lZlohAAvv9pdo4%2FmxM%2BqDW0eNeyWE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:33.6169589","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A37Z&sr=b&sp=r&sig=yz6xdBj4zzjhbBJh6yLBLTL5rT6xUq2Zqp0j8%2BToAzw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:37.1184495","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A37Z&sr=b&sp=r&sig=kocQCpZuuwNsBPoh2C1VZSKuqCESj9vDdqlxvA49wro%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:37.1183491","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A37Z&sr=b&sp=r&sig=2u7v2Dowtge36%2Fduk8QvUl4pldoDoQgK4xqdPFKFeR8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:37.1184699","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3230'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:37 GMT
+      mise-correlation-id:
+      - 58c9fb00-43d3-4080-9c4d-33a53d94129e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A42Z&sr=b&sp=r&sig=MfCiarUIZI3IPL0BS6FEINEzI%2FZ2dB1u9E3UPvlJOt0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:42.4681175","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A42Z&sr=b&sp=r&sig=7bFrp6T%2Bi%2Bwa37gWeVw3w9AZW4qfFiRUWA9b3%2BcZ734%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:42.4680403","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A42Z&sr=b&sp=r&sig=%2BQATiio37trO6bmopXGK7D2Bi0JBHKA8GaAKuKK2ebg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:42.4681331","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:42 GMT
+      mise-correlation-id:
+      - 9bae7e1d-1c7e-4006-8f68-7bd55a13ccbf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A47Z&sr=b&sp=r&sig=AGTOaonk4i33Oz4c2V7XDNemb4104E7uqEPSd%2Fk7wM8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:47.7772028","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A47Z&sr=b&sp=r&sig=QuNoaQ2%2BxGvLTxjVpV96NFrJ9LKCerjlQFXJ9sZgYYY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:47.7771356","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A47Z&sr=b&sp=r&sig=zPJJqPo7aUm89pzOfxNtqIDhGHlLLSY1E6PyFAc4deY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:47.7772182","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3230'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:47 GMT
+      mise-correlation-id:
+      - 27c3e164-2d27-45b8-a09b-01bdba2b75ac
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A53Z&sr=b&sp=r&sig=rwi3%2B2iOqSKgXFy1Bo7%2Fs8phlMo7Lq6MgIik%2FvONqn8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:53.120267","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A53Z&sr=b&sp=r&sig=RjPX8bab7gX1HM4Mg8FSF7vfpqyXTQn33BnDw67%2B%2FQY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:53.1201724","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A53Z&sr=b&sp=r&sig=hnhysdA4V07eCxMGB8SG%2B91WY7BGbalETjLAJxYELUs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:53.1202876","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1722,9 +1182,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:33 GMT
+      - Mon, 09 Oct 2023 19:25:53 GMT
       mise-correlation-id:
-      - ac13bfc5-86f6-4c9f-88ba-2efb6e2eb598
+      - 176f9b99-7cf7-4a62-8ef7-bb7c4079e5b1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,23 +1204,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A38Z&sr=b&sp=r&sig=IWYbUM1csflyRw01gblVuDEsdgyPw5uUnkE9At%2Ff%2Fc8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:38.8917836","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A38Z&sr=b&sp=r&sig=QQmpQ2EbZ0g%2BkWMS4D9UDED7cU%2FlAZXimA1WarFNvFo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:38.8917075","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A38Z&sr=b&sp=r&sig=uPVKxsVuD7oOf9M5nCipwaEMk3cGlTvAoSISr5abSkY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:38.8918066","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A58Z&sr=b&sp=r&sig=nABgAJcReGZgZ7Ui7l8p3leEKr4MZnU4uLdsnqGmtU4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:58.4564483","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A58Z&sr=b&sp=r&sig=pddOWPkT00JRY%2F81tFEx%2BCY2eX6Xl0u52IDEsmXp59c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:58.4563712","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A58Z&sr=b&sp=r&sig=FfYXWJeJChHOPt5MEdW1bW912e%2FxtNNFfWKg4lUUvbI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:58.4564626","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3235'
+      - '3232'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:38 GMT
+      - Mon, 09 Oct 2023 19:25:58 GMT
       mise-correlation-id:
-      - 08d41b6a-fe48-482c-82bd-dfbf24ffa40e
+      - ece2c170-7f7a-4c04-bac8-1e5664172e4f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,23 +1240,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A44Z&sr=b&sp=r&sig=CC1wXDj6PMZMs4bdVMJyVUt2F6sVCnZ95dzZQg9DYHQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:44.1840301","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A44Z&sr=b&sp=r&sig=%2Bbl7o6cR%2Brj80SoTNrgzuVUsfz2HXQrZmJNq8Kd8iJQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:44.1839192","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A44Z&sr=b&sp=r&sig=RsidXRl67Kx970HrggiF%2BffXmtBFFO%2BVcrj2mrFfefM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:44.1840699","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A03Z&sr=b&sp=r&sig=DkomZbWjYU0FS4ug8%2BSU9LP9Yw6bHC6wumknR5GlLTU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:03.7817156","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A03Z&sr=b&sp=r&sig=c%2BKvhAOTLSdS6G9vyZ3jp3D9ZTX307y600ldFYHzADw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:03.7815849","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A03Z&sr=b&sp=r&sig=LChyyJSYcWeu6GtjgI1ZwD2YYetg1Lm65Ta%2BoH%2F2VwE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:03.7817405","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3235'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:44 GMT
+      - Mon, 09 Oct 2023 19:26:03 GMT
       mise-correlation-id:
-      - 922a6af1-35e1-43b7-83cc-4fef0b77c228
+      - 03dac710-5609-4d79-8be9-ec912b0e285f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1816,10 +1276,154 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A49Z&sr=b&sp=r&sig=V4jrOXvP4QCIffydaqmtr7AJr3a3cnGvHzkwDnOJ%2Fjc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:49.4582538","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A49Z&sr=b&sp=r&sig=rp3bRvngKM4xEzBZWmx91dFJWIbNP6PsPR3doKdRWSc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:49.4581757","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A49Z&sr=b&sp=r&sig=t8vKyvW1Zt5nfTnFfacfUaVYY9n5opaoidtFyCp%2F%2Fjk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:49.4582684","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A09Z&sr=b&sp=r&sig=vb%2BiKdQp3iS%2BGcAh42yaIceQXy9QMQQmsk%2B9zatbHH0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:09.0609306","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A09Z&sr=b&sp=r&sig=NeP5FMt%2FTk41eGdHkEPdMToDSxfWyZjEcPTskqukiag%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:09.0608433","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A09Z&sr=b&sp=r&sig=YSS%2Fh5jYCrrdUQxNPzrE18WHmoBjkvqWwy2kMSusSLo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:09.0609539","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:09 GMT
+      mise-correlation-id:
+      - 4f437b3e-bf5f-4a36-883e-e7f018255396
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A14Z&sr=b&sp=r&sig=bGuhQ6OQk1c2b9KtxBRABvLI4II35sq9E%2BBlOGxf2n0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:14.3386641","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A14Z&sr=b&sp=r&sig=SltGBRnRXuxD0yeNnzfq%2FILNFL80gwSCXN0j%2ByWQtaM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:14.3385677","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A14Z&sr=b&sp=r&sig=W3JfSYfTpoP24TXbu9QDn%2Fz83vlX4S75sKPqdaTFa3s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:14.3386841","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:14 GMT
+      mise-correlation-id:
+      - ef2e4daa-c486-4c1f-883a-5c471a7208d7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A19Z&sr=b&sp=r&sig=HeiGUMqrbyvHvnWvecFJfdaAM5Ld28QdldMs7Oz3q%2Fc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:19.6474378","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A19Z&sr=b&sp=r&sig=HhwtpgdJluufzHpKMlGe9GyUqESqB1%2F9KFwW4ctmteU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:19.6473309","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A19Z&sr=b&sp=r&sig=RdCwgZG88yum8ShxbDw4yfyzFQoXWZ0tPz7TtSayjdc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:19.6474623","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3230'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:19 GMT
+      mise-correlation-id:
+      - e8f6706b-bfb1-4945-ba9f-29e85bae7e9c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A24Z&sr=b&sp=r&sig=YUU%2BdmktIghC0KuAJsPs9CiD%2BoCBBKEvsArZ1%2BtOAAE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:24.9628693","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A24Z&sr=b&sp=r&sig=O%2BhgospJqKhLRkunBoiTUvHnX4DLuNQS%2BsvF%2BJJPfz4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:24.962792","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A24Z&sr=b&sp=r&sig=H%2FIPOeiyhcEuKrkKVmnM7PrwnCaF3Zrtdj6y5FA2A%2FM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:24.9628867","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3241'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:24 GMT
+      mise-correlation-id:
+      - 9217e492-6148-4385-afe9-82ee73f0b315
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A30Z&sr=b&sp=r&sig=NnAcXxMsCtu5D3dyd35DqgmiNaMGFGcrMLZIoQ8TY%2FI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:30.2946831","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A30Z&sr=b&sp=r&sig=wKkA1OBgA5vobbaXJuyXMcERF4%2BMZ4mU7Xc0Hk6CLYw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:30.2946081","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A30Z&sr=b&sp=r&sig=apjJMPST3H8hFlaO9feBA%2BJrE5qcj4ayN2%2BnFu53XJQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:30.294697","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1830,9 +1434,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:49 GMT
+      - Mon, 09 Oct 2023 19:26:30 GMT
       mise-correlation-id:
-      - 715257e0-428b-4e83-b46e-e5a225fa7ba3
+      - 7001dc72-46fd-482f-bf9e-0b043ac40b9f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1852,10 +1456,190 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A54Z&sr=b&sp=r&sig=KVaFE73mgv1FBzISTLdIU5TPWYyQrHNuGapKZqMO7Xw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:54.7245537","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A54Z&sr=b&sp=r&sig=NuPGJ7nKnIpF2nQ7z2jTi3XJ5wDq4NP21ZSRo%2B8lJLc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:54.7244833","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A54Z&sr=b&sp=r&sig=K7NAfcycWRy%2BUUoLgQjxOt7noJ25Up1bvM8GouyI6Z8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:54.7245675","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A35Z&sr=b&sp=r&sig=AAPhrAsWVs1OKJtMVt8AYZrj61yk0MlXIA%2BvEaG5fr4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:35.6119136","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A35Z&sr=b&sp=r&sig=7OB9JBu5QLY7Q2%2FzkmCwmjJwiLVTD1lW%2BbUjBVUFkIs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:35.611835","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A35Z&sr=b&sp=r&sig=%2Br0BmECvAia34y83aF1q3kfnCb1z5USCarR6HdYju7U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:35.6119278","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:35 GMT
+      mise-correlation-id:
+      - 4abe2fc8-355f-4ff9-a110-62450b223626
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A40Z&sr=b&sp=r&sig=D3QiMTx4sOM0oy77LU%2FLJjmmWgPyZiWVtsRjGUmop4k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:40.9444161","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A40Z&sr=b&sp=r&sig=55sUhssD6yJGREsDILD53wU6nEAUtbP6I8u75FCdzLE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:40.9443452","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A40Z&sr=b&sp=r&sig=Wxu37WaqNd%2F4pQ6hxNCmiQxlHmCdN6G416raX9uGUxM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:40.9444412","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3230'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:40 GMT
+      mise-correlation-id:
+      - aa3ebabd-b7ee-426b-acec-20c3dbda72c2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A46Z&sr=b&sp=r&sig=UClgJYDhC%2FhWE3sWdAqtubfKDMSG0AKRjpIx1W6UvqQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:46.2606163","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A46Z&sr=b&sp=r&sig=7ovXU1IDjAzWKHpszpLpmyehR2w0j9%2F1IOuh9JMzdXY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:46.2605395","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A46Z&sr=b&sp=r&sig=RUN%2BTGJFIS977ANAeDgGlA4wm0QzwaCQ66jVtFAqQqs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:46.2606311","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:46 GMT
+      mise-correlation-id:
+      - 183a5fdd-b1ee-4f9f-840d-73b157048d13
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A51Z&sr=b&sp=r&sig=Mwum3%2F76fV1R%2BdOvibyWhia6AlG51RwtJzD%2FCJ5sOJw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:51.5853793","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A51Z&sr=b&sp=r&sig=HkHjG0PPi3WwPIfhjEpmWg4500dReWgrFKlEGAI6BhE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:51.5852967","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A51Z&sr=b&sp=r&sig=3M8JDGhuWiU2z2dGFFcFENhEdvWWAU6SgpFFRH7oVeY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:51.5854","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3229'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:51 GMT
+      mise-correlation-id:
+      - 988f8a92-6fd2-4957-ab99-786feaf1a800
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A56Z&sr=b&sp=r&sig=omDd5NRFHEJhxoTvPhAU47SnIABImcsX%2FsbrGa7QDSc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:56.8729441","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A56Z&sr=b&sp=r&sig=DiULRTqWEBUBE%2BkLfNIpSsKcBJRNu8dqTs03878HTx8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:56.8728531","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A56Z&sr=b&sp=r&sig=UYN92FTDLh8VmH0%2FYYZ54Bv6Y%2B76LuMFhHOyltsoCBU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:56.8729662","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:56 GMT
+      mise-correlation-id:
+      - 3be38cf5-0e8c-4226-b80a-44ae7b48e3c3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A02Z&sr=b&sp=r&sig=tgpX%2FERImRUrWkkmHdTkeoqpoSoHckblQxFCvBJx0ik%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:02.1517288","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A02Z&sr=b&sp=r&sig=g%2BWQwhZkH6tvwpfZI5IOBD1QPSdnldDhZd1GeJ%2BHv8s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:02.151631","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A02Z&sr=b&sp=r&sig=RHfLeZvootiypShnNHwkEHggqTwM5utj022axh1VSpc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:02.1517675","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1866,9 +1650,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:54 GMT
+      - Mon, 09 Oct 2023 19:27:02 GMT
       mise-correlation-id:
-      - 3c1f0f19-be1b-4d84-b779-389e0bb4293c
+      - cf9edc09-6bdc-4018-9f76-2ca52ba7b839
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1888,24 +1672,132 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A59Z&sr=b&sp=r&sig=leDihDW1T7jGkPnma88Rx5QPlzuU2vlFh%2FJm6wbJiWE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:59.996968","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A59Z&sr=b&sp=r&sig=YO7olv1vZ%2BmZ8twdEDdR17UU2IA2FNqEBlXtFOcdOSE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:59.9968686","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A59Z&sr=b&sp=r&sig=%2FsvfzqiDqzUvTlO9ScAPSRl33n3uCGosizrAf35enW8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:59.9969861","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-09T16:18:05.406Z","endDateTime":"2023-10-09T16:20:59.582Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:59.674Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A07Z&sr=b&sp=r&sig=7rYbJg8ZKlxj%2FWSUpH3BKq6i0ydvCwbuus%2FKYQXLLe0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:07.4582827","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A07Z&sr=b&sp=r&sig=J6IZ1wxDqAXIpzSZuvsSMmH0sR3j6vXw2ImkBTV7iJc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:07.4582122","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A07Z&sr=b&sp=r&sig=gkVkstM%2FxMJGkLt1H%2BACdZBHJSPgXttLbs52LZFeIEQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:07.4582989","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3367'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:59 GMT
+      - Mon, 09 Oct 2023 19:27:07 GMT
       mise-correlation-id:
-      - dc956d5a-4b22-44d0-a066-619d58f4cc65
+      - 6ad05047-8011-4cfe-9ba5-7f3119058008
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A12Z&sr=b&sp=r&sig=wVASu5QMeasCMIiIR86D91sfsrPuG1qCxvtW6Uelq5U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:12.7834553","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A12Z&sr=b&sp=r&sig=WniZVEGs8Mrt5iJOHwpBA9qpXJwh7NkWVDbvSOblC90%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:12.783381","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A12Z&sr=b&sp=r&sig=maXP0fq%2FxMidmtvWITRHL789n7vSCzsk4CaGZOJy0mI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:12.7834712","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3227'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:27:12 GMT
+      mise-correlation-id:
+      - 2c977a24-16d2-4bcb-bcac-294a3c13a6e9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A18Z&sr=b&sp=r&sig=licoaGjb%2BQN%2B2pYOSrw5yadVhS1Z%2FajucHgEIspom14%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:18.1242648","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A18Z&sr=b&sp=r&sig=ypAPGAK%2FFy1O28LZRGmONjVL5267h6V96RA3y7YtswE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:18.1241669","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A18Z&sr=b&sp=r&sig=hDOIuGIKj2x1y34t%2Bg3ZjLhWwjiiNZIgJ17et6dEXbY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:18.1242866","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:27:18 GMT
+      mise-correlation-id:
+      - 8f4cdfa7-1a5e-4b9a-b029-089e3c9ea96e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A23Z&sr=b&sp=r&sig=Zo3FqpZgwqZvYZ%2FXXz1q1sR%2FR8KaA751vSavVfruY1M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:23.4416906","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A23Z&sr=b&sp=r&sig=W58YM2OlSjJjx6hg7CG1Q6IVpyx6XSpSs%2F7ZKLOGR3E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:23.4415294","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A23Z&sr=b&sp=r&sig=T3NOzOHntGKGjAf%2FWMUbmBfJTkAU5Ucgwt42TjOzz5o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:23.4417518","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-09T19:24:44.003Z","endDateTime":"2023-10-09T19:27:21.284Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:21.481Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3369'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:27:23 GMT
+      mise-correlation-id:
+      - 27e2ca1b-d526-4524-be2b-48fa2ed54dfa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1928,7 +1820,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1937,9 +1829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:00 GMT
+      - Mon, 09 Oct 2023 19:27:24 GMT
       etag:
-      - '"920159da-0000-0100-0000-6524276d0000"'
+      - '"560063a9-0000-0100-0000-6524532b0000"'
       expires:
       - '-1'
       pragma:
@@ -1969,24 +1861,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=server-metric-test-case&api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=server-metric-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A02Z&sr=b&sp=r&sig=5SfeL5CkF1LuACGYGZQc1EOudN%2FzLY8FSNMewrcWcl8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:02.4801758","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A02Z&sr=b&sp=r&sig=CwnCgLH3aCUsQVuh9y%2Bn6OUZOK6ZZK5kcqYKykDZ7Z4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:02.4800903","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A02Z&sr=b&sp=r&sig=%2FN1pktG6Ul9HgUauGTsshoI06zZXzLSuwi6Vf7w5zF4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:02.4801969","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-09T16:18:05.406Z","endDateTime":"2023-10-09T16:20:59.582Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:59.674Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A25Z&sr=b&sp=r&sig=pYrK4SkPxlfw44x7wXzmiIOipbjzT%2BmHp65PXgnhpmo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:25.9162661","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A25Z&sr=b&sp=r&sig=On50a2xeIjYLNyODTDJWITopPg%2F1rqel5uJC6SbCBOQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:25.9161729","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A25Z&sr=b&sp=r&sig=5qUlJFa8%2FHoG7EMBjzbsGsAnLi5OJ9YH07i93Z6rJV4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:25.9162901","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-09T19:24:44.003Z","endDateTime":"2023-10-09T19:27:21.284Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:25.543Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3380'
+      - '3379'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:02 GMT
+      - Mon, 09 Oct 2023 19:27:25 GMT
       mise-correlation-id:
-      - 849ba6ce-5696-4e54-8b9b-83a3cda49786
+      - b5786568-1fe6-45af-8861-b17dadd38d91
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2013,7 +1905,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-09T16:17:17.6530100Z","key2":"2023-10-09T16:17:17.6530100Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T16:17:17.6530100Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T16:17:17.6530100Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-09T16:17:17.4498873Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-09T19:23:56.4764769Z","key2":"2023-10-09T19:23:56.4764769Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T19:23:56.4920647Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T19:23:56.4920647Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-09T19:23:56.2889390Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -2022,7 +1914,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:21:02 GMT
+      - Mon, 09 Oct 2023 19:27:26 GMT
       expires:
       - '-1'
       pragma:
@@ -2055,7 +1947,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2064,9 +1956,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:04 GMT
+      - Mon, 09 Oct 2023 19:27:28 GMT
       etag:
-      - '"920159da-0000-0100-0000-6524276d0000"'
+      - '"560063a9-0000-0100-0000-6524532b0000"'
       expires:
       - '-1'
       pragma:
@@ -2085,9 +1977,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ic2lcalbskxxyap6w/providers/Microsoft.Storage/storageAccounts/clitestloadwywsds3td":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ic2lcalbskxxyap6w/providers/Microsoft.Storage/storageAccounts/clitestloadwywsds3td",
-      "resourceName": "clitestloadwywsds3td", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testRunId": "server-metric-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-u3j5rc57mmljjtrla/providers/Microsoft.Storage/storageAccounts/clitestloadilb3d6zty":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-u3j5rc57mmljjtrla/providers/Microsoft.Storage/storageAccounts/clitestloadilb3d6zty",
+      "resourceName": "clitestloadilb3d6zty", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -2103,10 +1995,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-09T16:21:05.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:21:05.567Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-09T19:27:29.441Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:29.441Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2117,11 +2009,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:05 GMT
+      - Mon, 09 Oct 2023 19:27:29 GMT
       location:
-      - https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+      - https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - bcff5758-a766-41e9-b80c-dece5f810c46
+      - d3663908-a17f-4bd0-a83d-abc91df1fefa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2144,7 +2036,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2153,9 +2045,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:07 GMT
+      - Mon, 09 Oct 2023 19:27:30 GMT
       etag:
-      - '"920159da-0000-0100-0000-6524276d0000"'
+      - '"560063a9-0000-0100-0000-6524532b0000"'
       expires:
       - '-1'
       pragma:
@@ -2185,10 +2077,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-09T16:21:05.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:21:05.567Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-09T19:27:29.441Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:29.441Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2199,9 +2091,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:07 GMT
+      - Mon, 09 Oct 2023 19:27:31 GMT
       mise-correlation-id:
-      - 6b646cbb-fefb-4dfa-b6d1-b37d0f08d5a7
+      - 568e159e-097d-4d5c-ada8-077e47098a0f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2224,7 +2116,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2233,9 +2125,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:08 GMT
+      - Mon, 09 Oct 2023 19:27:32 GMT
       etag:
-      - '"920159da-0000-0100-0000-6524276d0000"'
+      - '"560063a9-0000-0100-0000-6524532b0000"'
       expires:
       - '-1'
       pragma:
@@ -2254,9 +2146,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ic2lcalbskxxyap6w/providers/Microsoft.Storage/storageAccounts/clitestloadwywsds3td/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-u3j5rc57mmljjtrla/providers/Microsoft.Storage/storageAccounts/clitestloadilb3d6zty/providers/microsoft.insights/metricdefinitions/Availability":
       {"name": " Availability", "metricNamespace": "microsoft.storage/storageaccounts",
-      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ic2lcalbskxxyap6w/providers/Microsoft.Storage/storageAccounts/clitestloadwywsds3td",
+      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-u3j5rc57mmljjtrla/providers/Microsoft.Storage/storageAccounts/clitestloadilb3d6zty",
       "resourceType": "Microsoft.Storage/storageAccounts"}}}'
     headers:
       Accept:
@@ -2272,25 +2164,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T16:21:05.627Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:21:10.417Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T19:27:29.5Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:33.787Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3242'
+      - '3240'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:10 GMT
+      - Mon, 09 Oct 2023 19:27:33 GMT
       mise-correlation-id:
-      - a91b86be-e765-4876-b3cc-3525faa360e8
+      - 22da4aa4-42e5-42e1-9d21-a62f00697964
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2313,7 +2205,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2322,9 +2214,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:11 GMT
+      - Mon, 09 Oct 2023 19:27:35 GMT
       etag:
-      - '"920159da-0000-0100-0000-6524276d0000"'
+      - '"560063a9-0000-0100-0000-6524532b0000"'
       expires:
       - '-1'
       pragma:
@@ -2354,25 +2246,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T16:21:05.627Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:21:10.417Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T19:27:29.5Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:33.787Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3242'
+      - '3240'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:11 GMT
+      - Mon, 09 Oct 2023 19:27:36 GMT
       mise-correlation-id:
-      - c1529bde-1048-4161-869a-386bda9c77a7
+      - f6444b1b-f599-4b9c-b1b0-f49d390435fe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2395,7 +2287,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2404,9 +2296,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:12 GMT
+      - Mon, 09 Oct 2023 19:27:37 GMT
       etag:
-      - '"920159da-0000-0100-0000-6524276d0000"'
+      - '"560063a9-0000-0100-0000-6524532b0000"'
       expires:
       - '-1'
       pragma:
@@ -2425,7 +2317,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ic2lcalbskxxyap6w/providers/Microsoft.Storage/storageAccounts/clitestloadwywsds3td/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-u3j5rc57mmljjtrla/providers/Microsoft.Storage/storageAccounts/clitestloadilb3d6zty/providers/microsoft.insights/metricdefinitions/Availability":
       null}}'
     headers:
       Accept:
@@ -2441,23 +2333,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T16:21:05.627Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:21:13.589Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T19:27:29.5Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:38.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2496'
+      - '2494'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:13 GMT
+      - Mon, 09 Oct 2023 19:27:38 GMT
       mise-correlation-id:
-      - c526d20c-d36f-4cea-9603-04ccf197ea7f
+      - 98b3f708-9a3a-4a10-b0da-8b8994cebea0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2480,7 +2372,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2489,9 +2381,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:15 GMT
+      - Mon, 09 Oct 2023 19:27:40 GMT
       etag:
-      - '"920159da-0000-0100-0000-6524276d0000"'
+      - '"560063a9-0000-0100-0000-6524532b0000"'
       expires:
       - '-1'
       pragma:
@@ -2521,23 +2413,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T16:21:05.627Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:21:13.589Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T19:27:29.5Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:38.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2496'
+      - '2494'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:15 GMT
+      - Mon, 09 Oct 2023 19:27:41 GMT
       mise-correlation-id:
-      - 79b3cb8d-344e-4a5a-bd7d-152004d08a7e
+      - dfbaeed4-611a-4150-a654-e80aa3a50219
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_server_metric.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_server_metric.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:51.6172705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:51.6172705Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:53 GMT
+      - Mon, 09 Oct 2023 16:17:38 GMT
       etag:
-      - '"1a0a0dda-0000-0100-0000-64af09bd0000"'
+      - '"920159da-0000-0100-0000-6524276d0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:15:54 GMT
+      - Mon, 09 Oct 2023 16:17:40 GMT
       mise-correlation-id:
-      - 5052072b-2259-438d-9dea-ebc6eba62c97
+      - 70732de9-d689-4871-a32d-f2a160c46c30
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -85,12 +85,12 @@ interactions:
 - request:
     body: '{"displayName": "CLI-Test", "description": "Test created from az load test
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
-      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "loadTestConfiguration":
+      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"04df79bb-f51f-4e93-9b3a-319618157f15": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "01f3d8b5-dc38-4191-9b50-28f2eac9526b":
+      {"passFailMetrics": {"50d832d8-2525-4501-94d2-2c57e3714d76": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "3c9f9403-19b1-4078-a94b-7ec8a40e17d0":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "a58632b7-a6d0-4d33-a948-115f2ef50ae9": {"aggregate": "avg", "clientMetric":
+      "50"}, "70577b9b-e56d-4d3a-beb1-80d92b045794": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -100,32 +100,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '768'
+      - '789'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04df79bb-f51f-4e93-9b3a-319618157f15":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"01f3d8b5-dc38-4191-9b50-28f2eac9526b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"a58632b7-a6d0-4d33-a948-115f2ef50ae9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:15:54.896Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:15:54.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:17:40.757Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:40.757Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1069'
+      - '1015'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:54 GMT
+      - Mon, 09 Oct 2023 16:17:40 GMT
       location:
-      - https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+      - https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 3845bc83-9a0f-4d0c-8f8a-0f1670603b12
+      - 47417845-e542-4719-8ebc-7638157e6058
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:55 GMT
+      - Mon, 09 Oct 2023 16:17:41 GMT
       mise-correlation-id:
-      - e13be4ef-68ae-4f12-9de3-6e297391531c
+      - 3cfd5bf7-5108-4e79-8279-ea50c9bf4c39
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A25%3A56Z&sr=b&sp=r&sig=fSBZf47W5QZsqcH1j29BIGJxXDGg9%2FL96v8HJvNIloA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:25:56.4045385","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A42Z&sr=b&sp=r&sig=IBF96qECUB5vw9%2B%2FUZCq4VpRx1KxmjBXoO%2Bpt71uNDg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:42.2444799","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:56 GMT
+      - Mon, 09 Oct 2023 16:17:42 GMT
       location:
-      - https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - f376ef5b-694d-4dcc-9fd7-0b8228f7a9f9
+      - d866f6dc-8609-4452-b521-444e0cacbff5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A25%3A56Z&sr=b&sp=r&sig=koh8tPf442u6myFpfRGS0uEh5sqBEsfAgV%2FaJt9QkU0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:25:56.7163469","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A42Z&sr=b&sp=r&sig=0z8zS0RUDd6PmmbxOumaxLZmKOtsiRLWWH%2FtYWex%2Be4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:42.5065749","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:56 GMT
+      - Mon, 09 Oct 2023 16:17:42 GMT
       mise-correlation-id:
-      - c1b32ca4-3c3c-4da1-848c-a1e33dbc1d33
+      - d04b1140-f9f9-4a51-a711-9015d79ab687
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A26%3A01Z&sr=b&sp=r&sig=CdLRNtX40Jv%2BMMUyHa4RI3F9P%2Fu0cZhEsfnb5%2F3jmx8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:26:01.9854071","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A47Z&sr=b&sp=r&sig=2z3mMuffUkvdTTgwCDGCiWcSrZM6xf%2BaHscJC4ZhmtU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:47.783645","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:01 GMT
+      - Mon, 09 Oct 2023 16:17:47 GMT
       mise-correlation-id:
-      - 42b99643-d9c6-4560-b006-8fc922172afc
+      - 9adea77b-5d41-4dec-92c8-c65b4c7652e3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,10 +385,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A26%3A07Z&sr=b&sp=r&sig=2jXssac2Jro1ktRsyfAGhjyhMPvxANkc97jgdFAMHd0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:26:07.2585706","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A53Z&sr=b&sp=r&sig=Knx5pXVzP79Wsm6KVKtlNB4gepp4zjlAU4XYr4n39Ek%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:53.0406324","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:07 GMT
+      - Mon, 09 Oct 2023 16:17:53 GMT
       mise-correlation-id:
-      - 5d8fd5e2-a06f-4579-849e-963dce5e048a
+      - e453e551-9ef3-4d5b-a6ba-e3f1693818bd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,10 +421,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A26%3A12Z&sr=b&sp=r&sig=03wUN9%2BXX90616BYCRpiGkhhGKMKfuUBJGqayLaFuHA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:26:12.5273799","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A58Z&sr=b&sp=r&sig=obtDATBnyLxR0OOtDL2qhgqgBJPPBxfGzVI%2FGntt9J8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:58.3149849","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:12 GMT
+      - Mon, 09 Oct 2023 16:17:58 GMT
       mise-correlation-id:
-      - d2a7003b-41f4-4aee-a141-bb6033e09e23
+      - 7059adf0-9b92-46cb-a3c6-d557b116c2ba
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04df79bb-f51f-4e93-9b3a-319618157f15":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"01f3d8b5-dc38-4191-9b50-28f2eac9526b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"a58632b7-a6d0-4d33-a948-115f2ef50ae9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A13Z&sr=b&sp=r&sig=3a4%2FdtJzgdSZa0K5dqx6IcaXR7CF1Q1qk8jake8sDjU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:13.1564549","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:15:54.896Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:10.293Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A58Z&sr=b&sp=r&sig=5R482S%2BayWetpanhAGApg1FAjXWiDyaEIidW1UToYwY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:58.6629526","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:17:40.757Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:55.733Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1640'
+      - '1586'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:13 GMT
+      - Mon, 09 Oct 2023 16:17:58 GMT
       mise-correlation-id:
-      - dc718041-c634-42a2-ac79-51328bef74c5
+      - b70a2f8a-6345-402c-8773-852752253973
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:51.6172705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:51.6172705Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:13 GMT
+      - Mon, 09 Oct 2023 16:18:00 GMT
       etag:
-      - '"1a0a0dda-0000-0100-0000-64af09bd0000"'
+      - '"920159da-0000-0100-0000-6524276d0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"04df79bb-f51f-4e93-9b3a-319618157f15":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"01f3d8b5-dc38-4191-9b50-28f2eac9526b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"a58632b7-a6d0-4d33-a948-115f2ef50ae9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A15Z&sr=b&sp=r&sig=Zufkkui73gSWN07wSS99uI3tj8%2FBEL3zWIZmdDSBLDQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:15.76232","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:15:54.896Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:10.293Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A01Z&sr=b&sp=r&sig=P9ELFQ25T%2B1p5YuFQKZ0TiZ%2FqbQqOEkT7VUVWKfADTc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:01.2257897","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:17:40.757Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:55.733Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1650'
+      - '1600'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:15 GMT
+      - Mon, 09 Oct 2023 16:18:01 GMT
       mise-correlation-id:
-      - 9ad0a94e-3d3b-440d-b72d-a7cea351c169
+      - efec835e-4765-4807-923e-b6f21cbf6b11
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:51.6172705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:51.6172705Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:17 GMT
+      - Mon, 09 Oct 2023 16:18:02 GMT
       etag:
-      - '"1a0a0dda-0000-0100-0000-64af09bd0000"'
+      - '"920159da-0000-0100-0000-6524276d0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:16:18 GMT
+      - Mon, 09 Oct 2023 16:18:03 GMT
       mise-correlation-id:
-      - 14f5a41d-6e6f-431a-9308-cda4494df69f
+      - 91415f42-95b3-454e-8dc1-db566e239dea
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04df79bb-f51f-4e93-9b3a-319618157f15":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"01f3d8b5-dc38-4191-9b50-28f2eac9526b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a58632b7-a6d0-4d33-a948-115f2ef50ae9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/74ec692f-c34d-42ac-bdc8-15c3ede9f6f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A18Z&sr=b&sp=r&sig=%2FhLU6jKbFOZBTyZcbNY1k%2FeYzLF7Zhr6ZtWBS983PVQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:18.8921694","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A18Z&sr=b&sp=r&sig=2TaRC%2F75FsVwcr%2FOJxEq8%2B45Cw0ps%2FlcH5s9x2sahSc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:18.8918604","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/cbb81a96-44b2-44bd-ae91-cb1724b32167?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A18Z&sr=b&sp=r&sig=3GQ1PxT0%2FTgM%2Bc7Iw6M6QW%2Fyj%2F2wZ2GHekaFr4azyws%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:18.8922166","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","testId":"server-metric-test-case","status":"ACCEPTED","executedDateTime":"2023-07-12T20:16:18.722Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-07-12T20:16:19.17Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:19.17Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A05Z&sr=b&sp=r&sig=cOd0D9A8WJQb1BbN9U0i3Pz9wgZMgYCplc1JNa3V1%2BI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:05.0365883","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A05Z&sr=b&sp=r&sig=ti3uTYaebSGy4I68isjXy9VIvJ2edYdMoVnEkrJMS10%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:05.036447","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A05Z&sr=b&sp=r&sig=lSykaN2QNx1nkjrAK5fEUiFfy8rwT6IXYT%2FIsHlaKWQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:05.0366097","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:04.965Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3229'
+      - '3186'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:19 GMT
+      - Mon, 09 Oct 2023 16:18:05 GMT
       location:
-      - https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+      - https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 80e0cc09-afc7-4f9b-acd4-fe3ef3e2576f
+      - b9e35488-00a0-48df-b293-335ab0d9b873
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04df79bb-f51f-4e93-9b3a-319618157f15":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"01f3d8b5-dc38-4191-9b50-28f2eac9526b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a58632b7-a6d0-4d33-a948-115f2ef50ae9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/74ec692f-c34d-42ac-bdc8-15c3ede9f6f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A19Z&sr=b&sp=r&sig=OhQKNF2gdTI0TCogtipeA8LKR2W7IPx01R5AZUSfWC0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:19.7088826","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A19Z&sr=b&sp=r&sig=ki1MfMM1nc1EXh%2FvYqxr5lGzwcwJsVdPfT6KsgOdnz8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:19.7087844","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/cbb81a96-44b2-44bd-ae91-cb1724b32167?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A19Z&sr=b&sp=r&sig=ulm0oQXwcUozXQdX6Ck9F4QPqlk9vfERKFE66x4dKQo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:19.7089084","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:19.306Z","executedDateTime":"2023-07-12T20:16:18.722Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-07-12T20:16:19.17Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:19.51Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A05Z&sr=b&sp=r&sig=Kia1SxHXVRSS1uM8CYYfIM87%2F77VU8fpXmARRh8Kh%2FI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:05.5265935","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A05Z&sr=b&sp=r&sig=5N1D2gzSQVsK7fTDK2eECdllaooJ7Dm1x2ztuTTY63w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:05.5265211","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A05Z&sr=b&sp=r&sig=rY6OE0SK7ldfNVFSvXXb6LHc%2ByleGrC5uflIyHjFmK8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:05.5266096","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.406Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3258'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:19 GMT
+      - Mon, 09 Oct 2023 16:18:05 GMT
       mise-correlation-id:
-      - c52a4ce4-a87d-497d-a950-cab8daf0c664
+      - dd5a7869-6ab3-4e88-8853-4c46528b0eab
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04df79bb-f51f-4e93-9b3a-319618157f15":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"01f3d8b5-dc38-4191-9b50-28f2eac9526b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a58632b7-a6d0-4d33-a948-115f2ef50ae9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/74ec692f-c34d-42ac-bdc8-15c3ede9f6f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A24Z&sr=b&sp=r&sig=%2BUwCx8cqjb1nyQ1Ruo2D8kqSnRnAzibTuJ%2FpORb3gLE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:24.9882163","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A24Z&sr=b&sp=r&sig=7KAB%2FLytXbbtowws9bGjhe%2ByMohl%2FEWCpt0S%2BccJhiw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:24.988146","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/cbb81a96-44b2-44bd-ae91-cb1724b32167?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A24Z&sr=b&sp=r&sig=8r5B8NjKfc3TPXtWUthSkOm9jgre5%2BOSW5uxsYh4Z84%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:24.9882304","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:19.306Z","executedDateTime":"2023-07-12T20:16:18.722Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-07-12T20:16:19.17Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:19.51Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A10Z&sr=b&sp=r&sig=4W4sCSem8WfUdSieCWSEe6Tr4dfV%2BAX1o4eFFskrZd0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:10.8151027","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A10Z&sr=b&sp=r&sig=XEJkZDpHEjl4ZO25Di16TcbFE2sUqhOt7KIiV2lh5Cg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:10.8150164","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A10Z&sr=b&sp=r&sig=Pe0BhMK5ppWhq4rP%2BHHlo24khonxg3NSV45i6hgtehs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:10.8151238","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3269'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:24 GMT
+      - Mon, 09 Oct 2023 16:18:10 GMT
       mise-correlation-id:
-      - 0888851f-75cb-420a-9f5e-d241f2e06c7e
+      - 0f16662d-fbab-4229-9c36-8c5399339e92
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04df79bb-f51f-4e93-9b3a-319618157f15":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"01f3d8b5-dc38-4191-9b50-28f2eac9526b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a58632b7-a6d0-4d33-a948-115f2ef50ae9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/74ec692f-c34d-42ac-bdc8-15c3ede9f6f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A30Z&sr=b&sp=r&sig=fAdkxUQIAFVkCZApgNBRGxNv64zkTJCu5DwVel723a4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:30.3498113","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A30Z&sr=b&sp=r&sig=J%2BTTzYfpEvzRElEN2TvUrxRO4smNWIXfUTgEvsS2cSs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:30.3497196","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/cbb81a96-44b2-44bd-ae91-cb1724b32167?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A30Z&sr=b&sp=r&sig=4mIEBcgMyPYAn1cVb3LYzooG10pWcl%2Bd6OXZAiJ7tO4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:30.3498259","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:19.306Z","executedDateTime":"2023-07-12T20:16:18.722Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-07-12T20:16:19.17Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:19.51Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A16Z&sr=b&sp=r&sig=j4pgitkY%2Fvnts3D2OpnMzZZewL7uZRS64p%2B%2Fl36J1Dc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:16.086683","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A16Z&sr=b&sp=r&sig=sd%2BYP844TBqcSdMGzcyITYWlEkLVYsLFz2TG3UR62CQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:16.0865975","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A16Z&sr=b&sp=r&sig=lX6DK9Z84ygMIfvJEeAr9PICOzhs1WUqotxHkmBTkkY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:16.086704","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3260'
+      - '3236'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:30 GMT
+      - Mon, 09 Oct 2023 16:18:16 GMT
       mise-correlation-id:
-      - d19688db-f246-4829-819f-12b22e4ce780
+      - 2e4aa907-d07c-432e-8a7e-c7ab7ebb946c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04df79bb-f51f-4e93-9b3a-319618157f15":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"01f3d8b5-dc38-4191-9b50-28f2eac9526b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a58632b7-a6d0-4d33-a948-115f2ef50ae9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/74ec692f-c34d-42ac-bdc8-15c3ede9f6f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A35Z&sr=b&sp=r&sig=ndpNThRHPsk%2BGM%2BnPt%2FGClCppIUjdpK%2Fx7wjD%2FQCbw8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:35.6573887","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A35Z&sr=b&sp=r&sig=5LrDW1ZRTzZMM%2BWMdTOFn%2BTUFLaoxUxs%2FpDmEhX17i8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:35.6572914","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/cbb81a96-44b2-44bd-ae91-cb1724b32167?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A35Z&sr=b&sp=r&sig=ZUMsfyI5wukfmxgGWZtNfdy5pXB8NHD5f71sxvTfW7o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:35.657417","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:19.306Z","executedDateTime":"2023-07-12T20:16:18.722Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-07-12T20:16:19.17Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:19.51Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A21Z&sr=b&sp=r&sig=grfPufuSn55%2BivgTUDwRYGIQ87XhyJ4UwKrr5MXaCPg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:21.3589417","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A21Z&sr=b&sp=r&sig=pGGPGExhsK8CLOlI%2Bg6uqBdH4USyo8U4Pa6KuvIrQpE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:21.3588733","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A21Z&sr=b&sp=r&sig=8RNQys8xQDy1zNs%2F3DHntV7svZfQpDjDbtMVA%2F1KTKQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:21.3589577","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3271'
+      - '3238'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:35 GMT
+      - Mon, 09 Oct 2023 16:18:21 GMT
       mise-correlation-id:
-      - c4c7ee4d-d3d1-411f-a46e-df16c048381e
+      - ad98228f-c025-41ed-9b4a-3498a232ab7a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04df79bb-f51f-4e93-9b3a-319618157f15":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"01f3d8b5-dc38-4191-9b50-28f2eac9526b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a58632b7-a6d0-4d33-a948-115f2ef50ae9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/74ec692f-c34d-42ac-bdc8-15c3ede9f6f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A40Z&sr=b&sp=r&sig=TApH8on55pKn6%2Fw%2F3jpao3v4IBsbljebYWHKmWWruLA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:40.9510527","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A40Z&sr=b&sp=r&sig=a0n0TVSK0tB4POLBnAI9w6YY9%2BuE%2F%2FS48PTpz2%2BHdNc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:40.9509669","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/cbb81a96-44b2-44bd-ae91-cb1724b32167?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A40Z&sr=b&sp=r&sig=oWlZpIVJNTHUEb5xqO%2F9QaoWzCUknA9VF7iIdqMPtgY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:40.9510887","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:19.306Z","executedDateTime":"2023-07-12T20:16:18.722Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-07-12T20:16:19.17Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:19.51Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A26Z&sr=b&sp=r&sig=mltKTGjoLOgEBWh88dUnb4ITsU6jDSUe%2F6ZdbDrxFDQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:26.646696","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A26Z&sr=b&sp=r&sig=bCcOJWomZWP3RNczjGinaADmq9ZMD83NN%2BcHDiQqRFU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:26.646588","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A26Z&sr=b&sp=r&sig=PaLRMosfjzxdOJIfYcBap97yVnefIGM6AdPGtu6aB9k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:26.6467233","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3270'
+      - '3232'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:40 GMT
+      - Mon, 09 Oct 2023 16:18:26 GMT
       mise-correlation-id:
-      - 6c1cc2b6-ef7b-4cb4-bbdd-4ad78b1cb3ff
+      - 81b1debc-c006-4cc7-a450-5e778eff053d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -880,23 +880,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04df79bb-f51f-4e93-9b3a-319618157f15":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"01f3d8b5-dc38-4191-9b50-28f2eac9526b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a58632b7-a6d0-4d33-a948-115f2ef50ae9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/74ec692f-c34d-42ac-bdc8-15c3ede9f6f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A47Z&sr=b&sp=r&sig=6d%2BxQ091IowR9SekFPfdZUskBEq7MIuus%2BQNocRxLF8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:47.3860951","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A47Z&sr=b&sp=r&sig=cyrheFiNzmyfDIv8%2BcmW4CU5EbJ95YFjodg1pP%2FRwBo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:47.3860257","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/cbb81a96-44b2-44bd-ae91-cb1724b32167?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A47Z&sr=b&sp=r&sig=1ys1L%2F7h%2B%2FeBgdTkmeS%2FHWKXoL8zF0kkLfondvkGIZ0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:47.3861174","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:19.306Z","executedDateTime":"2023-07-12T20:16:18.722Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-07-12T20:16:19.17Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:19.51Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A31Z&sr=b&sp=r&sig=WnzMs23%2Bjdds1Kp0WtcGBn2AC%2BoMGQp6xlABQpSxxQc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:31.9776947","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A31Z&sr=b&sp=r&sig=8Vm4sc8w%2BTVrvfsp1%2FQ4m3pO4DoD%2FV8kYN5exLjS1bM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:31.9776115","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A31Z&sr=b&sp=r&sig=89rs1PL3tqjrHIEK5a6029BwyIyDfgy6%2FJHhFT0zK3M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:31.977713","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3272'
+      - '3241'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:47 GMT
+      - Mon, 09 Oct 2023 16:18:31 GMT
       mise-correlation-id:
-      - 68312cc3-4ef9-47e1-9011-96d8c53dc322
+      - f7381d5a-46db-416d-9919-96e9baed7a59
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -916,23 +916,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04df79bb-f51f-4e93-9b3a-319618157f15":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"01f3d8b5-dc38-4191-9b50-28f2eac9526b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a58632b7-a6d0-4d33-a948-115f2ef50ae9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/74ec692f-c34d-42ac-bdc8-15c3ede9f6f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A52Z&sr=b&sp=r&sig=9XM4Z3A8%2F1F7miESpQp2plKCL6ByBlrZanvoSHesfdY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:52.8895356","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A52Z&sr=b&sp=r&sig=VsYEDU%2BlADnY7QLtiAxbMETqoE9U0%2BXrf6sUGxakPm4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:52.8894356","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/cbb81a96-44b2-44bd-ae91-cb1724b32167?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A52Z&sr=b&sp=r&sig=c%2FOH84f7jdFi87AJ9c1YfHJVF5dzLsh%2FxYtGv8PmSRc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:52.8895631","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:19.306Z","executedDateTime":"2023-07-12T20:16:18.722Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-07-12T20:16:19.17Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:19.51Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A37Z&sr=b&sp=r&sig=wS0I34JqKHBtXN8C6az2UcTZb7jtfTu%2BTZB5Q0waeWc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:37.4906732","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A37Z&sr=b&sp=r&sig=AQqCdpMagaev%2B7%2BqCd%2FKtgcocu00tJlKmF9vB4TJ7%2F0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:37.4905977","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A37Z&sr=b&sp=r&sig=4rDMTMsyKsnsg6x3VerPGE0JAOgCuxfwPZaLwhUGcTU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:37.4906902","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3266'
+      - '3240'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:52 GMT
+      - Mon, 09 Oct 2023 16:18:37 GMT
       mise-correlation-id:
-      - 5494acfd-2fd9-433c-8200-afe68e85ced1
+      - e9f3f7ab-84c1-4372-9df4-5bc0a5f8b4b7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -952,23 +952,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04df79bb-f51f-4e93-9b3a-319618157f15":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"01f3d8b5-dc38-4191-9b50-28f2eac9526b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a58632b7-a6d0-4d33-a948-115f2ef50ae9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/74ec692f-c34d-42ac-bdc8-15c3ede9f6f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A58Z&sr=b&sp=r&sig=%2Fd0CDVtWv%2Br%2FDkdmPuGoGtc3dwesrIUOg4HLuWH%2B5YA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:58.1900198","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A58Z&sr=b&sp=r&sig=KQ%2Bxz5tmsb8M%2BMlG6%2FANCuMKx87xsLF%2BqxXOnXKn%2Bcw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:58.1899402","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/cbb81a96-44b2-44bd-ae91-cb1724b32167?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A58Z&sr=b&sp=r&sig=ANu%2BY9Bj%2BppnVHfY%2Fj92qNniDPmtcJaJdhZcVe0yqEk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:58.1900416","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:19.306Z","executedDateTime":"2023-07-12T20:16:18.722Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-07-12T20:16:19.17Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:19.51Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A42Z&sr=b&sp=r&sig=MMyi5l8sp3lca7pwn%2F6O1JubrU2wH6xCBjHpPUzkUQQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:42.771467","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A42Z&sr=b&sp=r&sig=pN8y3sYbVSmNWJOEooKjM8wOHnwA52YoejGnlExRBKE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:42.7713774","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A42Z&sr=b&sp=r&sig=TQ6W968HVimdIbuUTafEr9N0nNZ59%2FUcedqEk3j1Rh8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:42.7714813","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3280'
+      - '3233'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:58 GMT
+      - Mon, 09 Oct 2023 16:18:42 GMT
       mise-correlation-id:
-      - 4616b08d-5462-47a5-9483-8ec89087da55
+      - 86bd1b5d-7032-47ad-8db5-511e4b1ee8b0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -988,23 +988,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04df79bb-f51f-4e93-9b3a-319618157f15":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"01f3d8b5-dc38-4191-9b50-28f2eac9526b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a58632b7-a6d0-4d33-a948-115f2ef50ae9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/74ec692f-c34d-42ac-bdc8-15c3ede9f6f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A03Z&sr=b&sp=r&sig=6i3y02cJh8BupnF86SXR4VCdcION8daPwjPPjLA2Pao%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:03.4717645","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A03Z&sr=b&sp=r&sig=%2B%2FPgcJ%2BMcFP6f%2Fw8I2dksmybAPnYeUOwfXw7Dt0HDQQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:03.4716883","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/cbb81a96-44b2-44bd-ae91-cb1724b32167?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A03Z&sr=b&sp=r&sig=F96p9aGLB7EzA6GHk%2Bhebyuqj%2FR6vtyZnC3Fh8wxALg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:03.4717785","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","testId":"server-metric-test-case","status":"CONFIGURING","startDateTime":"2023-07-12T20:16:19.306Z","executedDateTime":"2023-07-12T20:16:18.722Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-07-12T20:16:19.17Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:17:01.366Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A48Z&sr=b&sp=r&sig=LrPKu7BjmDRK855tcnBE3gEH1CXJAKW0%2FvRCtQMjXVI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:48.0541866","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A48Z&sr=b&sp=r&sig=bY1tsU2%2BlMF8APr9YtegAloCVVx1kDKgAXKJelVz86Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:48.0541148","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A48Z&sr=b&sp=r&sig=UNW9KCwIBO26t0emCLAcSkrFY2mWFT3yHPI0mutvr1I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:48.0542004","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3268'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:03 GMT
+      - Mon, 09 Oct 2023 16:18:48 GMT
       mise-correlation-id:
-      - 38c4b396-afbd-445f-a18d-1ac7a1ae24cb
+      - 53018a23-cb10-4747-be7d-7c41064f575f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1024,23 +1024,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04df79bb-f51f-4e93-9b3a-319618157f15":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"01f3d8b5-dc38-4191-9b50-28f2eac9526b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a58632b7-a6d0-4d33-a948-115f2ef50ae9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/74ec692f-c34d-42ac-bdc8-15c3ede9f6f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A08Z&sr=b&sp=r&sig=oz%2FR1HUrE4k1XIX85wcl4YE0R3wJcuYBMeBLZsXP0SY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:08.8316288","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A08Z&sr=b&sp=r&sig=uFOr4PElief8nvnBUddSkwMMYTvm7Bw8anTwW%2F2cTWM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:08.8315476","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/cbb81a96-44b2-44bd-ae91-cb1724b32167?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A08Z&sr=b&sp=r&sig=YrheUyYToaPdhxrPKv63m5t81Hiqz%2B4lpwFDhAev0jg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:08.8316458","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:19.306Z","executedDateTime":"2023-07-12T20:16:18.722Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-07-12T20:16:19.17Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:17:05.161Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A53Z&sr=b&sp=r&sig=gZRGhtrqa8dm5H4MQ9WODwAzT5nbCtuDYITgINEbj7o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:53.3289622","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A53Z&sr=b&sp=r&sig=9K%2FzpzHpnVgRMOu8k8coj7wWSYkgMLdAaRTbce%2Fy2YM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:53.3288734","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A53Z&sr=b&sp=r&sig=74x%2BJ9ZLrBrVw5f2HHcoACWAekOdNEqGEyPU%2FrVJUQc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:53.328983","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3260'
+      - '3237'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:08 GMT
+      - Mon, 09 Oct 2023 16:18:53 GMT
       mise-correlation-id:
-      - 83c8306d-a80e-49bd-bac0-ae66c57cdb00
+      - 5eb9e1a9-fd12-4dd6-9302-a264b1bc24aa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,23 +1060,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04df79bb-f51f-4e93-9b3a-319618157f15":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"01f3d8b5-dc38-4191-9b50-28f2eac9526b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a58632b7-a6d0-4d33-a948-115f2ef50ae9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/74ec692f-c34d-42ac-bdc8-15c3ede9f6f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A14Z&sr=b&sp=r&sig=17ZUd6l8BZE0UXPqMdx8sAPtLwudMGDkGiXIh1QcbTA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:14.5665587","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A14Z&sr=b&sp=r&sig=9eh094og1l3KYyzUO%2F33YH7yXtuMAzy%2Bl%2BneEm6ONYU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:14.5664546","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/cbb81a96-44b2-44bd-ae91-cb1724b32167?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A14Z&sr=b&sp=r&sig=mdfqq8zMo70dKOTuMuD%2FP%2BcdGUjspntYozkfGW8s9sw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:14.5670545","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:19.306Z","executedDateTime":"2023-07-12T20:16:18.722Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-07-12T20:16:19.17Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:17:05.161Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A58Z&sr=b&sp=r&sig=XyqB63D2rsvg%2FBgn%2Fvs9xAPTL3ZMtLWtdkqJb%2BjbugQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:58.6122484","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A58Z&sr=b&sp=r&sig=wJN4ylg1tdK7sf3%2BkmzHqts2Md%2F6ayakb53afN%2FXldg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:58.6121753","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A58Z&sr=b&sp=r&sig=Q3OxilVPZljUWlk%2FkBme%2BANwjOxhbJedCsj%2Fuhr2GU8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:58.6122644","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:05.619Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3264'
+      - '3248'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:14 GMT
+      - Mon, 09 Oct 2023 16:18:58 GMT
       mise-correlation-id:
-      - b10dfed4-3ad6-48a8-ba6e-f4d9b8cff573
+      - c46c8ca5-0d43-4ee6-82e5-3c0bcad4ccb7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1096,24 +1096,816 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04df79bb-f51f-4e93-9b3a-319618157f15":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"01f3d8b5-dc38-4191-9b50-28f2eac9526b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a58632b7-a6d0-4d33-a948-115f2ef50ae9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/74ec692f-c34d-42ac-bdc8-15c3ede9f6f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A19Z&sr=b&sp=r&sig=wY57Ucvtgp3CzE5wRUCfEuAvZ1V1IPNelxdL%2FrY8N8c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:19.8472408","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A19Z&sr=b&sp=r&sig=5X%2B5Jl%2FUgVzKxQe1d1rj7Z95lohxotfbJkAj6BHZfTY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:19.8471708","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/cbb81a96-44b2-44bd-ae91-cb1724b32167?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A19Z&sr=b&sp=r&sig=rPlmf2LwFuoXenu8hhKKWTJVLEvkROWaAHsn1Q5IuyM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:19.8472551","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-07-12T20:16:19.306Z","endDateTime":"2023-07-12T20:17:15.636Z","executedDateTime":"2023-07-12T20:16:18.722Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-07-12T20:16:19.17Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:17:19.726Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A03Z&sr=b&sp=r&sig=Ncz1DdDAmMRTG%2BcirGyYCV%2FPclGNfS5i38wMeJEkyZ8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:03.8807834","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A03Z&sr=b&sp=r&sig=kj7U9eSAMmWBacIl2acLv3%2BjPYCNBpiRperl%2FN6HkhQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:03.8806933","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A03Z&sr=b&sp=r&sig=Yd5ag7%2FfDStXVUMSe0VytmAUVvyqd88R34BxXg736OY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:03.8807987","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:02.484Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3395'
+      - '3239'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:19 GMT
+      - Mon, 09 Oct 2023 16:19:03 GMT
       mise-correlation-id:
-      - 9e03d46e-9fb9-4170-a17e-38efdaeeaa50
+      - 3046feff-f032-48e2-bc6c-950a31445089
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A09Z&sr=b&sp=r&sig=s229Q0fkfEsfdr53t2fBhMK4SBZXEpSdAinpp8wGzl0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:09.1629419","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A09Z&sr=b&sp=r&sig=ryIDGxzq0ANG0Up8wUiXsacT0KPcGXwPRFzKAUqFBN4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:09.1628525","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A09Z&sr=b&sp=r&sig=U32sWZrItrzoeTZVYY%2BK82PmBMAZ1Fk0mRsTd%2BfSNDA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:09.1629628","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:09 GMT
+      mise-correlation-id:
+      - 77c37db4-086e-448a-b4bb-0f2c1c8fcef7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A14Z&sr=b&sp=r&sig=IPMqc4XAXuW%2FC%2B%2BWSSkZmX%2BjIo8iJZGpr1ZiEcC65h0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:14.4454125","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A14Z&sr=b&sp=r&sig=ShTiaj%2Fw05rSE8t5CbJut5gb4fbq80M9cwhsGqGJAIo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:14.4453199","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A14Z&sr=b&sp=r&sig=B8NwHPn%2FUYjpyB%2FL42YIEjGn6qQkoEdzr6HIloZXpe4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:14.4454348","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3241'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:14 GMT
+      mise-correlation-id:
+      - 3500a041-f37d-4db0-a0a7-e5f815f9c2d8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A19Z&sr=b&sp=r&sig=GQSGjG7JC%2B5nLnBe8JpVjLxIAPCg90ddud6ZJK9MSLQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:19.7191356","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A19Z&sr=b&sp=r&sig=IEHV4u5S6dqrS%2FMnWt8RdwwqJr4Ak5zH2YXYgKdt%2Fs0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:19.7190667","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A19Z&sr=b&sp=r&sig=%2B1LZSX%2BmzkuWSaUg7hZb5pFGklGytIyaVHimgX5fUR8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:19.7191515","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:19 GMT
+      mise-correlation-id:
+      - c601bd66-acf5-43a3-be60-ee1b88def404
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A24Z&sr=b&sp=r&sig=CesKQjy%2B1JZB6dxKU7et3cdssmwrRvMLMEJjAwiCRBg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:24.9943909","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A24Z&sr=b&sp=r&sig=qOyf3fUyFbVOM22jIKlCWeEiARe8HcqUZuXXw3s9%2FSQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:24.9943012","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A24Z&sr=b&sp=r&sig=04UhfDQa9r0XHZQUyiEkJDgNzpFQpp4cbwWyXTtECjc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:24.9944135","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:24 GMT
+      mise-correlation-id:
+      - fabe40bd-49a5-497b-b373-769479d40f82
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A30Z&sr=b&sp=r&sig=v5KQTveDO1%2Fy8s2BalhMTWHksLW28EB4TuKVuB2f%2FdQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:30.2690336","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A30Z&sr=b&sp=r&sig=yTFvdK8dRgmBHmolYqdn1lAj6B0fAdalm3ZzRhB8frk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:30.2689345","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A30Z&sr=b&sp=r&sig=UFH6%2F3xtZ13o0PaSWIDmO48geTZ3R8MvBeIA14LFtwQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:30.2690514","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:30 GMT
+      mise-correlation-id:
+      - beab3c48-cdbb-4316-b6e5-3814d2a921fa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A35Z&sr=b&sp=r&sig=FgW2oC0n0jG6DfolA48Z2bnoz7x5CIq9ILiaMnM1iiw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:35.540172","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A35Z&sr=b&sp=r&sig=zcYU4zFmL9KBRU3heGrFZ4PeKzDCxkggPxKG29NcyNc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:35.5400777","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A35Z&sr=b&sp=r&sig=dBKms%2FQXqQWYOzIJb3S%2B7JanSPR%2BqoVpAtM1fzZKqwM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:35.5401943","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:35 GMT
+      mise-correlation-id:
+      - ba35429e-20a4-4786-8fd7-8109d90f877c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A40Z&sr=b&sp=r&sig=gS5sTvTBPDClw3T%2Fd8lMF878enx0cmybS3MaqH3F%2FSI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:40.8061572","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A40Z&sr=b&sp=r&sig=0ffM2VUMfOKEQjENAbdqcZF7TWEjL3B4IpsH9dCYRGk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:40.8060875","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A40Z&sr=b&sp=r&sig=La66F20lCo2IXXNq5L2whv05CzUu9cVOx6ld4wZBqC8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:40.8061711","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:40 GMT
+      mise-correlation-id:
+      - ee546845-8d69-40e1-a9a5-61e5652456db
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A46Z&sr=b&sp=r&sig=QWGCZavDMNFpQT5zTHIMTXVadMx8%2BHKVkDlM%2FFFILLs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:46.0846306","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A46Z&sr=b&sp=r&sig=Johzh5hORId5qkojc%2BjqyW4nslT8Gw1chzqZxvmt3Hs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:46.0845586","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A46Z&sr=b&sp=r&sig=%2Fh4EcuU%2BJ0ehFgHZ8s4qwjXl9rTRaqlqRguqFoF%2FyIA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:46.0846475","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3239'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:46 GMT
+      mise-correlation-id:
+      - 2b046c48-c558-484a-a1aa-747a09fadc38
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A51Z&sr=b&sp=r&sig=TMku%2F5tR%2F8JYBaAVQp67JeghiyoCCJ7hKhW6dvBH1xA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:51.3506298","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A51Z&sr=b&sp=r&sig=jN3DJq4n7jhWUOPCcZ1xSjVqFeC%2BkdGyL2IeaHP6Tow%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:51.3505659","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A51Z&sr=b&sp=r&sig=QFJigdUTtc5dXPJEaYj41w%2BZPjf4Dcm4%2BFxKOXTDvnc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:51.3506455","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:51 GMT
+      mise-correlation-id:
+      - 67c11e88-f8da-4de7-9ee8-31e085182e3f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A56Z&sr=b&sp=r&sig=Xwc6PHugsR%2F7lw5e8eLOQsw3SG5Fg6YPmxHepKI%2BTbo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:56.6432022","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A56Z&sr=b&sp=r&sig=4T0Jfx8SiHfH%2F8sYBzMgD4Jo8Gd4JgG%2F%2Fir5%2BroRw9w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:56.6431227","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A56Z&sr=b&sp=r&sig=%2F13PQgc25nfOZ1oDHy9JPAzkXAX95JAuUI%2FY81wbI4o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:56.6432193","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3243'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:56 GMT
+      mise-correlation-id:
+      - aa838f73-35ea-4959-bccf-243fca38a2c0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A01Z&sr=b&sp=r&sig=TlFSSurb4ioK5cwiPRYOfDHKQFhMNvclMmSe0PgGrv4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:01.9251704","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A01Z&sr=b&sp=r&sig=m1sv0%2Bzc2b40VfwV0yytm2SAg4U0GXv7TjpqBYn5YjM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:01.925067","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A01Z&sr=b&sp=r&sig=GSKvBNQcRZe27Om6i3upknz7upOnjZwW9fDKEF95ExQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:01.9251934","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3228'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:01 GMT
+      mise-correlation-id:
+      - 70e17bfd-a4d8-4a15-9926-8fadbc1a9d76
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A07Z&sr=b&sp=r&sig=s06QBqCSAAWMESZPWIIH5%2FBldBuVA8Agb%2BLAym9PFMo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:07.2031878","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A07Z&sr=b&sp=r&sig=MATTzW6qlvj2IhzT31ZNnK6NO7G7AwjrJnwFlXyLfus%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:07.2031226","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A07Z&sr=b&sp=r&sig=y4sLLPxQmjVzQqO52mY5tWAQFxIV4lyF4%2B4x5jH8ROA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:07.2032029","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:07 GMT
+      mise-correlation-id:
+      - c1d0a5f2-8519-4dc6-a4ad-f9fdf43dc8c6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A12Z&sr=b&sp=r&sig=hyWgPupcXQNszSTrJZPAMSVUUEbaFIiE7AyjtEV9%2B0c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:12.4942502","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A12Z&sr=b&sp=r&sig=1HHv7YTZo3zAP7asNY%2FkGCtIx00hJ3kXbou1fgZTxPw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:12.4941498","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A12Z&sr=b&sp=r&sig=DON1hxXyD2%2B3lFjQ%2F4MUvfxOZ125rzlEpGrnVeqS%2BG4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:12.4942776","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:12 GMT
+      mise-correlation-id:
+      - e51d8249-5231-47ba-beb8-5ebb4d685863
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A17Z&sr=b&sp=r&sig=wfMxJM2Iu%2FMok%2BYrlL%2BySDBX6H0nHcm7gvjTsfVApRM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:17.7705515","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A17Z&sr=b&sp=r&sig=yopfTCIlyCXaaWkbxap63%2B%2BoKrGwMASYtGfCfj6enRU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:17.770454","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A17Z&sr=b&sp=r&sig=B02D1U4TX5vOjvAsJmVqoY5iFdSthXNRT8ZLqXvqaVs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:17.770573","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:17 GMT
+      mise-correlation-id:
+      - 598b3d84-be7c-4c50-a727-803a66f15253
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A23Z&sr=b&sp=r&sig=WI1fCrYGvi7%2Bz8YrdRoPZ0KSjNWpPnct5kJW5Hy%2BNQ8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:23.0520483","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A23Z&sr=b&sp=r&sig=7GovyAetTOC2XQglh4hVsSv%2FV5u4MH1WDhyljEDx7yk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:23.0519708","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A23Z&sr=b&sp=r&sig=2angoIVWzvMnswSkv2zc%2FrBN6cAxxsDF0jLm5jdg%2Ft4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:23.052064","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:23 GMT
+      mise-correlation-id:
+      - 24fd52da-fb44-4016-b9dc-3b817775bf76
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A28Z&sr=b&sp=r&sig=KtlufDexmLaYPkg89Ucub%2BIevViKILV6tYZnIOiukZY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:28.340713","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A28Z&sr=b&sp=r&sig=AmaUe4MQf3q5Kq2Oit5aE7GvWvD1luBXCjYK69QpJGg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:28.3406172","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A28Z&sr=b&sp=r&sig=gF6Pq5Vd5m5oK6b0nN4HxaPyoig6ASZENuMH1JTzXIU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:28.3407349","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3228'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:28 GMT
+      mise-correlation-id:
+      - 0509ed82-1816-48bd-8735-f063f9837e5b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A33Z&sr=b&sp=r&sig=as2QKbjmx2tur4A491AA%2B4O%2BVinATZtvQylyBXUTMZ8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:33.6169446","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A33Z&sr=b&sp=r&sig=iOIgTJEVBuQNZMVIIte7%2BzlA5n7zEbcdWuCV6dnOqvc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:33.6168681","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A33Z&sr=b&sp=r&sig=47tXfUHfIpTTe1lZlohAAvv9pdo4%2FmxM%2BqDW0eNeyWE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:33.6169589","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:33 GMT
+      mise-correlation-id:
+      - ac13bfc5-86f6-4c9f-88ba-2efb6e2eb598
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A38Z&sr=b&sp=r&sig=IWYbUM1csflyRw01gblVuDEsdgyPw5uUnkE9At%2Ff%2Fc8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:38.8917836","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A38Z&sr=b&sp=r&sig=QQmpQ2EbZ0g%2BkWMS4D9UDED7cU%2FlAZXimA1WarFNvFo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:38.8917075","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A38Z&sr=b&sp=r&sig=uPVKxsVuD7oOf9M5nCipwaEMk3cGlTvAoSISr5abSkY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:38.8918066","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:38 GMT
+      mise-correlation-id:
+      - 08d41b6a-fe48-482c-82bd-dfbf24ffa40e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A44Z&sr=b&sp=r&sig=CC1wXDj6PMZMs4bdVMJyVUt2F6sVCnZ95dzZQg9DYHQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:44.1840301","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A44Z&sr=b&sp=r&sig=%2Bbl7o6cR%2Brj80SoTNrgzuVUsfz2HXQrZmJNq8Kd8iJQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:44.1839192","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A44Z&sr=b&sp=r&sig=RsidXRl67Kx970HrggiF%2BffXmtBFFO%2BVcrj2mrFfefM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:44.1840699","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:44 GMT
+      mise-correlation-id:
+      - 922a6af1-35e1-43b7-83cc-4fef0b77c228
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A49Z&sr=b&sp=r&sig=V4jrOXvP4QCIffydaqmtr7AJr3a3cnGvHzkwDnOJ%2Fjc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:49.4582538","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A49Z&sr=b&sp=r&sig=rp3bRvngKM4xEzBZWmx91dFJWIbNP6PsPR3doKdRWSc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:49.4581757","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A49Z&sr=b&sp=r&sig=t8vKyvW1Zt5nfTnFfacfUaVYY9n5opaoidtFyCp%2F%2Fjk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:49.4582684","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:49 GMT
+      mise-correlation-id:
+      - 715257e0-428b-4e83-b46e-e5a225fa7ba3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A54Z&sr=b&sp=r&sig=KVaFE73mgv1FBzISTLdIU5TPWYyQrHNuGapKZqMO7Xw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:54.7245537","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A54Z&sr=b&sp=r&sig=NuPGJ7nKnIpF2nQ7z2jTi3XJ5wDq4NP21ZSRo%2B8lJLc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:54.7244833","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A54Z&sr=b&sp=r&sig=K7NAfcycWRy%2BUUoLgQjxOt7noJ25Up1bvM8GouyI6Z8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:54.7245675","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:18:05.406Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:19:06.892Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:54 GMT
+      mise-correlation-id:
+      - 3c1f0f19-be1b-4d84-b779-389e0bb4293c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A59Z&sr=b&sp=r&sig=leDihDW1T7jGkPnma88Rx5QPlzuU2vlFh%2FJm6wbJiWE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:59.996968","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A59Z&sr=b&sp=r&sig=YO7olv1vZ%2BmZ8twdEDdR17UU2IA2FNqEBlXtFOcdOSE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:59.9968686","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A59Z&sr=b&sp=r&sig=%2FsvfzqiDqzUvTlO9ScAPSRl33n3uCGosizrAf35enW8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:59.9969861","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-09T16:18:05.406Z","endDateTime":"2023-10-09T16:20:59.582Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:59.674Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3367'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:59 GMT
+      mise-correlation-id:
+      - dc956d5a-4b22-44d0-a066-619d58f4cc65
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1136,7 +1928,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:51.6172705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:51.6172705Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1145,9 +1937,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:21 GMT
+      - Mon, 09 Oct 2023 16:21:00 GMT
       etag:
-      - '"1a0a0dda-0000-0100-0000-64af09bd0000"'
+      - '"920159da-0000-0100-0000-6524276d0000"'
       expires:
       - '-1'
       pragma:
@@ -1177,24 +1969,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=server-metric-test-case&api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=server-metric-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"04df79bb-f51f-4e93-9b3a-319618157f15":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"01f3d8b5-dc38-4191-9b50-28f2eac9526b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"a58632b7-a6d0-4d33-a948-115f2ef50ae9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/74ec692f-c34d-42ac-bdc8-15c3ede9f6f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A22Z&sr=b&sp=r&sig=Cl%2BM67G8%2Bw4sNa04dR5N%2FQbbyDpB8iYepCXGsE72E4w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:22.0492411","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/d93dc37c-2b72-42f3-ad8d-5cc7e2191eee?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A22Z&sr=b&sp=r&sig=9kUDnxTCqneKHTET9H3c0LeasDwob9rZr3DoeMRytKA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:22.0491755","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e9ea5e24-2977-419d-932a-a268e5e23ff1/cbb81a96-44b2-44bd-ae91-cb1724b32167?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A22Z&sr=b&sp=r&sig=jvQx5NxzOKiAaDRpej96csoV2P%2BXWGNsT8S4jtX5v4k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:22.0492558","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-07-12T20:16:19.306Z","endDateTime":"2023-07-12T20:17:15.636Z","executedDateTime":"2023-07-12T20:16:18.722Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-07-12T20:16:19.17Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:17:20.027Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"50d832d8-2525-4501-94d2-2c57e3714d76":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3c9f9403-19b1-4078-a94b-7ec8a40e17d0":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"70577b9b-e56d-4d3a-beb1-80d92b045794":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/439bfca0-8272-4fcc-9a15-d6b0ab80e7fc?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A02Z&sr=b&sp=r&sig=5SfeL5CkF1LuACGYGZQc1EOudN%2FzLY8FSNMewrcWcl8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:02.4801758","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/1a0f4134-a22d-4484-bae1-a9b3e3feaee6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A02Z&sr=b&sp=r&sig=CwnCgLH3aCUsQVuh9y%2Bn6OUZOK6ZZK5kcqYKykDZ7Z4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:02.4800903","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8883cd9c-869e-4898-adf4-b96b731452ba/36d951b6-eada-44a1-a3a2-b8e772b6fb26?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A02Z&sr=b&sp=r&sig=%2FN1pktG6Ul9HgUauGTsshoI06zZXzLSuwi6Vf7w5zF4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:02.4801969","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-09T16:18:05.406Z","endDateTime":"2023-10-09T16:20:59.582Z","executedDateTime":"2023-10-09T16:18:04.068Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T16:18:04.965Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:59.674Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3409'
+      - '3380'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:22 GMT
+      - Mon, 09 Oct 2023 16:21:02 GMT
       mise-correlation-id:
-      - 879a8b5a-fd74-4b06-bf86-ef344f7e5c71
+      - 849ba6ce-5696-4e54-8b9b-83a3cda49786
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1221,7 +2013,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-07-12T20:15:30.7111376Z","key2":"2023-07-12T20:15:30.7111376Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-07-12T20:15:30.7267638Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-07-12T20:15:30.7267638Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-07-12T20:15:30.4767849Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-09T16:17:17.6530100Z","key2":"2023-10-09T16:17:17.6530100Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T16:17:17.6530100Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T16:17:17.6530100Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-09T16:17:17.4498873Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -1230,7 +2022,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:17:22 GMT
+      - Mon, 09 Oct 2023 16:21:02 GMT
       expires:
       - '-1'
       pragma:
@@ -1263,7 +2055,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:51.6172705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:51.6172705Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1272,9 +2064,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:26 GMT
+      - Mon, 09 Oct 2023 16:21:04 GMT
       etag:
-      - '"1a0a0dda-0000-0100-0000-64af09bd0000"'
+      - '"920159da-0000-0100-0000-6524276d0000"'
       expires:
       - '-1'
       pragma:
@@ -1293,9 +2085,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-y6u3iqhy4ggihir3k/providers/Microsoft.Storage/storageAccounts/clitestloadknmu3vdbw":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-y6u3iqhy4ggihir3k/providers/Microsoft.Storage/storageAccounts/clitestloadknmu3vdbw",
-      "resourceName": "clitestloadknmu3vdbw", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testRunId": "server-metric-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ic2lcalbskxxyap6w/providers/Microsoft.Storage/storageAccounts/clitestloadwywsds3td":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ic2lcalbskxxyap6w/providers/Microsoft.Storage/storageAccounts/clitestloadwywsds3td",
+      "resourceName": "clitestloadwywsds3td", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -1311,10 +2103,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-07-12T20:17:27.798Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:17:27.798Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-09T16:21:05.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:21:05.567Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1325,11 +2117,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:27 GMT
+      - Mon, 09 Oct 2023 16:21:05 GMT
       location:
-      - https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+      - https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - b55d46ac-c2e2-4279-a1d5-7aab3d50f2ac
+      - bcff5758-a766-41e9-b80c-dece5f810c46
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1352,7 +2144,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:51.6172705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:51.6172705Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1361,9 +2153,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:29 GMT
+      - Mon, 09 Oct 2023 16:21:07 GMT
       etag:
-      - '"1a0a0dda-0000-0100-0000-64af09bd0000"'
+      - '"920159da-0000-0100-0000-6524276d0000"'
       expires:
       - '-1'
       pragma:
@@ -1393,10 +2185,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-07-12T20:17:27.798Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:17:27.798Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-09T16:21:05.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:21:05.567Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1407,9 +2199,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:30 GMT
+      - Mon, 09 Oct 2023 16:21:07 GMT
       mise-correlation-id:
-      - 15e6808b-d502-47ae-80f8-4da25bb0d9c1
+      - 6b646cbb-fefb-4dfa-b6d1-b37d0f08d5a7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1432,7 +2224,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:51.6172705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:51.6172705Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1441,9 +2233,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:31 GMT
+      - Mon, 09 Oct 2023 16:21:08 GMT
       etag:
-      - '"1a0a0dda-0000-0100-0000-64af09bd0000"'
+      - '"920159da-0000-0100-0000-6524276d0000"'
       expires:
       - '-1'
       pragma:
@@ -1462,9 +2254,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-y6u3iqhy4ggihir3k/providers/Microsoft.Storage/storageAccounts/clitestloadknmu3vdbw/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ic2lcalbskxxyap6w/providers/Microsoft.Storage/storageAccounts/clitestloadwywsds3td/providers/microsoft.insights/metricdefinitions/Availability":
       {"name": " Availability", "metricNamespace": "microsoft.storage/storageaccounts",
-      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-y6u3iqhy4ggihir3k/providers/Microsoft.Storage/storageAccounts/clitestloadknmu3vdbw",
+      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ic2lcalbskxxyap6w/providers/Microsoft.Storage/storageAccounts/clitestloadwywsds3td",
       "resourceType": "Microsoft.Storage/storageAccounts"}}}'
     headers:
       Accept:
@@ -1480,12 +2272,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-07-12T20:17:27.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:17:33.003Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T16:21:05.627Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:21:10.417Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1496,9 +2288,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:33 GMT
+      - Mon, 09 Oct 2023 16:21:10 GMT
       mise-correlation-id:
-      - a6d8e540-a253-4605-95e4-3f6d27f6d573
+      - a91b86be-e765-4876-b3cc-3525faa360e8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1521,7 +2313,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:51.6172705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:51.6172705Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1530,9 +2322,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:33 GMT
+      - Mon, 09 Oct 2023 16:21:11 GMT
       etag:
-      - '"1a0a0dda-0000-0100-0000-64af09bd0000"'
+      - '"920159da-0000-0100-0000-6524276d0000"'
       expires:
       - '-1'
       pragma:
@@ -1562,12 +2354,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-07-12T20:17:27.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:17:33.003Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T16:21:05.627Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:21:10.417Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1578,9 +2370,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:39 GMT
+      - Mon, 09 Oct 2023 16:21:11 GMT
       mise-correlation-id:
-      - 6997c228-ccd4-4558-b0e4-34736f22396a
+      - c1529bde-1048-4161-869a-386bda9c77a7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1603,7 +2395,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:51.6172705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:51.6172705Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1612,9 +2404,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:41 GMT
+      - Mon, 09 Oct 2023 16:21:12 GMT
       etag:
-      - '"1a0a0dda-0000-0100-0000-64af09bd0000"'
+      - '"920159da-0000-0100-0000-6524276d0000"'
       expires:
       - '-1'
       pragma:
@@ -1633,7 +2425,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-y6u3iqhy4ggihir3k/providers/Microsoft.Storage/storageAccounts/clitestloadknmu3vdbw/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ic2lcalbskxxyap6w/providers/Microsoft.Storage/storageAccounts/clitestloadwywsds3td/providers/microsoft.insights/metricdefinitions/Availability":
       null}}'
     headers:
       Accept:
@@ -1649,10 +2441,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-07-12T20:17:27.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:17:44.424Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T16:21:05.627Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:21:13.589Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1663,9 +2455,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:44 GMT
+      - Mon, 09 Oct 2023 16:21:13 GMT
       mise-correlation-id:
-      - fb0e3b5f-cc28-4525-8037-e237bccbfb55
+      - c526d20c-d36f-4cea-9603-04ccf197ea7f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1688,7 +2480,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:14:51.6172705Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:14:51.6172705Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:43.5101466Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:43.5101466Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1697,9 +2489,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:45 GMT
+      - Mon, 09 Oct 2023 16:21:15 GMT
       etag:
-      - '"1a0a0dda-0000-0100-0000-64af09bd0000"'
+      - '"920159da-0000-0100-0000-6524276d0000"'
       expires:
       - '-1'
       pragma:
@@ -1729,10 +2521,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d1cceb2c-56ee-4aef-a4e7-8517926f528d.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://4a3e214c-76a6-4b70-a7d8-3a4090985a4e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-07-12T20:17:27.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:17:44.424Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T16:21:05.627Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:21:13.589Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1743,9 +2535,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:47 GMT
+      - Mon, 09 Oct 2023 16:21:15 GMT
       mise-correlation-id:
-      - 5c1680b1-8b6d-4ce4-8e53-d286ed519f64
+      - 79b3cb8d-344e-4a5a-bd7d-152004d08a7e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_server_metric.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_server_metric.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:18 GMT
+      - Fri, 13 Oct 2023 13:57:12 GMT
       etag:
-      - '"560063a9-0000-0100-0000-6524532b0000"'
+      - '"d901f03b-0000-0100-0000-65294c820000"'
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:24:20 GMT
+      - Fri, 13 Oct 2023 13:57:13 GMT
       mise-correlation-id:
-      - 055e8dbb-7e27-403d-860d-89271ccc530b
+      - 80023910-7335-4f10-8864-901e06354185
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"63ebb138-6fec-468f-abf2-8dc64b7d33dc": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":
+      {"passFailMetrics": {"b87cdada-a656-4562-96ce-72772d110124": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "f92feb41-660a-412a-9cdd-1c52fe552ae1":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "15256d43-3829-4e81-b76b-2db1a045776e": {"aggregate": "avg", "clientMetric":
+      "50"}, "9e894f78-529a-4c7e-b383-94e81720cf3f": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -104,28 +104,28 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:24:20.466Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:20.466Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:57:13.96Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:13.96Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1015'
+      - '1013'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:20 GMT
+      - Fri, 13 Oct 2023 13:57:13 GMT
       location:
-      - https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+      - https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 28ae5d29-c04f-4371-82d9-35b16c3525e5
+      - ab96e055-b084-4b13-8cd5-a8b6207a9879
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -143,9 +143,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:20 GMT
+      - Fri, 13 Oct 2023 13:57:14 GMT
       mise-correlation-id:
-      - 314acfe9-5013-4dc7-bdc4-28e399b1e6ec
+      - 44e133b4-94c5-48a5-b4ec-87c94a96d080
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -273,27 +273,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A34%3A21Z&sr=b&sp=r&sig=xhmePXoIDKGuCelc8PpbSV4llExTyiaXHR4HoBGsJk0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:34:21.2707987","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A15Z&sr=b&sp=r&sig=MFRQrJts2r7YW3%2BqSdlD3qxq2rnUc37bah123ywxSAw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:15.9076632","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:21 GMT
+      - Fri, 13 Oct 2023 13:57:15 GMT
       location:
-      - https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 5d6e7c45-b1b9-4644-b666-b4ca739e6e2d
+      - f37165ae-7376-403a-98f1-c8a537b1c286
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -311,25 +311,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A34%3A21Z&sr=b&sp=r&sig=FTFlM9v%2BlZx8no%2B%2BFvS48Mxp8JmRtcfMWdRmdEiSiw0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:34:21.536365","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A16Z&sr=b&sp=r&sig=2vmB%2Foaobh8P1uhEOB3DsE719C8nHpyrZ1dx60NKaBw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:16.137236","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '554'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:21 GMT
+      - Fri, 13 Oct 2023 13:57:16 GMT
       mise-correlation-id:
-      - 12b69f3a-2e31-4a2b-b956-0704e06e20a9
+      - d7df1491-527c-4d35-b1ad-31e80aee2511
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -347,12 +347,84 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A34%3A26Z&sr=b&sp=r&sig=olJnTraEMmFi2nZq4iJlaxAa55GXy5TqaJef0A1Y32k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:34:26.8194595","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A21Z&sr=b&sp=r&sig=RKfCwNXse8%2FUB%2Fr7Imu6GmNBfx1gJ3JrBsSt%2BMvqCsc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:21.4018329","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '555'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:57:21 GMT
+      mise-correlation-id:
+      - 3ec91e69-7f32-45c1-80ed-60c03fe85333
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A26Z&sr=b&sp=r&sig=mUiIq2EpKvkkvHVHL9UBPBGxcHV%2FXMox512m2L2r9%2FI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:26.6651744","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:57:26 GMT
+      mise-correlation-id:
+      - cc732240-a9a8-4103-829e-463ee7c15a13
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A31Z&sr=b&sp=r&sig=8WavkEDfOYr3E4SD1b5tYmTUItfPeFzuYhlbt2z%2BmIU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:31.9744634","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:26 GMT
+      - Fri, 13 Oct 2023 13:57:31 GMT
       mise-correlation-id:
-      - cb10ef22-f9d5-488c-80dc-e8dcab2ec91e
+      - f92f92b3-2c1f-4d5e-a860-5f060400f216
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -383,85 +455,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A34%3A32Z&sr=b&sp=r&sig=Pjl5RPIb4m8vIbibWqyy3O5Ly5223PCzSytulv%2FQzTg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:34:32.1025373","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:32 GMT
-      mise-correlation-id:
-      - 3ceff4b7-5e95-49ab-b91f-b8a8943e27fd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A34%3A37Z&sr=b&sp=r&sig=sheZYCrq2f2nhy2Z1KBfSSfBnMGzV42n5roSKH%2FXQs8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:34:37.3808096","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:37 GMT
-      mise-correlation-id:
-      - d2d0a8d4-db28-4b99-a355-8aec35f70c82
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A37Z&sr=b&sp=r&sig=a5CYGkqfnWaOQnj3lvRNuiNvl2cX%2B9lpBuI1Lk322wY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:37.658286","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:24:20.466Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:34.407Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A32Z&sr=b&sp=r&sig=cNjjCByxuy9fMXp5S1VzK3yb0s4nU3FfxwgG%2BVXuXE0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:32.2865908","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:57:13.96Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:28.739Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,9 +472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:37 GMT
+      - Fri, 13 Oct 2023 13:57:32 GMT
       mise-correlation-id:
-      - b64b7f7f-938f-41d4-bf2a-1f5b7f6bc134
+      - 8f3441a0-1697-4337-8dbb-2e31692f8abc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:38 GMT
+      - Fri, 13 Oct 2023 13:57:32 GMT
       etag:
-      - '"560063a9-0000-0100-0000-6524532b0000"'
+      - '"d901f03b-0000-0100-0000-65294c820000"'
       expires:
       - '-1'
       pragma:
@@ -536,26 +536,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A40Z&sr=b&sp=r&sig=YSWWW01221ey4K660On1XCFpzJyX46LfwSXEKrEThL4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:40.1814181","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:24:20.466Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:34.407Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A34Z&sr=b&sp=r&sig=Tl4YnEh4BsTTbxu3ZOFqD5c8YXXZxETfjro8qxXTxmY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:34.4941958","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:57:13.96Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:28.739Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1596'
+      - '1595'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:40 GMT
+      - Fri, 13 Oct 2023 13:57:34 GMT
       mise-correlation-id:
-      - bb248259-f51d-4e2b-8d55-40320236dbee
+      - 5bf4292c-c323-4687-9ee7-ef391f30e879
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:41 GMT
+      - Fri, 13 Oct 2023 13:57:35 GMT
       etag:
-      - '"560063a9-0000-0100-0000-6524532b0000"'
+      - '"d901f03b-0000-0100-0000-65294c820000"'
       expires:
       - '-1'
       pragma:
@@ -617,9 +617,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:24:42 GMT
+      - Fri, 13 Oct 2023 13:57:36 GMT
       mise-correlation-id:
-      - eef73c1d-c33e-4db6-b7e9-cc1dd77f3d8f
+      - 53423755-f9e9-4e1b-922d-2f916041d656
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -660,27 +660,27 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A43Z&sr=b&sp=r&sig=56OwgTuT7l0Zuafx02njUheK00Iy9BobhJ8fAeN%2F4LM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:43.6640467","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A43Z&sr=b&sp=r&sig=QeHMHTUlj%2BrzXrW2pzKl3xTy1iyvhbYIgZ%2B%2BBpgsq9Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:43.6639215","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A43Z&sr=b&sp=r&sig=80YspEgrPKh9YrgdvVcvYLAYjYrKbiF9UVSu9dkmXPo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:43.6640745","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:43.594Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A39Z&sr=b&sp=r&sig=FYRH4BnsiGuQNrnHsRETxixZPZPPkZE77Bl2iZs9Ouo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:39.3606038","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A39Z&sr=b&sp=r&sig=wF%2BixUh6NwwgD9cBmOI2PCZqg8ML4tgrPvwE6vob4kc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:39.3605202","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A39Z&sr=b&sp=r&sig=Eh7lK4V7HYhoqytU9bz0OH9Br%2FGr%2FDCA96YkncMVaUg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:39.3606251","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:39.288Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3190'
+      - '3189'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:43 GMT
+      - Fri, 13 Oct 2023 13:57:39 GMT
       location:
-      - https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+      - https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - dab5024f-c043-4dc1-b47f-b9691ae1a7b4
+      - 684c7e65-5880-4405-b0ef-cad57e2b7219
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -698,120 +698,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A44Z&sr=b&sp=r&sig=AOt1zyWWwU%2FvmQH24bYGGkEgV4chGA22AhRh7ECggUE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:44.1484293","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A44Z&sr=b&sp=r&sig=g1UTTpTy7xsyPnPVAvpTEQn2M0PLwv8%2FliBgvRIT03g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:44.1483446","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A44Z&sr=b&sp=r&sig=pd0cl%2B37VxCjkzDE%2BWzaWroZfB2z2y3fOwr0b85dcbw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:44.1484455","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:44.003Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:44 GMT
-      mise-correlation-id:
-      - ea8eb7a4-71e9-4959-ab8a-3d05bf408504
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A49Z&sr=b&sp=r&sig=9RKLAT6lL5q03AVv8rb10CnGGH24BgdpdjFCXBJaOEE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:49.4365896","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A49Z&sr=b&sp=r&sig=WynPU7rj9233Lwuzy9J17bVib9%2Fk0IVtFXxH4JMkwK8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:49.4364932","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A49Z&sr=b&sp=r&sig=tyLPNw7JuX7yMD3gZWmQkwtK59Ti%2BkEQ%2Bh9ZxkPvPNA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:49.4366098","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:44.204Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:49 GMT
-      mise-correlation-id:
-      - fb4a3b1b-4fce-47c7-9018-4e9fc0832e1e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A54Z&sr=b&sp=r&sig=3VqxPrDGjUkYrkGUfMSbvw8I2%2FsMT9eFfmGO%2F3GKj60%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:54.7514495","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A54Z&sr=b&sp=r&sig=zsRsMOoLQxQFR2ki8OsqxqeNNF1eOcpS7JkQqLc2kh0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:54.7513676","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A54Z&sr=b&sp=r&sig=Wr8YJYm%2F8AL9oEe2EdvT8LwWeWI%2BWz24WOFthfR9cJc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:54.7514676","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:44.204Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:54 GMT
-      mise-correlation-id:
-      - 25107e9c-d2b4-43fa-84a3-9429f717a56d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A00Z&sr=b&sp=r&sig=WBEJywxLpMU3UFurHkcTX6LeUqE8gFcnLyr7i4jasTU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:00.060243","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A00Z&sr=b&sp=r&sig=EsB93OmehXiLgdMAE8ZlOBokwV0Lu01R6c%2F8QI7HH58%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:00.0601417","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A00Z&sr=b&sp=r&sig=%2FjuGb76YZFNxuYmc4hggXsKJhFQYsWBgM%2BO28w9jJGI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:00.0602666","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:44.204Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A39Z&sr=b&sp=r&sig=1MxrRbxSXmXidMcbs5SP9tLjZNeLfQ1KiY9y2VDGRIg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:39.7986062","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A39Z&sr=b&sp=r&sig=a6J5rfGIrAF52PE9%2FQWi9q2Vt%2BYvFSDQwqFdjoQkgQI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:39.7985182","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A39Z&sr=b&sp=r&sig=EsZtkZ3v%2Fb9uwOGxLCSkEAyKw4CmrvIL84MNJkPRVdc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:39.7986274","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"NOTSTARTED","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:39.722Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -822,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:00 GMT
+      - Fri, 13 Oct 2023 13:57:39 GMT
       mise-correlation-id:
-      - 29f7d870-5ce0-421a-a0f2-a6ec1a70247a
+      - a78e883b-21b5-4e1f-a205-577f591a9dd7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -842,25 +734,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A05Z&sr=b&sp=r&sig=2D%2F6fj%2B9qHWLKopQtRRkO6kgzTk%2BTfS%2BF4v4hZfaovs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:05.3434934","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A05Z&sr=b&sp=r&sig=ouPjRvoD2V5OuJr6KCeb05KZY3FJykCw1gn6ztSDOSc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:05.3433897","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A05Z&sr=b&sp=r&sig=v4Tywmr%2Fpt%2FIxHpFRDfQKKXQlW3%2BvmUi%2BXRn2rnFSkI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:05.3435165","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:44.204Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A45Z&sr=b&sp=r&sig=SiTW5e1htlYc%2BmC4phvDgdjd1L9rIqCazBbXxMpucTI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:45.0285426","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A45Z&sr=b&sp=r&sig=jl2aFC4znEC4b%2Flh6kK2va7V5KxDad%2BXAXIFYXQzRsI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:45.0284625","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A45Z&sr=b&sp=r&sig=2%2BXhrvcmylz90ufKh8cdZvcQkRsuiO09JdL05CdTZGQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:45.028563","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:39.903Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3245'
+      - '3237'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:05 GMT
+      - Fri, 13 Oct 2023 13:57:45 GMT
       mise-correlation-id:
-      - 73561e84-6b28-4ce8-8180-55b85dc6329e
+      - 97271693-ae52-4b22-80e5-b7305e34e061
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -878,12 +770,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A10Z&sr=b&sp=r&sig=uAa5X00BWPh%2F5K%2FhZs6MYxcQ7YIukgrVrUv3xVXB9LE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:10.6268601","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A10Z&sr=b&sp=r&sig=3jBnBL5qBktm7JcUDijw4yxmDtYN%2BrgjtrLlsxZy1uQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:10.6267758","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A10Z&sr=b&sp=r&sig=skc1mtiYLc01h7SReNGUGGe7kMRnvlcj13cvGGP1JXI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:10.6268806","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:44.204Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A50Z&sr=b&sp=r&sig=4k9VCVTLVRP69zEAMo7NmZAzExxUYxy9iIZmMj8SZho%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:50.300999","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A50Z&sr=b&sp=r&sig=C72mLpztcu7rSWeLsOGTfaFILY33%2BkiCUlC2ywGc6V4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:50.3009075","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A50Z&sr=b&sp=r&sig=NDrRD9koZhmsh1TAzYd6DBmdlvcUxrh%2FM7oPQ50qS%2Fw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:50.3010141","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:39.903Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -894,9 +786,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:10 GMT
+      - Fri, 13 Oct 2023 13:57:50 GMT
       mise-correlation-id:
-      - e7ff620d-ce72-4ed8-ae6a-cff5108395f1
+      - 09508f30-5ce8-410d-bf7a-b269c7089844
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -914,12 +806,120 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A15Z&sr=b&sp=r&sig=ll5AGMgzCe7KpdTjQD24yRA1BJSAkVJbj1%2F8WKIBVd4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:15.962599","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A15Z&sr=b&sp=r&sig=GrOzVokzHCFcEZLdQbmaXKFK2O%2Bu%2FjY2095stuT6Dzw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:15.9625142","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A15Z&sr=b&sp=r&sig=NJdj%2FLFmnFRshx%2FyoP7CCghjxhn7QiVmEe5GvwVIAxY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:15.9626164","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:44.204Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A55Z&sr=b&sp=r&sig=BIMqmf78ksbc8wtKj7upyOt%2FNWP1Hi3qhl8an2bjTLo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:55.5704432","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A55Z&sr=b&sp=r&sig=TN2ml00msT7CL61ihfNQO0izNKw7H7pbVvStTOiJ8uI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:55.5703326","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A55Z&sr=b&sp=r&sig=XaynARjiU%2FFvNEFBoELZxkZWfbHjDhKBjVssUnpLCw8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:55.5704621","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:39.903Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:57:55 GMT
+      mise-correlation-id:
+      - f9019530-069d-41d6-ab71-c659a238cd41
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A00Z&sr=b&sp=r&sig=HFlGcsyp3T9A15ZcoBtKT%2BQQBvdUYwIRzGC%2BFWlmEBE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:00.8238811","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A00Z&sr=b&sp=r&sig=xyC%2Fj2T3an3F8hg9kcAYFkRLeMelQ8Rww6VW1IOlxmE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:00.823778","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A00Z&sr=b&sp=r&sig=ip96uuO9CaBLUh67zMNlVYaDJooDFa34qBQmhI3R7cE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:00.823907","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:39.903Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:58:00 GMT
+      mise-correlation-id:
+      - b3b7f847-0d79-4412-823f-353b103f9a55
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A06Z&sr=b&sp=r&sig=C%2BvkAm%2BjjcXRqfkoJQ3A8l78IvEb8eryAD6oCmIJVqY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:06.1366955","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A06Z&sr=b&sp=r&sig=QfZxXPJaEYjc%2BT1Yrn%2FOT27pk9eqnx0npUjzzHuMeXQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:06.1365956","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A06Z&sr=b&sp=r&sig=Xv0p5zK3axVkT1iT7ddMzjtZK9lJM5E4RvK%2BuRUpf6E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:06.1367236","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:39.903Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3240'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:58:06 GMT
+      mise-correlation-id:
+      - 3891c7d9-df04-44cd-b71b-e11eb59e773b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A11Z&sr=b&sp=r&sig=0KvFublu9zxXQGxWo8LaaGR%2F1uFNeWr7maCxwXu%2BSVI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:11.8106761","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A11Z&sr=b&sp=r&sig=TtGdVj7ykyGxvBYIE7YWYC7UMh8PLe3%2BaSxON%2BNL04A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:11.8106252","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A11Z&sr=b&sp=r&sig=vBrDFww1qrNoAQzd85dniM92A94Qszm1KOsn8m1IRFA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:11.8106909","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:39.903Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -930,9 +930,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:15 GMT
+      - Fri, 13 Oct 2023 13:58:11 GMT
       mise-correlation-id:
-      - 37c9874f-dbfd-4820-9245-180d829e387b
+      - fb52760e-1d86-4823-b7a3-59400faf8fc4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -950,25 +950,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A21Z&sr=b&sp=r&sig=DY0RCzPBXuwnWXRlRfIngyYDFJ4ZnBMZCJDiitJmEHo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:21.2467402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A21Z&sr=b&sp=r&sig=fOL2hHFzSdh1ekKyDeZ0F23jDOtnyoErLY43kaxuXVg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:21.2466581","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A21Z&sr=b&sp=r&sig=dhe3fINSChSabhwPukGs0wqsvsYEzQinAVumq0S2Vc8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:21.2467564","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:44.204Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A17Z&sr=b&sp=r&sig=LFCcYdu3sOREPvCggONU5nc6hfC2AyogWxqqopkfoUE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:17.0961345","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A17Z&sr=b&sp=r&sig=VK%2FDY7vvWUfmDm1uH8XEmY5K4L%2Br%2BPKs8wnebm%2FYVGE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:17.0960642","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A17Z&sr=b&sp=r&sig=M8qzC9H05Sddq6NVoeMOZLienKZ6nxAk%2FlwB6GgHKjI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:17.0961488","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:39.903Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3229'
+      - '3240'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:21 GMT
+      - Fri, 13 Oct 2023 13:58:17 GMT
       mise-correlation-id:
-      - 3c218217-b7dc-4d31-8731-e6e3371f5c64
+      - 9ed3a582-a444-48f3-b62d-5810ee09d143
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -986,25 +986,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A26Z&sr=b&sp=r&sig=jwx%2BTCxs5MRxtBDOrJUtzshaMlyifCUqIu26VF8jXCM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:26.5273015","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A26Z&sr=b&sp=r&sig=J0MLHInmHwr2cNrm7FPtd8l4k51qpNeBffEB8unOYu8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:26.5271899","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A26Z&sr=b&sp=r&sig=%2B8%2BUWBgDemyioNAr5bmleqMtJAxugzxwa4R5%2FUIT7C4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:26.5273209","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:23.687Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A22Z&sr=b&sp=r&sig=DvAgL1f6soFGpi%2BDsxgYeh4yVyr2%2B55crv4hCn2ZolA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:22.4292575","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A22Z&sr=b&sp=r&sig=qDOqWtD4bQfQSgVJ9fhayEkiswTRw9xqZFW7VBhGRJs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:22.4291702","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A22Z&sr=b&sp=r&sig=xox%2Bo13aBqugT%2B%2B5gRkFvnCQZIe9RE%2F%2B9EJm4C73lCY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:22.4292788","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONED","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:22.402Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3236'
+      - '3243'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:26 GMT
+      - Fri, 13 Oct 2023 13:58:22 GMT
       mise-correlation-id:
-      - 3898c49f-a882-4e2d-84d1-b27261c5c6d3
+      - 34f30c1e-67a4-4817-abf7-0d8f4ec8ba14
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1022,25 +1022,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A31Z&sr=b&sp=r&sig=9Vg8pnua2jSxl3yiLDNzr4ScDPrYBItem8nI2V2K6%2Bk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:31.82818","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A31Z&sr=b&sp=r&sig=W3e7EsFV7%2FKfSHDC97TgT1V%2But%2BxLWFHzB4W680vHyA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:31.8280874","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A31Z&sr=b&sp=r&sig=bMEQQcNzn5T0jmwyElWAdVi6TCsC1i%2Bq0xdVY6%2FIg9E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:31.8282003","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A28Z&sr=b&sp=r&sig=wdP7gxyrz8O17JMOmQE9431pqpRzK0hfwL%2F3%2BEercvE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:28.495939","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A28Z&sr=b&sp=r&sig=XgKTXChJ%2BQ2uIhc6kehE%2BpTzCBbRbEvPoLt11RrtZ5I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:28.4958454","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A28Z&sr=b&sp=r&sig=Kcgj5%2F87a5FRpTCfGO6mJTC0d7h2URYmISMdKEXRJj4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:28.4959622","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:22.465Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3236'
+      - '3238'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:31 GMT
+      - Fri, 13 Oct 2023 13:58:28 GMT
       mise-correlation-id:
-      - fabb884c-874a-403f-a58f-19f2978b4bbf
+      - 9921ef55-6433-4613-becd-16c7a9de10ed
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1058,192 +1058,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A37Z&sr=b&sp=r&sig=yz6xdBj4zzjhbBJh6yLBLTL5rT6xUq2Zqp0j8%2BToAzw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:37.1184495","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A37Z&sr=b&sp=r&sig=kocQCpZuuwNsBPoh2C1VZSKuqCESj9vDdqlxvA49wro%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:37.1183491","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A37Z&sr=b&sp=r&sig=2u7v2Dowtge36%2Fduk8QvUl4pldoDoQgK4xqdPFKFeR8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:37.1184699","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3230'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:37 GMT
-      mise-correlation-id:
-      - 58c9fb00-43d3-4080-9c4d-33a53d94129e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A42Z&sr=b&sp=r&sig=MfCiarUIZI3IPL0BS6FEINEzI%2FZ2dB1u9E3UPvlJOt0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:42.4681175","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A42Z&sr=b&sp=r&sig=7bFrp6T%2Bi%2Bwa37gWeVw3w9AZW4qfFiRUWA9b3%2BcZ734%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:42.4680403","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A42Z&sr=b&sp=r&sig=%2BQATiio37trO6bmopXGK7D2Bi0JBHKA8GaAKuKK2ebg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:42.4681331","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3236'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:42 GMT
-      mise-correlation-id:
-      - 9bae7e1d-1c7e-4006-8f68-7bd55a13ccbf
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A47Z&sr=b&sp=r&sig=AGTOaonk4i33Oz4c2V7XDNemb4104E7uqEPSd%2Fk7wM8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:47.7772028","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A47Z&sr=b&sp=r&sig=QuNoaQ2%2BxGvLTxjVpV96NFrJ9LKCerjlQFXJ9sZgYYY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:47.7771356","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A47Z&sr=b&sp=r&sig=zPJJqPo7aUm89pzOfxNtqIDhGHlLLSY1E6PyFAc4deY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:47.7772182","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3230'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:47 GMT
-      mise-correlation-id:
-      - 27c3e164-2d27-45b8-a09b-01bdba2b75ac
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A53Z&sr=b&sp=r&sig=rwi3%2B2iOqSKgXFy1Bo7%2Fs8phlMo7Lq6MgIik%2FvONqn8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:53.120267","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A53Z&sr=b&sp=r&sig=RjPX8bab7gX1HM4Mg8FSF7vfpqyXTQn33BnDw67%2B%2FQY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:53.1201724","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A53Z&sr=b&sp=r&sig=hnhysdA4V07eCxMGB8SG%2B91WY7BGbalETjLAJxYELUs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:53.1202876","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3237'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:53 GMT
-      mise-correlation-id:
-      - 176f9b99-7cf7-4a62-8ef7-bb7c4079e5b1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A58Z&sr=b&sp=r&sig=nABgAJcReGZgZ7Ui7l8p3leEKr4MZnU4uLdsnqGmtU4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:58.4564483","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A58Z&sr=b&sp=r&sig=pddOWPkT00JRY%2F81tFEx%2BCY2eX6Xl0u52IDEsmXp59c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:58.4563712","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A58Z&sr=b&sp=r&sig=FfYXWJeJChHOPt5MEdW1bW912e%2FxtNNFfWKg4lUUvbI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:58.4564626","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3232'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:58 GMT
-      mise-correlation-id:
-      - ece2c170-7f7a-4c04-bac8-1e5664172e4f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A03Z&sr=b&sp=r&sig=DkomZbWjYU0FS4ug8%2BSU9LP9Yw6bHC6wumknR5GlLTU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:03.7817156","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A03Z&sr=b&sp=r&sig=c%2BKvhAOTLSdS6G9vyZ3jp3D9ZTX307y600ldFYHzADw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:03.7815849","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A03Z&sr=b&sp=r&sig=LChyyJSYcWeu6GtjgI1ZwD2YYetg1Lm65Ta%2BoH%2F2VwE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:03.7817405","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A33Z&sr=b&sp=r&sig=Wd%2BINMFcxxDgpexHWFobQngA2%2BojAUb6mXxjbaZqWWk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:33.812921","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A33Z&sr=b&sp=r&sig=mpQIXdBOK%2Fhdtx5b9PHqJaoL3VxmXPJlB6pInDDhp%2B0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:33.8128469","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A33Z&sr=b&sp=r&sig=BxItG48DTjzhoVlc3b0wVjwV822rqUWX2H8NGUBiNQg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:33.8129353","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1254,9 +1074,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:26:03 GMT
+      - Fri, 13 Oct 2023 13:58:33 GMT
       mise-correlation-id:
-      - 03dac710-5609-4d79-8be9-ec912b0e285f
+      - 16dcf17b-5336-4399-a6af-d4608a457377
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1274,120 +1094,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A09Z&sr=b&sp=r&sig=vb%2BiKdQp3iS%2BGcAh42yaIceQXy9QMQQmsk%2B9zatbHH0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:09.0609306","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A09Z&sr=b&sp=r&sig=NeP5FMt%2FTk41eGdHkEPdMToDSxfWyZjEcPTskqukiag%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:09.0608433","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A09Z&sr=b&sp=r&sig=YSS%2Fh5jYCrrdUQxNPzrE18WHmoBjkvqWwy2kMSusSLo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:09.0609539","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3236'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:09 GMT
-      mise-correlation-id:
-      - 4f437b3e-bf5f-4a36-883e-e7f018255396
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A14Z&sr=b&sp=r&sig=bGuhQ6OQk1c2b9KtxBRABvLI4II35sq9E%2BBlOGxf2n0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:14.3386641","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A14Z&sr=b&sp=r&sig=SltGBRnRXuxD0yeNnzfq%2FILNFL80gwSCXN0j%2ByWQtaM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:14.3385677","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A14Z&sr=b&sp=r&sig=W3JfSYfTpoP24TXbu9QDn%2Fz83vlX4S75sKPqdaTFa3s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:14.3386841","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3234'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:14 GMT
-      mise-correlation-id:
-      - ef2e4daa-c486-4c1f-883a-5c471a7208d7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A19Z&sr=b&sp=r&sig=HeiGUMqrbyvHvnWvecFJfdaAM5Ld28QdldMs7Oz3q%2Fc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:19.6474378","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A19Z&sr=b&sp=r&sig=HhwtpgdJluufzHpKMlGe9GyUqESqB1%2F9KFwW4ctmteU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:19.6473309","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A19Z&sr=b&sp=r&sig=RdCwgZG88yum8ShxbDw4yfyzFQoXWZ0tPz7TtSayjdc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:19.6474623","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3230'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:19 GMT
-      mise-correlation-id:
-      - e8f6706b-bfb1-4945-ba9f-29e85bae7e9c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A24Z&sr=b&sp=r&sig=YUU%2BdmktIghC0KuAJsPs9CiD%2BoCBBKEvsArZ1%2BtOAAE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:24.9628693","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A24Z&sr=b&sp=r&sig=O%2BhgospJqKhLRkunBoiTUvHnX4DLuNQS%2BsvF%2BJJPfz4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:24.962792","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A24Z&sr=b&sp=r&sig=H%2FIPOeiyhcEuKrkKVmnM7PrwnCaF3Zrtdj6y5FA2A%2FM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:24.9628867","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A39Z&sr=b&sp=r&sig=20w0ICmu9W66DhY%2BuEk%2F4AD%2B4R80fPwEtt41wUO465A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:39.0584403","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A39Z&sr=b&sp=r&sig=8JZQlwN7qgU%2B4Ek1zJxdKlTRbQILDBdVJfk8%2BhNtk%2Bs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:39.0583363","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A39Z&sr=b&sp=r&sig=krfCrrPz5wlLc3Ns2v%2B8tzfcgWztUUdznAUkVsWvOJ8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:39.0584633","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1398,9 +1110,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:26:24 GMT
+      - Fri, 13 Oct 2023 13:58:39 GMT
       mise-correlation-id:
-      - 9217e492-6148-4385-afe9-82ee73f0b315
+      - 901014be-383b-410b-b41e-6adb71c9690b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1418,25 +1130,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A30Z&sr=b&sp=r&sig=NnAcXxMsCtu5D3dyd35DqgmiNaMGFGcrMLZIoQ8TY%2FI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:30.2946831","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A30Z&sr=b&sp=r&sig=wKkA1OBgA5vobbaXJuyXMcERF4%2BMZ4mU7Xc0Hk6CLYw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:30.2946081","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A30Z&sr=b&sp=r&sig=apjJMPST3H8hFlaO9feBA%2BJrE5qcj4ayN2%2BnFu53XJQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:30.294697","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A44Z&sr=b&sp=r&sig=JAJmamv4IQkMrlQ5zBaLfO0dVAKEbRiECszg%2BH00SXs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:44.3031082","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A44Z&sr=b&sp=r&sig=jduqBcANYgQODbflqDslyakFqToK3AHcStir%2B83G2%2BM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:44.3030226","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A44Z&sr=b&sp=r&sig=tMXfXkV6r5pWS%2F33wSkm71oXD48KsA8QS0KzWeANvwY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:44.303131","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3233'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:26:30 GMT
+      - Fri, 13 Oct 2023 13:58:44 GMT
       mise-correlation-id:
-      - 7001dc72-46fd-482f-bf9e-0b043ac40b9f
+      - 1145bb50-733e-42ff-8834-16f10f34531b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1454,48 +1166,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A35Z&sr=b&sp=r&sig=AAPhrAsWVs1OKJtMVt8AYZrj61yk0MlXIA%2BvEaG5fr4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:35.6119136","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A35Z&sr=b&sp=r&sig=7OB9JBu5QLY7Q2%2FzkmCwmjJwiLVTD1lW%2BbUjBVUFkIs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:35.611835","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A35Z&sr=b&sp=r&sig=%2Br0BmECvAia34y83aF1q3kfnCb1z5USCarR6HdYju7U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:35.6119278","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3233'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:35 GMT
-      mise-correlation-id:
-      - 4abe2fc8-355f-4ff9-a110-62450b223626
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A40Z&sr=b&sp=r&sig=D3QiMTx4sOM0oy77LU%2FLJjmmWgPyZiWVtsRjGUmop4k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:40.9444161","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A40Z&sr=b&sp=r&sig=55sUhssD6yJGREsDILD53wU6nEAUtbP6I8u75FCdzLE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:40.9443452","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A40Z&sr=b&sp=r&sig=Wxu37WaqNd%2F4pQ6hxNCmiQxlHmCdN6G416raX9uGUxM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:40.9444412","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A49Z&sr=b&sp=r&sig=L3PQKGuMcrX1j2eq8tUjPnRDMY0Dl2DeRZLuNSQWOQA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:49.573024","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A49Z&sr=b&sp=r&sig=8KoKWG93GeF7HF98lt%2F11XFldjAxRWiT4R59xvZGnkI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:49.5729533","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A49Z&sr=b&sp=r&sig=z%2B5dQjSkIuoKOXrPEJvWme7nRc3HuZacl28XBDgUqh8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:49.5730418","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1506,9 +1182,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:26:40 GMT
+      - Fri, 13 Oct 2023 13:58:49 GMT
       mise-correlation-id:
-      - aa3ebabd-b7ee-426b-acec-20c3dbda72c2
+      - 72d7a2fd-c7f3-4b69-a00b-3d895675de93
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1526,25 +1202,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A46Z&sr=b&sp=r&sig=UClgJYDhC%2FhWE3sWdAqtubfKDMSG0AKRjpIx1W6UvqQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:46.2606163","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A46Z&sr=b&sp=r&sig=7ovXU1IDjAzWKHpszpLpmyehR2w0j9%2F1IOuh9JMzdXY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:46.2605395","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A46Z&sr=b&sp=r&sig=RUN%2BTGJFIS977ANAeDgGlA4wm0QzwaCQ66jVtFAqQqs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:46.2606311","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A54Z&sr=b&sp=r&sig=jnfygetiDSRFbZDS7Y%2B%2Fo5ZMr5FHa8rXqEuy3g2%2BSto%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:54.8201311","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A54Z&sr=b&sp=r&sig=6Cx444sVx5IuXhWJDT43IE82N60LqYCn8da%2FohH0BbU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:54.8200467","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A54Z&sr=b&sp=r&sig=47fn8%2FE%2BZqQveboMGmdUWwsYxkc6dPrwQxcaVqTg4NI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:54.8201524","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3232'
+      - '3239'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:26:46 GMT
+      - Fri, 13 Oct 2023 13:58:54 GMT
       mise-correlation-id:
-      - 183a5fdd-b1ee-4f9f-840d-73b157048d13
+      - d6461ac7-829c-4e3f-9bdc-4cc6ee211423
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1562,12 +1238,84 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A51Z&sr=b&sp=r&sig=Mwum3%2F76fV1R%2BdOvibyWhia6AlG51RwtJzD%2FCJ5sOJw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:51.5853793","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A51Z&sr=b&sp=r&sig=HkHjG0PPi3WwPIfhjEpmWg4500dReWgrFKlEGAI6BhE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:51.5852967","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A51Z&sr=b&sp=r&sig=3M8JDGhuWiU2z2dGFFcFENhEdvWWAU6SgpFFRH7oVeY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:51.5854","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A00Z&sr=b&sp=r&sig=%2B8WL%2BuCr3cCAThlM4ereh9Z4n2Ggchta12eQYWvXMZA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:00.0778727","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A00Z&sr=b&sp=r&sig=Q%2B%2BxPx2MuJNFaK0cULVY9xSpfO3Z9Zs62qQwhRuOJR4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:00.0777765","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A00Z&sr=b&sp=r&sig=tGF%2BMYYf%2FUVfjtsLFnXivViZiwuS3o47N4FEgH5jDYU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:00.0778955","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3239'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:00 GMT
+      mise-correlation-id:
+      - 721a2e4d-e90b-441f-8646-f8c8be0f4b36
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A05Z&sr=b&sp=r&sig=3cjCnXlMvymaIiazjizuVNctQ3%2B3sVgYZ0A5GqsGSGU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:05.3319855","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A05Z&sr=b&sp=r&sig=s7KyCYD6B6qL3AI9v3%2BRqABQjc75uYBc4ZlYpOm8LTs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:05.3319002","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A05Z&sr=b&sp=r&sig=zX5L5F9q6Ed3MZvmtz%2FICr%2BKL7bXosznbbIpJVa3HFw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:05.3320066","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:05 GMT
+      mise-correlation-id:
+      - d404fd1c-121b-46d9-afa1-3d1c23497f5a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A10Z&sr=b&sp=r&sig=0nyEajUE02isa6aqkfAkoumWshjLG5mzm51wZumJHNo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:10.5728907","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A10Z&sr=b&sp=r&sig=KbTuFicPepFm2wtoRw3pEwm3yojZM4AjsWZrk%2BHIup4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:10.5728276","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A10Z&sr=b&sp=r&sig=LQbtsw1UIYDCRNgBIAPXQN4Lk1fpgdfIX7DNGxf3k1o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:10.5729059","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1578,9 +1326,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:26:51 GMT
+      - Fri, 13 Oct 2023 13:59:10 GMT
       mise-correlation-id:
-      - 988f8a92-6fd2-4957-ab99-786feaf1a800
+      - 759f5b33-0933-4cce-a4e6-0696580a8948
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1598,12 +1346,228 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A56Z&sr=b&sp=r&sig=omDd5NRFHEJhxoTvPhAU47SnIABImcsX%2FsbrGa7QDSc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:56.8729441","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A56Z&sr=b&sp=r&sig=DiULRTqWEBUBE%2BkLfNIpSsKcBJRNu8dqTs03878HTx8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:56.8728531","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A56Z&sr=b&sp=r&sig=UYN92FTDLh8VmH0%2FYYZ54Bv6Y%2B76LuMFhHOyltsoCBU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:56.8729662","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A15Z&sr=b&sp=r&sig=wnM2k3Ziv8Vh8ur5gMFbRO97r6dg1vHvr9oJLl8GaFY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:15.9150598","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A15Z&sr=b&sp=r&sig=%2F7X1j7S8dX6j4Sd82llZaJaVYuSNoHHB5AtU%2BAVsS6A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:15.9149742","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A15Z&sr=b&sp=r&sig=07BAZDDkgtJLlh%2BPOzmqrch84lM0ZgwHowTujGjFhLM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:15.9150806","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:15 GMT
+      mise-correlation-id:
+      - 6865af57-ea59-4fec-97d2-8b0aff4b9204
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A21Z&sr=b&sp=r&sig=RMpsjvXo5vn4rXEifgtcUJn3smSRbDVY6IpvGLeVkic%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:21.1790374","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A21Z&sr=b&sp=r&sig=a8zb%2BXM1cCbuf6sn35nk9sst%2BYrPZ4Vh24cUFnzhByI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:21.1789617","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A21Z&sr=b&sp=r&sig=ee614xKJUhbCFyo3y8%2BXhNSpKBJkGPDyQBzK77ai9eA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:21.1790524","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:21 GMT
+      mise-correlation-id:
+      - f4bc9998-a236-409d-8d49-6bbb1483b3eb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A26Z&sr=b&sp=r&sig=H13WvKyVMywj9nB3zib4%2FxnDXhCz1OYXKi0lK4CgnQ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:26.4618109","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A26Z&sr=b&sp=r&sig=YmB6NS%2FvlBdvJJG7WwpobOU8Q8oooHbz9VGMirgBJjY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:26.4617369","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A26Z&sr=b&sp=r&sig=EGGmY3ba%2BuGU4CqtwBwAm%2B36zqrRDnkqv3G57QzHDfU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:26.4618272","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:26 GMT
+      mise-correlation-id:
+      - 45839d9b-f06b-4002-917a-82235394faa0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A31Z&sr=b&sp=r&sig=lwNb2Fc7%2FcqtYZQ8lZY%2FT4sF2sz7uaL4QRKZk%2BBV01M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:31.7821009","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A31Z&sr=b&sp=r&sig=pSeTasyS7kEikXIwGI2jyg8h8741hrXcwL1A3kXK3EI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:31.7820327","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A31Z&sr=b&sp=r&sig=qfTOC6pKrjtbOkmdl6S1rJMbyWoc2AZt49ryRZ4mK3I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:31.7821162","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:31 GMT
+      mise-correlation-id:
+      - 630350a6-7ef7-4119-a621-af37d1b63e23
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A37Z&sr=b&sp=r&sig=3i4gVvUefGxE%2BuxJPbwunUxa9z5%2Bt0a%2FgE59BspFRow%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:37.1166401","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A37Z&sr=b&sp=r&sig=6QPMbHQrwBbhUctcxkooLsR58GxFSnSBWD0dzL%2FIkRg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:37.11656","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A37Z&sr=b&sp=r&sig=8MrfWOj2X4GmimP83UbBG2Z%2BcjVrBXYJvUxzs6r%2FBDI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:37.1166545","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:37 GMT
+      mise-correlation-id:
+      - 13b1c09e-52c6-4c61-b7d2-7167e57e3082
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A42Z&sr=b&sp=r&sig=wHf8%2FlHL4mNZd15fSCA5osZ%2FjLM9YfN6eJMlKIzhJ3I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:42.4442298","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A42Z&sr=b&sp=r&sig=w8sF%2FMt2wAlmwlRs6FFngJVwVPsApgHcfR4AqM%2FD1BI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:42.4440711","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A42Z&sr=b&sp=r&sig=HZ9Tpl8jRIlyeuW5q15WC%2FXhZJNW9Ie9MLAakHraMZs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:42.4442716","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:42 GMT
+      mise-correlation-id:
+      - 5faa38dd-681b-46b8-b395-6bbf3ca033ac
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A47Z&sr=b&sp=r&sig=k6T%2BioeJAybBuUYj9q7iSvcZ%2FDKNL9%2FBjtjFwaATyE0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:47.770592","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A47Z&sr=b&sp=r&sig=maAzyzKL1hRjolURzvG9XVuDEn2%2FQH8iHjhdI12x5wE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:47.7705253","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A47Z&sr=b&sp=r&sig=lC0bYC6VFa7lKUjKTjdQeGORsVbEUeq0Meng6upY4jw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:47.7706072","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1614,9 +1578,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:26:56 GMT
+      - Fri, 13 Oct 2023 13:59:47 GMT
       mise-correlation-id:
-      - 3be38cf5-0e8c-4226-b80a-44ae7b48e3c3
+      - 12c2bc80-1d1b-46e8-bf4f-d64263dd7d7b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1634,12 +1598,120 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A02Z&sr=b&sp=r&sig=tgpX%2FERImRUrWkkmHdTkeoqpoSoHckblQxFCvBJx0ik%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:02.1517288","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A02Z&sr=b&sp=r&sig=g%2BWQwhZkH6tvwpfZI5IOBD1QPSdnldDhZd1GeJ%2BHv8s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:02.151631","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A02Z&sr=b&sp=r&sig=RHfLeZvootiypShnNHwkEHggqTwM5utj022axh1VSpc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:02.1517675","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A53Z&sr=b&sp=r&sig=%2Bj6NIYld5MhaTrnC%2F2X1gPYTMWLn9N7ye33xP4%2B67CY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:53.0319227","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A53Z&sr=b&sp=r&sig=xk0nVZXCap4%2BhpmvYcPwTzRecePrwX%2FSg8Uxq3B%2Bv1A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:53.0317456","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A53Z&sr=b&sp=r&sig=17NLGc5O5tTOhP%2FNm3NCgscWXz95nhKvsVOS2qXS9Ys%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:53.0319455","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3241'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:53 GMT
+      mise-correlation-id:
+      - 75508aa5-f408-4527-b3b3-41517273f1df
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A58Z&sr=b&sp=r&sig=O1C%2BvI%2BFKOKbZdHEvV6rUp4jm0s9AZDzmLhmiZCxS6I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:58.2964023","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A58Z&sr=b&sp=r&sig=GCzyU6GDqyTI3Ly6I9triicq4b5c7Qvvf1MJYCTzUFs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:58.2962899","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A58Z&sr=b&sp=r&sig=zNFA3JWu%2Bvc7%2BvC44Xxnett%2F6DCBs3dOg6VVgjTCvjY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:58.2964264","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:58 GMT
+      mise-correlation-id:
+      - 29285751-9173-414d-922c-16d7f188dbf0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A03Z&sr=b&sp=r&sig=cK%2BrpDpUcw9qD9g1LPT%2BZn5GqROR8hfanaSQwNgPi2Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:03.5117269","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A03Z&sr=b&sp=r&sig=FY5m%2FbBz1AfLAZYeaouf%2BjJwxoGWCjsNx3aUfYNL87Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:03.5116477","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A03Z&sr=b&sp=r&sig=UIqh6VZ%2F0LyD2C1OxfJy95AHrCh4yEtiaLNFVfC7YdE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:03.5117484","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:00:03 GMT
+      mise-correlation-id:
+      - d1993c76-faed-4c0b-bde1-f7075cc3932b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A08Z&sr=b&sp=r&sig=cW4hJp8LUfc1YILHKJELkwZWwDmUQEo1feNBhcHCkD4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:08.8624275","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A08Z&sr=b&sp=r&sig=ziFvbs2yDWj5xtNnK7ro%2Fj3GS8HDvkfHCgornjiaQvA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:08.8623197","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A08Z&sr=b&sp=r&sig=WhZnvq5wIpy3qEKm1OcDxoL3uAy8%2F14FBuR1umKAcqk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:08.8624479","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1650,9 +1722,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:02 GMT
+      - Fri, 13 Oct 2023 14:00:08 GMT
       mise-correlation-id:
-      - cf9edc09-6bdc-4018-9f76-2ca52ba7b839
+      - 514b1e3a-aaeb-4798-ab75-a3069ebe2f63
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1670,25 +1742,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A07Z&sr=b&sp=r&sig=7rYbJg8ZKlxj%2FWSUpH3BKq6i0ydvCwbuus%2FKYQXLLe0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:07.4582827","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A07Z&sr=b&sp=r&sig=J6IZ1wxDqAXIpzSZuvsSMmH0sR3j6vXw2ImkBTV7iJc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:07.4582122","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A07Z&sr=b&sp=r&sig=gkVkstM%2FxMJGkLt1H%2BACdZBHJSPgXttLbs52LZFeIEQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:07.4582989","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A14Z&sr=b&sp=r&sig=E6aJHBwimu7bKVEQo8Jrnlfn1EKdftcCPrpX8cjnB0U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:14.1867088","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A14Z&sr=b&sp=r&sig=OanVvAw1qjByKWMT%2BUwQDBWHaoKP5d2xSpqkzP3aVTg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:14.1866209","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A14Z&sr=b&sp=r&sig=NulsV2vL%2B24E%2Ft0GJl%2B%2FiJIuvrUC2pAUwJ7sX5aj32k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:14.1867308","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3234'
+      - '3237'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:07 GMT
+      - Fri, 13 Oct 2023 14:00:14 GMT
       mise-correlation-id:
-      - 6ad05047-8011-4cfe-9ba5-7f3119058008
+      - 316a00f3-49a0-4197-bf51-acce2597a7c7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1706,25 +1778,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A12Z&sr=b&sp=r&sig=wVASu5QMeasCMIiIR86D91sfsrPuG1qCxvtW6Uelq5U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:12.7834553","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A12Z&sr=b&sp=r&sig=WniZVEGs8Mrt5iJOHwpBA9qpXJwh7NkWVDbvSOblC90%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:12.783381","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A12Z&sr=b&sp=r&sig=maXP0fq%2FxMidmtvWITRHL789n7vSCzsk4CaGZOJy0mI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:12.7834712","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A19Z&sr=b&sp=r&sig=PPtlvC20LjUL5FhWhhMj1R45Qedp4boBQNHjAJ6vEtU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:19.5291281","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A19Z&sr=b&sp=r&sig=4CR9g%2BSPVJBySxdadr9XIufwKjMAKhyJoP8nqNtkkBM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:19.5290538","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A19Z&sr=b&sp=r&sig=ZOrTxxjiAgHnfaXIimxJPfv%2FST6%2FAlK2AJv8ybkXPZo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:19.5291466","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:39.722Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:30.463Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3227'
+      - '3233'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:12 GMT
+      - Fri, 13 Oct 2023 14:00:19 GMT
       mise-correlation-id:
-      - 2c977a24-16d2-4bcb-bcac-294a3c13a6e9
+      - 30e6c491-f657-4307-baaa-166f8d87c0c9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1742,62 +1814,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A18Z&sr=b&sp=r&sig=licoaGjb%2BQN%2B2pYOSrw5yadVhS1Z%2FajucHgEIspom14%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:18.1242648","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A18Z&sr=b&sp=r&sig=ypAPGAK%2FFy1O28LZRGmONjVL5267h6V96RA3y7YtswE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:18.1241669","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A18Z&sr=b&sp=r&sig=hDOIuGIKj2x1y34t%2Bg3ZjLhWwjiiNZIgJ17et6dEXbY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:18.1242866","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:44.003Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:28.268Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A24Z&sr=b&sp=r&sig=o7sTEwbSAs4%2BZvbbZ9iWVJGXm3fNafc9TzoJayMe3IY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:24.8152159","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A24Z&sr=b&sp=r&sig=74RmR6VUP50a9qlvtcQAhkDdBvCVzWNk8xNzimrpbyE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:24.8151273","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A24Z&sr=b&sp=r&sig=JIX8E%2F7goKQrvmaPtSmk5F9hq%2F1yHBBAi6dRulmOnZw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:24.8152363","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-13T13:57:39.722Z","endDateTime":"2023-10-13T14:00:24.237Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:24.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3236'
+      - '3368'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:18 GMT
+      - Fri, 13 Oct 2023 14:00:24 GMT
       mise-correlation-id:
-      - 8f4cdfa7-1a5e-4b9a-b029-089e3c9ea96e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A23Z&sr=b&sp=r&sig=Zo3FqpZgwqZvYZ%2FXXz1q1sR%2FR8KaA751vSavVfruY1M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:23.4416906","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A23Z&sr=b&sp=r&sig=W58YM2OlSjJjx6hg7CG1Q6IVpyx6XSpSs%2F7ZKLOGR3E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:23.4415294","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A23Z&sr=b&sp=r&sig=T3NOzOHntGKGjAf%2FWMUbmBfJTkAU5Ucgwt42TjOzz5o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:23.4417518","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-09T19:24:44.003Z","endDateTime":"2023-10-09T19:27:21.284Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:21.481Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3369'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:27:23 GMT
-      mise-correlation-id:
-      - 27e2ca1b-d526-4524-be2b-48fa2ed54dfa
+      - aa2d1219-321f-414a-8fc8-3bc51ca593d8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,7 +1856,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1829,9 +1865,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:24 GMT
+      - Fri, 13 Oct 2023 14:00:26 GMT
       etag:
-      - '"560063a9-0000-0100-0000-6524532b0000"'
+      - '"d901f03b-0000-0100-0000-65294c820000"'
       expires:
       - '-1'
       pragma:
@@ -1859,26 +1895,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=server-metric-test-case&api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=server-metric-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"63ebb138-6fec-468f-abf2-8dc64b7d33dc":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"55d6bc9d-aa8b-4ce9-b9fb-1a8f4a7cf8a3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"15256d43-3829-4e81-b76b-2db1a045776e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/a31ca79f-27dd-4b0b-8cee-169ff963773b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A25Z&sr=b&sp=r&sig=pYrK4SkPxlfw44x7wXzmiIOipbjzT%2BmHp65PXgnhpmo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:25.9162661","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/801b6e5b-6af0-49a4-b1d8-68070e073538?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A25Z&sr=b&sp=r&sig=On50a2xeIjYLNyODTDJWITopPg%2F1rqel5uJC6SbCBOQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:25.9161729","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ceb73983-26cc-4081-a147-0f507b8fe99c/4683a464-e1d9-4228-9e07-d9e01610ce3e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A25Z&sr=b&sp=r&sig=5qUlJFa8%2FHoG7EMBjzbsGsAnLi5OJ9YH07i93Z6rJV4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:25.9162901","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-09T19:24:44.003Z","endDateTime":"2023-10-09T19:27:21.284Z","executedDateTime":"2023-10-09T19:24:43.36Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-09T19:24:43.594Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:25.543Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"b87cdada-a656-4562-96ce-72772d110124":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f92feb41-660a-412a-9cdd-1c52fe552ae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9e894f78-529a-4c7e-b383-94e81720cf3f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/ea82e31c-2633-47de-a8ba-def1422d7236?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A27Z&sr=b&sp=r&sig=Iwarv5oTsisoIaF7RwWFuvlGsyjuCwIGo0BarVcjO7k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:27.1503555","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/e52ea730-e1e9-44ee-ace8-207e99ebfb7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A27Z&sr=b&sp=r&sig=PJp56IlImQDjVzEh2UY2V3iAydhbV9xIN89qd2ZdcmU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:27.1502836","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/33b3452a-c9e3-47f7-ab87-a30165e52128/0af7078c-b3f1-4066-906d-5723166df4ce?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A27Z&sr=b&sp=r&sig=nNFRxdlHnPGThPZn%2BMfDNNxZFvWPQaV9YJCkHfxdXDQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:27.1503718","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-13T13:57:39.722Z","endDateTime":"2023-10-13T14:00:24.237Z","executedDateTime":"2023-10-13T13:57:37.655Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-13T13:57:39.288Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:24.367Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3379'
+      - '3376'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:25 GMT
+      - Fri, 13 Oct 2023 14:00:27 GMT
       mise-correlation-id:
-      - b5786568-1fe6-45af-8861-b17dadd38d91
+      - 127d3850-5c0b-49a2-b239-6f4e00d2c4b1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1900,12 +1936,12 @@ interactions:
       ParameterSetName:
       - --name --resource-group
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-09T19:23:56.4764769Z","key2":"2023-10-09T19:23:56.4764769Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T19:23:56.4920647Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T19:23:56.4920647Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-09T19:23:56.2889390Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-13T13:56:51.3228153Z","key2":"2023-10-13T13:56:51.3228153Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-13T13:56:51.3228153Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-13T13:56:51.3228153Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-13T13:56:51.1040385Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -1914,7 +1950,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:27:26 GMT
+      - Fri, 13 Oct 2023 14:00:27 GMT
       expires:
       - '-1'
       pragma:
@@ -1947,7 +1983,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1956,9 +1992,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:28 GMT
+      - Fri, 13 Oct 2023 14:00:29 GMT
       etag:
-      - '"560063a9-0000-0100-0000-6524532b0000"'
+      - '"d901f03b-0000-0100-0000-65294c820000"'
       expires:
       - '-1'
       pragma:
@@ -1977,9 +2013,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-u3j5rc57mmljjtrla/providers/Microsoft.Storage/storageAccounts/clitestloadilb3d6zty":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-u3j5rc57mmljjtrla/providers/Microsoft.Storage/storageAccounts/clitestloadilb3d6zty",
-      "resourceName": "clitestloadilb3d6zty", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testRunId": "server-metric-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-vxzk6dtlrnyejency/providers/Microsoft.Storage/storageAccounts/clitestloadnq4tggts4":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-vxzk6dtlrnyejency/providers/Microsoft.Storage/storageAccounts/clitestloadnq4tggts4",
+      "resourceName": "clitestloadnq4tggts4", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -1993,12 +2029,12 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-09T19:27:29.441Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:29.441Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-13T14:00:30.809Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:30.809Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2009,11 +2045,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:29 GMT
+      - Fri, 13 Oct 2023 14:00:30 GMT
       location:
-      - https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+      - https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - d3663908-a17f-4bd0-a83d-abc91df1fefa
+      - d1f9012f-d667-4c4a-a263-6674bc74e509
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2036,7 +2072,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2045,9 +2081,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:30 GMT
+      - Fri, 13 Oct 2023 14:00:31 GMT
       etag:
-      - '"560063a9-0000-0100-0000-6524532b0000"'
+      - '"d901f03b-0000-0100-0000-65294c820000"'
       expires:
       - '-1'
       pragma:
@@ -2075,12 +2111,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-09T19:27:29.441Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:29.441Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-13T14:00:30.809Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:30.809Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2091,9 +2127,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:31 GMT
+      - Fri, 13 Oct 2023 14:00:33 GMT
       mise-correlation-id:
-      - 568e159e-097d-4d5c-ada8-077e47098a0f
+      - cf7ebd69-3a4b-4a5a-948e-65cd36545239
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2116,7 +2152,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2125,9 +2161,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:32 GMT
+      - Fri, 13 Oct 2023 14:00:35 GMT
       etag:
-      - '"560063a9-0000-0100-0000-6524532b0000"'
+      - '"d901f03b-0000-0100-0000-65294c820000"'
       expires:
       - '-1'
       pragma:
@@ -2146,9 +2182,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-u3j5rc57mmljjtrla/providers/Microsoft.Storage/storageAccounts/clitestloadilb3d6zty/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-vxzk6dtlrnyejency/providers/Microsoft.Storage/storageAccounts/clitestloadnq4tggts4/providers/microsoft.insights/metricdefinitions/Availability":
       {"name": " Availability", "metricNamespace": "microsoft.storage/storageaccounts",
-      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-u3j5rc57mmljjtrla/providers/Microsoft.Storage/storageAccounts/clitestloadilb3d6zty",
+      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-vxzk6dtlrnyejency/providers/Microsoft.Storage/storageAccounts/clitestloadnq4tggts4",
       "resourceType": "Microsoft.Storage/storageAccounts"}}}'
     headers:
       Accept:
@@ -2162,27 +2198,27 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T19:27:29.5Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:33.787Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-13T14:00:30.831Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:36.087Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3240'
+      - '3242'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:33 GMT
+      - Fri, 13 Oct 2023 14:00:36 GMT
       mise-correlation-id:
-      - 22da4aa4-42e5-42e1-9d21-a62f00697964
+      - 62d90224-9793-45e5-ae80-78995d7aeaa3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2205,7 +2241,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2214,9 +2250,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:35 GMT
+      - Fri, 13 Oct 2023 14:00:37 GMT
       etag:
-      - '"560063a9-0000-0100-0000-6524532b0000"'
+      - '"d901f03b-0000-0100-0000-65294c820000"'
       expires:
       - '-1'
       pragma:
@@ -2244,27 +2280,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T19:27:29.5Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:33.787Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-13T14:00:30.831Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:36.087Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3240'
+      - '3242'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:36 GMT
+      - Fri, 13 Oct 2023 14:00:38 GMT
       mise-correlation-id:
-      - f6444b1b-f599-4b9c-b1b0-f49d390435fe
+      - ce7bd4ad-950c-4360-a87f-93478909257c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2287,7 +2323,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2296,9 +2332,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:37 GMT
+      - Fri, 13 Oct 2023 14:00:39 GMT
       etag:
-      - '"560063a9-0000-0100-0000-6524532b0000"'
+      - '"d901f03b-0000-0100-0000-65294c820000"'
       expires:
       - '-1'
       pragma:
@@ -2317,7 +2353,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-u3j5rc57mmljjtrla/providers/Microsoft.Storage/storageAccounts/clitestloadilb3d6zty/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-vxzk6dtlrnyejency/providers/Microsoft.Storage/storageAccounts/clitestloadnq4tggts4/providers/microsoft.insights/metricdefinitions/Availability":
       null}}'
     headers:
       Accept:
@@ -2331,25 +2367,25 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T19:27:29.5Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:38.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-13T14:00:30.831Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:41.12Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2494'
+      - '2495'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:38 GMT
+      - Fri, 13 Oct 2023 14:00:41 GMT
       mise-correlation-id:
-      - 98b3f708-9a3a-4a10-b0da-8b8994cebea0
+      - d873fd4a-e138-44ab-8398-c6f3ed55a11a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2372,7 +2408,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:21.9600985Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:21.9600985Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:16.0788913Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:16.0788913Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2381,9 +2417,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:40 GMT
+      - Fri, 13 Oct 2023 14:00:42 GMT
       etag:
-      - '"560063a9-0000-0100-0000-6524532b0000"'
+      - '"d901f03b-0000-0100-0000-65294c820000"'
       expires:
       - '-1'
       pragma:
@@ -2411,25 +2447,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0982786f-5414-4b20-b8c8-30ac22e75663.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://304b58ab-5887-4572-86ca-9a1a5932250b.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T19:27:29.5Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:38.843Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-13T14:00:30.831Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:41.12Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2494'
+      - '2495'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:41 GMT
+      - Fri, 13 Oct 2023 14:00:43 GMT
       mise-correlation-id:
-      - dfbaeed4-611a-4150-a654-e80aa3a50219
+      - fc8d75e6-2a3d-4605-8807-25500b1bb575
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_server_metric.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_server_metric.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:51 GMT
+      - Sun, 29 Oct 2023 22:26:08 GMT
       etag:
-      - '"d300cf49-0000-0100-0000-6537b9780000"'
+      - '"3c001330-0000-0100-0000-653edbe80000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:33:52 GMT
+      - Sun, 29 Oct 2023 22:26:10 GMT
       mise-correlation-id:
-      - 15255de7-e1d1-419e-bbec-4dae8ecbbc9a
+      - d6b8b5bc-5ab5-4516-955b-4a66d2bbc83f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"04694ae7-22f2-4815-9972-9047a4152168": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "a194dfcb-4122-4997-ae60-04ec74401d91":
+      {"passFailMetrics": {"2e069b3e-5056-45bf-a355-e9bd38d8033f": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "2aa10b1b-303a-4698-881f-a2968b6b83ca":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "4e9f48fe-5417-4942-8763-f143c419890d": {"aggregate": "avg", "clientMetric":
+      "50"}, "c141ce4f-631c-441a-b867-0ec54c02a5f2": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:33:52.811Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:52.811Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:26:11.769Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:11.769Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:52 GMT
+      - Sun, 29 Oct 2023 22:26:11 GMT
       location:
-      - https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+      - https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 52602450-88f6-478e-a9fc-d89c0d961340
+      - ae8495ba-7309-4bbf-98fe-8fe15a21d32e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:53 GMT
+      - Sun, 29 Oct 2023 22:26:12 GMT
       mise-correlation-id:
-      - 22fc412b-15ab-423f-80f5-87e30ef76d9a
+      - cf48b9db-bb33-4d42-9231-3c2d0af48864
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A53Z&sr=b&sp=r&sig=1f5uQiUBejJDL3I1lR4BOdj7FAha7chpcahdop5JxIw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:53.6895423","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A13Z&sr=b&sp=r&sig=JcZdu3wTw%2FAkEKpLiCiUOZqqJvH%2FBSLS64EEK%2FseSFY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:13.4320231","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:53 GMT
+      - Sun, 29 Oct 2023 22:26:13 GMT
       location:
-      - https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - e18c20ab-6fc4-4749-91da-53cec3e421be
+      - fb000627-0532-4f0d-aedd-47d82b667784
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A54Z&sr=b&sp=r&sig=oNPUhtdbk27GFm9B9jAc1DMNDP4pVaw0SGqi0RbbLw4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:54.0507028","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:33:54 GMT
-      mise-correlation-id:
-      - 8e56c766-0a39-4d25-8f9d-2c1eaeb2c024
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A59Z&sr=b&sp=r&sig=%2F%2FRu4me1RRUNhXdKMVNqHtzHdKFDqA%2FYMQX%2B6XDCkyI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:59.6519629","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '557'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:33:59 GMT
-      mise-correlation-id:
-      - bbf71bd9-91e1-452d-88e8-49e0342a3f1e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A44%3A04Z&sr=b&sp=r&sig=rIvOunvaFjsfHxF%2B%2Bn4VxpHxJuWaKCAvZw6obwPzLnU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:44:04.9064326","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A13Z&sr=b&sp=r&sig=KPyYzc6CLpDxQEibMKIB%2B6AkcyysZgB%2FGVZz8Gl19jQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:13.6771241","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:34:04 GMT
+      - Sun, 29 Oct 2023 22:26:13 GMT
       mise-correlation-id:
-      - 16bc7dfc-dc88-4b84-a97b-41800ac16987
+      - 7bc93675-9012-4327-9bd8-5cee54717ddc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A44%3A10Z&sr=b&sp=r&sig=1dMvg2EAU%2F%2FZY3XJseGisSAEVMMCmpWcdBRrrUbeKZU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:44:10.5918353","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A18Z&sr=b&sp=r&sig=%2FmHOOyC7K3THsMDdkbj2SlVof42btOOMNuV00%2FLVuGA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:18.9454134","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:34:10 GMT
+      - Sun, 29 Oct 2023 22:26:18 GMT
       mise-correlation-id:
-      - 41442102-3691-4070-a66f-a3476dc56a53
+      - 85b3f3bb-8507-4f93-8cbc-9ee6cf2afc7e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +385,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A10Z&sr=b&sp=r&sig=m%2BUC0wa%2FAYZ4EAJeEmibw%2FTg%2BJha7QSSm53Ki%2FkbMBQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:10.8433265","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:33:52.811Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:05.676Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A24Z&sr=b&sp=r&sig=%2F4A8sjkori7Rdh5iDMQZzVp8FUWOJi9s%2Fwlm23n2SM8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:24.1894528","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1594'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:34:10 GMT
+      - Sun, 29 Oct 2023 22:26:24 GMT
       mise-correlation-id:
-      - 139b720a-bab4-4925-ab57-e6b0464235c6
+      - 868c99f6-731e-49f4-8d0d-b67bc83e9b63
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A36%3A29Z&sr=b&sp=r&sig=%2F318g7MINQmA4MHAH7w0TQ1N%2F%2F3QbTlR601DohBUh1Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:36:29.4748865","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:26:29 GMT
+      mise-correlation-id:
+      - ba124f36-c0a1-4964-8d72-74a5b15e02bb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A29Z&sr=b&sp=r&sig=p1qNB4z%2FqWEiUsjNo7q57uSulbsjjafKf%2FkiF4MapXg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:29.797602","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:26:11.769Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:27.642Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1587'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:26:29 GMT
+      mise-correlation-id:
+      - fdd85d05-ac2e-47f1-aea4-de9b3c2b75d3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:34:12 GMT
+      - Sun, 29 Oct 2023 22:26:31 GMT
       etag:
-      - '"d300cf49-0000-0100-0000-6537b9780000"'
+      - '"3c001330-0000-0100-0000-653edbe80000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A13Z&sr=b&sp=r&sig=Og7u028Mr37AuDi6WK87vUuo1IIJGZQSPhVE2mUJ07Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:13.0037348","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:33:52.811Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:05.676Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A32Z&sr=b&sp=r&sig=tAq1DH0KwfGTKDFrMPvUYuxb2RHOGuwE5Ef87Rbo3k0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:32.458633","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:26:11.769Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:27.642Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1596'
+      - '1595'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:34:13 GMT
+      - Sun, 29 Oct 2023 22:26:32 GMT
       mise-correlation-id:
-      - ebabcbf4-4f85-4d47-af62-b53f8f68619f
+      - a9b15327-aa29-4f15-afa1-d5360aff6fee
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:34:13 GMT
+      - Sun, 29 Oct 2023 22:26:33 GMT
       etag:
-      - '"d300cf49-0000-0100-0000-6537b9780000"'
+      - '"3c001330-0000-0100-0000-653edbe80000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:34:15 GMT
+      - Sun, 29 Oct 2023 22:26:34 GMT
       mise-correlation-id:
-      - d8bd6dce-c1bb-4569-ad34-7e83ea405f65
+      - 6b3dbbb9-1bfe-4fa5-9d79-3556f56cf498
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A16Z&sr=b&sp=r&sig=68ELqoedT2dhVZGBkWB2FNw969RwG%2F1MqEzMuf6wkNs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:16.1761083","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A16Z&sr=b&sp=r&sig=FYuUHk6Xj0oYeZMfp96ZKgTClyGtK%2BOM6rPfi7YraUs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:16.1759899","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A16Z&sr=b&sp=r&sig=Ef5K0m9hT%2FQHT8qL9dLy8%2FO10SveCsg8WHb6p2TxUa0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:16.1761452","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:16.089Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A37Z&sr=b&sp=r&sig=v%2BaF3R3dGUVRV2V27XXowzpOz0odU909%2BZSXr1bdXF4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:37.3623891","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A37Z&sr=b&sp=r&sig=WN2xwEJIiuZe8sD%2BmQ1FTsU9RqmmuPeTa%2Fr2j3miX3c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:37.3623059","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A37Z&sr=b&sp=r&sig=seVHBR%2FsOzY2gkaBy2xHbgDWtl1%2FjcUrWqrHQpQ%2B0ns%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:37.3624114","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:37.27Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3191'
+      - '3195'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:34:16 GMT
+      - Sun, 29 Oct 2023 22:26:37 GMT
       location:
-      - https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+      - https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 85ac225d-54e9-4230-b2fc-9744c67ea93f
+      - c3ca5b7b-b9f6-4cb2-b267-3ee3e1cea169
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A16Z&sr=b&sp=r&sig=PJ8tR5AHk4xYo2Dbxf%2FqKy8NHFRtLcNsshq%2BvW2IEyE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:16.6316387","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A16Z&sr=b&sp=r&sig=1RES%2BNcAkgslSA2mzB6YlnN9TxMYQSAZVIjzoTduTLk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:16.6315544","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A16Z&sr=b&sp=r&sig=q4QBU0Hp10Lj%2BhEqO5oqLQmvEq7IXa7aAL6MuKidU7E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:16.6316605","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"NOTSTARTED","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:16.514Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A37Z&sr=b&sp=r&sig=XOxLZYdakjz2i93ik%2BhDD5D%2FVrH2fS1dGg%2BL1uHP9AE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:37.7923781","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A37Z&sr=b&sp=r&sig=WUNwzQCsRH1UwKvszleVGteSX83hVP97SojWukKhYho%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:37.7922931","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A37Z&sr=b&sp=r&sig=kRc7sMydzr5YdbRlW%2Fn5o991ac8iImK9u4RHowFRf1w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:37.7923925","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:37.27Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3236'
+      - '3189'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:34:16 GMT
+      - Sun, 29 Oct 2023 22:26:37 GMT
       mise-correlation-id:
-      - cb0a09db-b473-4c3a-9b04-0f43bae276d6
+      - f19d150d-e624-411c-84f2-3747ebe4038f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,370 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A21Z&sr=b&sp=r&sig=sCDwlDUfSxM56BNbDZURDlYpZmE9W8VLE4Pdx8wayzA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:21.9049889","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A21Z&sr=b&sp=r&sig=ZfsJqtAlFfQ3f0lRxOQKn9I51GjoDJo%2BzQq1B43LzS0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:21.9049167","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A21Z&sr=b&sp=r&sig=uzu1fmaaY7MzDcZglygZinYBekB1E19HtbtB2nu0U3M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:21.9050037","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:16.71Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3231'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:21 GMT
-      mise-correlation-id:
-      - 64e14720-a593-4183-84b4-0a5313d21dfd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A27Z&sr=b&sp=r&sig=U%2FEaAHW1g82pwXlJzvQdvfUJg79o47K6CVj2XYN9HGs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:27.2343285","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A27Z&sr=b&sp=r&sig=WCnnU1u67xD9g7WHJmuEi9IdRPApcbI4mYjLC5E3vbI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:27.2342287","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A27Z&sr=b&sp=r&sig=G5jZYGqShNmlzLkxln78aWX%2Ft0kyOMZBxqH1g4r%2FEu0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:27.2343444","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:16.71Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:27 GMT
-      mise-correlation-id:
-      - b0e5d182-33b0-45ae-b73c-07ee80092c32
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A32Z&sr=b&sp=r&sig=KScwJSoQF3INGfF%2FsEf7hk1v9FFVKRGaow%2Fo5CywLSg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:32.5403257","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A32Z&sr=b&sp=r&sig=8OMdigwRLFa7NagwwyVY4Yjcf207Vxvo4CjMJjuWMQ0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:32.5402149","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A32Z&sr=b&sp=r&sig=PA1ygqntjUMOsXBBj0SAV6KVaFD5RVBvPEpTXgUI2XQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:32.5403549","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:16.71Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3233'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:32 GMT
-      mise-correlation-id:
-      - 7bb4ce7d-8c30-46fd-8d50-c7efef03405e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A38Z&sr=b&sp=r&sig=y30I4vFTNF%2BA5d6NPadmG269CHW95dyg%2B6U2WcqoIbc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:38.223304","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A38Z&sr=b&sp=r&sig=ehsBVmlcMMJIJci7iqCXYaiRyzG4MtZNXs%2Fu%2BFzwQFg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:38.2232088","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A38Z&sr=b&sp=r&sig=lY0Y3Vur%2BGeo%2BCQH6h685aYED3CidNlCaKRc7N3mPgY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:38.2233259","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:16.71Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3240'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:38 GMT
-      mise-correlation-id:
-      - f4fd7cbf-f1a9-4f59-945c-b400cb265829
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A43Z&sr=b&sp=r&sig=%2BYOgLuQlMh6uOlrO508jVxJGUzbJlJQCNW3SUJJWjMQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:43.4809193","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A43Z&sr=b&sp=r&sig=974GFOb4%2FHUY%2BkvV12%2Fq8SL7f8FWyQUZFSmQp9gfrlQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:43.4808398","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A43Z&sr=b&sp=r&sig=9nesRuPPJWFGA4heZm8cGCVx%2BtbLVeVKO2ehLfBaAWo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:43.4809337","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:16.71Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3239'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:43 GMT
-      mise-correlation-id:
-      - c3859070-aaee-4c07-8803-4e2c9f7a1107
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A48Z&sr=b&sp=r&sig=ZBNBdkaQh1iiCilZXsNf0mB8%2FibR02aH0ijKgHVizz4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:48.7300235","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A48Z&sr=b&sp=r&sig=A0ffxn%2BdbXTEbzl7OJeR8PALZRNU%2Fxe8J3vCpofnV%2Fw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:48.7299261","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A48Z&sr=b&sp=r&sig=1rxkAe0RKsD%2BomnFjZBlQVtqL23sEokpadvGdP2gpnA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:48.7300454","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:16.71Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3239'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:48 GMT
-      mise-correlation-id:
-      - ede03b95-fc92-4271-9349-92cb40ea823a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A54Z&sr=b&sp=r&sig=4ag5af0Kp%2BujeY1s0QlQ9khhmPqW0E1wJLvVfv%2FzqnY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:54.011401","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A54Z&sr=b&sp=r&sig=z9yRdN%2BrIJGW4xkGP8z2tWJa06V3Nw8%2FSQzUfTHe%2FRA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:54.011317","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A54Z&sr=b&sp=r&sig=p9v8xCWyFTZ%2FEXoUfa26o%2BsWHZ0Wc8ch1lN8YLg76q4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:54.0114188","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:16.71Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3241'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:54 GMT
-      mise-correlation-id:
-      - 58a5697d-459b-4f4c-8e28-f65561290340
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A59Z&sr=b&sp=r&sig=PtCXYchHQnHZohUpDFWNqNuHBNUdJT5GwfeP4%2BY1988%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:59.2870698","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A59Z&sr=b&sp=r&sig=RVBzEfYCtEMfnDGo5hTUA8d%2FXc9%2F%2BUUZQ6J7Uaxf9MY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:59.2869963","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A59Z&sr=b&sp=r&sig=vtbfI%2BP%2FvIrradkoYK05qwBszkW8qyJqb9CBUITpl4E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:59.2870843","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:57.416Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3241'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:59 GMT
-      mise-correlation-id:
-      - 5b1eee2a-ba2d-457b-bcf7-7add8f7cd330
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A04Z&sr=b&sp=r&sig=rNJV%2FIyzZ2rdYbYe2HkWcVL2FklQHfM3cXk2HPrPzwU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:04.5974569","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A04Z&sr=b&sp=r&sig=F0eKkApmWV0j1bcpz1%2FC4vA0pcJN00OqjddLIJrpoAg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:04.5973768","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A04Z&sr=b&sp=r&sig=GhtbXm3meQ7VnoznY3UJAm8Omx0spqZjqSxBqrBylos%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:04.5974789","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3231'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:04 GMT
-      mise-correlation-id:
-      - 5753ca69-1b2f-4221-a394-45585512dde7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A09Z&sr=b&sp=r&sig=zbOURYmZj%2BebabbVmvYQhDp3TUJxVJxY1iAnPpOjvTE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:09.9289956","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A09Z&sr=b&sp=r&sig=V3%2F2GkuIXRibV7UlhNAW6YiVaMbcYx%2BkCSq03IT9ACk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:09.9289066","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A09Z&sr=b&sp=r&sig=JnkNRFiXF1D1VRXeR7%2BdqZDjTb7naLwMtw7qW02SUgY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:09.9290179","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3235'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:09 GMT
-      mise-correlation-id:
-      - caf09e1d-85bc-41e4-97ab-b78d8c867a4e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A15Z&sr=b&sp=r&sig=6ccMjj8d2vBsE%2B%2BtvuG9FlhrxfmCCHwZGHHoL8yk%2FkY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:15.2596393","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A15Z&sr=b&sp=r&sig=idXlgksU8AXgnPCFPVugmzMBFRT3Rp%2FEr3pXnmOe%2FJA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:15.2595467","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A15Z&sr=b&sp=r&sig=NVUcJpfxG6AOn7kBpmnoWsIwoLHTqUuHHc06LnhdNYE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:15.2596616","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A43Z&sr=b&sp=r&sig=1FjW3zMncqaNvRtTvMZe2CG%2FdMKDU%2FKSPO4Y5Fm5PXU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:43.1172617","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A43Z&sr=b&sp=r&sig=USnR8BVVYprTsfH47i88PlhcpUAB0508BM%2Fn6pStfVY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:43.1171668","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A43Z&sr=b&sp=r&sig=IAFsM1iLiKRAtJ0GdXCXEooYr7rIx3ydI%2F1eCPT2R2o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:43.1172834","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1110,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:15 GMT
+      - Sun, 29 Oct 2023 22:26:43 GMT
       mise-correlation-id:
-      - f1305949-d066-47ce-800a-5e362c11a67b
+      - 1daf2426-fd81-4715-9aa3-e298df99160b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1132,10 +772,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A20Z&sr=b&sp=r&sig=c31eWbrZaSs0lp1XsOqGf1epAx6Uhqil%2Fuq523yJFxY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:20.5878869","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A20Z&sr=b&sp=r&sig=ADZi72NIJWJyaAHzibX4RACL%2BBHSWcqzAWBLkatwpBc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:20.5878098","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A20Z&sr=b&sp=r&sig=sOMDToFk6AHM4MMXvxe5KSsob1GKd0nXZ%2FsGczqcD5g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:20.5879009","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A48Z&sr=b&sp=r&sig=XWzmEws1a0wRVUGVHdIocGSzp7NIyJp1bBunWuO7O0s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:48.4183999","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A48Z&sr=b&sp=r&sig=prCpo84mHcutYGEi2M4YMQ8oVTZ8kn3P86fI6NhR410%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:48.4183299","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A48Z&sr=b&sp=r&sig=4%2BF%2Bko7qcxbzPAl0IEAvRaiI2F2f5gGmBfQcLigNpgQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:48.4184136","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1146,9 +786,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:20 GMT
+      - Sun, 29 Oct 2023 22:26:48 GMT
       mise-correlation-id:
-      - 54013f9f-4ab3-43cc-accc-50eaa400370e
+      - 85e92010-fa95-4571-bccb-02f5a3a9478e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1168,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A25Z&sr=b&sp=r&sig=aeOxbknWF14JvAhTHhku5DbdX2AkafprqN%2F0KF5KDa0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:25.8483654","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A25Z&sr=b&sp=r&sig=Az6bBsi5hvkGt%2FfoF2WY1LyZd%2FwOhu6RHYlKunEjkgs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:25.8482799","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A25Z&sr=b&sp=r&sig=gQM7GTLa7yUIj2shpj74jrQQtIBCcOzv4jLvH3BKL9I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:25.8483797","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A53Z&sr=b&sp=r&sig=kjnALWGylDQJachPx7ok2synGj%2FDI6UzoLOUBHRfNhI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:53.7056342","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A53Z&sr=b&sp=r&sig=4VdpG%2FBsRH4YbyDSZTuKiBdUQPJ4624Zto6EfQy2gVY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:53.705562","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A53Z&sr=b&sp=r&sig=s09uRrRobUGYfZ%2BPoMxJ%2BT7FLb8CzX%2BBYPDAeLt8Mmo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:53.7056498","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3233'
+      - '3238'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:25 GMT
+      - Sun, 29 Oct 2023 22:26:53 GMT
       mise-correlation-id:
-      - ce94f714-b133-4b82-a41e-e9ab852a3d6b
+      - 7da07bf8-973b-4f79-8c29-dc9c8245555b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1204,10 +844,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A31Z&sr=b&sp=r&sig=J2ApEe6skYoppABg%2BuCOiPmIISxAEVCqTmYLL1OnK5Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:31.1173682","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A31Z&sr=b&sp=r&sig=g9ySuI4%2BZwRvJ07SqwFJT1hudqfwpocP%2B4ESa%2B52QhA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:31.1172824","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A31Z&sr=b&sp=r&sig=aVmT3f0gaovcAB2U7WAC6uzSg1vSutM58pfCJzuRE30%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:31.1173863","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A58Z&sr=b&sp=r&sig=s1kPemmnq16aqHuNASdciJ9m50EvgKNqIUBeXqzT%2Fgc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:58.9844471","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A58Z&sr=b&sp=r&sig=9k0QMaANijLpLC6sHnpuy2jjiDsJ47BY6g77HEItUgw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:26:58.984355","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A26%3A58Z&sr=b&sp=r&sig=wUFqCn%2Bot6eqMF66YPqhBmFpMfKEZovp1WpIDWTVpKI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:26:58.9844685","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:26:59 GMT
+      mise-correlation-id:
+      - 5205241e-73f0-4d4b-9aaf-2ce7ec14bc24
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A04Z&sr=b&sp=r&sig=Dn6A1dYNwF5ir4vCweQUP4Rw9f9Obyla%2FQtXt9RrA7w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:04.520819","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A04Z&sr=b&sp=r&sig=hQb6%2BAz8Po1r1BIzNpC%2FBiKIVRPriPmYggHSHzy19iw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:04.520733","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A04Z&sr=b&sp=r&sig=U3AfHnI7iEI5GbPVLtpITlMpAKbjtPj%2FVuuOvwmd15o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:04.5208387","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1218,9 +894,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:31 GMT
+      - Sun, 29 Oct 2023 22:27:04 GMT
       mise-correlation-id:
-      - 7922f80b-9897-4d6c-9ac9-1f320e78d9d2
+      - 841266c8-d6b3-4a2b-8db5-22445076fbe0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1240,23 +916,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A36Z&sr=b&sp=r&sig=9c%2Bh2lf%2B0GakJ3afjq%2FiCmGQTH%2FgRsN9d15SdNGB4mQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:36.3829281","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A36Z&sr=b&sp=r&sig=fHD%2FoCIiIPhSRyyzKWMbp%2B5v2TYmlwBQR4DpjgpkSjE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:36.3828582","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A36Z&sr=b&sp=r&sig=293Pou6PmoULa2MMZ344%2B0uSSqZvrOUZ46s7b1PJjqA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:36.3829425","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A09Z&sr=b&sp=r&sig=dnsDKDLFmOsCD02YaF7faMwx%2FK3Qpp24Ml4ePHG3yDY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:09.8290522","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A09Z&sr=b&sp=r&sig=sjRyL8as8qj0cIZisVQsn1ZYu0J1eBpaJs17nXeluL8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:09.8289667","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A09Z&sr=b&sp=r&sig=B2UNKfm5Sfwjiti0TBCyBECg57sVyCO5xbRVAvC2h8Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:09.8290752","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3241'
+      - '3231'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:36 GMT
+      - Sun, 29 Oct 2023 22:27:09 GMT
       mise-correlation-id:
-      - b8a6a805-6834-4aa7-bcf5-54c0c5ee92da
+      - 32300316-32e2-47fd-9d8b-3f3c841f97c6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1276,10 +952,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A41Z&sr=b&sp=r&sig=dGbfyCexMFH9su%2Fn1IfkRfJjQXOywcFOWx2stoGYgd0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:41.6652124","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A41Z&sr=b&sp=r&sig=vZa%2FCanCHsylxcvvMvy2fE5ZM%2FsZfvbreNDPVXJyMiA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:41.6651319","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A41Z&sr=b&sp=r&sig=lZhzshSaKhxcnfg0Tet7D4r2UHi5NUE1CHfRuyozJ6s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:41.6652264","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A15Z&sr=b&sp=r&sig=wy5EBjnO1pFNaeGZJZSryKT5J0NCfjv3XsGKawrT1vg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:15.1504778","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A15Z&sr=b&sp=r&sig=2VtQmXZSO8Bwu2hj74GZIps4P049%2Bz4bGDTIgwMcGl8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:15.1504082","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A15Z&sr=b&sp=r&sig=yr9JCRcfk%2F7SyrjjHhzkDcVHHVn2FxfNo87nDZzkZTg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:15.1504923","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1290,9 +966,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:41 GMT
+      - Sun, 29 Oct 2023 22:27:15 GMT
       mise-correlation-id:
-      - 52af5a47-e904-4155-ba42-57a56c5a0b8e
+      - 6dccf5f6-7c08-4267-9ee7-84e0057f4f13
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1312,23 +988,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A46Z&sr=b&sp=r&sig=EAHhIoqkRZo7wQEzTVD8%2FEnNurnNYRAmW7CD3Kg3Wlo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:46.9308219","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A46Z&sr=b&sp=r&sig=5B3k82%2BkLmzixSd6r%2F69Rz19okNGwLwvV4odogauk%2BE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:46.9307476","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A46Z&sr=b&sp=r&sig=z%2FdLnj72J%2F4AFhyO5%2BLggxfb53IzGO4oebPgjUPB6QM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:46.9308368","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A20Z&sr=b&sp=r&sig=N%2FGMuqZiywtqptuUGTRf%2BxdJw6y%2B2t5N1FI51m%2B3LKk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:20.7728299","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A20Z&sr=b&sp=r&sig=dWd2q2NKZDxj6diK7jtWHiP2bOxymK1yxKa4wqLZITY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:20.7727567","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A20Z&sr=b&sp=r&sig=sxhUyyGTixxYMbnHUVrmsVAm%2FB5LyGB7SHfQngih42w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:20.7728446","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:26:39.367Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3241'
+      - '3239'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:46 GMT
+      - Sun, 29 Oct 2023 22:27:20 GMT
       mise-correlation-id:
-      - 8151ebc6-1953-483a-8176-2db6d265c948
+      - 346a2bfb-be62-48f9-b2ab-c04101985243
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1348,23 +1024,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A52Z&sr=b&sp=r&sig=5pB6xwhkBvxjmO5sgvYNjIeUEDE7X5lAz9OC3osQRMQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:52.1976221","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A52Z&sr=b&sp=r&sig=aBUBhbDat579fRqNwp9qV9tLJLrXo94aa3S29vtHss0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:52.1974262","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A52Z&sr=b&sp=r&sig=QUQMYTUWztgkh9FwsyFKCkdfBRd0wO0xXE4p45Z%2FAis%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:52.19764","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A26Z&sr=b&sp=r&sig=eeuCGECbI%2Bk9G4g1pHd6qeljPxtoA3Q097RZo5n3U6U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:26.0625114","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A26Z&sr=b&sp=r&sig=xqqB9GFyoY9ur0LpEgclb1cpwM%2Fo6fUFehmkoDiPeX0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:26.0624201","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A26Z&sr=b&sp=r&sig=4uvChTmwFAtIeLVyo4JnpQyqA4M%2BmKmOnLoQg02YwIY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:26.0625265","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"CONFIGURING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:23.249Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3227'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:52 GMT
+      - Sun, 29 Oct 2023 22:27:26 GMT
       mise-correlation-id:
-      - 47b2c241-127e-4168-ae44-97818018152a
+      - c72f65e3-bdb7-4039-8aa1-b75339ed19d1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1384,23 +1060,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A57Z&sr=b&sp=r&sig=3GQYSWeiBTzpya2WuHppCyzKfCPAc7hQADtl%2FLZNK9E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:57.5514237","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A57Z&sr=b&sp=r&sig=wNN%2F1J7u0DrxA3eBj9m7xaWooFs50otSwKzdhOuEi2Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:57.5513552","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A57Z&sr=b&sp=r&sig=5tVPcuRN96EklaDv3%2FWuMnHkNAN%2BjjE1lnJX880b62o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:57.5514383","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A31Z&sr=b&sp=r&sig=S%2BuiG0eBe8UbZ4TwzqJfLp%2B4A2O0ac6yPd%2B%2F%2BnWg3Rw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:31.3198484","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A31Z&sr=b&sp=r&sig=5k6hdw45qRymxPFP80fKgeq82Pni8kj4%2BjDUIlsxEVw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:31.3197825","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A31Z&sr=b&sp=r&sig=MrEWDhjsy3fwC8k9BrrTM5ClGqbV0gmPUGRAt7V%2BINA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:31.3198636","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3235'
+      - '3240'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:57 GMT
+      - Sun, 29 Oct 2023 22:27:31 GMT
       mise-correlation-id:
-      - d29a7a09-92ef-4e40-a0aa-202b9d5a41f5
+      - 86bcfeb6-254b-4557-8103-faf4f157a71f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1420,10 +1096,262 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A02Z&sr=b&sp=r&sig=WCOJOOtFawNmCA8rKVnU0OuqRVoCEWET7pKoQ7ge0SQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:02.8286069","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A02Z&sr=b&sp=r&sig=3bsZycEZl6B8cOexjiBnQrsLVQDqwiYLTDoS5mEPFJg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:02.8285206","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A02Z&sr=b&sp=r&sig=3nSzx4wQulgVFYJ%2FWcjCkhJNKuawJlg7QVN6RMDJX0Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:02.8286234","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A36Z&sr=b&sp=r&sig=RoRoaiHym4RxTFYmGB7T04%2FzDg7Eh0%2BZfTWUsSo8XMA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:36.6565746","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A36Z&sr=b&sp=r&sig=jVgYjmctYqjNxL1%2FK3cF%2Bl0HBIltvQAhV0wTwtHqAAo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:36.6564972","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A36Z&sr=b&sp=r&sig=SF5kz9Vwv2tCrq7PtB7Wg2JAjL81GDlNjO6jMsbDEac%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:36.6565924","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:27:36 GMT
+      mise-correlation-id:
+      - d7650290-9978-4dcb-8c5d-3a9ba1d9e482
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A41Z&sr=b&sp=r&sig=ErFIymDT%2BqcDZilYXy8D%2BV4wwKuRogF0ktbaoZpZfgA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:41.9173875","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A41Z&sr=b&sp=r&sig=YyMB9H2ISCD14ruw%2B%2Ff%2FtYjmWK1ucXou04qCBbAmfnw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:41.9173221","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A41Z&sr=b&sp=r&sig=KLeOwJi9%2BqAtXO1gaZrvFSefuzXLheOGTMSBYbNp6J8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:41.9174032","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3238'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:27:41 GMT
+      mise-correlation-id:
+      - 6f911d47-190f-448b-9a24-12ac8a1588ff
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A47Z&sr=b&sp=r&sig=DnJTA%2Bw6SntsBnnAAZsZYaMJZRTRKIw0Kp6ovqYJgcg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:47.1993511","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A47Z&sr=b&sp=r&sig=irxiI34S3urrIaNYfblK%2BZkzDzrmCER5Jz4RVwARTK8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:47.199286","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A47Z&sr=b&sp=r&sig=cysjrIyFKLcdVNNc2LvV8NQ8poi%2FQSvTGX5Wx%2Bgitf4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:47.1993671","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3233'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:27:47 GMT
+      mise-correlation-id:
+      - df032d0a-ac38-4dc0-ad30-1d47cfda9168
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A52Z&sr=b&sp=r&sig=Q9rxjU%2F6WjwxFhHczYjuF6vNo6gi%2FL9COFpaWnvTP4U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:52.8341344","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A52Z&sr=b&sp=r&sig=IyHCNpjxqFgRog%2Bdedvjfh9TjaIgswx2J6riEge3Dj8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:52.8340457","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A52Z&sr=b&sp=r&sig=MlNXuM%2FRw6MLeUPzrObm9XmAtdW%2FdoQH%2F7VvFUktUks%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:52.8341509","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3238'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:27:52 GMT
+      mise-correlation-id:
+      - a504505a-68bb-4593-aa7b-ea56073aa686
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A58Z&sr=b&sp=r&sig=Q%2FbLQjn0dAvx7u6tOH6OzH4IjsMQ5zp9B0gm%2B0yyThA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:58.1796314","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A58Z&sr=b&sp=r&sig=%2FHCoQOPWcWYWsqjJ1pEipgsBCFmjEg%2BMqFGMi3doDjA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:58.1795652","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A58Z&sr=b&sp=r&sig=f9LIbTvfuMAttFzVBarRzJ7xOS8vfFj7tUYhiKZzpqU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:58.1796462","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:27:58 GMT
+      mise-correlation-id:
+      - 2ee1ce08-80d0-46f7-a008-e227307f9608
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A03Z&sr=b&sp=r&sig=tF%2Brl%2Br39EqD6pbNLTVLW6w49ut1ZpafMQSeSZP9WaE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:03.4957377","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A03Z&sr=b&sp=r&sig=x%2FIOASSfXu3hDqjGkd3fRkDhLD19QE%2FsxgEVkF0r5ms%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:03.4956624","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A03Z&sr=b&sp=r&sig=Yar4%2FY3P4hBM8Y0JgZNCEwd7uus87Kxh%2F2nXhBvW9UU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:03.4957523","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3238'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:03 GMT
+      mise-correlation-id:
+      - 6eaa842e-283d-425f-8ab5-e616ce40a7f8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A08Z&sr=b&sp=r&sig=gjEgL%2BA8wFhfxJEYNf6RIpL3gI%2BFLHIW0Y3ZR%2Fd3hWM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:08.8113984","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A08Z&sr=b&sp=r&sig=geQqPuvuLcANozGiNsKHI0BUgTyVNTKLg04mFhmWhLE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:08.8113268","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A08Z&sr=b&sp=r&sig=QhI9UTWxcGyJwAhYkj1SYDA%2FvZhQKdZszX%2Bhjj5lPys%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:08.8114131","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:08 GMT
+      mise-correlation-id:
+      - 8ad36318-7789-4443-9810-47ebcb9d3466
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A14Z&sr=b&sp=r&sig=ADPdRV0oYCbZQAFl5VfrwWtMiVrjH9hPqbv0SMAdafA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:14.1543559","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A14Z&sr=b&sp=r&sig=1IjOFg2Jib%2Bv%2BVa4OVsrB6JIvOZ9hXR7qAfdkjFSInM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:14.1542732","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A14Z&sr=b&sp=r&sig=4N8DfKCHUhFcnKVcPWayBQc83nVCDeMQhSu7BYTy96o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:14.154378","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1434,9 +1362,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:02 GMT
+      - Sun, 29 Oct 2023 22:28:14 GMT
       mise-correlation-id:
-      - 04ebb0b7-e9aa-44e4-846a-9f773323e423
+      - b32e2103-5306-4a7b-98ee-cb7638c8c80c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1456,23 +1384,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A08Z&sr=b&sp=r&sig=4vErnSPuCsYD34W32AH9Amxb3Bhc4ya8%2F%2BJO7ETlAPA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:08.104237","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A08Z&sr=b&sp=r&sig=Th2%2FEIeb4YRjGgWgMGkkXK6Z%2FWUbXKr1Bz4B4L7hx8k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:08.1041641","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A08Z&sr=b&sp=r&sig=%2FZeSVorFyG%2B5YfOb6VMQyFVh30yw%2FY1bEeL8inwlX9s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:08.1042519","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A19Z&sr=b&sp=r&sig=cxiTVWnE%2FVB9HXBvRvPLH62XJus7gAu1KTYcABz%2Fzmk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:19.4641126","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A19Z&sr=b&sp=r&sig=Ke0BjTv59c2s51nXgEANkAJqonM8J4T1Hw2dmJXj2iY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:19.46404","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A19Z&sr=b&sp=r&sig=GT%2FVEFdSlZVpyP0I4HOAAqJpTq0mxjgajgWalmN2zEY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:19.4641291","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3240'
+      - '3230'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:08 GMT
+      - Sun, 29 Oct 2023 22:28:19 GMT
       mise-correlation-id:
-      - 711ed377-9189-46e8-9196-03dd9e981d3b
+      - 3b9ba58e-cb16-4f46-a7b7-e26e67b3bacb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1492,23 +1420,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A13Z&sr=b&sp=r&sig=F3Z8G%2B37yHbbXMllRvkt51IJXorO8NmuTS8eHMzRJ4M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:13.4131445","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A13Z&sr=b&sp=r&sig=R3JYJVqtMJ1Zgv4i4w0xR4rKcGF%2BMd1%2BtKxxJU%2FvWLk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:13.4130714","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A13Z&sr=b&sp=r&sig=boW3OErlXzv%2B7HmD%2Fj2QMQZVnFrYWNAJm06rbanBapM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:13.4131644","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A24Z&sr=b&sp=r&sig=Y2oGu%2Fzn9NUeCrXNkgh9cIqoV6NjK4JqmhYmPWIpGMA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:24.7377288","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A24Z&sr=b&sp=r&sig=5FNfP%2BuwUPPKB5sfkm3W2WhHC8XydjWXNVsKrLUX9Fo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:24.7376523","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A24Z&sr=b&sp=r&sig=mutfkrDaLUhw7s%2BdHI%2BEyAOUUM4aSD05rBfAcV1rkhQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:24.7377469","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3239'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:13 GMT
+      - Sun, 29 Oct 2023 22:28:24 GMT
       mise-correlation-id:
-      - 8312d4af-f752-4d59-9f41-8c761a08bf97
+      - 18e1f4ab-7fd4-43b4-8f3e-f8b3a2e21f5f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1528,10 +1456,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A18Z&sr=b&sp=r&sig=UhhWXpi6oZ3fx2vhreiBmndvqauUdGw6s1wVrooRxPc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:18.7513142","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A18Z&sr=b&sp=r&sig=Bzq8sUvHBDl3EVJLt9ZQ%2BXuSqu5bXHQ8MKYOLGfSHTw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:18.7512152","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A18Z&sr=b&sp=r&sig=m0%2ByemISM7P7I7tjShAcVJDKhlVbErvcs5%2B1FWKPgpI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:18.7513384","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A29Z&sr=b&sp=r&sig=BnIK3E%2F%2FDBNAOICq5uzmszT%2Fg8iQmyV%2BItlWLAIYkD4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:29.9987505","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A29Z&sr=b&sp=r&sig=zRLlWKEFDyfnvBN8CzHNiQ0jQvMq7xgFucWsFit1qkE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:29.9986658","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A29Z&sr=b&sp=r&sig=YpBBXZMCyDZCTAJOLYRWzdqU7E7%2FZczW%2FewRjBWh4nc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:29.9987724","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3238'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:30 GMT
+      mise-correlation-id:
+      - 1dc46fe5-1b4f-413f-b151-1fade91b32cb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A35Z&sr=b&sp=r&sig=D2dumRZw%2BXQ8gRnAOqJbNbP68Kgus1PNUY%2BDSUXYcBI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:35.2422418","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A35Z&sr=b&sp=r&sig=sMk5xglAPyEjIE0BJzmHhYpCuNpIpENyy9ESphj8uZ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:35.2421728","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A35Z&sr=b&sp=r&sig=UzwMfmrStpy0MJO%2FbT3oFB6BWnA0qpyQU4a%2B1kv8F6s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:35.2422564","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3234'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:35 GMT
+      mise-correlation-id:
+      - 504113b8-e9c8-4a96-879a-0028be6791e9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A40Z&sr=b&sp=r&sig=aEKqEBLVooc4zGN3hvTaMP94ylI6TAHgZMgqdLdQqT4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:40.559936","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A40Z&sr=b&sp=r&sig=ksXn0oAINUci7f3UYDthJjz43G4F6zGaJZO8PXgxjRQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:40.5598529","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A40Z&sr=b&sp=r&sig=0a609gk048X9%2BvL%2BVuLeO%2B2tQxzZxob%2FDlbfN2BpK2s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:40.5599613","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1542,9 +1542,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:18 GMT
+      - Sun, 29 Oct 2023 22:28:40 GMT
       mise-correlation-id:
-      - be120b46-ccfd-4387-bbb7-8fbb41577bc1
+      - 3d6dcca3-1c10-4d83-bc74-87ca7f791558
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,23 +1564,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A24Z&sr=b&sp=r&sig=He55P9BdDz4ZrWi82031M7xngnJIgiIw7hgNlstgcRE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:24.632128","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A24Z&sr=b&sp=r&sig=wKrIH57BAWgesD4D6CjI3DAga5xz4yRZlzLD4LzS7uI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:24.6320374","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A24Z&sr=b&sp=r&sig=PhEPvUReMYPLs%2FGx%2BxcuJb%2F7EIPEgwvT%2Bru%2BJEG7tqI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:24.6321421","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A46Z&sr=b&sp=r&sig=5R%2BdtC1UJiSGk6qFuHESpODRiKFVU36sBO3HiFoBFSQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:46.0561294","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A46Z&sr=b&sp=r&sig=F8Q45s4mKHyn3x77X7YJC4PeLiwy8aoh951C0i4pttg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:46.0560269","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A46Z&sr=b&sp=r&sig=YC6AM3Xux2Rb9CF6b0Cl7hOqCckO2zi7QyO2sV2heHI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:46.0561435","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3236'
+      - '3228'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:24 GMT
+      - Sun, 29 Oct 2023 22:28:46 GMT
       mise-correlation-id:
-      - 6aa90a4d-1fff-47d5-a3c3-a307aa59bf97
+      - 6ab2f8c0-8802-4bb2-b389-0d7c7f6a7694
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,10 +1600,154 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A30Z&sr=b&sp=r&sig=5T7yzAAI4yse92nFmDwJ8MMExR9Lyq3%2BliMIyb23iqk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:30.3632228","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A30Z&sr=b&sp=r&sig=p87QALgpssZchfw6pqr6pD6P4yO63eRc4%2BE9xmradiw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:30.3631574","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A30Z&sr=b&sp=r&sig=C%2BaVmk0amtm%2BP%2FGf3533kHWe8OpsQ12DXE7CvX5ZCZo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:30.3632371","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A51Z&sr=b&sp=r&sig=Gdt%2BH1lY1MZ9LCuc3PEtogZA7pf2mFFIDYtmYMkDphk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:51.3056465","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A51Z&sr=b&sp=r&sig=2sqOTIwW1b%2F05r2bUoizGq76MlIy5gXGbVhpGXzJJkM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:51.3055312","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A51Z&sr=b&sp=r&sig=1m%2FllyJS%2BAWaUaWUy%2BT%2Btp22dAzrGceP5T4s%2BZgameM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:51.3056667","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3240'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:51 GMT
+      mise-correlation-id:
+      - a795f496-5d85-44c8-a784-5794046ac5cc
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A57Z&sr=b&sp=r&sig=QYALrolPaiolvJkG5NRWce4znc0UVBzZzgJ3sSGUlMc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:57.0417379","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A57Z&sr=b&sp=r&sig=h86grxzj%2F4uZaHHTmLC7I3qfZfzmcot45lOrwXl5r3o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:57.0416478","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A57Z&sr=b&sp=r&sig=kksMaDn%2FVeJBbUj6KnixJsfgL7z9P0D5MzUAEooZusQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:57.0417588","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3230'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:57 GMT
+      mise-correlation-id:
+      - 9c810139-2edc-4847-a13a-8097e92695da
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A02Z&sr=b&sp=r&sig=yOMzal%2FkEE%2B%2Fm4SJvYb8vmg0%2FDnqHVG1g2stDJecSs4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:02.283151","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A02Z&sr=b&sp=r&sig=bURF6ObCUWj8JNdJZhcfU8hGmXeipEZU8KKZXcub5bU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:02.2830618","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A02Z&sr=b&sp=r&sig=t8j3KOc4blqXwlguemQYlyckHnMohyx%2FPjBBNSYWQVM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:02.2831732","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:02 GMT
+      mise-correlation-id:
+      - 1456b862-7c94-4892-a405-8235da39f439
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A07Z&sr=b&sp=r&sig=a6vCUExDYOHvj5J5%2BFUqeLvqGwF7QftLwtIWkbegFa8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:07.5884526","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A07Z&sr=b&sp=r&sig=osxpTPbyS5Q42AeLBEINtEfvbbouJrW7ZJLARKtDY64%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:07.5883704","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A07Z&sr=b&sp=r&sig=nlAI2M9AJwK9abGn%2BbnYOQ2ma2CtGW9%2BLO2imGY2Rj0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:07.5884735","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3232'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:07 GMT
+      mise-correlation-id:
+      - 06950e91-2dfa-435e-a7ee-1f86d9738800
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A12Z&sr=b&sp=r&sig=yhDht7Usk06P8mqlh9ZJlU8E6DuSk3cPP5oFlHObMI4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:12.8418479","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A12Z&sr=b&sp=r&sig=DYn30y8R3ZEdeskDjA%2BNQ6rINW%2Fyr1%2BgnmnefbJAeEk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:12.8417738","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A12Z&sr=b&sp=r&sig=vF6f%2FgGVN6Yi4YKmE3ZTdt%2BSLHd%2BCRtlGIouhZykTbM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:12.841862","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1614,9 +1758,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:30 GMT
+      - Sun, 29 Oct 2023 22:29:12 GMT
       mise-correlation-id:
-      - 9996a6f6-322d-4afa-9ba8-3179eb4f1093
+      - 8939b70c-8e2b-42c5-a93a-f594161d7ae2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,23 +1780,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A35Z&sr=b&sp=r&sig=xlyyXIA95ykRInGcEWZpJk6tuonIRNg5%2BxlRdk7GkTI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:35.6810632","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A35Z&sr=b&sp=r&sig=6xMRtJU7zmzk3qZCI0mGJZxT541syazlyVva%2BDx8q9g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:35.6809849","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A35Z&sr=b&sp=r&sig=L2zbPWTPc1KxkWo9NyNYhVRmJi9XzUWUPtYow4S%2BQOA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:35.681077","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A18Z&sr=b&sp=r&sig=IkyCEE9p8yYtWh4mOVzIOSkxyDJumw2RmsP3L2OEGEw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:18.1402909","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A18Z&sr=b&sp=r&sig=u6fZxR3FkOB32ALPvtK9aHOit0ktOZRTSCGpK5hHX%2FY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:18.1402232","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A18Z&sr=b&sp=r&sig=Vf4REtfv4nNLn6jTlvI2qJ63vydFDKuYwZQolwKPf%2B0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:18.1403072","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:26:39.217Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:27.218Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3232'
+      - '3230'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:35 GMT
+      - Sun, 29 Oct 2023 22:29:18 GMT
       mise-correlation-id:
-      - 6494004d-6c2d-4ca0-9299-271728a1e1d2
+      - 8e4a025d-1d6f-4760-aa70-c99e57f15cff
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,132 +1816,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A40Z&sr=b&sp=r&sig=E1ZfxFzO2juwwG33IJCJmm97qqp6Fb6dLzvaaKYd8mA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:40.985481","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A40Z&sr=b&sp=r&sig=86LghsyZwJbP2PePN6j4mVAWvClxJOC18xy%2Fu7Ko%2F2M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:40.9853949","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A40Z&sr=b&sp=r&sig=F%2BIlTqbSbnGF5lsWDeXBQZvAT5BXJQuTXj0tvYvqvvY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:40.9855032","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A23Z&sr=b&sp=r&sig=C7ZbIQRsatXhzskNfE12doZJyJjl8WXTLDmCsiBUep4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:23.4070475","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A23Z&sr=b&sp=r&sig=T2QWqNRaZbh81DncWEU2eucyqBZ7nmqPLkktysHHX3w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:23.4069603","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A23Z&sr=b&sp=r&sig=cL7x%2BJe%2F6muvomwkL7DcwfdI4fhQehp1j82TRkumlaw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:23.4070698","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-29T22:26:39.217Z","endDateTime":"2023-10-29T22:29:20.611Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:20.798Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3232'
+      - '3365'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:40 GMT
+      - Sun, 29 Oct 2023 22:29:23 GMT
       mise-correlation-id:
-      - 6f5b00f6-8650-483e-8cc4-9dc88d00e513
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A46Z&sr=b&sp=r&sig=%2Fqn3tmsh8dH7VwqorPmjHaG0oG6i9n7ZjZzUxxdJ2vw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:46.2764518","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A46Z&sr=b&sp=r&sig=7pz3jkn8hpLw4pPMAd6J2YNHR1eMlRsh9zaTzc0UVAI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:46.276353","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A46Z&sr=b&sp=r&sig=YcpOj78GPXj%2BMkIU%2Bg9vlUzLGDUoq2f3X3GfmddDg1E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:46.2764712","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3232'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:36:46 GMT
-      mise-correlation-id:
-      - 136c29f2-eac0-4f52-a2fa-f2ca9324c507
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A51Z&sr=b&sp=r&sig=z3Xhn2%2FLdjvZObKH59lisFQJf0i1Yqf6%2FzM%2FVPT%2FHS0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:51.5721679","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A51Z&sr=b&sp=r&sig=nx%2BK8DEZv8dqc6xxdvIwjOlVSnu5k3x14GgZZ%2F3XT0o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:51.5720808","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A51Z&sr=b&sp=r&sig=38A1hGVRFFSk3TOvrw9EA%2FBuc3jO5BLYS1K8AM2ui5U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:51.5721903","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:16.514Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:35:02.896Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3241'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:36:51 GMT
-      mise-correlation-id:
-      - 93107ec7-e9a8-49c7-88c4-b3cfc846e534
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A56Z&sr=b&sp=r&sig=qjZnT7fZHopNC3OcjjMo%2BCGne5abgi1HX8x61DCgz5E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:56.8542091","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A56Z&sr=b&sp=r&sig=O410seAdoaUNDzbEigpOMhFulE7lI2n62oFvvQH3n48%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:56.8541095","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A56Z&sr=b&sp=r&sig=fbes3wtpY6OOV%2Fts4DDmyLS1H6zYkS2EA5OoI%2BgSoXY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:56.8542238","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-24T12:34:16.514Z","endDateTime":"2023-10-24T12:36:54.947Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:36:55.036Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3368'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:36:56 GMT
-      mise-correlation-id:
-      - 5e54a7fc-57a6-478a-a031-7b096c2a79b1
+      - c166177e-3b94-4919-ae28-80ca9a78a91e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,18 +1856,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:57 GMT
+      - Sun, 29 Oct 2023 22:29:24 GMT
       etag:
-      - '"d300cf49-0000-0100-0000-6537b9780000"'
+      - '"3c001330-0000-0100-0000-653edbe80000"'
       expires:
       - '-1'
       pragma:
@@ -1861,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=server-metric-test-case&api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=server-metric-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"04694ae7-22f2-4815-9972-9047a4152168":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a194dfcb-4122-4997-ae60-04ec74401d91":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4e9f48fe-5417-4942-8763-f143c419890d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/3415a318-8350-4671-bc2f-26f93cb12fcf?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A59Z&sr=b&sp=r&sig=cd2nM%2FTWMjAH2WPYHbtYzKi2ugvfo%2Bxnqspvp5d32RU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:59.3992205","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/2aa37c14-332d-4671-a8d7-b6c84500ecc8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A59Z&sr=b&sp=r&sig=Lk%2FfWqKG9pK0mgWWjNnlOqXJMqAXmVyWkJQ2KT%2BAcJ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:59.3991315","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3214f2c3-58db-4d8d-b281-f93c7ddc8a2d/01cf2429-cbf9-4ba6-9ffe-74c2d679aa79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A59Z&sr=b&sp=r&sig=25OHeMztEdBk%2FcUiw7lhs5A5Z4NXJfrftPLjHYte0TM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:59.3992427","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-24T12:34:16.514Z","endDateTime":"2023-10-24T12:36:54.947Z","executedDateTime":"2023-10-24T12:34:15.842Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-24T12:34:16.089Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:36:57.591Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"2e069b3e-5056-45bf-a355-e9bd38d8033f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2aa10b1b-303a-4698-881f-a2968b6b83ca":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c141ce4f-631c-441a-b867-0ec54c02a5f2":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/2b849f78-250e-434e-94c6-616caa833a3a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A25Z&sr=b&sp=r&sig=347jx7AZ6bUusk4jYnqp46WP1g%2F17PkDfTxAGs6D548%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:25.6604473","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/3655b9fb-10c2-4e9e-91a5-5c2ebf2e5f52?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A25Z&sr=b&sp=r&sig=6H3o5Jzx%2FerlaKlwwBy1iv7nhK4z%2BG1Yb2P5txHFJjY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:25.66036","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a0c4ea19-c504-4a45-a0dd-c3e27962e4c5/84a87c60-b384-4cad-be87-9a9e80b75840?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A25Z&sr=b&sp=r&sig=2TU%2BS6d76tkMC2yXULjR9hWvBEHsYYY3L5D4ETmsDcQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:25.6604718","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"server-metric-test-run-case","displayName":"server-metric-test-run-case","testId":"server-metric-test-case","status":"FAILED","startDateTime":"2023-10-29T22:26:39.217Z","endDateTime":"2023-10-29T22:29:20.611Z","executedDateTime":"2023-10-29T22:26:35.105Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/server-metric-test-case/testRunId/server-metric-test-run-case","createdDateTime":"2023-10-29T22:26:37.27Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:20.798Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3384'
+      - '3379'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:59 GMT
+      - Sun, 29 Oct 2023 22:29:25 GMT
       mise-correlation-id:
-      - b4e417d3-9303-4f9d-94e8-803be3e860de
+      - 3c747835-ed40-425c-920b-a0e19006ea89
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1905,7 +1941,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-24T12:33:30.3393368Z","key2":"2023-10-24T12:33:30.3393368Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-24T12:33:30.3549625Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-24T12:33:30.3549625Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-24T12:33:30.1205929Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-29T22:25:46.9113240Z","key2":"2023-10-29T22:25:46.9113240Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-29T22:25:46.9113240Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-29T22:25:46.9113240Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-29T22:25:46.6926020Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -1914,7 +1950,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:36:59 GMT
+      - Sun, 29 Oct 2023 22:29:26 GMT
       expires:
       - '-1'
       pragma:
@@ -1947,18 +1983,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:01 GMT
+      - Sun, 29 Oct 2023 22:29:28 GMT
       etag:
-      - '"d300cf49-0000-0100-0000-6537b9780000"'
+      - '"3c001330-0000-0100-0000-653edbe80000"'
       expires:
       - '-1'
       pragma:
@@ -1977,9 +2013,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-egmus6nakyklp7dc4/providers/Microsoft.Storage/storageAccounts/clitestloadar6c4swry":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-egmus6nakyklp7dc4/providers/Microsoft.Storage/storageAccounts/clitestloadar6c4swry",
-      "resourceName": "clitestloadar6c4swry", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testRunId": "server-metric-test-run-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-k6wgjmj7wz23xxlwj/providers/Microsoft.Storage/storageAccounts/clitestload6ztzaj4yi":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-k6wgjmj7wz23xxlwj/providers/Microsoft.Storage/storageAccounts/clitestload6ztzaj4yi",
+      "resourceName": "clitestload6ztzaj4yi", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -1995,10 +2031,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-24T12:37:03.001Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:03.001Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-29T22:29:29.731Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:29.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2009,11 +2045,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:03 GMT
+      - Sun, 29 Oct 2023 22:29:29 GMT
       location:
-      - https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+      - https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - a76cf999-a140-4fde-a38b-1d216fc62bf0
+      - 6e0cacc6-ca2d-43a6-8840-29658834ed2d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2036,18 +2072,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:04 GMT
+      - Sun, 29 Oct 2023 22:29:30 GMT
       etag:
-      - '"d300cf49-0000-0100-0000-6537b9780000"'
+      - '"3c001330-0000-0100-0000-653edbe80000"'
       expires:
       - '-1'
       pragma:
@@ -2077,10 +2113,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-24T12:37:03.001Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:03.001Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testRunId":"server-metric-test-run-case","createdDateTime":"2023-10-29T22:29:29.731Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:29.731Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2091,9 +2127,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:05 GMT
+      - Sun, 29 Oct 2023 22:29:32 GMT
       mise-correlation-id:
-      - e6b45315-ab24-4111-b05a-462b19af998c
+      - 039dcfbf-a58b-4085-b0d8-a929448cc807
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2116,18 +2152,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:06 GMT
+      - Sun, 29 Oct 2023 22:29:32 GMT
       etag:
-      - '"d300cf49-0000-0100-0000-6537b9780000"'
+      - '"3c001330-0000-0100-0000-653edbe80000"'
       expires:
       - '-1'
       pragma:
@@ -2146,9 +2182,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-egmus6nakyklp7dc4/providers/Microsoft.Storage/storageAccounts/clitestloadar6c4swry/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-k6wgjmj7wz23xxlwj/providers/Microsoft.Storage/storageAccounts/clitestload6ztzaj4yi/providers/microsoft.insights/metricdefinitions/Availability":
       {"name": " Availability", "metricNamespace": "microsoft.storage/storageaccounts",
-      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-egmus6nakyklp7dc4/providers/Microsoft.Storage/storageAccounts/clitestloadar6c4swry",
+      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-k6wgjmj7wz23xxlwj/providers/Microsoft.Storage/storageAccounts/clitestload6ztzaj4yi",
       "resourceType": "Microsoft.Storage/storageAccounts"}}}'
     headers:
       Accept:
@@ -2164,12 +2200,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-24T12:37:03.024Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:08.036Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-29T22:29:29.801Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:34.558Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2180,9 +2216,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:08 GMT
+      - Sun, 29 Oct 2023 22:29:34 GMT
       mise-correlation-id:
-      - 9dafe1cc-7157-4be8-ad95-eabe746216ef
+      - 80fe14ca-9bd9-4c84-b1fa-f32b68d909fa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2205,18 +2241,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:09 GMT
+      - Sun, 29 Oct 2023 22:29:35 GMT
       etag:
-      - '"d300cf49-0000-0100-0000-6537b9780000"'
+      - '"3c001330-0000-0100-0000-653edbe80000"'
       expires:
       - '-1'
       pragma:
@@ -2246,12 +2282,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-24T12:37:03.024Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:08.036Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-29T22:29:29.801Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:34.558Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2262,9 +2298,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:10 GMT
+      - Sun, 29 Oct 2023 22:29:36 GMT
       mise-correlation-id:
-      - 5206e3af-0d17-45fa-9ae3-37c90c544735
+      - 82c5d6d8-947c-415c-ba67-ac3488d12348
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2287,18 +2323,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:11 GMT
+      - Sun, 29 Oct 2023 22:29:38 GMT
       etag:
-      - '"d300cf49-0000-0100-0000-6537b9780000"'
+      - '"3c001330-0000-0100-0000-653edbe80000"'
       expires:
       - '-1'
       pragma:
@@ -2317,7 +2353,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-egmus6nakyklp7dc4/providers/Microsoft.Storage/storageAccounts/clitestloadar6c4swry/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testRunId": "server-metric-test-run-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-k6wgjmj7wz23xxlwj/providers/Microsoft.Storage/storageAccounts/clitestload6ztzaj4yi/providers/microsoft.insights/metricdefinitions/Availability":
       null}}'
     headers:
       Accept:
@@ -2333,10 +2369,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-24T12:37:03.024Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:13.413Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-29T22:29:29.801Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:39.148Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2347,9 +2383,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:13 GMT
+      - Sun, 29 Oct 2023 22:29:39 GMT
       mise-correlation-id:
-      - 9e04f9f4-cecb-45e3-992d-8d744c4d8722
+      - b5872359-cc32-47de-a6ce-c776024f97d9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2372,18 +2408,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:32:54.4395215Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:32:54.4395215Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:25:41.4577393Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:25:41.4577393Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:14 GMT
+      - Sun, 29 Oct 2023 22:29:39 GMT
       etag:
-      - '"d300cf49-0000-0100-0000-6537b9780000"'
+      - '"3c001330-0000-0100-0000-653edbe80000"'
       expires:
       - '-1'
       pragma:
@@ -2413,10 +2449,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6ac0feaa-1373-4380-b785-944ef165921e.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
+    uri: https://405dacd1-6a37-4374-a1d9-003f3c9fc76c.eastus.cnt-prod.loadtesting.azure.com/test-runs/server-metric-test-run-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-24T12:37:03.024Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:13.413Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testRunId":"server-metric-test-run-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-29T22:29:29.801Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:39.148Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -2427,9 +2463,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:16 GMT
+      - Sun, 29 Oct 2023 22:29:40 GMT
       mise-correlation-id:
-      - 8ad1a590-3eb0-4288-ad66-d088c8d1d0e9
+      - afdf70f6-7f9a-4dfc-9003-151a0aa94d3e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_show.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_show.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:15:21.6710746Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:15:21.6710746Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:48.0691178Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:48.0691178Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:15:58 GMT
+      - Mon, 09 Oct 2023 16:17:22 GMT
       etag:
-      - '"1a0aafdf-0000-0100-0000-64af09dd0000"'
+      - '"9201d1da-0000-0100-0000-652427710000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:15:59 GMT
+      - Mon, 09 Oct 2023 16:17:23 GMT
       mise-correlation-id:
-      - fc10fd99-77ef-4259-b5ee-a39e1a3352ed
+      - 12872da1-9b6a-42d4-9374-1a478c0002dd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -85,12 +85,12 @@ interactions:
 - request:
     body: '{"displayName": "CLI-Test", "description": "Test created from az load test
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
-      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "loadTestConfiguration":
+      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"4fe1697c-3a4f-4f8c-88a7-22160fb24ac7": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "aa5d45e9-2686-460a-9ed1-0dc4f7d5ebec":
+      {"passFailMetrics": {"c3a745bb-a584-45d1-9754-d1648cc87359": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "9873454c-3b04-494f-8b78-517d55640068":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "4f7677c6-6b0e-40e5-96a0-d1a191c2bbe5": {"aggregate": "avg", "clientMetric":
+      "50"}, "230c0ec6-69bb-45b4-9c47-cc0c852d42ad": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -100,32 +100,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '768'
+      - '789'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4fe1697c-3a4f-4f8c-88a7-22160fb24ac7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"aa5d45e9-2686-460a-9ed1-0dc4f7d5ebec":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"4f7677c6-6b0e-40e5-96a0-d1a191c2bbe5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:16:00.392Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:00.392Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:17:24.124Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:24.124Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1060'
+      - '1006'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:00 GMT
+      - Mon, 09 Oct 2023 16:17:24 GMT
       location:
-      - https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+      - https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - b767e56f-1c31-4969-92eb-52116b5106b8
+      - 958a28ff-f0c6-404a-840f-98ec215b45b0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:00 GMT
+      - Mon, 09 Oct 2023 16:17:24 GMT
       mise-correlation-id:
-      - 798b0065-468e-4bdd-a372-3411324a0d34
+      - b8fd79a4-53fe-4a10-baa8-618842dfa144
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A26%3A01Z&sr=b&sp=r&sig=ZJyjdxqXr15Efxmw573o%2FRp59cbDY%2FXp0zYbmMd0PlQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:26:01.4805161","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A24Z&sr=b&sp=r&sig=c%2Fz3oeeWRa7R0wymO2RvdsJO4VNzLewSB4S900J8ulk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:24.9914471","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:01 GMT
+      - Mon, 09 Oct 2023 16:17:24 GMT
       location:
-      - https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 43e8d0dd-b1fc-4f3b-a605-46dfaebb24bc
+      - f6c9e66a-ccdc-4a8a-9728-16ecd7751dee
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A26%3A01Z&sr=b&sp=r&sig=8d%2FjSyuCQc8uDRuqokb9LUW%2F%2FDGV3UkwyKzsjySYZVA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:26:01.8463052","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A25Z&sr=b&sp=r&sig=tTbOBLomcVCjjX%2FRuGiLY%2FjoNwHEFGH%2B0vLw82Runl0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:25.7102629","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:01 GMT
+      - Mon, 09 Oct 2023 16:17:25 GMT
       mise-correlation-id:
-      - b213133e-a5c6-4926-aabf-05d50f39775b
+      - f9b3cdb4-bfa2-4fa4-9aaf-6137bdaf63a0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,10 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A26%3A07Z&sr=b&sp=r&sig=ENResfxzfKIpPYnOWoUHo2pN%2FEktQ1HDMThn7xNu5AY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:26:07.1170943","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A30Z&sr=b&sp=r&sig=oUj19elFLsdSgwZl%2FqNJBUiWMLDBCqWy4Vp1mptkhHg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:30.9821474","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:07 GMT
+      - Mon, 09 Oct 2023 16:17:30 GMT
       mise-correlation-id:
-      - bf7c0fc6-7798-4b50-b940-0d6a4e232c56
+      - d659cd7b-d7b3-4225-abf0-e38029e0eda1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A26%3A12Z&sr=b&sp=r&sig=ZBQqmHX%2F6NoT5JQ1JiE8WWGwCMPmGbndyL9730fdEbw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:26:12.3795976","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A36Z&sr=b&sp=r&sig=vynmMOa3DC90F%2FYWEHfgAylIaQ5eIPjVS4VhKOB9Q5Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:36.76704","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:12 GMT
+      - Mon, 09 Oct 2023 16:17:36 GMT
       mise-correlation-id:
-      - b85b2671-f142-4b6a-a8a7-a45c7997644e
+      - 3dc10cb5-e2ae-4c5e-bea8-7d45eb2e1c29
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A26%3A17Z&sr=b&sp=r&sig=Xrlo37NvEFyBq5jQIYPbuMGP%2FyvcXnoS%2Bnofn3Xyzy8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:26:17.9283392","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A42Z&sr=b&sp=r&sig=CkdWpzMg6iW7hvxqZdS4TGrVDYdsFwBR0uQmjDYE0QI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:42.0586465","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:17 GMT
+      - Mon, 09 Oct 2023 16:17:42 GMT
       mise-correlation-id:
-      - 07619bec-13d9-4350-a5a8-f25ebe574c44
+      - 28737e2f-f2ef-4856-bab2-66aecb05d74a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4fe1697c-3a4f-4f8c-88a7-22160fb24ac7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"aa5d45e9-2686-460a-9ed1-0dc4f7d5ebec":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"4f7677c6-6b0e-40e5-96a0-d1a191c2bbe5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A18Z&sr=b&sp=r&sig=lQbCYoAclJwSzFX8Xg9xT6r7OnDQUd4581afe6Uqez0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:18.2248016","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:16:00.392Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:14.147Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A42Z&sr=b&sp=r&sig=zjDme2sMu3o4n53kcFHw%2Ff6dQ6p9Z5uq7rLRBwT2r5U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:42.3343296","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:17:24.124Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:37.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1629'
+      - '1575'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:18 GMT
+      - Mon, 09 Oct 2023 16:17:42 GMT
       mise-correlation-id:
-      - e311d1ac-cf49-46c9-bf00-fb230dbdb883
+      - a4b272eb-32f5-4a6e-a45e-c6f2b97adebf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:15:21.6710746Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:15:21.6710746Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:48.0691178Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:48.0691178Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:19 GMT
+      - Mon, 09 Oct 2023 16:17:43 GMT
       etag:
-      - '"1a0aafdf-0000-0100-0000-64af09dd0000"'
+      - '"9201d1da-0000-0100-0000-652427710000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4fe1697c-3a4f-4f8c-88a7-22160fb24ac7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"aa5d45e9-2686-460a-9ed1-0dc4f7d5ebec":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"4f7677c6-6b0e-40e5-96a0-d1a191c2bbe5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A20Z&sr=b&sp=r&sig=V%2BdTrXblEyBGPEDJFzBVeWGd0Nbpzez6%2Bmi1EkJ4dH4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:20.5190892","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:16:00.392Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:14.147Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A44Z&sr=b&sp=r&sig=wXKD8OaPaUAFYX1vngo9LctJ3M8E%2Bf5pfTsoW5wKQ7w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:44.6022952","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:17:24.124Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:37.9Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1645'
+      - '1587'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:20 GMT
+      - Mon, 09 Oct 2023 16:17:44 GMT
       mise-correlation-id:
-      - 1b929a06-9062-4bda-9c62-351d8f976004
+      - dd8085bf-b52d-4360-be96-fd25a6d24cdb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:15:21.6710746Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:15:21.6710746Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:48.0691178Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:48.0691178Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:22 GMT
+      - Mon, 09 Oct 2023 16:17:46 GMT
       etag:
-      - '"1a0aafdf-0000-0100-0000-64af09dd0000"'
+      - '"9201d1da-0000-0100-0000-652427710000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:16:23 GMT
+      - Mon, 09 Oct 2023 16:17:46 GMT
       mise-correlation-id:
-      - dc90fb1e-19bc-4084-91b6-0588ea61571c
+      - bc84b9fd-d8d2-4947-841e-246adb755bcc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4fe1697c-3a4f-4f8c-88a7-22160fb24ac7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"aa5d45e9-2686-460a-9ed1-0dc4f7d5ebec":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f7677c6-6b0e-40e5-96a0-d1a191c2bbe5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/82263423-52d8-4fa9-90f8-d23116276314?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A23Z&sr=b&sp=r&sig=COZquQycdEWjM9jklIWsHrlyaLcRuSsAPx7ACHVAlXM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:23.74283","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A23Z&sr=b&sp=r&sig=aE3xJjRaCr4wOzaoQjMLShZvY3PoLGxBRTxheB%2FjWh4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:23.7427077","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/ba8f18fc-4dc5-4b03-96a7-4a9883d24e11?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A23Z&sr=b&sp=r&sig=X6bpw9mB%2F6wVKxdMDR6PloOB7SrwiwrnTMbwZwnAYM8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:23.7428664","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","testId":"show-test-case","status":"ACCEPTED","executedDateTime":"2023-07-12T20:16:23.608Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-07-12T20:16:24.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:24.019Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A48Z&sr=b&sp=r&sig=kh52zmmtGlkdsWxG2OdBaTz89UclWHkEbucovW1E7a4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:48.5656139","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A48Z&sr=b&sp=r&sig=AyTXj7NRQL8tckuyn%2F%2BhtnClu%2BT1ZfFBSmndxx1NrVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:48.5655109","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A48Z&sr=b&sp=r&sig=FKKrPdyJlAY3kFjwj0vKZVQ9c0BvM8CALw6u5nSAcSs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:48.5656284","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:48.493Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3177'
+      - '3144'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:24 GMT
+      - Mon, 09 Oct 2023 16:17:48 GMT
       location:
-      - https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+      - https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 6ec73991-ed1a-4646-85e8-30cf1e718bd0
+      - d7f59e9a-a47d-4576-a395-aa9f3d78a652
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4fe1697c-3a4f-4f8c-88a7-22160fb24ac7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"aa5d45e9-2686-460a-9ed1-0dc4f7d5ebec":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f7677c6-6b0e-40e5-96a0-d1a191c2bbe5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/82263423-52d8-4fa9-90f8-d23116276314?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A24Z&sr=b&sp=r&sig=OuuV5Tcvpeq6wEYR6hVqwQ5al9WaGDRw1%2FBX2xZ%2BQJw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:24.3704711","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A24Z&sr=b&sp=r&sig=JKZWvZI3P8XC%2FlkS7B%2B2fIY8BiPES1WZAAFHqNsy%2B5Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:24.370406","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/ba8f18fc-4dc5-4b03-96a7-4a9883d24e11?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A24Z&sr=b&sp=r&sig=KsiNKnd2QBrnOOnVwvWNUY1XYVlQDGUE02wlT%2F4JaSA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:24.3704857","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:24.167Z","executedDateTime":"2023-07-12T20:16:23.608Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-07-12T20:16:24.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:24.355Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A49Z&sr=b&sp=r&sig=ndBszNSYNEJ%2FRcBKOvZ7oNtAiffEYgRWOcT1vxVUZ3o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:49.0196522","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A49Z&sr=b&sp=r&sig=9gfWy8SDGFxYmvqqpLRkwo3XtA7retTLeC%2BS48%2B1rxo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:49.019587","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A49Z&sr=b&sp=r&sig=V2imVxmtl0c9YfV5aqpwgVeTJNpLYiNCFWYyEUvDtek%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:49.0196895","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:48.952Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3233'
+      - '3188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:24 GMT
+      - Mon, 09 Oct 2023 16:17:49 GMT
       mise-correlation-id:
-      - defe83fa-eb7f-41de-8204-6c8622c18d03
+      - cff0095d-a73e-4cbb-9473-440928ccce54
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4fe1697c-3a4f-4f8c-88a7-22160fb24ac7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"aa5d45e9-2686-460a-9ed1-0dc4f7d5ebec":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f7677c6-6b0e-40e5-96a0-d1a191c2bbe5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/82263423-52d8-4fa9-90f8-d23116276314?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A29Z&sr=b&sp=r&sig=si2FH%2B7vNoCNwtV75FTn9XoUyuAEYQG9ferjxCqAS0w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:29.7312644","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A29Z&sr=b&sp=r&sig=jER4%2Bc0NCT5tFhAHPNR3zoY8zoQ5jwcWiNmE66S9VFs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:29.7311929","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/ba8f18fc-4dc5-4b03-96a7-4a9883d24e11?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A29Z&sr=b&sp=r&sig=Tl9etsLVHB%2B%2F4sr%2FYXldGm4onKlQ2dXEXO1IxCdGTFQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:29.7312781","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:24.167Z","executedDateTime":"2023-07-12T20:16:23.608Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-07-12T20:16:24.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:24.355Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A54Z&sr=b&sp=r&sig=Hcp6s%2BZhF%2BFyNKe%2F95wcHbxhHiMx9qnvk7fUO5t77gE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:54.3013288","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A54Z&sr=b&sp=r&sig=xC3TuN0rLPBNreeA1uq1oIEyeipXza0OmyzzHnAvYRE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:54.3012614","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A54Z&sr=b&sp=r&sig=HDuH8Hne0GcF94huH7QDMQy7sVuAgYB6N8JOwyhVUUc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:54.301345","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:49.146Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3232'
+      - '3190'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:29 GMT
+      - Mon, 09 Oct 2023 16:17:54 GMT
       mise-correlation-id:
-      - 666ace74-a8f0-487f-9460-b07cc37a26d7
+      - 7fc50e1a-77ac-4014-b3c3-437363115547
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4fe1697c-3a4f-4f8c-88a7-22160fb24ac7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"aa5d45e9-2686-460a-9ed1-0dc4f7d5ebec":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f7677c6-6b0e-40e5-96a0-d1a191c2bbe5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/82263423-52d8-4fa9-90f8-d23116276314?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A35Z&sr=b&sp=r&sig=5QpDfoH9Wv0tkFmYanNGmyBEZ6I4DB78evNRQMJFysU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:35.3754074","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A35Z&sr=b&sp=r&sig=Bm98FnI6MqHAiNV3FpJEQhZAQBbdXyA3GKJE33SICUg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:35.3753442","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/ba8f18fc-4dc5-4b03-96a7-4a9883d24e11?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A35Z&sr=b&sp=r&sig=GFreq0PUuHCj3zW00pm3ZmnLimv0UKP9TRiVb4JIiGw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:35.3754212","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:24.167Z","executedDateTime":"2023-07-12T20:16:23.608Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-07-12T20:16:24.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:24.355Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A59Z&sr=b&sp=r&sig=ChmA0k33sf9%2BI5tRpuAHvnuEiPbqTvVhkC%2FUi66mcak%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:59.5927107","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A59Z&sr=b&sp=r&sig=%2BHp0WiQ9hY%2FcuPTG5r6c0Sz9uMvhZxnWJqPJlLAWBD4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:59.5926112","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A59Z&sr=b&sp=r&sig=sC6h%2FJgKjKxLtwaq6vSh2HAUMg5w125gTlR7yYw96HE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:59.592728","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:49.146Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3222'
+      - '3194'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:35 GMT
+      - Mon, 09 Oct 2023 16:17:59 GMT
       mise-correlation-id:
-      - 3b81bb5f-9d70-4a75-a380-c542533b9350
+      - 54f3de6f-4c0e-4eae-ac66-f0af4866fafa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4fe1697c-3a4f-4f8c-88a7-22160fb24ac7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"aa5d45e9-2686-460a-9ed1-0dc4f7d5ebec":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f7677c6-6b0e-40e5-96a0-d1a191c2bbe5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/82263423-52d8-4fa9-90f8-d23116276314?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A40Z&sr=b&sp=r&sig=F1NGNbaKKqmFQyWYzXCsZ%2F8rxFwg%2BgBt5wulHcMj6g0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:40.6425759","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A40Z&sr=b&sp=r&sig=QcBxvEc1JvljAac3o48L9bvqNV7mZaRjs%2Fg3%2BXJF4tY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:40.6425124","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/ba8f18fc-4dc5-4b03-96a7-4a9883d24e11?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A40Z&sr=b&sp=r&sig=48gqwWQsg5%2BIvHx4xHNdw2ik7OW1Jxfx5aUQxWOK8ic%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:40.6425894","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:24.167Z","executedDateTime":"2023-07-12T20:16:23.608Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-07-12T20:16:24.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:24.355Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A04Z&sr=b&sp=r&sig=tWOfNaMdHS0N1xKxhCp3J3hHaiUB9sOIXtRTo%2FRMZeA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:04.887335","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A04Z&sr=b&sp=r&sig=RiI2lmMf8GiiVHQpyEyiXBJeglomYCotnCWS1N2Ee%2Bw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:04.8872654","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A04Z&sr=b&sp=r&sig=zOJr%2FEwuIQF%2Fyim9kb63xFSr9RsUJxVEmX%2BP4uedItA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:04.887349","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:49.146Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3232'
+      - '3193'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:40 GMT
+      - Mon, 09 Oct 2023 16:18:04 GMT
       mise-correlation-id:
-      - 6a45c091-77fc-46aa-a4ea-eaf1869a8226
+      - c21dd87f-44e4-48aa-8f18-b51ef5916da8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4fe1697c-3a4f-4f8c-88a7-22160fb24ac7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"aa5d45e9-2686-460a-9ed1-0dc4f7d5ebec":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f7677c6-6b0e-40e5-96a0-d1a191c2bbe5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/82263423-52d8-4fa9-90f8-d23116276314?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A46Z&sr=b&sp=r&sig=Eu94gh4Vm2jJpBCS0X24aR66v%2BXG44QQoPuFEGoxZ%2BI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:46.4215911","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A46Z&sr=b&sp=r&sig=99zBGSIHjPtrGthjZCTeqn1qtfvf%2Bt%2FLdtvtO%2B%2BAKAQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:46.421497","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/ba8f18fc-4dc5-4b03-96a7-4a9883d24e11?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A46Z&sr=b&sp=r&sig=YDvLsy7%2Bz1au3dKjdBcqTEUfojspSMyK8JH36FaBt4M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:46.4216155","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:24.167Z","executedDateTime":"2023-07-12T20:16:23.608Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-07-12T20:16:24.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:24.355Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A10Z&sr=b&sp=r&sig=AFOaZsyZuDR6ZLRlqIUGoY3j3O1yLBXxB1C9tFQPkyA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:10.1611151","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A10Z&sr=b&sp=r&sig=c3z0TaN0ZsCaOq1FjyPvYiMpYDDUnBbwK7iWkFy0rug%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:10.161032","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A10Z&sr=b&sp=r&sig=QCFX2F1QnZral2O2TGt6vSF6XKi%2BBNJ7PSN11iYtqCA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:10.1611362","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:49.146Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3235'
+      - '3186'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:46 GMT
+      - Mon, 09 Oct 2023 16:18:10 GMT
       mise-correlation-id:
-      - e4fca7b3-929a-4c5c-bea5-c4c95b88b610
+      - 1b226c02-463e-464f-9002-88cb72747228
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -880,23 +880,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4fe1697c-3a4f-4f8c-88a7-22160fb24ac7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"aa5d45e9-2686-460a-9ed1-0dc4f7d5ebec":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f7677c6-6b0e-40e5-96a0-d1a191c2bbe5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/82263423-52d8-4fa9-90f8-d23116276314?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A51Z&sr=b&sp=r&sig=JfXgbXV1bGHGM3X%2BiByAgPHs%2B7YNmTgIeg4R5E723b0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:51.7303075","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A51Z&sr=b&sp=r&sig=AmXbRomgW%2FCUt0jp0hG0rKNZjz3%2BzqagtPh09HMtewE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:51.7302344","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/ba8f18fc-4dc5-4b03-96a7-4a9883d24e11?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A51Z&sr=b&sp=r&sig=erGFlxhQSQvEA2HUVcKU3P3jUpnDVG2HCManxtYmirY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:51.730322","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:24.167Z","executedDateTime":"2023-07-12T20:16:23.608Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-07-12T20:16:24.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:24.355Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A15Z&sr=b&sp=r&sig=RYR4aAouPXFK07tn5vojzONxAqhcjUBI4E2qvWHN1so%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:15.4874096","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A15Z&sr=b&sp=r&sig=IwDkYGjmVzbweEJEZmUDOrBOu2nCl9EQYfm0lbnKRG4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:15.4873423","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A15Z&sr=b&sp=r&sig=9U19MX6Nc4leflnq%2BPYaVHmS7elsqHWRVEjpDAEqaZY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:15.4874248","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:49.146Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3229'
+      - '3187'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:51 GMT
+      - Mon, 09 Oct 2023 16:18:15 GMT
       mise-correlation-id:
-      - 9be5c355-301b-460d-9f94-a52fb62cc6d2
+      - 2cf609fb-a64e-4bb9-ba5d-32ca86060e9b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -916,23 +916,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4fe1697c-3a4f-4f8c-88a7-22160fb24ac7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"aa5d45e9-2686-460a-9ed1-0dc4f7d5ebec":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f7677c6-6b0e-40e5-96a0-d1a191c2bbe5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/82263423-52d8-4fa9-90f8-d23116276314?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A57Z&sr=b&sp=r&sig=HQzwa63hpa9RBy%2BPsbkS9oObJ3hb9%2BBTNo86rEuVxew%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:57.3834244","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A57Z&sr=b&sp=r&sig=Jm8WUVjcGVJ7Ti5fXMJX%2BW4KjHnqxMWM7DBVfatYjD0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:16:57.3833248","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/ba8f18fc-4dc5-4b03-96a7-4a9883d24e11?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A16%3A57Z&sr=b&sp=r&sig=T%2BL%2F7Js3Lc9%2F9wI%2FzpKqrHai7cpmusmjZV8p4CcFvtA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:16:57.3834489","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:24.167Z","executedDateTime":"2023-07-12T20:16:23.608Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-07-12T20:16:24.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:24.355Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A20Z&sr=b&sp=r&sig=t7Uz5zixAeWmpYrgeBdaXN2jkeVMK02gBrphwQ6LdXI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:20.7725796","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A20Z&sr=b&sp=r&sig=9%2BlSLUsn%2Fg%2BuJFMJLbTIW2KHe2%2Figtr%2BVD8KPdVjQ2M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:20.7725081","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A20Z&sr=b&sp=r&sig=YWYHpJ%2B1K3yoHK55stwk4qWaqpArQ0LywBSssSxiYS8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:20.7725937","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:49.146Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3236'
+      - '3197'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:16:57 GMT
+      - Mon, 09 Oct 2023 16:18:20 GMT
       mise-correlation-id:
-      - cf0828d9-d1e7-416d-809d-161baec5c9ea
+      - 1c665132-1ed5-4bbd-9c77-e48d3c737917
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -952,23 +952,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4fe1697c-3a4f-4f8c-88a7-22160fb24ac7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"aa5d45e9-2686-460a-9ed1-0dc4f7d5ebec":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f7677c6-6b0e-40e5-96a0-d1a191c2bbe5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/82263423-52d8-4fa9-90f8-d23116276314?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A02Z&sr=b&sp=r&sig=lJ6xu3uvgJ%2F4eyoh1qWrji1ITUlqolTcwGseQ3dKZxc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:02.6578877","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A02Z&sr=b&sp=r&sig=exAiQzc5R5nHXN0saOUdWMbnykLdJrMbJx%2BiFpGCAn8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:02.6578037","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/ba8f18fc-4dc5-4b03-96a7-4a9883d24e11?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A02Z&sr=b&sp=r&sig=OsI1yU%2B2g1uEYh2D1D1TJK2L6tzonhqMm2uCM0jvtyE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:02.6579059","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:16:24.167Z","executedDateTime":"2023-07-12T20:16:23.608Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-07-12T20:16:24.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:16:24.355Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A26Z&sr=b&sp=r&sig=rBYTCVaNd7CvUlFmSQYdVPUBOvKnoza7y7QgN7hBfVI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:26.0397579","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A26Z&sr=b&sp=r&sig=fg90%2FfJjRkNh%2BBIYQ9u8HvRqDbIVdEM4lDJLVoSlBgE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:26.0396675","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A26Z&sr=b&sp=r&sig=ep8A3polpdcELDfCSSijmf2DWWJzUieE4QfR%2BWg4oSw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:26.0397736","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:49.146Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3228'
+      - '3191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:02 GMT
+      - Mon, 09 Oct 2023 16:18:26 GMT
       mise-correlation-id:
-      - 83a591c1-407b-4fea-bb3a-9c73f716a238
+      - edffe75a-08b2-4e45-bed3-86bddf2dab1c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -988,23 +988,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4fe1697c-3a4f-4f8c-88a7-22160fb24ac7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"aa5d45e9-2686-460a-9ed1-0dc4f7d5ebec":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f7677c6-6b0e-40e5-96a0-d1a191c2bbe5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/82263423-52d8-4fa9-90f8-d23116276314?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A07Z&sr=b&sp=r&sig=jvIRp5%2BMgGLzQJgWU95gwjfJ9lCqhK2CD8EZAHAJuYA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:07.9807067","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A07Z&sr=b&sp=r&sig=p%2FCHWM9yDtXVIp%2F5a90kvepaI6INqymZb4S%2F0v2XuPI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:07.9806352","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/ba8f18fc-4dc5-4b03-96a7-4a9883d24e11?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A07Z&sr=b&sp=r&sig=XW4toKG30arabwSJHvtGGmrL86BkZaQ%2BebaFct2ajD8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:07.9807211","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:24.167Z","executedDateTime":"2023-07-12T20:16:23.608Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-07-12T20:16:24.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:17:07.949Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A31Z&sr=b&sp=r&sig=gR9%2BQhlMLa46n3Q5Vw9QEloG9Ik7ytH267IYXlZkJXQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:31.3326446","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A31Z&sr=b&sp=r&sig=UppRaepW%2BNSoWQNaFQyzhgNFLEqedRRUjdjmTmktegc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:31.3325606","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A31Z&sr=b&sp=r&sig=CbaV4VYWPk%2B4OdFyFwZCxbek5PwgkvfkYQyGO%2B6csXs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:31.3326668","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:30.724Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3229'
+      - '3192'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:07 GMT
+      - Mon, 09 Oct 2023 16:18:31 GMT
       mise-correlation-id:
-      - 51bfc3fb-8b78-49bc-bf9e-e21db4fd4e65
+      - c31adb32-1305-41ff-abad-1a04f7f1f3ec
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1024,23 +1024,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4fe1697c-3a4f-4f8c-88a7-22160fb24ac7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"aa5d45e9-2686-460a-9ed1-0dc4f7d5ebec":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f7677c6-6b0e-40e5-96a0-d1a191c2bbe5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/82263423-52d8-4fa9-90f8-d23116276314?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A13Z&sr=b&sp=r&sig=ZMjj3PyL3ycbeTijs9ngeGulpWX1AlNi2%2BOC1cM%2FVHI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:13.3611263","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A13Z&sr=b&sp=r&sig=0dgNw6tqcdm%2B28Owoh%2B6WJGwZb0yzPtjVXX8fXiH1nE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:13.3610438","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/ba8f18fc-4dc5-4b03-96a7-4a9883d24e11?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A13Z&sr=b&sp=r&sig=8Zh96oYdAQR4qr86XF7%2FxNbpmJEhh3PSKtS9oL8w4Lc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:13.3611485","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:16:24.167Z","executedDateTime":"2023-07-12T20:16:23.608Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-07-12T20:16:24.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:17:07.949Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A36Z&sr=b&sp=r&sig=7kyjyqAjL6ZObW1UpUKl9I9qyyS5%2FTax4pq3F37CycE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:36.6140815","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A36Z&sr=b&sp=r&sig=A05k6cqQxufEjh%2BafIWCrme%2Fnt1z3ck5KSSRcvfr97M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:36.6139857","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A36Z&sr=b&sp=r&sig=GF1%2FSAeYLpNkI9TzhsFXClVmmcdni%2BT9h1Mlvop1mLU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:36.6141001","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3229'
+      - '3192'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:13 GMT
+      - Mon, 09 Oct 2023 16:18:36 GMT
       mise-correlation-id:
-      - 572c4aa3-fd93-4067-8c3a-d95150cabf0f
+      - d9049736-c4e4-4fb2-9e22-5256123ccffb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,24 +1060,744 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4fe1697c-3a4f-4f8c-88a7-22160fb24ac7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"aa5d45e9-2686-460a-9ed1-0dc4f7d5ebec":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f7677c6-6b0e-40e5-96a0-d1a191c2bbe5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/82263423-52d8-4fa9-90f8-d23116276314?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A18Z&sr=b&sp=r&sig=NiwxtrMyljL8tRnYeRkWQHG0%2BcFPpQHFw1luvKZ6Guc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:18.6356723","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A18Z&sr=b&sp=r&sig=HBllQMldFHZU0GcbGmlC9AD1LGU2HfSwcm1iFi2nCJM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:18.6355771","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/ba8f18fc-4dc5-4b03-96a7-4a9883d24e11?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A18Z&sr=b&sp=r&sig=1e%2FXhfqTUV1rJRrHRrS49cucTbD2lshG1P4dAWes7MM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:18.6356865","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-07-12T20:16:24.167Z","endDateTime":"2023-07-12T20:17:18.41Z","executedDateTime":"2023-07-12T20:16:23.608Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-07-12T20:16:24.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:17:18.485Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A41Z&sr=b&sp=r&sig=i%2FpG9SaREjnQLB3IhTEbwjmqnOr2rkK34q98BgMUMqE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:41.8956617","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A41Z&sr=b&sp=r&sig=zcaC1jRsaEmEYZ4kaAuTkeDBjDreCTl%2F5e686MNEbGU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:41.8955771","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A41Z&sr=b&sp=r&sig=28imxF7GfpQyvQa3FPOhmKqJLZkEETPynhyzAHxEepA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:41.8956783","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3357'
+      - '3186'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:18 GMT
+      - Mon, 09 Oct 2023 16:18:41 GMT
       mise-correlation-id:
-      - 56dffdb4-5269-4906-9beb-64278ab95cb7
+      - 6bd6fd12-8cd3-4aec-9ed7-f3f57aa22481
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A47Z&sr=b&sp=r&sig=735BNCw8%2BtwBtTc4sJ0C1k6WHy9EnbIQMniaPoKcE0k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:47.1764717","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A47Z&sr=b&sp=r&sig=DgYKIvb3NBWyqxhIhQvcrHvX%2FE0HM4xSJ9YFWH%2BYTf4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:47.176363","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A47Z&sr=b&sp=r&sig=5klnaXwJmF7BGa2sn2js9K%2By9gDLSLEhomfD7C9sYHA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:47.1764947","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:47 GMT
+      mise-correlation-id:
+      - 1dbb5f9d-4a43-4392-9a11-5944c163ad4f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A52Z&sr=b&sp=r&sig=nLfP5n0%2B8p66r7TchaUKpkvCbXu0tXIjfXyosNMQzuY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:52.4655739","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A52Z&sr=b&sp=r&sig=YWh%2FkGPlI5AXizSVboLJcv8w%2FJ%2Bhnzsqp0mzBXfVpTU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:52.4654813","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A52Z&sr=b&sp=r&sig=JAt7Im%2Bj0B44zKCCkUG30yuVFE%2BaBuPtHkRRui0U9oA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:52.4655948","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:52 GMT
+      mise-correlation-id:
+      - 0511c4d4-be2a-4ed8-9c09-1fc99921c19e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A57Z&sr=b&sp=r&sig=I8zUP9aA1nnHEKQuc9LWdcb5Q9dPXCAZidLgrTw48UM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:57.7353184","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A57Z&sr=b&sp=r&sig=2sli9g52yykY8hHBLLHVS8IeB0JqW3NsdIByDgZm5gA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:57.735229","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A57Z&sr=b&sp=r&sig=ZhnMFizfGHPhyKAL3zc7KNxDaQ9gQhYJtrAyk4FmMCk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:57.7353398","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3181'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:18:57 GMT
+      mise-correlation-id:
+      - 5a8b1f4a-96eb-4a2e-8bc4-ca1b86201f12
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A03Z&sr=b&sp=r&sig=6OcKaI27Wl003ZQZOoony3tXtu4ygnCS%2FZ2tKbVb9OA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:03.0325647","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A03Z&sr=b&sp=r&sig=4cThkcXPzXTrnG3%2BtAN6u3%2BVm1LkTBr6THxjC4mjSSA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:03.0324759","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A03Z&sr=b&sp=r&sig=hjH6RyW0noPyBaUVYRnn1m6ygoFDOltLmU5%2FvBrGj5c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:03.0325874","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:03 GMT
+      mise-correlation-id:
+      - 07095c57-e5e8-4add-9b52-b956f69d6374
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A08Z&sr=b&sp=r&sig=EA4zgEx6PxIbtWXKQR%2BNR2bGToWPIpFD%2Fyx%2FrZcUpvk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:08.3126651","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A08Z&sr=b&sp=r&sig=J77oPtMR2Hc21GrXurNbIK5UA%2FsRRGmfmJg%2BhTsdYzk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:08.3125755","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A08Z&sr=b&sp=r&sig=n0%2FSh2cY2tLSus%2Byufm2Cn65SRmL8u1gfS3mhqcndkk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:08.3126864","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:08 GMT
+      mise-correlation-id:
+      - 4b7c94be-a8eb-45d5-9589-c3735f1f1a91
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A13Z&sr=b&sp=r&sig=1nHOuBQg618HHH5afI2zv%2BAuo2sioAR3CVNJoZgfNm8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:13.5913403","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A13Z&sr=b&sp=r&sig=EhT5CPNxYJuuQOjgHspjsvbG5GM%2Bn%2F0Puj9kx5ObAmc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:13.5912589","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A13Z&sr=b&sp=r&sig=N9xKW1Ui3yFHpz6hJLDU2pbRLdeJfNkEuuZn1mizRVc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:13.591362","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:13 GMT
+      mise-correlation-id:
+      - ec30ca51-ceed-43c8-acfe-19196fd0dba8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A18Z&sr=b&sp=r&sig=4HgAG9w7Dxbxn6OgBCIVK%2FPuyeQPIYU%2BXdw1OVtgxlg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:18.8688879","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A18Z&sr=b&sp=r&sig=cJB4d%2FoUKxQUbvW4%2FnN5td3FsnnDETp0o4USvtZF6KU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:18.8687715","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A18Z&sr=b&sp=r&sig=obRX0%2Fc4nUnfWdhMcrUYIW1R4iCg1v0g%2FYDWc%2FkzkdU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:18.8689116","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:18 GMT
+      mise-correlation-id:
+      - b20d14b0-becd-47ee-965d-0fb846ff3319
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A24Z&sr=b&sp=r&sig=jj5IlsQjE6lFdDuMpkOJRniLBGcDJeBv4PknABmYRa0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:24.1436127","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A24Z&sr=b&sp=r&sig=57bbjoMXWSUXUuDWG1uklwiSVeUev%2FXyzZ9pZnUsU%2BY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:24.1435408","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A24Z&sr=b&sp=r&sig=WyAa%2BBOt7tjVfhy0JxF%2FAumh5btFJQl8Wy%2FpaNqrMJc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:24.1436269","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:24 GMT
+      mise-correlation-id:
+      - 0f00f1a5-2315-40e7-9ad7-66f229013a03
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A29Z&sr=b&sp=r&sig=krWk5fi1u1IkmZKUDJjkUEN2NI1NgILv6e6J8d9a2VM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:29.4336672","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A29Z&sr=b&sp=r&sig=qgB6hjWXyK6i0iZgU7nX0rocgHqHJ3IDTE25ZHwodQ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:29.4335629","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A29Z&sr=b&sp=r&sig=fAQGOVfRo9aXpxGPHDnOiR97SkbZpCbuGUo5m%2B2%2BGEY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:29.4336925","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:29 GMT
+      mise-correlation-id:
+      - 5cb00304-83ab-4c40-a973-d806214b8788
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A34Z&sr=b&sp=r&sig=SSqfoXo1KjSuvVQB1fv5oRH5hCQSIs%2Bgr6CpbOAgEns%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:34.7106171","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A34Z&sr=b&sp=r&sig=4EPJ5AlLxJLLXzDyxmzAdx2gs7XmLXoWE9ZRdOzkB9A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:34.7105362","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A34Z&sr=b&sp=r&sig=JtWe7qNnRRfbEG6Bop07D43J%2FU4iFL65kDTu6X0Gyq4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:34.7106325","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:34 GMT
+      mise-correlation-id:
+      - 796223a0-4525-46ca-a2f4-94047fdc6880
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A39Z&sr=b&sp=r&sig=dTYMj40Ii3QwqFDDHIfYp7UsP%2Boxmb19a%2BJYdxxufrw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:39.9930844","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A39Z&sr=b&sp=r&sig=fuG%2F%2FmKgia1FWlQZjNsBcnDjYcm6l9UsarsHd9orwcc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:39.9930028","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A39Z&sr=b&sp=r&sig=7c4fmy3%2FiMDKsi2bw%2Bb0rRJjMb5m3fBf0Z22b4qnaW4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:39.9930986","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:39 GMT
+      mise-correlation-id:
+      - c30bd6d4-bbdd-4aa1-ad64-21be5fe02f7f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A45Z&sr=b&sp=r&sig=M5Re6M%2BEdig25knxctCoT0n%2FoT%2FuWIgzZd0mYT4NcA4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:45.2789308","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A45Z&sr=b&sp=r&sig=xlKseyv%2BYJQ4xb15BI0%2Fl0rcJFj%2FMp21HZBXS%2FJFyDE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:45.2788487","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A45Z&sr=b&sp=r&sig=OS8KZPcNgc0X%2FZabbnv0OhIPEu8IsKBaxi2Hbz1LolE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:45.2789484","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:45 GMT
+      mise-correlation-id:
+      - fe0333f4-1acb-4134-9f54-e01e5c934a78
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A50Z&sr=b&sp=r&sig=ZYXqiUvEM9e%2FbgH8co%2FZefcQs496P578Ic52vLml3iA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:50.5516804","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A50Z&sr=b&sp=r&sig=0K7UoqIspcHPVcXpbCGyL7gEffY7lrKenj6f1glhLrU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:50.5515881","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A50Z&sr=b&sp=r&sig=yRNJuH%2FGlQErvL8XNS7vgFnfUiYN7TDQnGfPLvWCiHI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:50.5516958","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:50 GMT
+      mise-correlation-id:
+      - 0ef964e9-ac3b-4f57-a1c6-6ef3173bdf2b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A55Z&sr=b&sp=r&sig=JOWL6ReT0qdR%2BjKNMIx3o7ghOo5Jg%2FbvLTIUSLT3A2k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:55.8434168","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A55Z&sr=b&sp=r&sig=mkwGEjKMvtXl%2Fcj5RVXrkrrTNWv3rPl954uMnGyj33c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:55.843338","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A55Z&sr=b&sp=r&sig=OFQ30kz5VbRABFLpmFwIdafGrgsa%2BLntUV1kyurQWVQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:55.8434332","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:19:55 GMT
+      mise-correlation-id:
+      - a533285b-abe7-4b57-9ece-c162bd36f244
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A01Z&sr=b&sp=r&sig=rtCsXekTNWzKuUtF4qS93zmqKKGjXADePwcQ%2BJhyZJ8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:01.1323863","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A01Z&sr=b&sp=r&sig=rQtQANxC1nVwR4IG8o7vSGSxExBTvsqp4tgWDWUqT%2Bk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:01.1322646","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A01Z&sr=b&sp=r&sig=Ja3Re%2FQrdwmDgHy0HiFkwBGbj0%2ByEgRRkWglzZq1Qv8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:01.1324127","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:01 GMT
+      mise-correlation-id:
+      - f2ebbf0a-e969-46b6-9052-5f2ebf190daa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A06Z&sr=b&sp=r&sig=LtrKPLJa7XtBTrY9kIOwocZWTUfOFPSjVyk9mpDSARw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:06.4252927","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A06Z&sr=b&sp=r&sig=vRxVsqwQgIMdFvCoizqK58donpjGxl%2F3V4lzM1s6MRY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:06.4252188","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A06Z&sr=b&sp=r&sig=DRygAdALrPm8My9eQtsNIth1I0QPsmWQEryMOHrUms4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:06.4253103","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:06 GMT
+      mise-correlation-id:
+      - 01f485b9-b908-4c66-a272-edba270bb182
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A11Z&sr=b&sp=r&sig=7JjG4216CfK7Ijq9ueeYP%2FbPyZGrHsGxdTV4whn%2B1vM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:11.7053015","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A11Z&sr=b&sp=r&sig=Brz6%2F9aQxVO5RUYwWapEgD%2FaC4bfEYQ4QaHMIoLVVNU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:11.7052341","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A11Z&sr=b&sp=r&sig=MfaoFPhKwBq0EuKMRFa%2Bug%2Fk886XcR%2FqHOBR7f8489U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:11.7053168","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:11 GMT
+      mise-correlation-id:
+      - 48dfc1e1-c14f-4b59-a2e9-da93ab14f85c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A17Z&sr=b&sp=r&sig=snj%2BEH%2F44BFmOearB7X3%2FJmN9RcFQ7ZOOlx7VHD28S4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:17.0027858","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A17Z&sr=b&sp=r&sig=bsuwHOLQ%2FRLUR4HPDUKvWyVZNjs83TyhE3aU7qXyzP4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:17.0026836","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A17Z&sr=b&sp=r&sig=oYfTHl%2BYa43ZMx%2Bwr%2Fq4fNL6EkAjM1NEUq4ZXNpYDwk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:17.0028295","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:17 GMT
+      mise-correlation-id:
+      - f4bc1bbc-7b30-4ce4-929c-25217ff37d14
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A22Z&sr=b&sp=r&sig=K9bcbB3HWwrqqAqbAz%2F1ZINQBnHJN2Kjnqike4U%2Bv6g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:22.2902919","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A22Z&sr=b&sp=r&sig=4G5QKO2noHanfRuPfBrbGW47kUjsUeeV4zyVxhv1hCU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:22.2902183","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A22Z&sr=b&sp=r&sig=l%2F7SojRFiUSEru3JHlKePjPFTZ7w4cIA7QrVbwZAVwQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:22.2903064","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:22 GMT
+      mise-correlation-id:
+      - aa16d1c5-25e5-452c-b94d-3e7fc5b6c15e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A27Z&sr=b&sp=r&sig=cKLGtuVgDVBA2nNCfnYOO9yK0GZzYcCEh9w6cqSa8Gw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:27.5609908","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A27Z&sr=b&sp=r&sig=8DYo5utKU1sDDJQaGhHs1w8B1FfjUVG4oG8Lu6sUOe8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:27.5609051","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A27Z&sr=b&sp=r&sig=BOIFqdExAuOjBuh1q7%2FsAbTNE51cuF%2BVzA%2BZxXqrenI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:27.5610137","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-09T16:17:48.952Z","endDateTime":"2023-10-09T16:20:24.146Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:24.237Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3323'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:27 GMT
+      mise-correlation-id:
+      - 9ef6c13d-b316-479a-9213-8ec1cf9f5f75
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1100,7 +1820,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:15:21.6710746Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:15:21.6710746Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:48.0691178Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:48.0691178Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1109,9 +1829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:19 GMT
+      - Mon, 09 Oct 2023 16:20:27 GMT
       etag:
-      - '"1a0aafdf-0000-0100-0000-64af09dd0000"'
+      - '"9201d1da-0000-0100-0000-652427710000"'
       expires:
       - '-1'
       pragma:
@@ -1141,24 +1861,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=show-test-case&api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=show-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4fe1697c-3a4f-4f8c-88a7-22160fb24ac7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"aa5d45e9-2686-460a-9ed1-0dc4f7d5ebec":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f7677c6-6b0e-40e5-96a0-d1a191c2bbe5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/82263423-52d8-4fa9-90f8-d23116276314?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A22Z&sr=b&sp=r&sig=t8zMpstYTY%2FpPrDUCTbtAvr1VJ4z1eNX3pG1cT%2FR0mc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:22.7192512","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A22Z&sr=b&sp=r&sig=ynd09mHMOvPdJKOU5PWwqcp5AfHzC9XBubulWluVDe8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:22.7190915","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/ba8f18fc-4dc5-4b03-96a7-4a9883d24e11?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A22Z&sr=b&sp=r&sig=18mbsu4j3zV7W7FwD2KjRXTDsEufblW50uXHaYU1yi4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:22.719268","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-07-12T20:16:24.167Z","endDateTime":"2023-07-12T20:17:18.41Z","executedDateTime":"2023-07-12T20:16:23.608Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-07-12T20:16:24.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:17:18.485Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A29Z&sr=b&sp=r&sig=TKuIHznSIkVBEq%2FFtH6VPXyzE22HvtWnn5bSZnl2q%2Bc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:29.5317097","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A29Z&sr=b&sp=r&sig=WeKgRDps83M4NYIgds%2BsNf68mQbqLsCpPcPbVbBr5m0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:29.5316424","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A29Z&sr=b&sp=r&sig=dN%2BCJGk22CkiezNi1QU7HzAyu1nzwPcMZBr307EAnaE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:29.5317247","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-09T16:17:48.952Z","endDateTime":"2023-10-09T16:20:24.146Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:24.237Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3368'
+      - '3337'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:22 GMT
+      - Mon, 09 Oct 2023 16:20:29 GMT
       mise-correlation-id:
-      - 9273900b-4895-4e1f-b878-cf3819d257e9
+      - c3680749-a68c-4fdc-9c73-17a53e89a860
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1181,7 +1901,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:15:21.6710746Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:15:21.6710746Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:48.0691178Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:48.0691178Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1190,9 +1910,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:22 GMT
+      - Mon, 09 Oct 2023 16:20:30 GMT
       etag:
-      - '"1a0aafdf-0000-0100-0000-64af09dd0000"'
+      - '"9201d1da-0000-0100-0000-652427710000"'
       expires:
       - '-1'
       pragma:
@@ -1222,24 +1942,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf29fc40-57a2-4501-b9ed-05d774d9b457.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4fe1697c-3a4f-4f8c-88a7-22160fb24ac7":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"aa5d45e9-2686-460a-9ed1-0dc4f7d5ebec":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"4f7677c6-6b0e-40e5-96a0-d1a191c2bbe5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/82263423-52d8-4fa9-90f8-d23116276314?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A25Z&sr=b&sp=r&sig=r0%2Bpd8o10TqsmxFR%2FaTHFC8DAD6iM4y%2B9VIYVWw0Yfk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:25.4103905","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/4d07ff12-7585-48e1-9281-06ea2e02bce0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A25Z&sr=b&sp=r&sig=ERlbWrYcxSXEC2NQGzdFMsySsncpXab4Aq9Yo1QHfao%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:17:25.4103229","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/be8960c9-c954-4019-be93-291f30516390/ba8f18fc-4dc5-4b03-96a7-4a9883d24e11?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A17%3A25Z&sr=b&sp=r&sig=BbNRpxmGaq3qk0xks%2FyVkC2ymvFqX85bH9HnF4MuFM8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:17:25.4104071","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-07-12T20:16:24.167Z","endDateTime":"2023-07-12T20:17:18.41Z","executedDateTime":"2023-07-12T20:16:23.608Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-07-12T20:16:24.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:17:25.024Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A31Z&sr=b&sp=r&sig=%2FCHdMZExqYpDgojr39d7RNO1rnuCfcG6lzYX7HVa5Us%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:31.7806341","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A31Z&sr=b&sp=r&sig=dyLE2dVtB2iixN33XuGjTbjdNxYYZ3SW0Z%2BMIzymIfI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:31.7805411","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A31Z&sr=b&sp=r&sig=vif2ga%2BbYFEbVWKmfcqiDrzNe0XC4UahcTqig1yUhY0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:31.7806562","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-09T16:17:48.952Z","endDateTime":"2023-10-09T16:20:24.146Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:30.178Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3361'
+      - '3323'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:17:25 GMT
+      - Mon, 09 Oct 2023 16:20:31 GMT
       mise-correlation-id:
-      - 05d23c52-176e-4d54-a782-660f8f06a953
+      - dde2b486-c2fd-4f94-9324-832820af3dd8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_show.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_show.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:41.315522Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:41.315522Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:33:04.2189798Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:33:04.2189798Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:45 GMT
+      - Tue, 24 Oct 2023 12:33:37 GMT
       etag:
-      - '"7500796c-0000-0100-0000-6530468b0000"'
+      - '"d300094a-0000-0100-0000-6537b9820000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:56:46 GMT
+      - Tue, 24 Oct 2023 12:33:38 GMT
       mise-correlation-id:
-      - 10ebc745-6a84-4a2d-b5fc-fa89c3526d2c
+      - 95501169-de93-4728-9b45-c6ec58edee0f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"cec1289e-2c8c-4969-bd84-592b5bfb9066": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "ddc5e70d-9668-4807-93cd-cf3bae67f800":
+      {"passFailMetrics": {"f8ee81d5-6518-43ad-9a4e-b9700d69e096": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "d1604977-5345-4f60-ada4-93691cd760f1":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "f86aaddc-a9b5-47c8-b632-d07b3c59455f": {"aggregate": "avg", "clientMetric":
+      "50"}, "363ef462-9754-481e-98ac-f0093447de46": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:47.131Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:47.131Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:33:39.566Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:39.566Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:47 GMT
+      - Tue, 24 Oct 2023 12:33:39 GMT
       location:
-      - https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+      - https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - b0e8a1cd-4a95-4ede-975b-82efe247678e
+      - f0764e68-aae9-4b46-a2ab-f45f6ae086e0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:47 GMT
+      - Tue, 24 Oct 2023 12:33:39 GMT
       mise-correlation-id:
-      - 48f1ba3f-d688-4e84-bc71-2a2cab2571c2
+      - 52a721c4-428c-40ed-b3dc-1617406293be
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,10 +275,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A47Z&sr=b&sp=r&sig=ToC6ZsoiFwK8U0tENMnwz3W%2BmYw%2FeqAj3v8X8VOBnL0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:47.9316717","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A40Z&sr=b&sp=r&sig=aM4VDHMQXyNjpX6bv%2FgQYjkN36y6vEgw0y1t%2B1dIrPc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:40.5858898","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -289,11 +289,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:47 GMT
+      - Tue, 24 Oct 2023 12:33:40 GMT
       location:
-      - https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - b18457d9-dfb6-4f57-8dcc-efd88a5d1a3f
+      - e17e3014-00d5-43c3-b750-fd13e2166258
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A48Z&sr=b&sp=r&sig=HLy9RQ7uefG9WfFtAAHb0hnNyLkN6WDKHaeQYgCdByY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:48.1927327","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A40Z&sr=b&sp=r&sig=F9ufS0jVy0gKS2VNU26I%2BaA97KlUZcDfG6cjEUcRt0E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:40.9358879","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:33:40 GMT
+      mise-correlation-id:
+      - d5622301-4f58-4b08-b421-7c9deb4c73d9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A46Z&sr=b&sp=r&sig=z79%2F%2BGpza0xThcv4pvJutW44WmeHsSYwWSYGKBlBWU0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:46.2264304","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:33:46 GMT
+      mise-correlation-id:
+      - 2c167aba-df92-4c3d-9070-8ced1f69d12d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A51Z&sr=b&sp=r&sig=dRy0ZieM9sTuGPmc2jg5blQEsY%2B1ml3prdTdXZZ3dfg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:51.5012162","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:33:51 GMT
+      mise-correlation-id:
+      - 2e1a7dd6-a7f3-4b67-b439-2abfdfa9ecaa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A56Z&sr=b&sp=r&sig=qf0oJ33PAq5koiiC0%2BWkLPgoIqYV7dyuJILkkhqphK0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:56.7691944","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:48 GMT
+      - Tue, 24 Oct 2023 12:33:56 GMT
       mise-correlation-id:
-      - b53e5f64-46be-45e0-b92a-74863302e4db
+      - 6f157c76-94b9-446b-bb7d-6cce89069cc9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,132 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A53Z&sr=b&sp=r&sig=4uOQF7klx%2Bsyb2Gjd6TKc%2F0HQ8B%2BkcDqCnDsw6y3YOI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:53.4620394","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A57Z&sr=b&sp=r&sig=kbdN%2F%2FWLM28uU3wR51PXYn85wNjagUHEnxTe6p8RuDI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:57.0057418","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:33:39.566Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:53.443Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '1579'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:56:53 GMT
+      - Tue, 24 Oct 2023 12:33:57 GMT
       mise-correlation-id:
-      - 3e18ed56-b547-495b-8d0d-81b26b2d22a9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A58Z&sr=b&sp=r&sig=1ilzn7U3OZUYvDrXvDV9VaL62jh29ZXgNTRaBthBtsw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:58.7418798","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:56:58 GMT
-      mise-correlation-id:
-      - ad0651b4-00b2-42a2-9e08-4b496a53ccb2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A07%3A04Z&sr=b&sp=r&sig=66R2No3EDOr%2BdrKd93%2B%2BoVVYwoLX%2FgMVZku2P0bPKa4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:07:04.5515123","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:04 GMT
-      mise-correlation-id:
-      - 5e18180e-09fb-4150-96dc-e792272c322c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A04Z&sr=b&sp=r&sig=GYVbjvD%2BCt%2F%2BQ1XtBb1IJLaNAxf1Am1Rx5M0eiFJTC8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:04.7977994","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:47.131Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.448Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1581'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:04 GMT
-      mise-correlation-id:
-      - 3eba0810-289f-4a8d-8c0d-7b75301e7e18
+      - 7dd282c5-6e7e-433b-8874-51fb1062d344
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:41.315522Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:41.315522Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:33:04.2189798Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:33:04.2189798Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:05 GMT
+      - Tue, 24 Oct 2023 12:33:57 GMT
       etag:
-      - '"7500796c-0000-0100-0000-6530468b0000"'
+      - '"d300094a-0000-0100-0000-6537b9820000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A07Z&sr=b&sp=r&sig=ORI%2BL6mI1FenzeU78A1id%2FEFfm9%2F6ZkUOqQYv34dv4w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:07.0569558","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:47.131Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.448Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A58Z&sr=b&sp=r&sig=NSyn596lUAwROcvfU8hV52VFbEZtU3SS22MNfo94N%2Bk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:58.5839333","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:33:39.566Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:53.443Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1593'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:07 GMT
+      - Tue, 24 Oct 2023 12:33:58 GMT
       mise-correlation-id:
-      - 667b0585-bdd9-47ec-a37e-c8a9ce383f39
+      - b858fe85-933e-4d25-8d6b-2483be42e64b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:41.315522Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:41.315522Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:33:04.2189798Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:33:04.2189798Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:07 GMT
+      - Tue, 24 Oct 2023 12:33:58 GMT
       etag:
-      - '"7500796c-0000-0100-0000-6530468b0000"'
+      - '"d300094a-0000-0100-0000-6537b9820000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:57:08 GMT
+      - Tue, 24 Oct 2023 12:34:00 GMT
       mise-correlation-id:
-      - ec11f406-bdd3-4668-a040-505c5e1e15c8
+      - 531d387a-4ebb-447d-adf7-e484fae444f8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A10Z&sr=b&sp=r&sig=AXqQMIq3NrQHbHWmJUWNws1Joqp8FT1zXg901Z9eHSQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:10.1483719","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A10Z&sr=b&sp=r&sig=Ozfa0XUKE2ZeoCg78eyhau%2F4JKfMNwvycV2grHyFmuQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:10.1482448","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A10Z&sr=b&sp=r&sig=Si6WN8Cr2MW%2BC2Y78Qr3nIScO82kB7yPfF8w0xlAZSI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:10.1484001","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A00Z&sr=b&sp=r&sig=5iI%2FhPEZIcwrOMB9OGtzxwDt4M4fDMeUvqMyW1cbb%2BM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:00.8837233","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A00Z&sr=b&sp=r&sig=%2BqHtFwBgQm%2Fx1eK812b16MlIfoWNX1UWReHugBxQFJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:00.8836243","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A00Z&sr=b&sp=r&sig=XInDjlyqTbO6FhL6BOUSbdmLTruDgRvaTI31wxklX8s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:00.8837572","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:00.795Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3142'
+      - '3146'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:10 GMT
+      - Tue, 24 Oct 2023 12:34:01 GMT
       location:
-      - https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+      - https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 2d6f1ea0-8207-4dac-a39e-c078197b6c3d
+      - ac0af053-b61b-4f6f-99a7-60d9e09b74ff
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,118 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A10Z&sr=b&sp=r&sig=D2kM0ZJnJCYZmhzL9M6y10v5kX4Q7RuEenQnq70fnUg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:10.6271936","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A10Z&sr=b&sp=r&sig=9%2BfotjipKyo4pkSt8Pib7JRJfqTwVVjyM2SGfphxutM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:10.6271191","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A10Z&sr=b&sp=r&sig=GBlVLpGP%2F255rQKhTIoOgy9tqKbnrh%2BfVpgBBsG7RwM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:10.627208","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"NOTSTARTED","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.508Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:10 GMT
-      mise-correlation-id:
-      - 8afa1d4c-0028-455b-ba7b-dc24c46f6abb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A15Z&sr=b&sp=r&sig=nngWdOxcKdiSin8FvtTYC2i%2Boj%2BC3uEee65rfeEfZEA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:15.8932038","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A15Z&sr=b&sp=r&sig=0xfg%2BjGiRc27sNXwVdPyQP1Q9FlJzoBDuFc1BraKF0I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:15.8931305","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A15Z&sr=b&sp=r&sig=NhW2xy33Mc4Yt08z3fuBLg3YbPYgShFec1AJLmPeFhU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:15.8932181","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:15 GMT
-      mise-correlation-id:
-      - be4ec8b0-3275-4845-b56c-8de23fbfe146
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A21Z&sr=b&sp=r&sig=vT%2FXT0DLtYgb2LbXuJM6FVQZMkFeY%2BVF7vqvH2CxVWA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:21.2087963","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A21Z&sr=b&sp=r&sig=BPEo2LHOWoXL3NCpp0zJKWRmvAIRTndYesvoft0COQM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:21.2087252","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A21Z&sr=b&sp=r&sig=3Ys0Dqr7u8L6SNSKtVtwH87vn6KgOTP%2FxHqXjrCDFF8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:21.2088107","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:21 GMT
-      mise-correlation-id:
-      - e0443ae1-2311-48bb-a55c-44c5beb7d590
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A26Z&sr=b&sp=r&sig=%2BZALeX9siB%2BXk3ceVfs%2Bo%2FzAUHKhH0gqfuscu3khtXA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:26.544484","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A26Z&sr=b&sp=r&sig=ivmBh7KbMUpCwPAmkxHeGCBPlkDtLeh1RakESwEMQyY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:26.5443539","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A26Z&sr=b&sp=r&sig=5sJbMbgvmUpx8eHtZ2PmZ9RqYdivspbyqtA7IS0M2kc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:26.5445059","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A01Z&sr=b&sp=r&sig=OGcHVakYc6jESrKPLLMkLKziA9nCw%2FVEKVRlCRautUQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:01.4235434","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A01Z&sr=b&sp=r&sig=PxLWGsiQV%2FRMMn3xhLEZzqSupi5AP33XB0CL0WWK%2Bv0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:01.423437","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A01Z&sr=b&sp=r&sig=Zc2qrmhT9ALwvh2mDCNPKtjFfO1hfuBwoEJV%2BUmK70A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:01.4235673","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:01.349Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -822,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:57:26 GMT
+      - Tue, 24 Oct 2023 12:34:01 GMT
       mise-correlation-id:
-      - a5b22318-2635-4f30-afd5-fca79709823f
+      - 67f1bfcb-d082-4b54-a885-a095e6d27f01
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,262 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A31Z&sr=b&sp=r&sig=phZ2kuHUpafoxHeFERHvOh0v%2BzKWeq4R4tt6cawMYNk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:31.8110558","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A31Z&sr=b&sp=r&sig=MwjJaZi1e%2BgDQv9VrDKF29cSKJADEQx0b6gmM%2FGuK9A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:31.8109826","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A31Z&sr=b&sp=r&sig=z1QRTeXukvQovxTem0CdOQPA%2F9P0MG0ormau%2Ft8RgV0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:31.8110707","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3195'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:31 GMT
-      mise-correlation-id:
-      - 44a1777c-1cba-4894-8823-2cf023a4db03
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A37Z&sr=b&sp=r&sig=tuYl%2Bx9ocBghh1Lq7sgadVJuMa8DWfG4oRPyYgy123s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:37.0873229","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A37Z&sr=b&sp=r&sig=HwQZjx%2Bm969TTqrgpst7CxvVqaQdj%2Fzpr1TSLg%2F7t%2Fw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:37.0870834","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A37Z&sr=b&sp=r&sig=1elbIUX%2BQuXfdeJW5uxyWhxE0teOBnIFdvI8%2FLu%2Bs%2B4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:37.0873444","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:37 GMT
-      mise-correlation-id:
-      - f085d29a-d41f-49a6-b993-5413fa135d6a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A42Z&sr=b&sp=r&sig=ywuC3qqa7SB412aoPSa5fFdM85qcUiNwm0ZjLVnDOBA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:42.4160214","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A42Z&sr=b&sp=r&sig=WfRgc3THmBxMJqKXmn%2B4L7zT58c6KYuiEcLGE5H8Wjs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:42.4159448","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A42Z&sr=b&sp=r&sig=tsQK2F77P9Ko6PAmp7FSInVrdyWFCxf%2Bs%2BHxnYKbauM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:42.416036","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:42 GMT
-      mise-correlation-id:
-      - 0d1355ab-bc36-4ba6-a0ec-4d23202fd389
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A47Z&sr=b&sp=r&sig=Ff4GXUa7CS901o0KDkHdHXZTIUPpvLSEMI3K22wuO9k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:47.7440541","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A47Z&sr=b&sp=r&sig=WHUSu7rlI8t8idaG%2FF%2FOBEg4J1gTUL2oapU4ceVBBDM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:47.7439628","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A47Z&sr=b&sp=r&sig=w2%2B6UhKNpuie331wP5sYIzRF6B11Xy9poydCOWsYFa4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:47.7440765","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:47 GMT
-      mise-correlation-id:
-      - 2dcd705d-419f-4bbb-a376-49a38e8b0695
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A53Z&sr=b&sp=r&sig=Xwa3PC90jE%2B34irZrvdJifcqtXo8K9s%2FFPmXnLRhXrc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:53.0477834","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A53Z&sr=b&sp=r&sig=8%2Fi2ZHNzeIsbq%2B4uNO%2FGD7INBfoxUQrYJxut%2Fp4A0Gs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:53.0476998","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A53Z&sr=b&sp=r&sig=no3M9JBHT3rTJjW1YDfICTk4PsDRyjWQ1ug%2FqDGIB%2F8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:53.0478015","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:53 GMT
-      mise-correlation-id:
-      - c7664075-547d-403b-b43a-892193a9fc24
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A58Z&sr=b&sp=r&sig=UyygEFdY%2BQMCHzNTo%2BDF36nNhIts2ZV1sm99tljZA94%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:58.5520543","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A58Z&sr=b&sp=r&sig=b1U1AxsuJYk7LIwG2SGy1t3bLeyHXq3QSjlCZzA3Lac%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:58.5519651","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A58Z&sr=b&sp=r&sig=ADX7l4E9obDWyJeIREechVM5l%2FCU5r2LlheVxh%2FDG4Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:58.5520687","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"CONFIGURING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:56.07Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:57:58 GMT
-      mise-correlation-id:
-      - e232de38-5041-4d7c-ad45-a9c985c87db9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A03Z&sr=b&sp=r&sig=f6fX%2BYKWlA1qtm7qv1OPseF3Vr5ql1%2FLMfOrJZy4CbM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:03.8248937","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A03Z&sr=b&sp=r&sig=fo6d28%2B%2BDcnQxbvahGXnVQTXc8MjwEOMmQ2k8WkBfCc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:03.8248245","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A03Z&sr=b&sp=r&sig=JrzG%2FqrXxjCYnwCoYnJ8DLvHuFRsWQrFv5KAiXnkVKo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:03.8249083","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:03 GMT
-      mise-correlation-id:
-      - 56fe129d-e30e-413a-ad28-0fb4a28deb48
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A09Z&sr=b&sp=r&sig=K9ZGps4L7%2Fwqd1CBdE0WUJvIOivuGdDueYjjjOuBgMA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:09.1835001","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A09Z&sr=b&sp=r&sig=MgdwRxADN8o27GXOW3R8tfd6cjT%2B4%2FYcP3MpPuXhAxQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:09.1833855","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A09Z&sr=b&sp=r&sig=6UYOn4LxFRuthzsFdB2Brw%2FakSUX6hK02oZ5sQZsbRE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:09.1835253","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A06Z&sr=b&sp=r&sig=GabkuGt3Ks2dOCbalR2y63bSrFcZbQm3CAgqJ9BKMf8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:06.7499919","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A06Z&sr=b&sp=r&sig=%2BsKrGNH2UQsN47fPCA1VUXmrcSeHzmzbgMmoDFm1H0s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:06.7499124","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A06Z&sr=b&sp=r&sig=OCdGW7Y%2FRK3Q5kCa6Xn2f2uylRPmv0sdJSYGEQBpX0k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:06.7500096","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:01.349Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1110,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:58:09 GMT
+      - Tue, 24 Oct 2023 12:34:06 GMT
       mise-correlation-id:
-      - 115055ae-86e4-42d3-b5f8-414f5bc25eca
+      - 0f444c27-6372-474d-87ed-05967c67ee21
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1132,262 +772,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A15Z&sr=b&sp=r&sig=oPprFkHS9n%2BzuUA1JlGc24i0xPH2f%2BnPEJ7Qxm3sFx0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:15.0571404","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A15Z&sr=b&sp=r&sig=UwrYOAwWBZJ8UYeoHJdYkTb5bjfxged6gO5vF6Zvr8k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:15.0570724","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A15Z&sr=b&sp=r&sig=PeX9LyKJ3WyqqQZ8vmAPyeE7DWvdz0pPkF%2B2PvY2RAM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:15.0571578","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:15 GMT
-      mise-correlation-id:
-      - 80eca696-a7c6-42b5-a101-7ff8ad444fbb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A20Z&sr=b&sp=r&sig=tKTkJDAOl1Q%2BIqxEsy%2FZOZ31AHVA99tojgAJPG%2Fmeds%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:20.4652821","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A20Z&sr=b&sp=r&sig=EI2WVBZstslc8l9fgHdVwYnGK7fucebKtaVZiCgiv0g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:20.4652114","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A20Z&sr=b&sp=r&sig=gf6uIXhJALvYvCL3At0i2BUCXGBSef62XLol0EkgZ70%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:20.4652982","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:20 GMT
-      mise-correlation-id:
-      - 74adc8bd-9e50-4006-bb5a-4f7679a07dd5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A26Z&sr=b&sp=r&sig=mcoI%2FRggHufQZPACqcjoLCi7TGO1cmiDuFvKRiq7XHc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:26.0905888","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A26Z&sr=b&sp=r&sig=UYuOHEkx5BgNpEeAsEaokA0H5ra2Rt9lkSu0LjO%2FlAg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:26.0905143","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A26Z&sr=b&sp=r&sig=TtjpKleA%2B9Nx3VAmgn5CX8NmHs1ToIWTW0psrS%2FuBpA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:26.0906063","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3189'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:26 GMT
-      mise-correlation-id:
-      - 06d08c3c-cffc-45f8-ac47-0c5dc403844e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A31Z&sr=b&sp=r&sig=aClYpuUH8hwt0A35w%2FmZ4VnM8B%2BVL5qJGZXrAncsvyI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:31.3704135","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A31Z&sr=b&sp=r&sig=DevB11MHPG4VO49goDvjXApIIOFGZ3ND5Xin%2FKpiMqA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:31.3703397","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A31Z&sr=b&sp=r&sig=8AfBn149q34VnHeIk1E0OrAyfpofJgoNn5doiZGCEvs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:31.370428","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:31 GMT
-      mise-correlation-id:
-      - 80ad016b-2b2e-4e36-b857-5dbddadf8095
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A36Z&sr=b&sp=r&sig=xE3czcb%2FJ1Ur7wTQkdQNBLoFeIA9jAVvUMZZYC%2Bpetc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:36.6258382","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A36Z&sr=b&sp=r&sig=zeq6dpX9zcQ%2B3H45VwiLohU0vo55gi2AXSroIQZ0DUM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:36.6257494","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A36Z&sr=b&sp=r&sig=nRDSqVCo3kzlNUOHZbRXhT18hOOML3v%2BoNf%2FC0rCwD4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:36.6258573","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:36 GMT
-      mise-correlation-id:
-      - 73543ae6-84c1-4d68-af21-cdb1debfdb08
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A41Z&sr=b&sp=r&sig=9c9otglJDwD75ZStrK%2F0ZGg6PXDceRQTWnNAPAUMauc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:41.9003335","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A41Z&sr=b&sp=r&sig=L%2Fqsl2yyWsq9TuakjizMPLjzF7e8FnMSwQ4dKeqYRlc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:41.9002614","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A41Z&sr=b&sp=r&sig=LwUQcaClWpFl4I8n0kOGE9uUTZNFT8nDEhVpOSRggkk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:41.9003469","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3185'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:41 GMT
-      mise-correlation-id:
-      - 09530697-3a24-445c-be95-79e18c480726
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A47Z&sr=b&sp=r&sig=z10PAN8bE29oDVS%2BGqct3A4CzAFUfh0HYYBuWpxMXuY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:47.2441662","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A47Z&sr=b&sp=r&sig=Wa7zK5b06Qv4lRyq0GaV43eyilAqBwNdi%2BcKMt0lq3c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:47.2440418","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A47Z&sr=b&sp=r&sig=xRuhKiZ67kXm1zkmoJYwElmwdqMx%2BEPepjxr5x759R8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:47.2441909","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:58:47 GMT
-      mise-correlation-id:
-      - f00d517a-1d56-4077-a03f-0fdcb73f67f8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A52Z&sr=b&sp=r&sig=935pXJA76vKBIysHuE5uev8rmDKJ%2B0PzNag1gHbm2Kc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:52.5065778","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A52Z&sr=b&sp=r&sig=w%2F%2FzBC0qgfvRs%2F215H4jVByO3C39laZ%2BsE36ZmkDYug%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:52.5065019","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A52Z&sr=b&sp=r&sig=ns0365%2FtJmB%2FyIRw5dE08sjSCWvakZzNKPZ5FWeTecQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:52.5065922","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A12Z&sr=b&sp=r&sig=tY2WJtrPDV7oGfgJsj7KDfdROXDcvVF120hIqGlSFJc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:12.0334418","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A12Z&sr=b&sp=r&sig=hEiTl1IcTpvsU8Y1I6z7ptCJhW%2FwNIqdZbyIMlHE0iI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:12.0333698","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A12Z&sr=b&sp=r&sig=H%2BE%2BO8LiT8%2FTdFxJKSUpno%2B4Z4ydW4EveaoXM1ef91w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:12.0334559","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:01.349Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1398,9 +786,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:58:52 GMT
+      - Tue, 24 Oct 2023 12:34:12 GMT
       mise-correlation-id:
-      - d63f4fe4-b40d-44df-a6f9-d261e0259a0e
+      - b255cf68-de0e-4f7f-8e29-621ead3cbe39
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1420,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A57Z&sr=b&sp=r&sig=O48KTmYbbV7OEfCCMjLLOFKT7PVrFcHnGpLfya3uHh8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:57.8021436","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A57Z&sr=b&sp=r&sig=Nv3nTLEZo01f6jfTy%2BIJNsEnPICgttLSxMgBOvKnbEQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:57.8020542","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A57Z&sr=b&sp=r&sig=XOaH47eIjBkErA%2ByhevG0sbknFttsRoYd7mEd%2BdnsH8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:57.8021584","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A17Z&sr=b&sp=r&sig=bvC%2FjEvm7RQVqjgk%2FLadRqVTO%2FNiMr81yZHnLWmPuB0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:17.2784257","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A17Z&sr=b&sp=r&sig=psf%2FjVx6ZNmplUcg%2FO70u1lcq9ayzHZDtDawe3fC050%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:17.2783395","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A17Z&sr=b&sp=r&sig=2THt7cKEZLHJ1RdQBBXDiZ9ciLJa922tSwOd7JROC5M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:17.2784409","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:01.349Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3187'
+      - '3195'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:58:57 GMT
+      - Tue, 24 Oct 2023 12:34:17 GMT
       mise-correlation-id:
-      - 510a56dd-3845-40c3-a0dc-9274e9c523cb
+      - 46e9aa8c-ca74-4153-b0cd-f2ba91e7e5a6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1456,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A03Z&sr=b&sp=r&sig=1jzJ4GBBXMYLvvTjlRPwu1bZYWwMBG1QxqzU5qqDUi4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:03.1193985","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A03Z&sr=b&sp=r&sig=LEebXRFbRj%2BeIsNqWD2zmXDuL2ce3%2Fz1FYeeGOOrIfY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:03.1192981","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A03Z&sr=b&sp=r&sig=acm4MGC3kP3bS43N%2FdlzgT%2BzCvVLenDB6y7JmuwNr%2BQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:03.1194247","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A22Z&sr=b&sp=r&sig=vuX9YAlAcFboLqyKAFdevfLzBHcdzu3486dcu%2FFHuLM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:22.5698773","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A22Z&sr=b&sp=r&sig=yC1oevi0HxZ9nsQMcG%2BnPoLvLWNb4ATmGegIP3nTIj0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:22.5697658","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A22Z&sr=b&sp=r&sig=UBvRdt8UlDuwcMWyWcfaJKIX2kOFhke6C6hGCAU2d7o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:22.5699018","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:01.349Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3191'
+      - '3189'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:03 GMT
+      - Tue, 24 Oct 2023 12:34:22 GMT
       mise-correlation-id:
-      - af996638-5a80-485e-81d4-9f9a030ef7bd
+      - 54cf0416-1635-4991-a2ae-1649e6fb45d8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1492,118 +880,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A08Z&sr=b&sp=r&sig=DOPdXsqXhUBtwYCtrGgSHjiAAtNtHDePI3kjLZAsLjI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:08.4449536","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A08Z&sr=b&sp=r&sig=yZObz5pdT3HZ9%2BCSJzQqv0cuwGVgoekagn%2FL48NuP8Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:08.4448811","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A08Z&sr=b&sp=r&sig=YpUGKkTqQem5vYnk08wyYYkm84o%2BLnwZZ9WEI8B3rtk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:08.4449677","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:08 GMT
-      mise-correlation-id:
-      - 894e8191-e1e1-47c6-be85-5d83da0ec746
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A13Z&sr=b&sp=r&sig=QMTR1N6lKh6f%2BY2O2ReyXBJgqobpOv%2ByIws%2F7G4R3Co%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:13.7137621","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A13Z&sr=b&sp=r&sig=7RbKpqIMLjzg82vOCZSo0AB3pASi9gUqeY2U%2FFB69JY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:13.7136762","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A13Z&sr=b&sp=r&sig=BdklVExj69MNfZQ%2BIQRhDqg7cvxK3bCIq36%2BzwTtDHc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:13.713777","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:13 GMT
-      mise-correlation-id:
-      - 5ac7a67e-eeaf-4ee4-9243-b1b5d8decc66
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A18Z&sr=b&sp=r&sig=1mGqnQYGJacvnnePe2d3DgnlCTce0ThIxHheqE5RF4o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:18.9934985","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A18Z&sr=b&sp=r&sig=6UvolU6d4CFT2qI2tVjaOCQIuu1lwK6yg7flWWXoSvU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:18.9934287","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A18Z&sr=b&sp=r&sig=u8F5P5k1K2%2BsqeUMv%2F848u2dDIVz9gwV16I1tQveSjg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:18.9935122","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3185'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:18 GMT
-      mise-correlation-id:
-      - 9f1a5e82-881e-4cdd-b3f7-be150a361175
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A24Z&sr=b&sp=r&sig=HVL8BhitI7p104wdNkUgeNRK2%2BUbiJ0%2BCzyGAxqODEQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:24.3308405","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A24Z&sr=b&sp=r&sig=aDmJgKXV3SsNBLYcsee7fDahFkU2Nch98OmZv6xgH1Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:24.3306788","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A24Z&sr=b&sp=r&sig=TWsFz2wrY2wfOEhtuOgaL%2B%2BHQJEcmI1JdUNLAu%2BCw%2Bs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:24.3308655","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A27Z&sr=b&sp=r&sig=229B0Ta%2Fvbo6CwQxbtlf3bU2av8VzBtIhxrsbchT%2FIo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:27.8536129","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A27Z&sr=b&sp=r&sig=6Dmbp9KRCMndOxqLblhI93zo%2B2BYNw3zk4kTtrlIxLU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:27.8535105","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A27Z&sr=b&sp=r&sig=J6Rre12pa7GQx0Zi0qZBQ3NahceQ2uwwHkM%2BFof4OSs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:27.8536353","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:01.349Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1614,9 +894,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:24 GMT
+      - Tue, 24 Oct 2023 12:34:27 GMT
       mise-correlation-id:
-      - 12473745-982d-4a52-a740-b8a6d95f1109
+      - 11f5ab12-cde3-4797-87b3-a471db503ac9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,46 +916,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A29Z&sr=b&sp=r&sig=dHCSWuDw2l9xQ6BJSqfOxRwE6AUJWbYaKfE53LJvgwA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:29.6478203","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A29Z&sr=b&sp=r&sig=gnn%2FghtsyDJG9npqssNQVaNzFC3mUhLOE2xasmm1R7A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:29.6477458","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A29Z&sr=b&sp=r&sig=QUuzhbHxoXYlJC%2BS%2FBTMu%2BqAmU84mXnuRjmyYhObZLw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:29.6478346","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3189'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:29 GMT
-      mise-correlation-id:
-      - 243627cb-0062-4e52-a283-3eabe7b5fb88
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A34Z&sr=b&sp=r&sig=TV%2B%2BjMBAPeFAZ0WDYLwcSJJuA%2BU%2FGqnzlWg1NClFhc8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:34.913759","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A34Z&sr=b&sp=r&sig=FGdSjgL6ZYQk5HUKpO7%2BC7Y2LruQ9sUd12ialJ5Q0vs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:34.9136803","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A34Z&sr=b&sp=r&sig=sEdqqh%2FPq4vX%2BdCu56BidxFbqxGH4tAQgOv4bWl8SCA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:34.9137755","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A33Z&sr=b&sp=r&sig=XvexfLaJiNScpQpUOifGoNZxIodxTXi122GgcVLx2Bk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:33.1152152","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A33Z&sr=b&sp=r&sig=ATKPxCRAjUFx%2BG%2Fw6NCMwpd%2BYS%2FcuCmCaodzLSghkak%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:33.115116","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A33Z&sr=b&sp=r&sig=%2FlsK67Z0WoKi5P9rS4kcQI9BvCJ414JNdeogSsyLnf4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:33.1152414","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:01.349Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1686,9 +930,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:34 GMT
+      - Tue, 24 Oct 2023 12:34:33 GMT
       mise-correlation-id:
-      - 7c304e7b-b95d-4bd4-af07-45e005eb0b3e
+      - b506bf9e-09c1-4c49-bb3e-1cacd6d1a6a9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,10 +952,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A40Z&sr=b&sp=r&sig=lN%2Bljm%2BQqAMeUYQZQG2hsaBpZIUQb8bJdXJQeFbnQhA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:40.1760413","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A40Z&sr=b&sp=r&sig=m8McorW2uHeH0a1Wk%2FUt%2BI36XeJXgPNBdGJaKnFJIwo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:40.1759716","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A40Z&sr=b&sp=r&sig=CqMLLeEqxsiXOBTz4jPNLqfaJUWqsQo6DOrb%2FiwQ1YU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:40.1760576","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A38Z&sr=b&sp=r&sig=GAIQCoAj%2Bh7kgFfZj%2FNPeeDyBZQaYrrxcp9FT1Newlk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:38.3791825","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A38Z&sr=b&sp=r&sig=bPdh74aLfFlbgNI9XPBoGgLy0PKFLNQ8sSKc4Hkym6o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:38.3791122","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A38Z&sr=b&sp=r&sig=4lyVP5B0ZF4Bky858%2BidnH2gRUkGYAujvKjeZHiZuUk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:38.3791963","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:01.349Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1722,9 +966,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:40 GMT
+      - Tue, 24 Oct 2023 12:34:38 GMT
       mise-correlation-id:
-      - 4d216492-275b-422a-9707-66385c0c8488
+      - b6b253b8-0d78-4543-9c63-78fdf2dba2ed
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,10 +988,190 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A45Z&sr=b&sp=r&sig=rJmMu5umGLcdXrTF1d0Oy2%2BixPfvEz7IFFq3Prj2TtU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:45.4314199","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A45Z&sr=b&sp=r&sig=6LCbV%2BtJcqrkxB4LDEYnTJ5VVbpT55OrFY3Gy99k1Ok%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:45.4313348","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A45Z&sr=b&sp=r&sig=n5TAm1irC28V8%2F1peM4QHkyr6yecvL70nY8cT12Efrs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:45.431441","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A43Z&sr=b&sp=r&sig=8Qf5rP29F4U2er6PL7jQwr3skrA9%2FEInd6qmMYE75z4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:43.6607729","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A43Z&sr=b&sp=r&sig=me9qgBCOy9kthHir97KY3NgjtxOjG3l0P60JVu02vw8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:43.6607025","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A43Z&sr=b&sp=r&sig=9XxkReZKL9IMlm%2FitBUU8rzps65zTfoAy7SMTeeSoME%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:43.6607867","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:01.349Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:34:43 GMT
+      mise-correlation-id:
+      - 4d63310b-9efe-4a70-89cd-ef32d53567c7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A48Z&sr=b&sp=r&sig=J0%2BkcPf18FHWTn1ZCNc03PH6wz8Ax%2FY5oeh2tIqSAiI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:48.9058954","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A48Z&sr=b&sp=r&sig=V7rp5ApbwYrtxhXjG4gSqKqP85SG%2BNJgNpvcmGFLgoM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:48.9058103","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A48Z&sr=b&sp=r&sig=Vheo3W%2BXwiHE3yuYV%2FfYNsG6p3eanf7Ius93o%2BiCBQE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:48.905911","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:34:48 GMT
+      mise-correlation-id:
+      - 0bbd537a-287a-4984-b1a4-113c16f45055
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A54Z&sr=b&sp=r&sig=71%2B67HRKxgOWqPjSJAe6u5jiCZKZIxH1PfSUaVOjKLs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:54.9646518","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A54Z&sr=b&sp=r&sig=54H6iriFtCFZlisVWmNggu6DudhUrAVpm9D6eyQMe%2B8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:54.9645715","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A54Z&sr=b&sp=r&sig=q1pHI05uKgIDGrzi4KZsKRYXZf%2Fj3kl%2BuD1pORPNRi4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:54.9646657","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:34:54 GMT
+      mise-correlation-id:
+      - f5d1f12b-3de2-4497-9bfe-19ec74d92f22
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A00Z&sr=b&sp=r&sig=f2TKnV6pNPi8lkCsZV%2FK62y6r2Fmn2t0fprZ%2BslDSTY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:00.2972422","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A00Z&sr=b&sp=r&sig=qCtZYwnkl1V2YIp7K0OFiGMWzCig3veF532rZjYeU0o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:00.2971753","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A00Z&sr=b&sp=r&sig=osZjTP2Td%2BRmnjlxauujW1SPMFj537Wf0BldzzwkJ7c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:00.2972567","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:00 GMT
+      mise-correlation-id:
+      - 26bb13b0-f366-4d7f-9dc9-001be9e1db20
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A05Z&sr=b&sp=r&sig=08F8yXiKxmrGW8wokpd0tKtNzcdSWCx1Em8YCP7lVNI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:05.6195356","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A05Z&sr=b&sp=r&sig=%2FV%2BfxR6bqwKy5cVxfZNSR2pZMnweoTdkVtBM7o6HKpI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:05.6194583","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A05Z&sr=b&sp=r&sig=EwD%2B77P9xJGUEAh0z2DfQdLcRt1SMEkpjMktdeyU8uc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:05.6195496","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:05 GMT
+      mise-correlation-id:
+      - 181af0d8-0d0f-4fd2-b12a-ff3550931ad9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A10Z&sr=b&sp=r&sig=0SWypKVOlciYB%2B%2Bgs2p4PhWPURGAeNFuhl1yI0MatvI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:10.9309656","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A10Z&sr=b&sp=r&sig=xDmBduCsBdTz4arMNfzmM992W2WxNOVFEUGB565GLGc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:10.9308856","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A10Z&sr=b&sp=r&sig=m22sKmE9bxqyd4HT6sVHPe4VClW3uDIVbnbtYO1FE4s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:10.9309811","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +1182,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:45 GMT
+      - Tue, 24 Oct 2023 12:35:10 GMT
       mise-correlation-id:
-      - 534a84c0-8a7e-4369-b5b8-28be511ba536
+      - 5b92a49d-a0a0-40bc-b2ed-0ebfd10e4cc8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,10 +1204,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A50Z&sr=b&sp=r&sig=1xfETGNBsn7sizxAUivWZroJuRwO5BdK2pNYdhU9rzs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:50.7209048","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A50Z&sr=b&sp=r&sig=EZBPU%2BqrdXmgtQR6YR%2F%2FG4GEmCU8opFzDRAt914b9yY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:50.7208168","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A50Z&sr=b&sp=r&sig=4RR7XafM50A8RDAtRauNQszn3Xbk6vxZ6UwIhMjUDec%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:50.720926","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A16Z&sr=b&sp=r&sig=zUlr2f7YUyMuKTDTCamacaDRbjSl6zNSmUFFBoBFXHA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:16.2632645","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A16Z&sr=b&sp=r&sig=2F4WK%2BjYAW0OYUIZzhWcecYwKm72DMEex2Uh4Wx5E4s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:16.2631954","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A16Z&sr=b&sp=r&sig=laTRtA4Jj7aOyclOQ9zgQ0BpPjwJetzDqdy1edJSogk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:16.2632783","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:16 GMT
+      mise-correlation-id:
+      - 09818514-4a8d-4e7e-8b78-456649c059aa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A21Z&sr=b&sp=r&sig=0cDgXMb8kWTCZKvWcg7ghvUItTWqK8DNU16qQGYdFXs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:21.5677544","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A21Z&sr=b&sp=r&sig=wSGUefHk7pnLaEX5NtjP5LR1WYfJhs8woro%2F%2B7HW6pk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:21.5676684","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A21Z&sr=b&sp=r&sig=Tf9mZ8wAeQSD9BWT6npKL%2B5tw2mVBkkivK1Hg2Gj8kY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:21.5677763","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:21 GMT
+      mise-correlation-id:
+      - 590dc300-b2fc-499f-8e05-6a4a429970a2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A26Z&sr=b&sp=r&sig=8hH9R1kz7qcdgDN0giViTVYq5S9l6bz60cmeos34e04%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:26.9103319","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A26Z&sr=b&sp=r&sig=TKk34bjFuDI37yDiu5Pco6QX8us2h3tdLDY0k2GAc%2Bk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:26.9102249","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A26Z&sr=b&sp=r&sig=YjZxq2iMhFDq9VfiP71qE3h4oqUz2J19%2BBitHrDVZtE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:26.9103466","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1794,9 +1290,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:50 GMT
+      - Tue, 24 Oct 2023 12:35:26 GMT
       mise-correlation-id:
-      - a824f222-6c51-47af-8a09-8a1ca8322426
+      - 6776ae65-68f9-4ece-b84a-c8ab7364a920
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1816,11 +1312,641 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A55Z&sr=b&sp=r&sig=bMW6Yqhbv%2FwwQ3vmdtDNUAhgUCPOz910oRO7fMf30JI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:55.9718486","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A55Z&sr=b&sp=r&sig=raTcFv9pjlKJjqTiw8H2QWH3gyyS%2BcvMlQTi9UhSPMo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:55.9717449","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A55Z&sr=b&sp=r&sig=EUdJM6we2EcAc3J8toKJc%2FP%2BYO0ZH8awYRb1lX0eVuA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:55.9718754","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-18T20:57:10.508Z","endDateTime":"2023-10-18T20:59:52.788Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:52.899Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A32Z&sr=b&sp=r&sig=IooXMLIZvFwzn5vNzXy%2FwCoq5ZBL4jPJaJm4MqAi%2F0A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:32.182662","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A32Z&sr=b&sp=r&sig=UFRqMi082bcx%2BPwnMUaX5AXKx4T3182BaLOOf2mnDAs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:32.1825781","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A32Z&sr=b&sp=r&sig=PeEWX3YwzzyvNnp9SA%2FZZNecxz5YTUJ52c%2FRazP4WNM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:32.182682","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:32 GMT
+      mise-correlation-id:
+      - 8fc67ad4-16c1-4dbb-926c-5e3e809e0c04
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A37Z&sr=b&sp=r&sig=1i3uUDK7a00szwjjSV5XZO7PzxVKwUo%2F2yr6wPdl89A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:37.4717536","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A37Z&sr=b&sp=r&sig=hClWpusnLr8%2BZd6cvgixvLmLQdXn%2BWAT%2FbWYC5X8Ppg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:37.4716743","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A37Z&sr=b&sp=r&sig=cWazmP%2FjkNHlIr65RGX4zD1ltCV9k8etDOxJNuot7is%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:37.4717687","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:37 GMT
+      mise-correlation-id:
+      - e0ceb6bc-6f8e-4bca-b50a-d10f351951c5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A42Z&sr=b&sp=r&sig=zSTb8U4tKWiioh8uIOpA6u3hhReLsaipEuMVTrTFEmk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:42.7662548","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A42Z&sr=b&sp=r&sig=ZSlQvGcZv42teV1TogZcpefckwlCg6R3iSQKtiBr%2BR0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:42.7661096","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A42Z&sr=b&sp=r&sig=d8aQ9s6wf9rgUBnLPejXjxmhyx7hb9vu%2BN8tiwyyuPM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:42.7662806","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:42 GMT
+      mise-correlation-id:
+      - 60a18e42-a49a-4ceb-b2e2-a0e4a76db138
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A48Z&sr=b&sp=r&sig=rMaij2qK1rFkq4xOIAgEB5tsnWPPCNoxSvchdBF3BPI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:48.0258152","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A48Z&sr=b&sp=r&sig=8L0KN%2F3jPAHEPQS%2B%2FrgfK%2BQsCoUvTNrOA6YIyp5NDpA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:48.0257443","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A48Z&sr=b&sp=r&sig=TeVN2J7tudrPnR9SLN0sj5LRBlR5Nnyv7Azmtzpb%2BDM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:48.025829","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:48 GMT
+      mise-correlation-id:
+      - 1aed1475-0cf5-4acc-a55e-d0751172a73d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A53Z&sr=b&sp=r&sig=bedLLGUhUfIq6NESM%2B8BFEDUn%2B0yP%2FR0rXKYjdcgjlI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:53.3791045","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A53Z&sr=b&sp=r&sig=Hp5oCMQIloKXLxlGjD2o1WQJlVHtTg1or5ZcOBYstL0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:53.3790193","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A53Z&sr=b&sp=r&sig=AcJ%2FuRASkS6M5byYZTb2246T%2FLrnB9f9e%2FgbNYKxyAM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:53.3791257","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:53 GMT
+      mise-correlation-id:
+      - d4847993-bc98-486a-a134-bcfcf15b76b7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A58Z&sr=b&sp=r&sig=81AJ4R8gpRbLzmK%2BHzFX9iUeIH%2FYD%2FUHUpHjBu9sVLs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:58.6542911","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A58Z&sr=b&sp=r&sig=son%2BHdbIKvVd5XOdltdYm5REYVLJIoZJR%2FKDmWzcFUc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:58.6542257","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A58Z&sr=b&sp=r&sig=X%2BI1HRv7D%2BQMhFHErfWhZfQNDSD7y3zzbALUtNYwvDw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:58.6543054","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:35:58 GMT
+      mise-correlation-id:
+      - 5890ab62-8310-4552-a92c-d2cf41988d19
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A03Z&sr=b&sp=r&sig=uyVg%2FTpGFn6wBli7u%2FMeNPIF2G8pCHoZz9zHsjSAKJM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:03.9042792","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A03Z&sr=b&sp=r&sig=UwkvHJAK7XcTMeiFUGQX%2F9VQMOp79eFDq6udj2T1dOk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:03.9041913","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A03Z&sr=b&sp=r&sig=er%2BQy2f2SxYHNQWSY5o3YTlliCNfS6gCfffLtAoslJA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:03.9042948","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:03 GMT
+      mise-correlation-id:
+      - 72082be2-f0f3-46a6-a31e-79e2f9a5e013
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A09Z&sr=b&sp=r&sig=9roINJyZH0kiC8TClgpcs3s0uQx4niGW5f8gC%2FCpceo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:09.1945831","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A09Z&sr=b&sp=r&sig=f7TtUXVahCKFDiquqpVCPh0lCEdKHFGzyqizU4IJBko%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:09.1945078","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A09Z&sr=b&sp=r&sig=PipQqs6g0quCo6nKQ4jKqKTz6jeKxMUR0l7FZ8RFLIE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:09.1946072","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:09 GMT
+      mise-correlation-id:
+      - 9e4be7e0-8fe1-47cb-bf3a-4e054d431209
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A14Z&sr=b&sp=r&sig=hnjlX3fE7g7JuAwr1wO6lRedmtwmIEZXn5gE5gMBt9g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:14.476862","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A14Z&sr=b&sp=r&sig=yNwSfiRkKhR1KmvBnX58atOSsR4nmM95lPWa64%2Fqhtw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:14.4767642","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A14Z&sr=b&sp=r&sig=LSnKirz3o6%2FeCztUC0cGzjtSW6lE7eLp5F4%2BudTQhdo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:14.476884","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:14 GMT
+      mise-correlation-id:
+      - 46b90387-f050-447a-8748-0091986b234c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A19Z&sr=b&sp=r&sig=6xkFO92budn73KdLgWLx5IPB5kV1%2FPoK1pNS0ufUtbM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:19.7720703","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A19Z&sr=b&sp=r&sig=yGmN5EhFbpD5RH%2Fe5%2Btx%2BVFo878BqRCw%2F8V73a6cHVk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:19.7719774","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A19Z&sr=b&sp=r&sig=645es%2F9TSsP9v6i3GQfzQr3lm5OCyxIMotdEvZCZMV0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:19.7720858","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:19 GMT
+      mise-correlation-id:
+      - e0712a1c-2dbd-4c67-9cb8-9f1e327c825e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A25Z&sr=b&sp=r&sig=rSB45mRZREFW65aWncPdyTNtfk9f9W2cXtdNh0lEIbI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:25.0940874","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A25Z&sr=b&sp=r&sig=N7Pk%2BXj4GiQpOG%2FqWJHasV7pMx7mH1SH1N2pz5jTIBo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:25.0940103","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A25Z&sr=b&sp=r&sig=UqWd5ikm8ZiNbzvbTk9WZwZAwWl%2BAmITi7W0tx%2BcKHU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:25.0941013","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:25 GMT
+      mise-correlation-id:
+      - 8c535545-3baf-478f-ad48-350b4f8c5475
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A30Z&sr=b&sp=r&sig=qOnOLRu37OsbHic4REWMp33yaFXjDhcIjSoi6S8bb%2Bw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:30.4607278","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A30Z&sr=b&sp=r&sig=ZBEsvjwMcXkIujugShPJVd%2BIvnss2Qzclx4sJQM4FZI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:30.4606606","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A30Z&sr=b&sp=r&sig=%2BMxsdTabgXS1NmKdgZ2NBncTcWEWx52SS1GUElLQ%2FiQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:30.4607413","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:30 GMT
+      mise-correlation-id:
+      - 2b49565e-2bbc-400c-8da8-36eb63024dca
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A35Z&sr=b&sp=r&sig=y%2BV5CYXYeB0JuJyOBfncWN%2FYLpehnCBDTZFqrUgpO%2B0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:35.7200037","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A35Z&sr=b&sp=r&sig=AbQYxd7y5NIuLvYnz35FqvSqszwJjidDBZQkIbPnuOI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:35.7199118","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A35Z&sr=b&sp=r&sig=h4whPQDlVTgLR5izsiR6Srq6r0x4RG4cMMw2dy%2FueQY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:35.7200252","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:35 GMT
+      mise-correlation-id:
+      - 050061d0-7584-4d90-8042-1ca6f992ad91
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A41Z&sr=b&sp=r&sig=LC2NrrU3aGDNMQHT0m8j6zsuc1OjelqY%2BFsoIVfZ1pk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:41.0277121","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A41Z&sr=b&sp=r&sig=03PzGN9ck9KQJLrcpT7LQZDYFAiSjfRnoTdoyU7Yrlc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:41.0276262","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A41Z&sr=b&sp=r&sig=0LWSnhaHPA%2FsJOjukvcjO3YtjekKOGBnUMwWW5vs6mo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:41.0277353","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-24T12:34:01.194Z","endDateTime":"2023-10-24T12:36:40.471Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:36:40.685Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3321'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:41 GMT
+      mise-correlation-id:
+      - 87d84ac4-2d10-4939-9d20-e31f5fae33a5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:33:04.2189798Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:33:04.2189798Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:42 GMT
+      etag:
+      - '"d300094a-0000-0100-0000-6537b9820000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=show-test-case&api-version=2022-11-01
+  response:
+    body:
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A43Z&sr=b&sp=r&sig=kGZApBu9PThKm7SPrJ02BotObWZ4Qcqz%2BVyWldfOP%2Fk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:43.6820447","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A43Z&sr=b&sp=r&sig=%2FlKIfJJr6rdAoII%2B0uKzmxDNDK5rOtbJHseSF0XF760%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:43.6819553","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A43Z&sr=b&sp=r&sig=qYlZnuWtnFJ3JR3wbW1FlsfRjN4Wp3Fglo%2BGVv0OS7U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:43.6820675","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-24T12:34:01.194Z","endDateTime":"2023-10-24T12:36:40.471Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:36:43.573Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3339'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:43 GMT
+      mise-correlation-id:
+      - 48dca7a7-b8e5-4a8f-a582-5fbb96b5d55e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:33:04.2189798Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:33:04.2189798Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:36:44 GMT
+      etag:
+      - '"d300094a-0000-0100-0000-6537b9820000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A46Z&sr=b&sp=r&sig=%2BbHqvl8wzAxJje2ST6XTqu%2FKCdVg7MoXkY9mUpXQ92s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:46.8190766","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A46Z&sr=b&sp=r&sig=kv%2F777qUwBbbdjrH8EKKV4XCc0wFZy8xjfdxfqZYX6I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:46.8189867","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A46Z&sr=b&sp=r&sig=Rl3TVsGDAf2RlS6GkNCata5M1oQsZG%2BUA99PsF97gc4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:46.8190915","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-24T12:34:01.194Z","endDateTime":"2023-10-24T12:36:40.471Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:36:43.573Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1831,171 +1957,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:59:55 GMT
+      - Tue, 24 Oct 2023 12:36:46 GMT
       mise-correlation-id:
-      - 1535c79d-f4e2-439b-bd22-632301e5523c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:41.315522Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:41.315522Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '688'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:56 GMT
-      etag:
-      - '"7500796c-0000-0100-0000-6530468b0000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=show-test-case&api-version=2022-11-01
-  response:
-    body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A58Z&sr=b&sp=r&sig=Dady1G8sF%2FAGfiINq%2BpkxW6nm8VCEqZxc%2BBdqVB3yFI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:58.2255954","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A58Z&sr=b&sp=r&sig=6O%2F9LIlAQ4rXqAmepFAC8YgzrByHIk6R2Io8I6AfQEA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:58.2255075","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A58Z&sr=b&sp=r&sig=bv5heuJn84t0dt27HMHYVxcIYDchrSPbRwlm3kLmDEE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:58.2256096","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-18T20:57:10.508Z","endDateTime":"2023-10-18T20:59:52.788Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:52.899Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3337'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:58 GMT
-      mise-correlation-id:
-      - 9dc86b45-a204-49d6-a04a-fff98acdfc09
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:41.315522Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:41.315522Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '688'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:59:59 GMT
-      etag:
-      - '"7500796c-0000-0100-0000-6530468b0000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A00Z&sr=b&sp=r&sig=QDw%2FgiHjmkRv5szipfsnCvLPsmwJWC815plVy0lmk2U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:00.5018443","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A00Z&sr=b&sp=r&sig=3Mm2loxiPLEa5MTZ%2F6CEUEk%2B7pROM%2B4BiSPENOpxZLQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:00.5017529","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A00Z&sr=b&sp=r&sig=i5J%2FRWxb8aMr3RheeT4WvQ0tbAlsm%2BeootZImTNXviQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:00.5018592","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-18T20:57:10.508Z","endDateTime":"2023-10-18T20:59:52.788Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:52.899Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3329'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:00:00 GMT
-      mise-correlation-id:
-      - 0c6ca375-bc89-489b-8a68-d20873fd9ef1
+      - 2cbb0b3c-ef16-4552-832e-2a9b0bbe39ae
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_show.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_show.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:30.3512589Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:30.3512589Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:41.315522Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:41.315522Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:04 GMT
+      - Wed, 18 Oct 2023 20:56:45 GMT
       etag:
-      - '"d901923f-0000-0100-0000-65294c900000"'
+      - '"7500796c-0000-0100-0000-6530468b0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:57:05 GMT
+      - Wed, 18 Oct 2023 20:56:46 GMT
       mise-correlation-id:
-      - 4e9d9fa6-5f32-4a9f-9106-78327a3e18c0
+      - 10ebc745-6a84-4a2d-b5fc-fa89c3526d2c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"4accade2-1b0b-43e5-8323-7ba7081159f6": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "bc389940-a451-48ba-8d83-d9239fa07b46":
+      {"passFailMetrics": {"cec1289e-2c8c-4969-bd84-592b5bfb9066": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "ddc5e70d-9668-4807-93cd-cf3bae67f800":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "c7b16299-1892-43ab-ac63-bd00f2172567": {"aggregate": "avg", "clientMetric":
+      "50"}, "f86aaddc-a9b5-47c8-b632-d07b3c59455f": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:57:06.036Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:06.036Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:47.131Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:56:47.131Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:06 GMT
+      - Wed, 18 Oct 2023 20:56:47 GMT
       location:
-      - https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+      - https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 612d13ef-bd61-4eb6-94a2-4cce81a7ab45
+      - b0e8a1cd-4a95-4ede-975b-82efe247678e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:06 GMT
+      - Wed, 18 Oct 2023 20:56:47 GMT
       mise-correlation-id:
-      - bc8d6bb2-bdca-499b-8ca9-ca659f090617
+      - 48f1ba3f-d688-4e84-bc71-2a2cab2571c2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A07Z&sr=b&sp=r&sig=qGrTPVF7XU4LOHSeZ7RpPxRpkMGwoeP1ycUTZAP0iPk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:07.6522284","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A47Z&sr=b&sp=r&sig=ToC6ZsoiFwK8U0tENMnwz3W%2BmYw%2FeqAj3v8X8VOBnL0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:47.9316717","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:07 GMT
+      - Wed, 18 Oct 2023 20:56:47 GMT
       location:
-      - https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 5fd8882c-9143-4a92-8743-dcf8311c9eb7
+      - b18457d9-dfb6-4f57-8dcc-efd88a5d1a3f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A07Z&sr=b&sp=r&sig=2VcW8qP3QFUDdqZi7lEzG9ucrWKT5lyPmFTqKNcZQXE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:07.8604235","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A48Z&sr=b&sp=r&sig=HLy9RQ7uefG9WfFtAAHb0hnNyLkN6WDKHaeQYgCdByY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:48.1927327","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:07 GMT
+      - Wed, 18 Oct 2023 20:56:48 GMT
       mise-correlation-id:
-      - 65739f34-dfc9-44d3-aa59-748c2d33218f
+      - b53e5f64-46be-45e0-b92a-74863302e4db
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,46 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A13Z&sr=b&sp=r&sig=uIgeZRIwRPGPZLYOa3DRgZeqM%2FbanIbK7uzEqonTq6c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:13.1796698","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:13 GMT
-      mise-correlation-id:
-      - 46b588f5-a941-45aa-8de2-6d6e2a98241d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A18Z&sr=b&sp=r&sig=1DAzX%2BAfNGDLcS%2FJo%2FCZwfHE2O4Pe8N3Zb18jCwT2qU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:18.4211043","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A53Z&sr=b&sp=r&sig=4uOQF7klx%2Bsyb2Gjd6TKc%2F0HQ8B%2BkcDqCnDsw6y3YOI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:53.4620394","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:18 GMT
+      - Wed, 18 Oct 2023 20:56:53 GMT
       mise-correlation-id:
-      - 993d119c-afd0-4e95-885e-30dbf6179896
+      - 3e18ed56-b547-495b-8d0d-81b26b2d22a9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A23Z&sr=b&sp=r&sig=c18vr9WsfxW9JVpBFyyGKdNv0DWoh5tGyJjnApBIk8M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:23.6681103","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A06%3A58Z&sr=b&sp=r&sig=1ilzn7U3OZUYvDrXvDV9VaL62jh29ZXgNTRaBthBtsw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:06:58.7418798","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:23 GMT
+      - Wed, 18 Oct 2023 20:56:58 GMT
       mise-correlation-id:
-      - c0621080-9847-427f-ad24-e61f2dc3cf3a
+      - ad0651b4-00b2-42a2-9e08-4b496a53ccb2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +421,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A23Z&sr=b&sp=r&sig=746zdQCyKloqvgatpKZ7yji2wMvVLMhcPOvpUmQW7Gs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:23.9448416","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:57:06.036Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:22.422Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A07%3A04Z&sr=b&sp=r&sig=66R2No3EDOr%2BdrKd93%2B%2BoVVYwoLX%2FgMVZku2P0bPKa4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:07:04.5515123","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1575'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:23 GMT
+      - Wed, 18 Oct 2023 20:57:04 GMT
       mise-correlation-id:
-      - 94ce4c86-75d9-4137-bd7f-5052abdd5d95
+      - 5e18180e-09fb-4150-96dc-e792272c322c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A04Z&sr=b&sp=r&sig=GYVbjvD%2BCt%2F%2BQ1XtBb1IJLaNAxf1Am1Rx5M0eiFJTC8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:04.7977994","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:47.131Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.448Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1581'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:04 GMT
+      mise-correlation-id:
+      - 3eba0810-289f-4a8d-8c0d-7b75301e7e18
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:30.3512589Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:30.3512589Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:41.315522Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:41.315522Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:24 GMT
+      - Wed, 18 Oct 2023 20:57:05 GMT
       etag:
-      - '"d901923f-0000-0100-0000-65294c900000"'
+      - '"7500796c-0000-0100-0000-6530468b0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A26Z&sr=b&sp=r&sig=VwyAmnXxHHq%2FjaLZkatPATYovqLAgWsoTfBSUT4F1o4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:26.0235904","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:57:06.036Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:22.422Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A07Z&sr=b&sp=r&sig=ORI%2BL6mI1FenzeU78A1id%2FEFfm9%2F6ZkUOqQYv34dv4w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:07.0569558","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:56:47.131Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:02.448Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1589'
+      - '1593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:26 GMT
+      - Wed, 18 Oct 2023 20:57:07 GMT
       mise-correlation-id:
-      - 4f7d3370-1b9c-4314-9716-3f4417e1bb35
+      - 667b0585-bdd9-47ec-a37e-c8a9ce383f39
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:30.3512589Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:30.3512589Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:41.315522Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:41.315522Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:26 GMT
+      - Wed, 18 Oct 2023 20:57:07 GMT
       etag:
-      - '"d901923f-0000-0100-0000-65294c900000"'
+      - '"7500796c-0000-0100-0000-6530468b0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:57:28 GMT
+      - Wed, 18 Oct 2023 20:57:08 GMT
       mise-correlation-id:
-      - d3ff6c44-63c6-48d3-919d-ef1608110128
+      - ec11f406-bdd3-4668-a040-505c5e1e15c8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A29Z&sr=b&sp=r&sig=WRVt7Dul%2BJtvr0qVr0W6shf8vNte68QWDLHYFXNms4Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:29.5188096","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A29Z&sr=b&sp=r&sig=wtTrFSxTlgb7FVm9K159Jz0iLHbNQ3J3%2FCsX%2BgPNhW8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:29.5187067","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A29Z&sr=b&sp=r&sig=NIOB3kvDWhmVBYcjwaNiZH8pbuegKVzbq%2FG8%2FSSJvFY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:29.5188358","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:29.437Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A10Z&sr=b&sp=r&sig=AXqQMIq3NrQHbHWmJUWNws1Joqp8FT1zXg901Z9eHSQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:10.1483719","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A10Z&sr=b&sp=r&sig=Ozfa0XUKE2ZeoCg78eyhau%2F4JKfMNwvycV2grHyFmuQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:10.1482448","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A10Z&sr=b&sp=r&sig=Si6WN8Cr2MW%2BC2Y78Qr3nIScO82kB7yPfF8w0xlAZSI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:10.1484001","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3147'
+      - '3142'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:29 GMT
+      - Wed, 18 Oct 2023 20:57:10 GMT
       location:
-      - https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+      - https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 51209dfc-75a7-47f3-99f2-89f83e08d079
+      - 2d6f1ea0-8207-4dac-a39e-c078197b6c3d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,10 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A30Z&sr=b&sp=r&sig=Uk4MRsJGcncX867A54kprM6prC%2B0mSCcJjsRCS67sIg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:30.0003536","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A30Z&sr=b&sp=r&sig=60YPcV2spZKw5%2BIKDZBlbOgz5bmO81anDa9S%2FUfHUuc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:30.0002152","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A30Z&sr=b&sp=r&sig=68b5E6Vt2CzSpFD0mZngK9QDw3phsjanZBJoczsVv5Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:30.0003758","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"NOTSTARTED","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:29.834Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A10Z&sr=b&sp=r&sig=D2kM0ZJnJCYZmhzL9M6y10v5kX4Q7RuEenQnq70fnUg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:10.6271936","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A10Z&sr=b&sp=r&sig=9%2BfotjipKyo4pkSt8Pib7JRJfqTwVVjyM2SGfphxutM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:10.6271191","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A10Z&sr=b&sp=r&sig=GBlVLpGP%2F255rQKhTIoOgy9tqKbnrh%2BfVpgBBsG7RwM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:10.627208","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"NOTSTARTED","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.508Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -714,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:30 GMT
+      - Wed, 18 Oct 2023 20:57:10 GMT
       mise-correlation-id:
-      - 61dfa004-a863-49f4-bd44-b49dfaee9e00
+      - 8afa1d4c-0028-455b-ba7b-dc24c46f6abb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,10 +736,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A35Z&sr=b&sp=r&sig=Ej6jTmae5zLpyHD0BSF8KN9W2ccTePOfysyFDIKvJVg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:35.331519","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A35Z&sr=b&sp=r&sig=SynfVr0%2F%2FTNBSAKgIPGNpeFJmP90ey4WJo%2B%2Bq2ztwbs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:35.331434","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A35Z&sr=b&sp=r&sig=tgNDUStaG8tFY3YTJ%2BxQQqdgh8Y4eqw0IVuTzka9vHQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:35.3315404","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:30.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A15Z&sr=b&sp=r&sig=nngWdOxcKdiSin8FvtTYC2i%2Boj%2BC3uEee65rfeEfZEA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:15.8932038","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A15Z&sr=b&sp=r&sig=0xfg%2BjGiRc27sNXwVdPyQP1Q9FlJzoBDuFc1BraKF0I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:15.8931305","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A15Z&sr=b&sp=r&sig=NhW2xy33Mc4Yt08z3fuBLg3YbPYgShFec1AJLmPeFhU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:15.8932181","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:15 GMT
+      mise-correlation-id:
+      - be4ec8b0-3275-4845-b56c-8de23fbfe146
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A21Z&sr=b&sp=r&sig=vT%2FXT0DLtYgb2LbXuJM6FVQZMkFeY%2BVF7vqvH2CxVWA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:21.2087963","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A21Z&sr=b&sp=r&sig=BPEo2LHOWoXL3NCpp0zJKWRmvAIRTndYesvoft0COQM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:21.2087252","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A21Z&sr=b&sp=r&sig=3Ys0Dqr7u8L6SNSKtVtwH87vn6KgOTP%2FxHqXjrCDFF8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:21.2088107","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:21 GMT
+      mise-correlation-id:
+      - e0443ae1-2311-48bb-a55c-44c5beb7d590
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A26Z&sr=b&sp=r&sig=%2BZALeX9siB%2BXk3ceVfs%2Bo%2FzAUHKhH0gqfuscu3khtXA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:26.544484","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A26Z&sr=b&sp=r&sig=ivmBh7KbMUpCwPAmkxHeGCBPlkDtLeh1RakESwEMQyY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:26.5443539","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A26Z&sr=b&sp=r&sig=5sJbMbgvmUpx8eHtZ2PmZ9RqYdivspbyqtA7IS0M2kc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:26.5445059","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -750,9 +822,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:57:35 GMT
+      - Wed, 18 Oct 2023 20:57:26 GMT
       mise-correlation-id:
-      - ffce07c4-0c0e-47fd-93a5-988bb672dcd0
+      - a5b22318-2635-4f30-afd5-fca79709823f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,370 +844,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A40Z&sr=b&sp=r&sig=fYRdWbWYz7hmpe4KwSzg1AU12L0rxXIXjfoAgmPe%2BlA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:40.6387987","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A40Z&sr=b&sp=r&sig=LomCsukE0ibsWCqxlxPeCA%2BqlMaVrIIttXI%2FryyG4z4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:40.638715","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A40Z&sr=b&sp=r&sig=TF55v8YMMfRaegCVe3CUX%2BDCQrfPoPIKkRoICRMuv%2FU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:40.6388145","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:30.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:40 GMT
-      mise-correlation-id:
-      - b8819e2a-e2b9-4cc6-87fc-852f9a6fc369
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A45Z&sr=b&sp=r&sig=63vjX7AgSo33efpopF99J9P6sDsNqcEFs98RrhL4sJc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:45.9140817","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A45Z&sr=b&sp=r&sig=aS9AOyeEuVkELD85Y0cKvIaotIGdVaExeFnYksJyBa4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:45.9139995","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A45Z&sr=b&sp=r&sig=vuhsQVtLIyVhQiNTelVP2ziPIHgE2h7DJ09Nj%2FhcuoU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:45.9141009","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:30.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:45 GMT
-      mise-correlation-id:
-      - 867da1e4-a011-4378-b3cc-67223e9a2a6d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A51Z&sr=b&sp=r&sig=ns%2BQW5PBKeN7aJQ6MFYXDPavwPF7jP3qMVE315%2FHzFQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:51.1931899","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A51Z&sr=b&sp=r&sig=OGWhisNHol1t0LTWJoSCkzlpz3Qhubg6qZ7zcURKCgo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:51.1931233","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A51Z&sr=b&sp=r&sig=t1gWVymJ%2F0ODYWmeGPd6xf%2FbR0h4lRZA4%2Blltk6r5O4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:51.1932041","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:30.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:51 GMT
-      mise-correlation-id:
-      - d1e3a53a-5c62-4086-8bde-f130fb26df8f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A56Z&sr=b&sp=r&sig=ljHmSmmbEDu560jutMJFwZlpIvxMbwQYrKn1tfA8umQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:56.4481111","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A56Z&sr=b&sp=r&sig=ed63eho0xdK5%2F%2FpTZt%2Fv%2Fyw25Byi8gls1%2FS6HzygGlE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:56.4480405","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A56Z&sr=b&sp=r&sig=R0uKgY5yuLx0jvLhk6orEVgP7aVIl2ontjlio4J%2B7yI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:56.4481262","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:30.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:57:56 GMT
-      mise-correlation-id:
-      - d0d93a01-47b7-463c-9e6f-e993d1619dbb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A01Z&sr=b&sp=r&sig=pJ%2FrclRKEEq1EPvV3Zdi9ft7DcQEpGDXo6FMfPPFniI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:01.6661238","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A01Z&sr=b&sp=r&sig=BXptz7VBcZKg%2BFDwND4VCwC9bnGfaOMVXtfxX50tWvU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:01.6660371","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A01Z&sr=b&sp=r&sig=elR7qAuXELqcNxQJlO9b6zHyGANDHjB4HTmXv%2Foa5ZM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:01.6661456","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:30.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:01 GMT
-      mise-correlation-id:
-      - 907aa013-054c-4986-aa4b-1604b318169e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A06Z&sr=b&sp=r&sig=hZjYmauG6xSquYhYuHFsI1hUV5MsvTcJ7U%2B%2BUou%2BqUc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:06.9515645","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A06Z&sr=b&sp=r&sig=jPXqe3XhKEa2uvmbtxNppPSXzF1uGVFtztrXxYBdvAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:06.9514974","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A06Z&sr=b&sp=r&sig=J8yHXrUArfOxGFA48L2zZ%2BM1NjE556JXfyHPWG981jo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:06.9515796","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:30.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:06 GMT
-      mise-correlation-id:
-      - 5e5b47f6-f177-4ef9-a007-4586c4415d79
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A12Z&sr=b&sp=r&sig=%2ByA8v1YDnlvo2DSikHculCKG431lmZ3HKfyQHikqaM0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:12.1940659","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A12Z&sr=b&sp=r&sig=%2FwGofsQfrtokOaSADBtEcCWCYqm%2BIIVQBVoh2ymSZcs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:12.1939953","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A12Z&sr=b&sp=r&sig=wycdyLQuIVIEtOys8cRQPNA%2B%2Fm2cAxJgqn%2FP9ygreV8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:12.1940822","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:30.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:12 GMT
-      mise-correlation-id:
-      - d55a6856-fe5d-4012-878c-8b9d1d0b8eb2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A17Z&sr=b&sp=r&sig=wqzAVcrlJfmE%2Bi5bJcgTJPMX7rJqDdsFjcsLqkMYdUQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:17.5135787","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A17Z&sr=b&sp=r&sig=UsIKjZ4gCTX01g7ijjSFxsqhTb6ZJwSoPJWE95FVm8Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:17.5134915","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A17Z&sr=b&sp=r&sig=Cqsu9NUzKRjhyVpyJR2oSkbHYZg2sJLZyLMECQFVSQI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:17.5136006","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3183'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:17 GMT
-      mise-correlation-id:
-      - 038046b3-9497-4306-ba7b-7db1f2c638ae
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A22Z&sr=b&sp=r&sig=%2BZPB%2BpEKTxWQaINt6omJSq9gEKoI2GLebt2CMJ9TLs0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:22.7694557","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A22Z&sr=b&sp=r&sig=7YEFMmePLGjw0J6aCwqCNzoJtdsFx9a05NFDvefrQLk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:22.7693535","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A22Z&sr=b&sp=r&sig=Wr%2B6t6lVHZkInRHJ2E%2BMV%2FgpoJqLHrX2HFXQXCem%2Fnc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:22.7694784","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:22 GMT
-      mise-correlation-id:
-      - ca705444-64e5-4e4a-a4dd-505f667e89ff
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A28Z&sr=b&sp=r&sig=QrrILc7lnloa4jP5QrB5v8PA1t5f0t2Kw4p%2Bu3j%2Fbrk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:28.0777925","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A28Z&sr=b&sp=r&sig=lTNW4xQrVIU11FUpV8oE9LjAKkizY5%2F1g6ySRvRQYDw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:28.0777263","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A28Z&sr=b&sp=r&sig=LoibX5dUq7STuJ3XPvYta7M8wXSUwY3MXIP0Qrlzrso%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:28.0778077","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:28 GMT
-      mise-correlation-id:
-      - 01d929da-47b9-416a-b8f2-5c71f48bfbc2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A33Z&sr=b&sp=r&sig=%2BvXWk7qeydVTd5%2FV%2BVm%2BRgS3zoWcJ%2FeYLfVv82Gxkfc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:33.3872383","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A33Z&sr=b&sp=r&sig=scbCuO4b6gZKh7pWLeXVSDV%2B4DtKwxJ6Gxd5WtDfQ0Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:33.3871589","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A33Z&sr=b&sp=r&sig=hN1XSlgUGsC%2FfSGUtA6DrzREsMasADm84WZ8Tv0wvT4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:33.3872555","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A31Z&sr=b&sp=r&sig=phZ2kuHUpafoxHeFERHvOh0v%2BzKWeq4R4tt6cawMYNk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:31.8110558","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A31Z&sr=b&sp=r&sig=MwjJaZi1e%2BgDQv9VrDKF29cSKJADEQx0b6gmM%2FGuK9A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:31.8109826","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A31Z&sr=b&sp=r&sig=z1QRTeXukvQovxTem0CdOQPA%2F9P0MG0ormau%2Ft8RgV0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:31.8110707","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1146,9 +858,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:58:33 GMT
+      - Wed, 18 Oct 2023 20:57:31 GMT
       mise-correlation-id:
-      - 5625f69e-e17e-4438-b6e5-991a4b057680
+      - 44a1777c-1cba-4894-8823-2cf023a4db03
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1168,10 +880,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A38Z&sr=b&sp=r&sig=C8QYcAlrcAplMa1%2F0H0C%2FFxcxV5o19GWbDxHgrS8PoE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:38.7008566","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A38Z&sr=b&sp=r&sig=XuNpwki%2FST9o6gtMb3PL926Rt%2Ffd1w6Ir7Tz14rOOGs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:38.7007924","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A38Z&sr=b&sp=r&sig=RLNqWcyjk%2BaRanxEc2ceyel653tkH8qgPNbBmJKm51o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:38.7008719","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A37Z&sr=b&sp=r&sig=tuYl%2Bx9ocBghh1Lq7sgadVJuMa8DWfG4oRPyYgy123s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:37.0873229","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A37Z&sr=b&sp=r&sig=HwQZjx%2Bm969TTqrgpst7CxvVqaQdj%2Fzpr1TSLg%2F7t%2Fw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:37.0870834","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A37Z&sr=b&sp=r&sig=1elbIUX%2BQuXfdeJW5uxyWhxE0teOBnIFdvI8%2FLu%2Bs%2B4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:37.0873444","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:37 GMT
+      mise-correlation-id:
+      - f085d29a-d41f-49a6-b993-5413fa135d6a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A42Z&sr=b&sp=r&sig=ywuC3qqa7SB412aoPSa5fFdM85qcUiNwm0ZjLVnDOBA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:42.4160214","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A42Z&sr=b&sp=r&sig=WfRgc3THmBxMJqKXmn%2B4L7zT58c6KYuiEcLGE5H8Wjs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:42.4159448","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A42Z&sr=b&sp=r&sig=tsQK2F77P9Ko6PAmp7FSInVrdyWFCxf%2Bs%2BHxnYKbauM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:42.416036","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:42 GMT
+      mise-correlation-id:
+      - 0d1355ab-bc36-4ba6-a0ec-4d23202fd389
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A47Z&sr=b&sp=r&sig=Ff4GXUa7CS901o0KDkHdHXZTIUPpvLSEMI3K22wuO9k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:47.7440541","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A47Z&sr=b&sp=r&sig=WHUSu7rlI8t8idaG%2FF%2FOBEg4J1gTUL2oapU4ceVBBDM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:47.7439628","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A47Z&sr=b&sp=r&sig=w2%2B6UhKNpuie331wP5sYIzRF6B11Xy9poydCOWsYFa4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:47.7440765","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1182,9 +966,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:58:38 GMT
+      - Wed, 18 Oct 2023 20:57:47 GMT
       mise-correlation-id:
-      - 2368e401-6e85-4b41-8e76-7b0f3c7cc4cc
+      - 2dcd705d-419f-4bbb-a376-49a38e8b0695
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1204,23 +988,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A44Z&sr=b&sp=r&sig=xLVdvHdIRZ%2BbwhX0MCBBuV7%2F91WwKEll3EV5MJIprvs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:44.0525587","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A44Z&sr=b&sp=r&sig=iC83GGbxABXHwOIFkLhRRGz2u1lB9Xd3bLm7rNLMikY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:44.0524802","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A44Z&sr=b&sp=r&sig=kYDtJa9oexSG3NJe5fr4pwIPsZmgGzz9te9TsgvWQ04%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:44.0525726","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A53Z&sr=b&sp=r&sig=Xwa3PC90jE%2B34irZrvdJifcqtXo8K9s%2FFPmXnLRhXrc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:53.0477834","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A53Z&sr=b&sp=r&sig=8%2Fi2ZHNzeIsbq%2B4uNO%2FGD7INBfoxUQrYJxut%2Fp4A0Gs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:53.0476998","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A53Z&sr=b&sp=r&sig=no3M9JBHT3rTJjW1YDfICTk4PsDRyjWQ1ug%2FqDGIB%2F8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:53.0478015","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:10.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3185'
+      - '3201'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:58:44 GMT
+      - Wed, 18 Oct 2023 20:57:53 GMT
       mise-correlation-id:
-      - 20898465-7be3-4eb4-99ec-ac90b926f08a
+      - c7664075-547d-403b-b43a-892193a9fc24
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1240,10 +1024,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A49Z&sr=b&sp=r&sig=th2KS0boJzEsOdinS%2FJCXtu2p5%2BGNzbFVb7uQs8hgug%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:49.3117532","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A49Z&sr=b&sp=r&sig=mYSfGslDh90voff%2BdWQ2edk7aE2akiBzQJ0XGRKQCCk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:49.3116897","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A49Z&sr=b&sp=r&sig=dZxAnaf2vnAxnLFE2u6aIff4bY%2FLP2Wxsao3GqKA9sQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:49.3117685","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A58Z&sr=b&sp=r&sig=UyygEFdY%2BQMCHzNTo%2BDF36nNhIts2ZV1sm99tljZA94%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:58.5520543","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A58Z&sr=b&sp=r&sig=b1U1AxsuJYk7LIwG2SGy1t3bLeyHXq3QSjlCZzA3Lac%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:57:58.5519651","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A57%3A58Z&sr=b&sp=r&sig=ADX7l4E9obDWyJeIREechVM5l%2FCU5r2LlheVxh%2FDG4Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:57:58.5520687","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"CONFIGURING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:56.07Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:57:58 GMT
+      mise-correlation-id:
+      - e232de38-5041-4d7c-ad45-a9c985c87db9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A03Z&sr=b&sp=r&sig=f6fX%2BYKWlA1qtm7qv1OPseF3Vr5ql1%2FLMfOrJZy4CbM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:03.8248937","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A03Z&sr=b&sp=r&sig=fo6d28%2B%2BDcnQxbvahGXnVQTXc8MjwEOMmQ2k8WkBfCc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:03.8248245","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A03Z&sr=b&sp=r&sig=JrzG%2FqrXxjCYnwCoYnJ8DLvHuFRsWQrFv5KAiXnkVKo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:03.8249083","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:03 GMT
+      mise-correlation-id:
+      - 56fe129d-e30e-413a-ad28-0fb4a28deb48
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A09Z&sr=b&sp=r&sig=K9ZGps4L7%2Fwqd1CBdE0WUJvIOivuGdDueYjjjOuBgMA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:09.1835001","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A09Z&sr=b&sp=r&sig=MgdwRxADN8o27GXOW3R8tfd6cjT%2B4%2FYcP3MpPuXhAxQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:09.1833855","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A09Z&sr=b&sp=r&sig=6UYOn4LxFRuthzsFdB2Brw%2FakSUX6hK02oZ5sQZsbRE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:09.1835253","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1254,9 +1110,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:58:49 GMT
+      - Wed, 18 Oct 2023 20:58:09 GMT
       mise-correlation-id:
-      - 97654ea3-96fa-4ccf-ad64-2a33b1831a2b
+      - 115055ae-86e4-42d3-b5f8-414f5bc25eca
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1276,82 +1132,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A54Z&sr=b&sp=r&sig=VPFhBh3kk2YlDNtBJRxZO0HwB8LEy%2Bn%2FQ2of4Mf0TI4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:54.5872505","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A54Z&sr=b&sp=r&sig=tT97WxAZV%2FwWbZBJuW8Fl5cBz00smlhDewdQmHCl7ZI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:54.5871647","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A54Z&sr=b&sp=r&sig=5giuoM0mfh3f%2FPsvsDyIJDvKpW%2BNwgxaUOYzeYcWSdI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:54.5872713","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:54 GMT
-      mise-correlation-id:
-      - b3460d3c-46dc-4d70-b510-290b6439ee1b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A59Z&sr=b&sp=r&sig=grWXwu4j0Zbkw%2BMHrAkNTwp81%2Fhl6pX16GvGmP0YMes%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:59.8166882","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A59Z&sr=b&sp=r&sig=zzkn1XIy0uf%2BrcmEg%2Btf0AdmglQ2H0o5rSB0nVj1DdE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:59.8166048","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A59Z&sr=b&sp=r&sig=5cmox8XXoGHDZ%2F6hUnnjyRsini7U51QcUkGVbfK0bH8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:59.8167089","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:58:59 GMT
-      mise-correlation-id:
-      - 59802a8d-adcc-484b-8781-647c40e803d9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A05Z&sr=b&sp=r&sig=BAo4rNmjgfbC2o0Raa5mZoMuyp3JI%2B95e1mwcELHRfw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:05.0849253","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A05Z&sr=b&sp=r&sig=00Me78E0k%2FmOCDHL%2BXbIAdJ4oLQWH8VQ6vNVIgLV1FY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:05.0848464","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A05Z&sr=b&sp=r&sig=6pbATAMdszYOaA8c16B9gC3futnbodSa3P1aqnaDxUo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:05.0849387","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A15Z&sr=b&sp=r&sig=oPprFkHS9n%2BzuUA1JlGc24i0xPH2f%2BnPEJ7Qxm3sFx0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:15.0571404","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A15Z&sr=b&sp=r&sig=UwrYOAwWBZJ8UYeoHJdYkTb5bjfxged6gO5vF6Zvr8k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:15.0570724","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A15Z&sr=b&sp=r&sig=PeX9LyKJ3WyqqQZ8vmAPyeE7DWvdz0pPkF%2B2PvY2RAM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:15.0571578","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1362,9 +1146,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:59:05 GMT
+      - Wed, 18 Oct 2023 20:58:15 GMT
       mise-correlation-id:
-      - 0944834c-7a64-42c9-890a-03f3be42e027
+      - 80eca696-a7c6-42b5-a101-7ff8ad444fbb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1384,10 +1168,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A10Z&sr=b&sp=r&sig=ZAF0WyGtW15Tvkas7iwzkXgX6KLQicev6vsM6pUANYw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:10.3420075","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A10Z&sr=b&sp=r&sig=8Rj%2FfTwToeUiX7HEMeDt8VeSBF6mLdZNN6dLMUKx2%2B4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:10.3419052","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A10Z&sr=b&sp=r&sig=qMnpBefX%2BeeNykPETH5rcCTOmgv4259xs4eNJm%2F2s3Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:10.3420286","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A20Z&sr=b&sp=r&sig=tKTkJDAOl1Q%2BIqxEsy%2FZOZ31AHVA99tojgAJPG%2Fmeds%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:20.4652821","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A20Z&sr=b&sp=r&sig=EI2WVBZstslc8l9fgHdVwYnGK7fucebKtaVZiCgiv0g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:20.4652114","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A20Z&sr=b&sp=r&sig=gf6uIXhJALvYvCL3At0i2BUCXGBSef62XLol0EkgZ70%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:20.4652982","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:20 GMT
+      mise-correlation-id:
+      - 74adc8bd-9e50-4006-bb5a-4f7679a07dd5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A26Z&sr=b&sp=r&sig=mcoI%2FRggHufQZPACqcjoLCi7TGO1cmiDuFvKRiq7XHc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:26.0905888","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A26Z&sr=b&sp=r&sig=UYuOHEkx5BgNpEeAsEaokA0H5ra2Rt9lkSu0LjO%2FlAg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:26.0905143","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A26Z&sr=b&sp=r&sig=TtjpKleA%2B9Nx3VAmgn5CX8NmHs1ToIWTW0psrS%2FuBpA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:26.0906063","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1398,9 +1218,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:59:10 GMT
+      - Wed, 18 Oct 2023 20:58:26 GMT
       mise-correlation-id:
-      - b31d7cfd-c709-412c-ac84-bb14b5d04098
+      - 06d08c3c-cffc-45f8-ac47-0c5dc403844e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1420,10 +1240,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A15Z&sr=b&sp=r&sig=Q9pmbg8q3uK0mOkbZNEPwzG%2B4nR45%2FeVuYV6CZ01z2g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:15.6216745","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A15Z&sr=b&sp=r&sig=0uTo2r8SgqNJhbVk0qlnO82cUYmmPsIAuDOQWIYoz1c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:15.6216054","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A15Z&sr=b&sp=r&sig=tsXxVcC5W0ij9K4MquwwHTUbKSAUUashsTlZdyIIkxE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:15.6216894","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A31Z&sr=b&sp=r&sig=aClYpuUH8hwt0A35w%2FmZ4VnM8B%2BVL5qJGZXrAncsvyI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:31.3704135","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A31Z&sr=b&sp=r&sig=DevB11MHPG4VO49goDvjXApIIOFGZ3ND5Xin%2FKpiMqA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:31.3703397","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A31Z&sr=b&sp=r&sig=8AfBn149q34VnHeIk1E0OrAyfpofJgoNn5doiZGCEvs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:31.370428","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:31 GMT
+      mise-correlation-id:
+      - 80ad016b-2b2e-4e36-b857-5dbddadf8095
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A36Z&sr=b&sp=r&sig=xE3czcb%2FJ1Ur7wTQkdQNBLoFeIA9jAVvUMZZYC%2Bpetc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:36.6258382","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A36Z&sr=b&sp=r&sig=zeq6dpX9zcQ%2B3H45VwiLohU0vo55gi2AXSroIQZ0DUM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:36.6257494","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A36Z&sr=b&sp=r&sig=nRDSqVCo3kzlNUOHZbRXhT18hOOML3v%2BoNf%2FC0rCwD4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:36.6258573","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:36 GMT
+      mise-correlation-id:
+      - 73543ae6-84c1-4d68-af21-cdb1debfdb08
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A41Z&sr=b&sp=r&sig=9c9otglJDwD75ZStrK%2F0ZGg6PXDceRQTWnNAPAUMauc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:41.9003335","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A41Z&sr=b&sp=r&sig=L%2Fqsl2yyWsq9TuakjizMPLjzF7e8FnMSwQ4dKeqYRlc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:41.9002614","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A41Z&sr=b&sp=r&sig=LwUQcaClWpFl4I8n0kOGE9uUTZNFT8nDEhVpOSRggkk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:41.9003469","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1434,9 +1326,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:59:15 GMT
+      - Wed, 18 Oct 2023 20:58:41 GMT
       mise-correlation-id:
-      - 8f6bc995-99d8-445c-a2dc-e2e5493b219f
+      - 09530697-3a24-445c-be95-79e18c480726
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1456,23 +1348,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A20Z&sr=b&sp=r&sig=%2BvZeiElB8uObEbwZ7iQk0gvK%2FsrhsTdOyPPaIxhFrxk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:20.8957537","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A20Z&sr=b&sp=r&sig=kv%2BhC2Zs9JTCvyurfmlY9i6r1e3TJsB2cmU9N00DcXE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:20.8956885","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A20Z&sr=b&sp=r&sig=voGFzOPgoTmzmFvmiCWdGCDE26CHov5UTFZUD%2B3aVSQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:20.8957689","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A47Z&sr=b&sp=r&sig=z10PAN8bE29oDVS%2BGqct3A4CzAFUfh0HYYBuWpxMXuY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:47.2441662","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A47Z&sr=b&sp=r&sig=Wa7zK5b06Qv4lRyq0GaV43eyilAqBwNdi%2BcKMt0lq3c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:47.2440418","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A47Z&sr=b&sp=r&sig=xRuhKiZ67kXm1zkmoJYwElmwdqMx%2BEPepjxr5x759R8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:47.2441909","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3189'
+      - '3187'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:59:20 GMT
+      - Wed, 18 Oct 2023 20:58:47 GMT
       mise-correlation-id:
-      - 7d053ec8-42bf-48a6-9c56-0dac6e8bd5cf
+      - f00d517a-1d56-4077-a03f-0fdcb73f67f8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1492,10 +1384,226 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A26Z&sr=b&sp=r&sig=HHXJT56sh%2FZVzmc6AE0uPXXAaqjYVdYTC9oFTDIR9Vc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:26.2162761","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A26Z&sr=b&sp=r&sig=%2FH%2FRykPc50ELn%2FWWfgli90abc6Y19CdDogNTZmXvIqM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:26.2161909","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A26Z&sr=b&sp=r&sig=H%2FsPufp1EUYEHGmDn5Ag122OefjFNCSZtSj%2Bs2yT0w8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:26.2162975","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A52Z&sr=b&sp=r&sig=935pXJA76vKBIysHuE5uev8rmDKJ%2B0PzNag1gHbm2Kc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:52.5065778","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A52Z&sr=b&sp=r&sig=w%2F%2FzBC0qgfvRs%2F215H4jVByO3C39laZ%2BsE36ZmkDYug%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:52.5065019","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A52Z&sr=b&sp=r&sig=ns0365%2FtJmB%2FyIRw5dE08sjSCWvakZzNKPZ5FWeTecQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:52.5065922","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:52 GMT
+      mise-correlation-id:
+      - d63f4fe4-b40d-44df-a6f9-d261e0259a0e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A57Z&sr=b&sp=r&sig=O48KTmYbbV7OEfCCMjLLOFKT7PVrFcHnGpLfya3uHh8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:57.8021436","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A57Z&sr=b&sp=r&sig=Nv3nTLEZo01f6jfTy%2BIJNsEnPICgttLSxMgBOvKnbEQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:58:57.8020542","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A58%3A57Z&sr=b&sp=r&sig=XOaH47eIjBkErA%2ByhevG0sbknFttsRoYd7mEd%2BdnsH8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:58:57.8021584","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:58:57 GMT
+      mise-correlation-id:
+      - 510a56dd-3845-40c3-a0dc-9274e9c523cb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A03Z&sr=b&sp=r&sig=1jzJ4GBBXMYLvvTjlRPwu1bZYWwMBG1QxqzU5qqDUi4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:03.1193985","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A03Z&sr=b&sp=r&sig=LEebXRFbRj%2BeIsNqWD2zmXDuL2ce3%2Fz1FYeeGOOrIfY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:03.1192981","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A03Z&sr=b&sp=r&sig=acm4MGC3kP3bS43N%2FdlzgT%2BzCvVLenDB6y7JmuwNr%2BQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:03.1194247","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:03 GMT
+      mise-correlation-id:
+      - af996638-5a80-485e-81d4-9f9a030ef7bd
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A08Z&sr=b&sp=r&sig=DOPdXsqXhUBtwYCtrGgSHjiAAtNtHDePI3kjLZAsLjI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:08.4449536","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A08Z&sr=b&sp=r&sig=yZObz5pdT3HZ9%2BCSJzQqv0cuwGVgoekagn%2FL48NuP8Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:08.4448811","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A08Z&sr=b&sp=r&sig=YpUGKkTqQem5vYnk08wyYYkm84o%2BLnwZZ9WEI8B3rtk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:08.4449677","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:08 GMT
+      mise-correlation-id:
+      - 894e8191-e1e1-47c6-be85-5d83da0ec746
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A13Z&sr=b&sp=r&sig=QMTR1N6lKh6f%2BY2O2ReyXBJgqobpOv%2ByIws%2F7G4R3Co%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:13.7137621","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A13Z&sr=b&sp=r&sig=7RbKpqIMLjzg82vOCZSo0AB3pASi9gUqeY2U%2FFB69JY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:13.7136762","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A13Z&sr=b&sp=r&sig=BdklVExj69MNfZQ%2BIQRhDqg7cvxK3bCIq36%2BzwTtDHc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:13.713777","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:13 GMT
+      mise-correlation-id:
+      - 5ac7a67e-eeaf-4ee4-9243-b1b5d8decc66
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A18Z&sr=b&sp=r&sig=1mGqnQYGJacvnnePe2d3DgnlCTce0ThIxHheqE5RF4o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:18.9934985","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A18Z&sr=b&sp=r&sig=6UvolU6d4CFT2qI2tVjaOCQIuu1lwK6yg7flWWXoSvU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:18.9934287","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A18Z&sr=b&sp=r&sig=u8F5P5k1K2%2BsqeUMv%2F848u2dDIVz9gwV16I1tQveSjg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:18.9935122","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3185'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:18 GMT
+      mise-correlation-id:
+      - 9f1a5e82-881e-4cdd-b3f7-be150a361175
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A24Z&sr=b&sp=r&sig=HVL8BhitI7p104wdNkUgeNRK2%2BUbiJ0%2BCzyGAxqODEQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:24.3308405","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A24Z&sr=b&sp=r&sig=aDmJgKXV3SsNBLYcsee7fDahFkU2Nch98OmZv6xgH1Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:24.3306788","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A24Z&sr=b&sp=r&sig=TWsFz2wrY2wfOEhtuOgaL%2B%2BHQJEcmI1JdUNLAu%2BCw%2Bs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:24.3308655","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1506,9 +1614,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:59:26 GMT
+      - Wed, 18 Oct 2023 20:59:24 GMT
       mise-correlation-id:
-      - e125927d-7f3c-4806-9dfc-466e4cb2c2d2
+      - 12473745-982d-4a52-a740-b8a6d95f1109
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1528,82 +1636,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A31Z&sr=b&sp=r&sig=4zjFB0OID4EQbfvYMy8Q9aahThqGvA%2FnrHmjqmB9hQU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:31.4295167","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A31Z&sr=b&sp=r&sig=Bwdoie%2B4Vz2v0sLpwD1D4NjJV3f9VlC%2BJDqhrD%2BCNbA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:31.4294361","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A31Z&sr=b&sp=r&sig=IHYv5dSx%2FHjubfmAjgexiBp0FeQrcswNxUacuUz32EA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:31.4295376","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:31 GMT
-      mise-correlation-id:
-      - cc1b4b93-3d1b-4fda-b32d-64789c775eac
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A36Z&sr=b&sp=r&sig=oWcA1DT8%2BXQCt7rgFY7KSZJBUkvy8oDsOWVlbCMZ1ic%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:36.6963889","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A36Z&sr=b&sp=r&sig=os6cNeJgsitz1hwr4fKrTfcuh4fWKjUsB8OnFLCfHJ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:36.6962619","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A36Z&sr=b&sp=r&sig=KoVhZlZvNsjN2dDqi%2BQt1HMrifRvx9hSAsGWc1AtlGE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:36.6964169","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3185'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:36 GMT
-      mise-correlation-id:
-      - be60b465-50ec-4f5c-b8e8-48657658f84e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A41Z&sr=b&sp=r&sig=sC3i7dpO5%2B9CPp9wfvSvEUpeLlTXarsYm1nuH2hQXOQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:41.995049","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A41Z&sr=b&sp=r&sig=6DgIoUirkyOqqprMCGBGe7wwhM6PgPmYJv1N0EdcmaM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:41.9949844","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A41Z&sr=b&sp=r&sig=%2F7sY8%2F12xkL0wA5rkhp6GedZ%2FO64lF1B%2BnbDDRWj3SE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:41.995064","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A29Z&sr=b&sp=r&sig=dHCSWuDw2l9xQ6BJSqfOxRwE6AUJWbYaKfE53LJvgwA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:29.6478203","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A29Z&sr=b&sp=r&sig=gnn%2FghtsyDJG9npqssNQVaNzFC3mUhLOE2xasmm1R7A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:29.6477458","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A29Z&sr=b&sp=r&sig=QUuzhbHxoXYlJC%2BS%2FBTMu%2BqAmU84mXnuRjmyYhObZLw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:29.6478346","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1614,9 +1650,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:59:42 GMT
+      - Wed, 18 Oct 2023 20:59:29 GMT
       mise-correlation-id:
-      - e21aa116-15cb-4e8c-bb7a-a5c2599a8649
+      - 243627cb-0062-4e52-a283-3eabe7b5fb88
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,23 +1672,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A48Z&sr=b&sp=r&sig=xeIYZYbIZHpQRNCfZwuJnGSybyVxGh8%2FhQ18zzdEYiI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:48.1718543","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A48Z&sr=b&sp=r&sig=UsCRBqeA9bkxpA%2BdgmGBGBDWLN2kvNged1xcZS%2Bumhs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:48.1717858","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A48Z&sr=b&sp=r&sig=z5Y0fBA9FzXi04FLk0Oi%2BgivUt28210BEOe13fBgEIE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:48.1718689","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A34Z&sr=b&sp=r&sig=TV%2B%2BjMBAPeFAZ0WDYLwcSJJuA%2BU%2FGqnzlWg1NClFhc8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:34.913759","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A34Z&sr=b&sp=r&sig=FGdSjgL6ZYQk5HUKpO7%2BC7Y2LruQ9sUd12ialJ5Q0vs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:34.9136803","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A34Z&sr=b&sp=r&sig=sEdqqh%2FPq4vX%2BdCu56BidxFbqxGH4tAQgOv4bWl8SCA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:34.9137755","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3189'
+      - '3194'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:59:48 GMT
+      - Wed, 18 Oct 2023 20:59:34 GMT
       mise-correlation-id:
-      - d940c02d-5573-4444-af5b-3be43f0ace7e
+      - 7c304e7b-b95d-4bd4-af07-45e005eb0b3e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,82 +1708,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A54Z&sr=b&sp=r&sig=Ix2Fr9MEbQWNaaUh7lRNOoDEBsaEroA22iL84EuFHfk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:54.1565528","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A54Z&sr=b&sp=r&sig=FSYI0aYdqdVOlRb3SysdMXmQNYLIOriIe8ygR6LbbA8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:54.15647","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A54Z&sr=b&sp=r&sig=9Wov23lNUgF9Ap8luyKRM%2F6MBuJH3Svajm3sMSW20pI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:54.1565667","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3181'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:54 GMT
-      mise-correlation-id:
-      - b4097db7-19b4-4440-a5d0-e8216c67ae8f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A59Z&sr=b&sp=r&sig=gKgUPpTRIvGaOkcGJeL6H23eLjOLBFol8UWOeDwU2rA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:59.3938058","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A59Z&sr=b&sp=r&sig=vG6xn9UVvVCXFce0IcuMZymIsqDrmgujeQsE7aMWfLA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:59.3937125","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A59Z&sr=b&sp=r&sig=EHNt4tN8xhsWqBRr0lcoIbclb4MGx%2B6PZafbvDuKlMM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:59.3938278","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3183'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:59:59 GMT
-      mise-correlation-id:
-      - dcf32c66-f318-458c-8221-9b3e1154d43c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A04Z&sr=b&sp=r&sig=SUJr70Rj4bePbPEF%2BSkvVA0SlfiWAzMZV6mBhgJOjGQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:04.6901565","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A04Z&sr=b&sp=r&sig=juTcwZs6VZWO3cDv9N%2FJsyut3TIEJm7Z8Ha%2Fr1PuLJ8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:04.6900814","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A04Z&sr=b&sp=r&sig=FX24hPOVSAAJHmKryvxYNkgGD7TC1kAT5EmkFO%2BH%2FrQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:04.6901712","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A40Z&sr=b&sp=r&sig=lN%2Bljm%2BQqAMeUYQZQG2hsaBpZIUQb8bJdXJQeFbnQhA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:40.1760413","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A40Z&sr=b&sp=r&sig=m8McorW2uHeH0a1Wk%2FUt%2BI36XeJXgPNBdGJaKnFJIwo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:40.1759716","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A40Z&sr=b&sp=r&sig=CqMLLeEqxsiXOBTz4jPNLqfaJUWqsQo6DOrb%2FiwQ1YU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:40.1760576","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +1722,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:04 GMT
+      - Wed, 18 Oct 2023 20:59:40 GMT
       mise-correlation-id:
-      - e26c4e21-5bf8-4772-a6c0-e2fa8ebcf38b
+      - 4d216492-275b-422a-9707-66385c0c8488
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,24 +1744,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A10Z&sr=b&sp=r&sig=krk5Ws34xj0rL7l0y4cTP3TmZa3BXtyLXdT42%2BrFtd8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:10.6789066","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A10Z&sr=b&sp=r&sig=jkZHAWYrwsytUsh4adqAko9iM68Z25gsibB14Do25sQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:10.6787867","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A10Z&sr=b&sp=r&sig=HzUMsjinoQZSZ7piz5POW5INDiC03vlWDZ655WDbG2E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:10.6789337","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-13T13:57:29.834Z","endDateTime":"2023-10-13T14:00:09.464Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:10.415Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A45Z&sr=b&sp=r&sig=rJmMu5umGLcdXrTF1d0Oy2%2BixPfvEz7IFFq3Prj2TtU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:45.4314199","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A45Z&sr=b&sp=r&sig=6LCbV%2BtJcqrkxB4LDEYnTJ5VVbpT55OrFY3Gy99k1Ok%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:45.4313348","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A45Z&sr=b&sp=r&sig=n5TAm1irC28V8%2F1peM4QHkyr6yecvL70nY8cT12Efrs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:45.431441","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3318'
+      - '3186'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:10 GMT
+      - Wed, 18 Oct 2023 20:59:45 GMT
       mise-correlation-id:
-      - d505ca77-00b4-4b92-a4f7-73b81f1ef682
+      - 534a84c0-8a7e-4369-b5b8-28be511ba536
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A50Z&sr=b&sp=r&sig=1xfETGNBsn7sizxAUivWZroJuRwO5BdK2pNYdhU9rzs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:50.7209048","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A50Z&sr=b&sp=r&sig=EZBPU%2BqrdXmgtQR6YR%2F%2FG4GEmCU8opFzDRAt914b9yY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:50.7208168","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A50Z&sr=b&sp=r&sig=4RR7XafM50A8RDAtRauNQszn3Xbk6vxZ6UwIhMjUDec%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:50.720926","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-18T20:57:10.508Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:57:59.76Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:50 GMT
+      mise-correlation-id:
+      - a824f222-6c51-47af-8a09-8a1ca8322426
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A55Z&sr=b&sp=r&sig=bMW6Yqhbv%2FwwQ3vmdtDNUAhgUCPOz910oRO7fMf30JI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:55.9718486","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A55Z&sr=b&sp=r&sig=raTcFv9pjlKJjqTiw8H2QWH3gyyS%2BcvMlQTi9UhSPMo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:55.9717449","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A55Z&sr=b&sp=r&sig=EUdJM6we2EcAc3J8toKJc%2FP%2BYO0ZH8awYRb1lX0eVuA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:55.9718754","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-18T20:57:10.508Z","endDateTime":"2023-10-18T20:59:52.788Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:52.899Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3325'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:59:55 GMT
+      mise-correlation-id:
+      - 1535c79d-f4e2-439b-bd22-632301e5523c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,18 +1856,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:30.3512589Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:30.3512589Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:41.315522Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:41.315522Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:11 GMT
+      - Wed, 18 Oct 2023 20:59:56 GMT
       etag:
-      - '"d901923f-0000-0100-0000-65294c900000"'
+      - '"7500796c-0000-0100-0000-6530468b0000"'
       expires:
       - '-1'
       pragma:
@@ -1861,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=show-test-case&api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=show-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A12Z&sr=b&sp=r&sig=r9gUyVLYDjN4CO0W9e6lZQYHKW5ov5Kofsj2w5zYAGk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:12.7609866","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A12Z&sr=b&sp=r&sig=Kq8euYTmRS%2FFUuUviTE9qhG1K4Ev8%2B4BWvovBmsQBvY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:12.7609178","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A12Z&sr=b&sp=r&sig=pJXt%2B8E2vdtkkN56G4GFM6DQB5N5M47p2ONpxBJsBjU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:12.7610001","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-13T13:57:29.834Z","endDateTime":"2023-10-13T14:00:09.464Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:10.415Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A58Z&sr=b&sp=r&sig=Dady1G8sF%2FAGfiINq%2BpkxW6nm8VCEqZxc%2BBdqVB3yFI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:58.2255954","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A58Z&sr=b&sp=r&sig=6O%2F9LIlAQ4rXqAmepFAC8YgzrByHIk6R2Io8I6AfQEA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:59:58.2255075","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A59%3A58Z&sr=b&sp=r&sig=bv5heuJn84t0dt27HMHYVxcIYDchrSPbRwlm3kLmDEE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T21:59:58.2256096","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-18T20:57:10.508Z","endDateTime":"2023-10-18T20:59:52.788Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:52.899Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3334'
+      - '3337'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:12 GMT
+      - Wed, 18 Oct 2023 20:59:58 GMT
       mise-correlation-id:
-      - 848a24ea-e1d5-4691-b043-e46106bd1f7f
+      - 9dc86b45-a204-49d6-a04a-fff98acdfc09
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1901,18 +1937,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:30.3512589Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:30.3512589Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:56:41.315522Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:56:41.315522Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:13 GMT
+      - Wed, 18 Oct 2023 20:59:59 GMT
       etag:
-      - '"d901923f-0000-0100-0000-65294c900000"'
+      - '"7500796c-0000-0100-0000-6530468b0000"'
       expires:
       - '-1'
       pragma:
@@ -1942,24 +1978,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://c1aaa9a0-9b32-4732-87c1-c56da6bcd9b4.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A14Z&sr=b&sp=r&sig=NidWx%2BINAR0cXqTY574cxv1Hu%2Bewe7MRHb9UEwU0ykA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:14.8169255","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A14Z&sr=b&sp=r&sig=dpvN5K4ZrLasm1SnuVUCYnb2mknrVW0i92Ct0rCO0D8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:14.81685","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A14Z&sr=b&sp=r&sig=TsX1H8cfyqvAT1lLEf4CQn3F5SmhWrhD17DQEUNRVCg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:14.8169406","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-13T13:57:29.834Z","endDateTime":"2023-10-13T14:00:09.464Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:10.415Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cec1289e-2c8c-4969-bd84-592b5bfb9066":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ddc5e70d-9668-4807-93cd-cf3bae67f800":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f86aaddc-a9b5-47c8-b632-d07b3c59455f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/18f9605c-aa25-455c-8d56-6dc5f0b4034b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A00Z&sr=b&sp=r&sig=QDw%2FgiHjmkRv5szipfsnCvLPsmwJWC815plVy0lmk2U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:00.5018443","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/40fbad86-b2e2-4fb0-bd80-ccfaebf76ea3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A00Z&sr=b&sp=r&sig=3Mm2loxiPLEa5MTZ%2F6CEUEk%2B7pROM%2B4BiSPENOpxZLQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:00:00.5017529","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8c164d79-4c0f-4bd1-93e8-113d9b31e070/e395194e-3995-4998-a1ef-b5662ac1098b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A00%3A00Z&sr=b&sp=r&sig=i5J%2FRWxb8aMr3RheeT4WvQ0tbAlsm%2BeootZImTNXviQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:00:00.5018592","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-18T20:57:10.508Z","endDateTime":"2023-10-18T20:59:52.788Z","executedDateTime":"2023-10-18T20:57:09.259Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-18T20:57:10.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:59:52.899Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3318'
+      - '3329'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:14 GMT
+      - Wed, 18 Oct 2023 21:00:00 GMT
       mise-correlation-id:
-      - 7a7b8f73-d887-4152-9a72-c5ffaf675238
+      - 0c6ca375-bc89-489b-8a68-d20873fd9ef1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_show.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_show.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:26:24.0632488Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:26:24.0632488Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:57.2139165Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:57.2139165Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:26:58 GMT
+      - Mon, 30 Oct 2023 07:26:30 GMT
       etag:
-      - '"3c005c31-0000-0100-0000-653edc120000"'
+      - '"3f003772-0000-0100-0000-653f5a860000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:26:59 GMT
+      - Mon, 30 Oct 2023 07:26:31 GMT
       mise-correlation-id:
-      - 819a4517-8a6b-4a44-9c05-5eeaf39f814c
+      - b69a99f1-bd68-483d-af98-71b0fd3f3657
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"4baa0483-5376-4dd0-b0d0-62320513018f": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "811593e5-691c-4840-9970-9165295eeb75":
+      {"passFailMetrics": {"eb09de58-960e-4810-98ca-ff827253eb0a": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "581ed9b2-1b69-4c65-9e12-99ebefe90d72":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "f9a7c530-55ea-478d-ab6c-095e020abbfd": {"aggregate": "avg", "clientMetric":
+      "50"}, "1a03473d-5e23-40fb-b9ff-05bf5bf4d29d": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:27:00.304Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:00.304Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:26:32.146Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:32.146Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:00 GMT
+      - Mon, 30 Oct 2023 07:26:32 GMT
       location:
-      - https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+      - https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 517e70ec-4a45-4681-b5b7-7b01f3bab5ae
+      - 60d11562-37f0-4070-b783-22ae5775b65e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:00 GMT
+      - Mon, 30 Oct 2023 07:26:32 GMT
       mise-correlation-id:
-      - 2718fa7e-eb15-49c4-9230-62267aa16bd9
+      - 5b577896-bcee-4272-945a-1ba332fbe336
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A37%3A01Z&sr=b&sp=r&sig=y2YtCZrMCMenWVHRWiYxVsutiabuYqR01Q5X3iTMkqA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:37:01.1598011","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A36%3A33Z&sr=b&sp=r&sig=wnKiYtb3vS8Wdsq2GdKMaAKcAmgGCV3NSDW7G%2B%2F36f0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:36:33.4874755","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:01 GMT
+      - Mon, 30 Oct 2023 07:26:33 GMT
       location:
-      - https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 601e711d-3464-4aaa-8da1-38cc9de5f4e4
+      - dc72bd7c-7206-4f11-982d-0004420f88f4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A37%3A01Z&sr=b&sp=r&sig=heCrjU0oxtG%2FSu%2BIisp9Y6u6dy9%2B7CWBmgEjLi4DUVs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:37:01.5333623","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:01 GMT
-      mise-correlation-id:
-      - 2a23efaa-f20b-463e-85c0-778a2a208aac
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A37%3A07Z&sr=b&sp=r&sig=EkJ56rPmWrB3huxdETuWfsx4q1w5AzaKmG4oPen9dQU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:37:07.4929721","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:07 GMT
-      mise-correlation-id:
-      - 792fbd36-a30d-45e5-8987-5f1b9b725073
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A37%3A12Z&sr=b&sp=r&sig=eoAVlvseM05NfG63xaew9lPSRSEFmr%2FShx0LyZCiihI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:37:12.7471957","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A36%3A33Z&sr=b&sp=r&sig=mDfG7kuaQYeUHRz%2Fe31kFyrjSjKEt8SvClVr80df9eo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:36:33.7920108","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:12 GMT
+      - Mon, 30 Oct 2023 07:26:33 GMT
       mise-correlation-id:
-      - 235b252f-f1a0-4089-8dbc-799a6a72fa31
+      - aa660938-7a5f-42d1-807a-fecd60bd62f9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A37%3A18Z&sr=b&sp=r&sig=71gFzxQDFZIjYOL04WTTwDVvR1X5kYyNG0wO3ll8drc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:37:18.0527548","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A36%3A39Z&sr=b&sp=r&sig=%2Fp9kwzB%2FqebRzOSFeRHlaiGYKSZP6%2FYHzhpe23eKWyg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:36:39.055009","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '554'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:18 GMT
+      - Mon, 30 Oct 2023 07:26:39 GMT
       mise-correlation-id:
-      - a834c322-ade9-4323-9daf-00580e75d3af
+      - c4be877e-e92a-4275-875e-bb181f186323
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +385,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A18Z&sr=b&sp=r&sig=CQ%2BBZ0L8PXBWOe70KavM9VM8KDoBP6IdKaYj764g6TM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:18.3131914","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:27:00.304Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:13.229Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A36%3A44Z&sr=b&sp=r&sig=Tgdqt5ju6qydAgREvNq3c47ONocnz5zI6jQI1qE4ku8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:36:44.3456178","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1577'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:18 GMT
+      - Mon, 30 Oct 2023 07:26:44 GMT
       mise-correlation-id:
-      - 3f7c8732-464b-4f10-b3fb-fb79eb7fe785
+      - e56f38a7-5baa-4bdb-bcde-885254df7721
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A36%3A49Z&sr=b&sp=r&sig=lnj6ikYrrBIrg8oHsd922SmNDZHCTC0SYUAtdTLSyz8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:36:49.583912","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '546'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:26:49 GMT
+      mise-correlation-id:
+      - 4e6428f8-cdba-4413-acfe-a32de131a75e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A49Z&sr=b&sp=r&sig=P27V%2FYpU%2FeN5NmuRqrr%2FWA%2F%2BJdZ88H0m%2FSuybBEB5w8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:49.9040262","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:26:32.146Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:46.346Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1587'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:26:49 GMT
+      mise-correlation-id:
+      - 31363287-8281-4d56-8d02-6b1660f10050
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:26:24.0632488Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:26:24.0632488Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:57.2139165Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:57.2139165Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:19 GMT
+      - Mon, 30 Oct 2023 07:26:50 GMT
       etag:
-      - '"3c005c31-0000-0100-0000-653edc120000"'
+      - '"3f003772-0000-0100-0000-653f5a860000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A20Z&sr=b&sp=r&sig=2zD9fYkY%2BtSpZNDRxhAu0Zbc49ZLlSZHCSsrpJbCCSs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:20.5748943","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:27:00.304Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:13.229Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A52Z&sr=b&sp=r&sig=X8%2FFkaC8YcAKJFduQY6aYDX4B1KNugdgxUb%2F4wz5%2Bsk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:52.1672386","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:26:32.146Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:46.346Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1589'
+      - '1593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:20 GMT
+      - Mon, 30 Oct 2023 07:26:52 GMT
       mise-correlation-id:
-      - e631f29d-3ade-4e2b-908e-419ae0a89fa9
+      - d07ac589-791a-49c6-b7fe-00e6eff5b754
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:26:24.0632488Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:26:24.0632488Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:57.2139165Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:57.2139165Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:21 GMT
+      - Mon, 30 Oct 2023 07:26:53 GMT
       etag:
-      - '"3c005c31-0000-0100-0000-653edc120000"'
+      - '"3f003772-0000-0100-0000-653f5a860000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:27:22 GMT
+      - Mon, 30 Oct 2023 07:26:54 GMT
       mise-correlation-id:
-      - 2a359599-33e8-4940-bce7-e3ee07787bed
+      - 5ecbebe9-9054-47f5-a0c9-5f3d70efa10d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A23Z&sr=b&sp=r&sig=1TgbKQKhsc6qcsQAlpZLRv8Owl0u4E5q33xc7nQ095k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:23.5671602","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A23Z&sr=b&sp=r&sig=C4%2B2BowHt1bVQVtoNlpAGwmJuzwVZUxhrAj4Iwfg6vU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:23.5670596","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A23Z&sr=b&sp=r&sig=rAmATosRhTUHJEbNOV5udPP%2F9aLoRPQK1saFOTn6cXo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:23.5671834","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:23.474Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A55Z&sr=b&sp=r&sig=H6oX1kIobQ1160y4gW5FipAcJ4VClNlEjyZiHl8oC7A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:55.5185789","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A55Z&sr=b&sp=r&sig=eIoL2nASNxBdfYG6mtlZx3%2Bj%2FKVynWmJdkjUY2vEepg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:55.5184622","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A55Z&sr=b&sp=r&sig=VmauPTB9GQJUNjD2BrSvVATT0cxELhTc8RXy%2FQqJhs8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:55.518606","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"ACCEPTED","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:55.431Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3142'
+      - '3143'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:23 GMT
+      - Mon, 30 Oct 2023 07:26:55 GMT
       location:
-      - https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+      - https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 8a4c975e-113e-480b-9ee4-64a5c2615ddd
+      - a0041fd0-804a-48f4-8421-7946f9290c06
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,118 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A24Z&sr=b&sp=r&sig=L4SiOem9NozloRAFxCge90fB2KkkHyp0NLpN2wutq5I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:24.0078672","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A24Z&sr=b&sp=r&sig=pZswC6yAHWVpv2ib%2FN5rWybdPrCRBitaEehmn%2BY95QU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:24.0077967","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A24Z&sr=b&sp=r&sig=DegIpmuSadXjaDoC36miCGMHFvhcP%2FTmIZ9ZBxT4ulI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:24.0078822","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"NOTSTARTED","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:23.963Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3189'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:24 GMT
-      mise-correlation-id:
-      - 709fddd2-990f-439c-9712-8620f535dc18
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A29Z&sr=b&sp=r&sig=WgLOuO4%2BF%2F4qDr9zVbqtvDuAzPfN1C07xW%2BueE5mB0Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:29.2810135","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A29Z&sr=b&sp=r&sig=cJdd73gmvWAe0NDT8%2BPb8EtLjXhiRJuwez8LDgn037k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:29.280929","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A29Z&sr=b&sp=r&sig=EGnKXo2%2BXpoaS9XuLOldFeJAYIZL9Nkq2bJtHddnciU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:29.281035","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:24.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:29 GMT
-      mise-correlation-id:
-      - 67606bb9-19cc-4af9-b1f2-79063b086337
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A34Z&sr=b&sp=r&sig=BD42119LpnxxqaXfrzaHuhjG11BSGC1oZgLjccHtUuk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:34.5605395","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A34Z&sr=b&sp=r&sig=atJV8NhuRx2yg9mIJUhLz18Eri0DN9q1p2KUHI9Dpug%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:34.5604529","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A34Z&sr=b&sp=r&sig=2%2BGOKo1lsQqr4F2QhiQ4%2FsEZ82IjgawWtx90GeXruYk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:34.5605613","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:24.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3189'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:34 GMT
-      mise-correlation-id:
-      - adda895b-e7da-4d07-a579-b67dab277ea0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A39Z&sr=b&sp=r&sig=cTxIOM%2BI4vQ8EovmSpw1C9vPdkRZ8vvjWIxdo55Adyw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:39.8395151","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A39Z&sr=b&sp=r&sig=jPllPqWQlHBH5SgkKhFGXJoJTrv6EZHqf0SJMus0n4Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:39.839427","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A39Z&sr=b&sp=r&sig=LG3yHtf%2FEXjtMqEzsHFOsvFeHruLQHbtw4WZhWDiipI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:39.8395373","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:24.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A55Z&sr=b&sp=r&sig=U8IebwyzEdGF8VS17sUWfs%2FxspROLn0doWZLW%2BALwUQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:55.914379","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A55Z&sr=b&sp=r&sig=IB1TDUv7bf%2Fqz9ZDsPsHkgsWbEVQuWVjlRNeGvkHHgs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:26:55.9142972","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A26%3A55Z&sr=b&sp=r&sig=jMzOAJ2R4ckUM3V7KaOtTyGpkCnrp3Ah1IEunH5Lcmo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:26:55.9144005","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"NOTSTARTED","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:55.816Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -822,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:39 GMT
+      - Mon, 30 Oct 2023 07:26:55 GMT
       mise-correlation-id:
-      - 9c3e2805-7a71-4c1d-8fde-86ffefffa275
+      - 982cb41f-d8b3-48f2-aadf-95865f7915c6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A45Z&sr=b&sp=r&sig=LnyT%2BN2HMsQQ4%2FozKEXCZdVQuAeSgUY67rKM4mACD1I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:45.1504608","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A45Z&sr=b&sp=r&sig=wogLVXgEJaiAbnT4%2FowVBT%2F7meolMg8g7ty%2FZsxptis%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:45.1502779","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A45Z&sr=b&sp=r&sig=cQ4kQH6xW96cYhallTYOifr5o1LVoy6yMqwo7d%2FCjD8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:45.1504833","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:24.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A01Z&sr=b&sp=r&sig=Tnjhl7gwgP%2FRV7NKSHFgEYliqTqnAUCG3hSqkD%2FupvQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:01.1827152","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A01Z&sr=b&sp=r&sig=sk%2BBfEvh%2FruouzQoVJQZ%2FfA0hA%2BsrQc4bfPhLffmhdQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:01.1826458","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A01Z&sr=b&sp=r&sig=cOQZJlyUu7bSGJJUR7qmhbco4vU%2FDlr77RG8brlbnxw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:01.1827294","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:56.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3197'
+      - '3199'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:27:45 GMT
+      - Mon, 30 Oct 2023 07:27:01 GMT
       mise-correlation-id:
-      - c64fbaf7-7549-48c7-9294-469699a08d24
+      - aa1ef493-9c55-4c5c-932e-6b0fee71aa18
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -880,82 +772,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A50Z&sr=b&sp=r&sig=2AkkUWvLk8n%2BzqmRzUUKWDsLLrF%2FPtuKWyXilGPCoRg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:50.7965019","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A50Z&sr=b&sp=r&sig=Z1DPt6LE8GITygr0qF7jc65BGBAhmY24zc7Sml5e10g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:50.7964238","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A50Z&sr=b&sp=r&sig=Ujw0%2FhjBM%2FeAHtE8W7UFT2vs%2B4adX97%2FCxguDz5rbzI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:50.796516","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:24.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:50 GMT
-      mise-correlation-id:
-      - f2e8d17a-e44d-4945-82fe-5f766e98720e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A56Z&sr=b&sp=r&sig=lRyD96W%2FpYS02Bdkx8dpGTNbNRuDbne7FXpBrJ6nkPI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:56.1270944","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A56Z&sr=b&sp=r&sig=gfTOqWyM7wgGR53nfKirYQ4IMiYtjjjEc9KQUHwl1Dk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:56.1270171","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A56Z&sr=b&sp=r&sig=HgfrolMDN36T3nY%2FW%2B3yv0R4opYK89emulxCRFe6bfw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:56.127109","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:24.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:27:56 GMT
-      mise-correlation-id:
-      - 2c6ba059-1afb-43a7-8eac-01e4b201e1ff
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A01Z&sr=b&sp=r&sig=7e5QFevBdekZjksFWH2DQ7rvZlJ%2F%2BiTENzmuPsut7Qw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:01.4374628","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A01Z&sr=b&sp=r&sig=8hIRPJMlIP4m1tjOVrGDVdE1xEFktZ0FVI8kgaPJH9A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:01.4373987","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A01Z&sr=b&sp=r&sig=nfAxis69YTL3f2YyKCa5djY2Sb6LW9BZm8MRFX%2B2n6g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:01.4374831","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:24.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A06Z&sr=b&sp=r&sig=GzWceEuwF462mNvSmTmCrT%2Floibqo%2FdVMBGqOs7qGL4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:06.4737504","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A06Z&sr=b&sp=r&sig=YzwRozSepQwrQjbxq1sZH8PDOQm87ALE0fdpGOJiCQg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:06.4736829","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A06Z&sr=b&sp=r&sig=ET8qQyC45hfODZSTHIRCE8YR0EXr2%2FCJ20jC3OvRNBk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:06.4737657","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:56.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -966,9 +786,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:28:01 GMT
+      - Mon, 30 Oct 2023 07:27:06 GMT
       mise-correlation-id:
-      - 27fbfa67-14ba-4306-afdd-50031949718e
+      - f4dda1bc-c857-4628-a609-fac4157dca02
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -988,82 +808,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A06Z&sr=b&sp=r&sig=MwNfbGKke6ctfoVM6UZoUbiStg8Dura2mnacICiZacc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:06.7097626","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A06Z&sr=b&sp=r&sig=yb%2FvvbrhEk%2BRCaKOK3XmGrMHyYBUkpkIeaxRD6CMeRY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:06.7097108","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A06Z&sr=b&sp=r&sig=tgnrk%2ByxXO5mkhQP3xRep55gb5BTR%2F7sSYP2rTMLfFo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:06.7097764","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:24.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:06 GMT
-      mise-correlation-id:
-      - 9abf8b53-e972-4545-8d6c-9620bb9c0fe5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A12Z&sr=b&sp=r&sig=uvuqL6pkuKOAag7awWHvbsNtXqrbGE69w3XyS1IJBYE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:12.0424761","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A12Z&sr=b&sp=r&sig=mCm8BPOh4QLMpjAOZGsbddcZGCrPQ9m0RwBhjwyIQd0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:12.0424074","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A12Z&sr=b&sp=r&sig=%2BhOcQTw569Llko%2B5rlzNqg4ASqXQ%2FytmTbmy7JJ0wro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:12.0424899","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:12 GMT
-      mise-correlation-id:
-      - beb22685-77c3-496d-a30b-3e191b0348f7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A17Z&sr=b&sp=r&sig=dioH9ylQpl11so5WfsAFEo%2F7mXoX%2B3ZEFxvAdw1pv9o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:17.3488055","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A17Z&sr=b&sp=r&sig=VRc1Zdcz1bKyAL4GYOYt1efbztX1QvXsmlvMV8qbXg8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:17.348739","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A17Z&sr=b&sp=r&sig=xAcwT7hHasEpa5oj%2FCJAtSk%2B2g0W6yvaz57GsPYVPU4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:17.34882","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A11Z&sr=b&sp=r&sig=t7EJOJj0TEqBxjF2qxb1hUmdksqpqK5Nd1bvZCCAJXo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:11.7193913","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A11Z&sr=b&sp=r&sig=jpgwP%2B8FVS3amvjKzsTjpAIqLdgOOCYd7BwBEkWLjKo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:11.7193041","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A11Z&sr=b&sp=r&sig=qKZvVxLz5bobJqn6oUidKL1lTed2TnRp7dVliayeg3s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:11.7194123","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:56.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1074,9 +822,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:28:17 GMT
+      - Mon, 30 Oct 2023 07:27:11 GMT
       mise-correlation-id:
-      - ef96309a-b75e-43d9-9c81-43b361c5d265
+      - 485d7a06-9f23-4562-8ef5-a5de80562d15
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1096,262 +844,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A23Z&sr=b&sp=r&sig=F0gUpCQALNB5KtZvIdol3DOCt%2Fzii%2BI5%2BRvf26HfvDU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:23.0615341","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A23Z&sr=b&sp=r&sig=TlNSw0dderQ5Jrg%2BrtITqeuiyuhpQ77hUhsI1HYHG%2FM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:23.0614658","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A23Z&sr=b&sp=r&sig=2AVIZkx0F0ejs13pZMNnPLRygNVbPaRlnFEQRiHrcNc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:23.0615489","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:23 GMT
-      mise-correlation-id:
-      - 05f8dcf7-8b10-4c5b-9397-fb0009ecb91b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A28Z&sr=b&sp=r&sig=K4HagAKmUfTzLfNhvFvUHt7W4u1VjoIH4p7%2FNxR9LRM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:28.3163849","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A28Z&sr=b&sp=r&sig=M2tRLzdKeC5bbzRrpR%2BTasf8%2FiMSB69IjRdD2n0q5MY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:28.3163082","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A28Z&sr=b&sp=r&sig=Q%2Fpwy0EBtAGwxmFQ8s1m85KutfnnaeFL3f6UvBhdJ58%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:28.3163984","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:28 GMT
-      mise-correlation-id:
-      - e8143ff6-b496-418c-8b24-47ced0ac4b90
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A33Z&sr=b&sp=r&sig=AcdYyT85fx1x9FzHMYMmb9wvI2FRTM0ngvhyH0DOmus%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:33.5590193","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A33Z&sr=b&sp=r&sig=nBTqntuSik96satC%2F5a7xx%2FNZD0ZFW5elxDm0riiIzI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:33.5589459","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A33Z&sr=b&sp=r&sig=41r8DjcDQ9UgL0hB7sWjHrIm4vi2klyez3yNw%2Fk%2FhJo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:33.5590357","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:33 GMT
-      mise-correlation-id:
-      - 0b31d14c-5a16-4753-8ec9-43c111fceebe
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A38Z&sr=b&sp=r&sig=ka9SjDzm3baWwjtd0rHRMvqP085pf6hkOjBdu41QfKw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:38.806574","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A38Z&sr=b&sp=r&sig=xlA8zQCs11pFlzOE9xijO59a9zpmSSLB233lPzeXtbE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:38.8064857","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A38Z&sr=b&sp=r&sig=UyTq230o%2FjgELZJGxB6Gp%2FYVh7Sh78%2Btr6sY6cMG9Qc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:38.8065969","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:38 GMT
-      mise-correlation-id:
-      - 84efa710-ed7b-4f33-a029-76f56afd71b5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A44Z&sr=b&sp=r&sig=B3txgzQY1vWUj1ZBS20M8GbSgEcOKoA3992QFYL9diU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:44.0504619","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A44Z&sr=b&sp=r&sig=ipuIU%2FHRPodJPXKPoeA7AUvqhQHVNVbJuovWQzYX5fA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:44.0503661","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A44Z&sr=b&sp=r&sig=9SrvjEh3zsCr5jYxlCCl%2F3TnjfUFnou12o%2FLgeoDDV8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:44.0504783","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:44 GMT
-      mise-correlation-id:
-      - 4f036402-1c56-44a0-84ec-3ed9740bd930
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A49Z&sr=b&sp=r&sig=v3EEm6yM0h%2FbRX7tqBa37BUsx8LsdUFQwV3VUJVbtPo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:49.4861432","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A49Z&sr=b&sp=r&sig=xulFvHeKeTZ6Gd34N90RYX0a5lu8g3Mfc8OBIEi3XoA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:49.486059","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A49Z&sr=b&sp=r&sig=5%2BCq4lqv97z82VNgwd9q83TlZkFIMom6VEwR1HBnmnI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:49.4861658","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3185'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:49 GMT
-      mise-correlation-id:
-      - 5ced5978-507b-4bf5-80ea-353e36159323
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A54Z&sr=b&sp=r&sig=3O0q%2FrGgUvyzJHdKqUC0kno3B5EGgOO1rCKJP0Ld%2BUU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:54.7828343","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A54Z&sr=b&sp=r&sig=lhnrgeK8akW5HHcN8igjttAAkSm0ltRk5ICxV9DtFFU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:54.7827597","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A54Z&sr=b&sp=r&sig=jUF9x1INV036iIPZzF%2FVf%2BhBf%2BxxJcjWdctzqy1xMvI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:54.7828491","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:28:54 GMT
-      mise-correlation-id:
-      - 08486d18-5c4b-4735-ade0-e5907afbcd21
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A00Z&sr=b&sp=r&sig=BfjqIvYGRtZDidFPWaEKt%2BSuF%2FnH9MA1qiqaQ%2B4cgFw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:00.0331543","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A00Z&sr=b&sp=r&sig=8rGd2a7WEULBcSeGEmb0dR4jXIidxQDSvgCIyDLGq6A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:00.033046","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A00Z&sr=b&sp=r&sig=4%2BrTP3aAGGjyj91H9HjdDP8QoYvKyvZwzYoCyj9AqDo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:00.0331789","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A17Z&sr=b&sp=r&sig=%2BdnQNg6dwAwTlLLAOPXSVouFOzfU3ZkO3Kkrrp0twrQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:17.0047335","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A17Z&sr=b&sp=r&sig=VAPBOy018tLWH7n1ygXP5i%2BIABsCMy0RIhC9CobJF1c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:17.0046344","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A17Z&sr=b&sp=r&sig=buE5z7tELSToHcOC8iZZYQJvYVwon5JMz3vJ7F2aVJY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:17.0047583","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:56.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1362,9 +858,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:00 GMT
+      - Mon, 30 Oct 2023 07:27:17 GMT
       mise-correlation-id:
-      - db1630fe-9b3d-4ca1-9f77-4b35b5e0b477
+      - 4794d9da-4152-451e-aa47-eae14dcbb83e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1384,10 +880,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A05Z&sr=b&sp=r&sig=QUE3sRhy%2F6675cR67u8yUJ7wJp5hLoAQmwIKwKGO7h4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:05.3183947","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A05Z&sr=b&sp=r&sig=4zbjb%2BrtTKSKzIsO2GWS3QiZ4rz5azlf6%2Bn9qeLCdgw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:05.3183251","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A05Z&sr=b&sp=r&sig=PPLHu7ydbgvsd1tC3TZpPLmWQGSGCXuC7DoEiJRJ2eo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:05.3184146","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A22Z&sr=b&sp=r&sig=RA%2BhwkggkXjYsA55sn%2FnX8Xx7E3UFFBt1M6Pinde8i0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:22.3210306","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A22Z&sr=b&sp=r&sig=pCHv%2BNhctmMLPBd317QXgdWn%2FGPl3qqiiLEMnzRl578%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:22.3209538","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A22Z&sr=b&sp=r&sig=PXVXB1pap16GgZQjfn%2B4%2Bt1xNR5oWuN12Hcnib%2FbrhA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:22.3210442","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:56.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:27:22 GMT
+      mise-correlation-id:
+      - 74071456-71ea-4a02-8cfd-95e064f7f49b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A27Z&sr=b&sp=r&sig=qHF8uQJ6TCdcR%2BcZWLjH%2Fj6Hwy79VIpWzNt2SjbenzA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:27.6548186","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A27Z&sr=b&sp=r&sig=uhxuo79mDlHZ7NpfP0ClUHAvu577iczv9LrgRXmUIjA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:27.654749","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A27Z&sr=b&sp=r&sig=8RKo38aXHqEN7fyGEfCp32OutBKQxVW1vF3IqORF7Fk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:27.6548334","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:56.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1398,9 +930,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:05 GMT
+      - Mon, 30 Oct 2023 07:27:27 GMT
       mise-correlation-id:
-      - 8e32df7b-5211-46b7-ab3b-fc3359a1810f
+      - 74268327-c7e7-479d-81e6-69247075241e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1420,23 +952,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A10Z&sr=b&sp=r&sig=lkjJJwfscU%2B9JW%2FOTOucvs6Xz69fa1VPqSLBUNymtCU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:10.6705709","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A10Z&sr=b&sp=r&sig=ZJxsMhNwfcYQWPY344FgoRULeU69J9tqL2pHj4dEa58%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:10.6704819","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A10Z&sr=b&sp=r&sig=g%2FxLbReTH27HRTamVy4KPNM4elQc5vveV774oiA2oK4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:10.670593","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A32Z&sr=b&sp=r&sig=LFWhOj4T%2FV9irRFlS9AB8RDwgjXygvvZJNknro%2F6gHY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:32.9094405","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A32Z&sr=b&sp=r&sig=pDTv74GXvHrIc%2FlkVTdp8d2%2FZqs9lEeRdEqG3M5yK0g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:32.9093729","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A32Z&sr=b&sp=r&sig=UlFr1FDh7pVsvr6t%2FTtxCdBSRXdwjZQD%2BRanoUwM720%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:32.9094537","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:56.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3187'
+      - '3197'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:10 GMT
+      - Mon, 30 Oct 2023 07:27:32 GMT
       mise-correlation-id:
-      - a0a27f38-5390-495d-b23c-d92678de9821
+      - 17d28163-a473-49c7-9c9b-765fc84cc1e1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1456,10 +988,154 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A15Z&sr=b&sp=r&sig=HzEYo6GD91fp8PHaMcv6RRwZbsMKx%2Bc%2FrnZeHR8iqJs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:15.9177812","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A15Z&sr=b&sp=r&sig=KCpvAXJKBrVeIe2xs4Uirijt4WICEiNROHZsjNEzs5o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:15.9177097","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A15Z&sr=b&sp=r&sig=ZBLMWyW%2Fz4lwiX1Nmjnen73Tv5LDJYIcXf%2Bu7IJIXIk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:15.9177951","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A38Z&sr=b&sp=r&sig=0iGgpBcyitbV%2FtN2zf7XlZatxcpcMaTCuF%2F32ZOJDUU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:38.2068687","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A38Z&sr=b&sp=r&sig=eSEuv1iQi4vyX3OAabQuUqM33uJACBaMkBGPlcjoiPU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:38.2067652","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A38Z&sr=b&sp=r&sig=aMc4UcYU%2BwhGXqtTl4OaNkU49EgVOA0ZNbX7xR2UAVw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:38.2068949","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:56.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:27:38 GMT
+      mise-correlation-id:
+      - 4166b179-56d2-487e-82e1-7bb24a6a025c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A43Z&sr=b&sp=r&sig=qrVY%2B5hYUoa4dOM5MKLrkPaeAOQJOOlbiO2OQoZ%2B1bc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:43.4671613","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A43Z&sr=b&sp=r&sig=cYJKFHXctYEUbtO0pcfe85Qsgi5d2XpcKaPAkYieZKM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:43.4670739","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A43Z&sr=b&sp=r&sig=ZGvRqk%2B2pSA68QjuwX9xFUyLeclSPEORf7%2B6NA4Is6o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:43.467182","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:26:56.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:27:43 GMT
+      mise-correlation-id:
+      - b28231c7-7470-40c9-ba8b-573dce6c2102
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A48Z&sr=b&sp=r&sig=2uF24oQ7yv1kpKA7iZQ%2FKs55iu1DS9HLoP6TsFMqXQs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:48.7405991","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A48Z&sr=b&sp=r&sig=I2yyHMyU8F%2FYkt%2Bdcw%2BnJnAn%2F6AHP%2Fwk12r0izdIjFA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:48.7405148","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A48Z&sr=b&sp=r&sig=Er4rq%2BRusfCg%2BdGCqBWRt2WkD7E1popM8Vt7fepnZ%2FQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:48.7406217","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:27:48 GMT
+      mise-correlation-id:
+      - ad9741d0-9994-4a30-9e15-0cab5683ea7c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A53Z&sr=b&sp=r&sig=0L0qsA3wh%2FBj4Q9DfcU9u4dZYigqtCXBguydf3%2BZecM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:53.9998115","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A53Z&sr=b&sp=r&sig=RUc3UFfdPsXH4WqsI%2FpBa4f1pAG0vWgSrpfpCexyMLc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:53.9997351","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A53Z&sr=b&sp=r&sig=H%2F%2BzCd3hG%2FbqoFHv7E7QDx2Q03L3BAv2YzagH3B7zjo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:53.9998258","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:27:54 GMT
+      mise-correlation-id:
+      - d0bbd75a-f205-4e13-b7e6-a007ee9f15ca
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A59Z&sr=b&sp=r&sig=ZZhkG3vj8LVhT3ylMwnbGI8buG%2BHVCz8Q%2Fh4SQzqLOI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:59.2884049","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A59Z&sr=b&sp=r&sig=wS0Nzh2R8dm7D0F2oIuTcelniXRlMayO05QQy3xt28o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:27:59.2883367","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A27%3A59Z&sr=b&sp=r&sig=w45%2BgtvxpdebC%2Bg08UKLrq9zCHuGyp0f5tWgw0oRgRk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:27:59.2884197","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1470,9 +1146,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:15 GMT
+      - Mon, 30 Oct 2023 07:27:59 GMT
       mise-correlation-id:
-      - 6a80edee-b861-4701-8f14-a12dda9efa50
+      - 61f3add0-6833-4dc1-b720-069dcdb4f1d9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1492,23 +1168,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A21Z&sr=b&sp=r&sig=LxDaLvmVw%2FzRfgBJZSJSVOVGiUisug42jxUTcTovdI0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:21.2065765","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A21Z&sr=b&sp=r&sig=GI9hdowbq8tm7528ZZ2N2TBHX4DqljnVei9d%2FcjmmhA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:21.2065089","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A21Z&sr=b&sp=r&sig=3fpBYbctwSL0lSB5T1awEUHTsJrdCIzjcmOwtuw8R2o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:21.206591","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A04Z&sr=b&sp=r&sig=y%2FLQJSe1oz%2BuDoowv5ujg5%2BfqcuuWBcKeb4AqETSDPs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:04.6211295","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A04Z&sr=b&sp=r&sig=3BPIGeLXdk%2FKXsTzBjamaXYAEVFYRyRpM7K1Y2NnVls%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:04.6210294","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A04Z&sr=b&sp=r&sig=lj7IIGocvNTZa5%2Fp7uFoUHUmUF68NRhiaejvMpF8sq8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:04.6211514","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3185'
+      - '3192'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:21 GMT
+      - Mon, 30 Oct 2023 07:28:04 GMT
       mise-correlation-id:
-      - 623eae70-cbf9-438b-9226-8d7948675a07
+      - 5c186617-b678-487d-bb24-70aae45d93cc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1528,10 +1204,226 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A26Z&sr=b&sp=r&sig=twPmjrRbnadMUBMrYZ5AjmAhFw41fRwTJ6iVnZl7HIE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:26.552734","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A26Z&sr=b&sp=r&sig=TnPSov6%2FRsyk%2BH6TcTeLtSbUOj7nsdMiPfOLXtSSItA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:26.5526648","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A26Z&sr=b&sp=r&sig=sa5qshrZgc1I8X%2Fh2%2Fp%2BSxxmD7RRtfwQP%2FTkAtMY0HQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:26.5527488","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A09Z&sr=b&sp=r&sig=uP4qpclAT0ibwssrxEaExRE0kSl90A5UPA0OnHnl6JU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:09.8652757","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A09Z&sr=b&sp=r&sig=B6ErHcDJeDRcmHvnbD0j2k3doQV31I5i4%2FHQVXO0u24%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:09.8651786","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A09Z&sr=b&sp=r&sig=xNndUTa8i39niRw9a3DoMkRvc0pdz0SnfWPwswPXyCU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:09.8653039","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:09 GMT
+      mise-correlation-id:
+      - 6af21961-4558-4dd9-acb8-7df983283dae
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A15Z&sr=b&sp=r&sig=cEJqygkszuf64BsInic%2FTAWWpQRiUTsBnuh0evF6X6s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:15.1183649","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A15Z&sr=b&sp=r&sig=RzmyfGfHuDsBFpfnALWzT3ARZtuOyCuA%2FvJszp2vb1A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:15.1182985","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A15Z&sr=b&sp=r&sig=QY0FnYwNBYWa%2BNuMea9ymN5F34LVqywO%2F6EcO1XbiR0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:15.1183792","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:15 GMT
+      mise-correlation-id:
+      - 4764f313-259d-47dc-b132-e4b946223f45
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A20Z&sr=b&sp=r&sig=nYiS%2FWBkQuzTPJ6eVTm%2Fb3jftJADOAkCeUOEDE4l%2Fos%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:20.3771975","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A20Z&sr=b&sp=r&sig=SzLLOKHO0eNE%2B0mw0kL0vYEkceQZ8wLn9AmuJW2IDCs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:20.3771226","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A20Z&sr=b&sp=r&sig=5GFd8AgEK4RFhQNTvzy%2Fc3c5NTwQzu0dPgcywb6%2Brho%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:20.3772198","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:20 GMT
+      mise-correlation-id:
+      - e8943f3a-6cf3-4d4f-a86d-28b90b649527
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A26Z&sr=b&sp=r&sig=AnINH%2FfjlaWA9CPP5mM73NnEyTR79JVzvA6qQeagn4Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:26.0615994","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A26Z&sr=b&sp=r&sig=LJOhOAlp6rrO51dsYXeZD%2FDDOrmRBgZyKa7YvnnuUok%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:26.0615222","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A26Z&sr=b&sp=r&sig=4V6oFby1RIoyejDmMAdrzrwuLDRcBAT85Eyug7V%2BF2w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:26.0616302","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:26 GMT
+      mise-correlation-id:
+      - ba95eb4c-abdc-4d3e-9ca0-210967f5cc38
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A31Z&sr=b&sp=r&sig=XV7QMJtTfWd4zZgzk36T0zY8krU%2FzWrN7fFiOCCY7ic%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:31.3399216","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A31Z&sr=b&sp=r&sig=2doyQqlLc%2BGEXytswl6k2syv2WXngyPwGhmxGX%2Bq4zw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:31.3398348","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A31Z&sr=b&sp=r&sig=HmxPHgEgg%2FRskcPORufdQuzxt1xQ2GcbOPV0Vh6XtJM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:31.3399372","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:31 GMT
+      mise-correlation-id:
+      - be19bb79-d512-49ae-95be-5e63a53fe5a3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A36Z&sr=b&sp=r&sig=xuO%2FnscbxGbgt4gvnN11wHEckSGt3HzR57n5oWMdkT4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:36.6607431","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A36Z&sr=b&sp=r&sig=qNICJGmJkFGCNGJ71nMycEIgGT6Vw5kZXv3XRYr8J7g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:36.6606637","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A36Z&sr=b&sp=r&sig=ujTzhNZ5cu8%2Fb841zc5ja2hrFn5ISSZBE02LmarYugM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:36.6607652","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:36 GMT
+      mise-correlation-id:
+      - 241f3c93-a610-4cee-8ce5-b92c17fa2693
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A41Z&sr=b&sp=r&sig=Onr1Jk%2FkQ%2FPF5ykaMEKi9G4uMVmEyNKH7gy1%2BDQN8jU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:41.9902029","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A41Z&sr=b&sp=r&sig=Srrs0n8G6oAnZuzjI5y%2BRelGus%2FzxvpPZZ9vNxqZq5o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:41.9901358","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A41Z&sr=b&sp=r&sig=YuB2dQFw9S9Ir3qkf3TcSsZcDdyfBSLxLyenp95%2BHE4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:41.990218","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1542,9 +1434,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:26 GMT
+      - Mon, 30 Oct 2023 07:28:41 GMT
       mise-correlation-id:
-      - fa269303-aaa0-4912-841b-8ff4a5f8e11f
+      - 1e3f43b7-0cad-44f0-b4e9-38fd28f06631
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,10 +1456,154 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A31Z&sr=b&sp=r&sig=df6RvVXmmSH1RXhA4uOJlXE0UThGTa7gxEAx2R75BYg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:31.8472969","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A31Z&sr=b&sp=r&sig=2eUGYNoY2tKg8kbdgJlBMTAKD1D20DdO%2FwJLw8NOrf8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:31.8472274","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A31Z&sr=b&sp=r&sig=MzBLi9%2F8cdFrtPSH0Pg7YrEQ37rJKkyl7YxBvn%2B2bgc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:31.8473109","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A47Z&sr=b&sp=r&sig=z8vUytRZ0Chkq7%2BX9gIvGnZqSa%2BCWey%2BT1WGrA6WMR0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:47.5428278","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A47Z&sr=b&sp=r&sig=t9cTjJiIq5NIJ04krwgXw70pSp%2FTaduKu0tKuTz3HCQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:47.5427454","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A47Z&sr=b&sp=r&sig=nKDGeRHRiGT%2F9acESl7z6344DVjq7zyRLjIT0mkFr2M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:47.5428427","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:47 GMT
+      mise-correlation-id:
+      - 331ee9ef-b6bd-40a6-a656-4bb2c05837a6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A52Z&sr=b&sp=r&sig=Kv8RzXvkn54BADL8b0A2%2FpD9fcFcyQcj2%2BW%2BamitCUk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:52.7891448","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A52Z&sr=b&sp=r&sig=Pk%2Fenfa0I4ZlKRHxwdmoKrBwKXciXADmH1lCTgYCh04%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:52.7890533","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A52Z&sr=b&sp=r&sig=taOkjIH6UOYNhTjzK%2FfpPrjEV8dYa%2Fd1XJ8hVtrnSm8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:52.7891676","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:52 GMT
+      mise-correlation-id:
+      - 366b85ae-b94f-48b0-b4c1-636b3362ed1a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A58Z&sr=b&sp=r&sig=Cg5ziI%2FDNAXmXZ2tkLXhgU1oTu%2Fv%2FJiaFGCFq9MIZ2Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:58.0761347","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A58Z&sr=b&sp=r&sig=vkrN5L3fb8z0%2BjqEO8rizSSr0JbJnBqjDpKqcACQzsQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:28:58.0760462","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A28%3A58Z&sr=b&sp=r&sig=dI0dzmSwvn2AUw6jbuMR8KxJPmY9SG4VlEFv2JdYdw0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:28:58.0761586","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:28:58 GMT
+      mise-correlation-id:
+      - 5fc863d4-8674-4af7-8934-b871518d9886
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A03Z&sr=b&sp=r&sig=udqKYBp1CryAv4GqIPVHABBWEZnpVsC8kAxtjcyOVNk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:03.3899337","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A03Z&sr=b&sp=r&sig=KLpxlHoIx1%2F2xZs7gAAzWYBjwADgizhPG57u9ZxJeUE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:03.3898645","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A03Z&sr=b&sp=r&sig=6XOxMgjF4pp3X%2BolaVNrCvHWqqVliRo%2FmGQ3n%2FY6svs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:03.3899481","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:29:03 GMT
+      mise-correlation-id:
+      - 4847b033-baa7-41b9-9c04-39fe2d95c654
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A08Z&sr=b&sp=r&sig=eKTw9wsUr4sVaTkbjOAx1kjAqQbHoxGmVWA5aBGy3vU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:08.7127247","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A08Z&sr=b&sp=r&sig=qLGgRFWjpPRS2z2dzfSjO4z6d3Q%2BHucvMxd8LOAVhHI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:08.7126538","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A08Z&sr=b&sp=r&sig=bq7h4oh%2FNuPVgN6nM9rZZMVbqyYTFZY9WCZ%2F9ZXYBqw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:08.7127398","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1578,9 +1614,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:31 GMT
+      - Mon, 30 Oct 2023 07:29:08 GMT
       mise-correlation-id:
-      - fed12f95-510d-413a-b325-4a5e8d49a11a
+      - b03c0d6d-85b9-4a1b-81fa-02d2a0524610
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,10 +1636,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A37Z&sr=b&sp=r&sig=LgYteABW1vVEa%2FpNN8L7qr7HDFkQrMYSYMr70LWs%2Bws%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:37.0958108","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A37Z&sr=b&sp=r&sig=5CBS8VON6dY%2BsgBGE9OuthyPm%2BdZV3cd6bcIX0p3mUc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:37.0957423","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A37Z&sr=b&sp=r&sig=k9XTFnAmb4w1nPJBaDbZ0sT0nulWFlMtwkfUxoG2%2Bxk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:37.0958247","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A13Z&sr=b&sp=r&sig=ESPgA7w19ubCZ%2BkfJDiqVzKrEAwseQlovkmgDp1ZaQE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:13.9598072","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A13Z&sr=b&sp=r&sig=8enol2PWfkiF0ow2n%2FTHX6YONPwdOr3DTvZGZkDNgts%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:13.9597275","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A13Z&sr=b&sp=r&sig=5Je%2BHDU3fUQi0W18zZzmGPwh7MwZeZp7pqLHWYhxGKk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:13.9598243","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:29:13 GMT
+      mise-correlation-id:
+      - d4343f2c-4f57-4125-92db-69e7ac8e38b8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A19Z&sr=b&sp=r&sig=wXgn4Zik54eKSWfFbdqKXwEyOvGB%2BvI8deB7MDZmtOw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:19.2701759","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A19Z&sr=b&sp=r&sig=HWXGPikUAHpLisFm5It%2FvYn5g7n%2FurSvjRtGyMFSaEk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:19.2700847","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A19Z&sr=b&sp=r&sig=d4WLDpcsu3MVSizA9GfXDAFA0iGtnH0lWIUjnSxnPV8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:19.2701989","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:29:19 GMT
+      mise-correlation-id:
+      - 4b827bd1-0f4b-4ab7-a9d0-aee42ac7815e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A24Z&sr=b&sp=r&sig=Gy2FHpq3czgeptHoJ5H0W6zXu%2Bciy1o7461koq15nBk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:24.588397","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A24Z&sr=b&sp=r&sig=Q6RYKAGd8lPAK0nolLphQ9A9PueXwHcPZFmT6ERhJik%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:24.5883115","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A24Z&sr=b&sp=r&sig=HPBka%2FfauocB1M1w2NWbXNk%2FYbsuqDvIKzGLLsHz0Ic%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:24.5884192","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:29:24 GMT
+      mise-correlation-id:
+      - 497d8f95-a717-4c29-839f-d7dc5c418c77
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A29Z&sr=b&sp=r&sig=mSAR%2BiEy%2FJHypnKbJeIvScda3qN2jLh%2FEupnR1qGzP8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:29.83872","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A29Z&sr=b&sp=r&sig=IwzSFZgggfKE0QNpa6JZ%2FfMMJommYckbCJktgWCuRPA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:29.8386503","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A29Z&sr=b&sp=r&sig=zHZN%2Bz4ruEIWNd3cJ4ushVkpuIn%2FcdAjfWGCW7WykVI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:29.8387386","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1614,9 +1758,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:37 GMT
+      - Mon, 30 Oct 2023 07:29:29 GMT
       mise-correlation-id:
-      - 73876809-f040-4acf-9363-17ff9280d3c4
+      - b541eb44-2143-4a2b-a948-7e198f596786
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,10 +1780,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A42Z&sr=b&sp=r&sig=yPvMOiD6DEfb0CdEcNIvpG90tbUcjez7AjOCcKynRWs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:42.3509463","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A42Z&sr=b&sp=r&sig=URpEH8rjJJjksoRTr7qm2Vuyyqckelt9%2Bb6%2BEojJwSk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:42.3508786","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A42Z&sr=b&sp=r&sig=i6D%2BV%2F%2F3W6mJie1PrE6DcRMNZffqLSJSBH1DbroeMT8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:42.3509611","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A35Z&sr=b&sp=r&sig=QqF%2Fqb9fJWOPH6hOtGuV71YhDXc6mq7mgEC%2FIhbiVJM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:35.1354081","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A35Z&sr=b&sp=r&sig=1zGmVpxR8PdwEcnFYoIvszNs03Zb1TeFk2FsE5Yym%2F8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:35.1353222","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A35Z&sr=b&sp=r&sig=2xlZX9u8cqeIMCpxQ3vhJpmeda4O%2B0ow8N%2BkTEFcq7A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:35.1354219","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:26:55.816Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:27:47.176Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1650,9 +1794,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:42 GMT
+      - Mon, 30 Oct 2023 07:29:35 GMT
       mise-correlation-id:
-      - f05711c7-1e72-4879-b4dd-f2801e71d7e8
+      - b56cdd5d-2cd7-4617-b77f-058cffcd28c6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,132 +1816,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A47Z&sr=b&sp=r&sig=Jyrb%2BBy2LXVeI0Z3htzDgJy74EnsUYCb0LYZKwB0bG4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:47.6049756","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A47Z&sr=b&sp=r&sig=5q6I4DFTcrOLT0FvqriTHQY2a%2BybGWwl%2FabKuaN55O0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:47.6048791","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A47Z&sr=b&sp=r&sig=DvQHjXX7hDKKRlSoOHsJo%2ByME5ntY7GXZoFBoh11VFA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:47.6049913","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A40Z&sr=b&sp=r&sig=2zODUESBL1s6WVGb3C3PqAXhRkZmyMlUDmBPuy1sluY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:40.47711","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A40Z&sr=b&sp=r&sig=rrh9j7pCJVclKjsW84DnOiUECUscDrZVDrDJyWtPVrI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:40.4770451","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A40Z&sr=b&sp=r&sig=wuERabXqwIVe%2F9Xm1YElSBoD2HzfoX8%2BAGTWqEcxYyU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:40.477124","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-30T07:26:55.816Z","endDateTime":"2023-10-30T07:29:39.8Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:40.009Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3190'
+      - '3316'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:47 GMT
+      - Mon, 30 Oct 2023 07:29:40 GMT
       mise-correlation-id:
-      - 8f3cd646-d027-40ee-b873-7563027dac4b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A52Z&sr=b&sp=r&sig=XVToJkn4BN0x4t%2BWd9dZus4UnnYBG9W%2Fm6fGiyvt1Hg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:52.8498142","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A52Z&sr=b&sp=r&sig=gpuWWqXejleXRNh7vzBXFmQzBaSeB880qFumYWNiIuQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:52.8497304","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A52Z&sr=b&sp=r&sig=32F1wL%2FOBXzAt33%2BLCIb6X5hxcYEJMerFdVelDkiyzA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:52.8498348","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:29:52 GMT
-      mise-correlation-id:
-      - 16715bf2-b00a-4d89-bcff-84541b2343a5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A58Z&sr=b&sp=r&sig=de3DOUm8I1p5AZHhfOlvyMDlPivxI68fXXbOFvnbR3E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:58.1149621","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A58Z&sr=b&sp=r&sig=g90EcpXSI75ncxXZD6awhuGuDoldoMrNlbO8ggm5NWA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:58.1148904","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A58Z&sr=b&sp=r&sig=34DdUHRHx6cW4tLDs7l11vJjqEkZjKsqvmGGJozYuto%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:58.1149788","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3182'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:29:58 GMT
-      mise-correlation-id:
-      - e3d27b0a-8262-4428-a269-4bbeae0d3a05
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A03Z&sr=b&sp=r&sig=aNuF3bTKcV5qM624IgmeLh2e9lkknGtUq2ZEBPLk4vk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:03.8078766","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A03Z&sr=b&sp=r&sig=bCyDOlJfPE6Q6xv8SwPHyD%2FXLDwUIK%2BNLbUCrXreJb8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:03.8078054","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A03Z&sr=b&sp=r&sig=9msRlilu8WzEn336mpTMVNesbMp1HToMkksoa6U%2BlN4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:03.8078919","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-29T22:27:23.963Z","endDateTime":"2023-10-29T22:29:59.602Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:59.754Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3323'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:30:03 GMT
-      mise-correlation-id:
-      - 919fd0a3-8045-418e-9b07-7a41c3af3684
+      - d9f24285-e76a-4a7c-a893-062b0780b7a6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,7 +1856,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:26:24.0632488Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:26:24.0632488Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:57.2139165Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:57.2139165Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1829,9 +1865,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:30:04 GMT
+      - Mon, 30 Oct 2023 07:29:41 GMT
       etag:
-      - '"3c005c31-0000-0100-0000-653edc120000"'
+      - '"3f003772-0000-0100-0000-653f5a860000"'
       expires:
       - '-1'
       pragma:
@@ -1861,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=show-test-case&api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=show-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A06Z&sr=b&sp=r&sig=FNBQJnpFEr3AyyNTWhXz%2FgKTTdGgt8AsB5YupyNCQIU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:06.077065","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A06Z&sr=b&sp=r&sig=X9%2BXCds8SSC1rXTZlyMeKkHOD7YuWf3N1z%2BSAL2cHKE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:06.0769821","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A06Z&sr=b&sp=r&sig=6YDH%2BQ%2FvGAD2PWrmf2%2BKQ5BP22JOtfmRgfXd4uzOvJ4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:06.077086","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-29T22:27:23.963Z","endDateTime":"2023-10-29T22:29:59.602Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:30:05.784Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A42Z&sr=b&sp=r&sig=aTj33qMZIIYzCiejWGN6%2Fw%2BwOJt0SW2C4irZyN04Q1M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:42.7304906","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A42Z&sr=b&sp=r&sig=1cW%2FP7QfF%2B5XidYEMAzPOmnsoCPUk7puRVhwEnXbxck%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:42.7304125","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A42Z&sr=b&sp=r&sig=TvLlizSOvtSPK6oXDBu3XKhUQ3hIpEYkkLXMQ5%2FGG8U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:42.7305066","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-30T07:26:55.816Z","endDateTime":"2023-10-30T07:29:39.8Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:40.009Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3339'
+      - '3337'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:30:06 GMT
+      - Mon, 30 Oct 2023 07:29:42 GMT
       mise-correlation-id:
-      - 97761943-1214-4761-83a4-5bba23c40434
+      - f52b3983-91ce-4223-9a8b-b1f7ffd758c5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1901,7 +1937,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:26:24.0632488Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:26:24.0632488Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:25:57.2139165Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:25:57.2139165Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1910,9 +1946,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:30:06 GMT
+      - Mon, 30 Oct 2023 07:29:43 GMT
       etag:
-      - '"3c005c31-0000-0100-0000-653edc120000"'
+      - '"3f003772-0000-0100-0000-653f5a860000"'
       expires:
       - '-1'
       pragma:
@@ -1942,24 +1978,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://bbe8689e-cab6-4084-acf1-a090ac4ba53b.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A08Z&sr=b&sp=r&sig=Z9M8GZRXQ8nG9w3bEnclkr2%2F3T3eml12Qmw2p9%2B%2B4Vc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:08.4332433","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A08Z&sr=b&sp=r&sig=cBTgOwyaOsJsSYQzl6Bxt1bKY2oVJKdCqvRPUtMFqXU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:08.4331467","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A08Z&sr=b&sp=r&sig=JUyCdm1TV9qf0fiFtXEQdYNtxrVf9xSVYEZzSuV73dY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:08.4332662","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-29T22:27:23.963Z","endDateTime":"2023-10-29T22:29:59.602Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:30:05.784Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"eb09de58-960e-4810-98ca-ff827253eb0a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"581ed9b2-1b69-4c65-9e12-99ebefe90d72":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1a03473d-5e23-40fb-b9ff-05bf5bf4d29d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/93eafd2e-2046-40a7-846e-f825e64b193f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A44Z&sr=b&sp=r&sig=ZPZvP1f5qMS6DQK00b7%2FXnrnCjutyNxpz%2FoevmzlhPE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:44.9564352","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/292e93d9-f097-4e23-a1af-e470007e3f39?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A44Z&sr=b&sp=r&sig=KXS%2FZczvz3Fv%2Fnttsqwm4pjnBjabNV1%2BXUL%2FurWFvgQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:44.9563695","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e6ce5f2-ef59-41ce-b00c-50e48cec87a4/baa69acf-d3f4-4832-a84a-79b4607745e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A44Z&sr=b&sp=r&sig=d0GVSJBl3rrrNE%2BGfWbMb2R%2BrDTgjBsUejLivSDgZ4M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:44.9564499","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-30T07:26:55.816Z","endDateTime":"2023-10-30T07:29:39.8Z","executedDateTime":"2023-10-30T07:26:55.186Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-30T07:26:55.431Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:40.009Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3323'
+      - '3331'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:30:08 GMT
+      - Mon, 30 Oct 2023 07:29:44 GMT
       mise-correlation-id:
-      - f21cb2f9-58e8-45e2-9e34-5d54c7a78583
+      - 47896ff7-17bb-4b81-8094-917cb304fa02
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_show.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_show.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:48.0691178Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:48.0691178Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:11.7118206Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:11.7118206Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:22 GMT
+      - Mon, 09 Oct 2023 19:23:46 GMT
       etag:
-      - '"9201d1da-0000-0100-0000-652427710000"'
+      - '"56002ea3-0000-0100-0000-652453210000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:17:23 GMT
+      - Mon, 09 Oct 2023 19:23:47 GMT
       mise-correlation-id:
-      - 12872da1-9b6a-42d4-9374-1a478c0002dd
+      - 93483d6c-35c8-4cb3-b3ef-6e5b4a29fdcf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"c3a745bb-a584-45d1-9754-d1648cc87359": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "9873454c-3b04-494f-8b78-517d55640068":
+      {"passFailMetrics": {"2d828163-cd89-43a0-82e8-45ff414c793f": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "198a8c96-1fdf-43a5-953e-4365b55e501f":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "230c0ec6-69bb-45b4-9c47-cc0c852d42ad": {"aggregate": "avg", "clientMetric":
+      "50"}, "e156d481-b9a9-4175-8796-aa08651643f1": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:17:24.124Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:24.124Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:23:47.577Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:47.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:24 GMT
+      - Mon, 09 Oct 2023 19:23:47 GMT
       location:
-      - https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+      - https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 958a28ff-f0c6-404a-840f-98ec215b45b0
+      - 70c8bb7f-efd3-4f1f-9f0f-4e33bc931021
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:24 GMT
+      - Mon, 09 Oct 2023 19:23:47 GMT
       mise-correlation-id:
-      - b8fd79a4-53fe-4a10-baa8-618842dfa144
+      - 33e0388b-d966-44a5-912f-7edbd6c290ef
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A24Z&sr=b&sp=r&sig=c%2Fz3oeeWRa7R0wymO2RvdsJO4VNzLewSB4S900J8ulk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:24.9914471","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A48Z&sr=b&sp=r&sig=8YqKmg55PfJPpv14ffxscnCdsfFkvMtlWbvrPdUzV3g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:48.4772332","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:24 GMT
+      - Mon, 09 Oct 2023 19:23:48 GMT
       location:
-      - https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - f6c9e66a-ccdc-4a8a-9728-16ecd7751dee
+      - 83aaca1c-8ed4-48f1-8b9c-836a98049d77
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A25Z&sr=b&sp=r&sig=tTbOBLomcVCjjX%2FRuGiLY%2FjoNwHEFGH%2B0vLw82Runl0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:25.7102629","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:25 GMT
-      mise-correlation-id:
-      - f9b3cdb4-bfa2-4fa4-9aaf-6137bdaf63a0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A30Z&sr=b&sp=r&sig=oUj19elFLsdSgwZl%2FqNJBUiWMLDBCqWy4Vp1mptkhHg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:30.9821474","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:30 GMT
-      mise-correlation-id:
-      - d659cd7b-d7b3-4225-abf0-e38029e0eda1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A36Z&sr=b&sp=r&sig=vynmMOa3DC90F%2FYWEHfgAylIaQ5eIPjVS4VhKOB9Q5Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:36.76704","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A48Z&sr=b&sp=r&sig=BJxGadcN7PkbWlPPf0U4J3phTfSah3JDu9f6aI6k5y4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:48.8107275","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:36 GMT
+      - Mon, 09 Oct 2023 19:23:48 GMT
       mise-correlation-id:
-      - 3dc10cb5-e2ae-4c5e-bea8-7d45eb2e1c29
+      - 5ea5e815-3fbf-40f5-97d2-f1f6ea3d6e45
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A27%3A42Z&sr=b&sp=r&sig=CkdWpzMg6iW7hvxqZdS4TGrVDYdsFwBR0uQmjDYE0QI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:27:42.0586465","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A54Z&sr=b&sp=r&sig=vC8pdLJ0ejuwk8KK0sQzQIzldr0ZfWOh9vvgKRWF570%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:54.1310637","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:42 GMT
+      - Mon, 09 Oct 2023 19:23:54 GMT
       mise-correlation-id:
-      - 28737e2f-f2ef-4856-bab2-66aecb05d74a
+      - c63982d4-da87-4682-92ce-7d170ac40c63
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +385,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A42Z&sr=b&sp=r&sig=zjDme2sMu3o4n53kcFHw%2Ff6dQ6p9Z5uq7rLRBwT2r5U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:42.3343296","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:17:24.124Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:37.9Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A59Z&sr=b&sp=r&sig=myVIa%2BH5eiRw13OOZrRvZEu71ClQzMF%2BT8RkrFwi2iM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:59.4155517","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1575'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:42 GMT
+      - Mon, 09 Oct 2023 19:23:59 GMT
       mise-correlation-id:
-      - a4b272eb-32f5-4a6e-a45e-c6f2b97adebf
+      - 7c31eaac-a019-4887-854e-043c57949a33
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A34%3A04Z&sr=b&sp=r&sig=91ROY4MUzrOmqZcYsc%2BVMQ1iA4TLpK248Ze2j4zVCSM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:34:04.7718565","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:04 GMT
+      mise-correlation-id:
+      - 397c2752-de79-49ce-bc5c-256549214d90
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A05Z&sr=b&sp=r&sig=EqiwpzRKf53%2BDlLadN4c9P%2BmU1GCcd%2FYKx70jaB8oxo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:05.100397","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:23:47.577Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:02.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1580'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:05 GMT
+      mise-correlation-id:
+      - a8b33bd2-ab44-484a-9447-1f5eabbcbf06
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:48.0691178Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:48.0691178Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:11.7118206Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:11.7118206Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:43 GMT
+      - Mon, 09 Oct 2023 19:24:06 GMT
       etag:
-      - '"9201d1da-0000-0100-0000-652427710000"'
+      - '"56002ea3-0000-0100-0000-652453210000"'
       expires:
       - '-1'
       pragma:
@@ -538,11 +538,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A44Z&sr=b&sp=r&sig=wXKD8OaPaUAFYX1vngo9LctJ3M8E%2Bf5pfTsoW5wKQ7w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:44.6022952","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:17:24.124Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:37.9Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A07Z&sr=b&sp=r&sig=T7QlpFIAU2hdIZsNeRf3ZdUYZq35cRrZqnERRIHvfaw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:07.8006197","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:23:47.577Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:02.442Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:44 GMT
+      - Mon, 09 Oct 2023 19:24:07 GMT
       mise-correlation-id:
-      - dd8085bf-b52d-4360-be96-fd25a6d24cdb
+      - ae3246df-b44c-4bcb-99d6-6fd9265feced
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:48.0691178Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:48.0691178Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:11.7118206Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:11.7118206Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:46 GMT
+      - Mon, 09 Oct 2023 19:24:09 GMT
       etag:
-      - '"9201d1da-0000-0100-0000-652427710000"'
+      - '"56002ea3-0000-0100-0000-652453210000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:17:46 GMT
+      - Mon, 09 Oct 2023 19:24:10 GMT
       mise-correlation-id:
-      - bc84b9fd-d8d2-4947-841e-246adb755bcc
+      - c3ea32d0-bdfc-487b-afeb-b641709b395e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A48Z&sr=b&sp=r&sig=kh52zmmtGlkdsWxG2OdBaTz89UclWHkEbucovW1E7a4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:48.5656139","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A48Z&sr=b&sp=r&sig=AyTXj7NRQL8tckuyn%2F%2BhtnClu%2BT1ZfFBSmndxx1NrVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:48.5655109","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A48Z&sr=b&sp=r&sig=FKKrPdyJlAY3kFjwj0vKZVQ9c0BvM8CALw6u5nSAcSs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:48.5656284","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:48.493Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A11Z&sr=b&sp=r&sig=8yTpkVBptonhlEid1KcZyLW8PMJNuE%2B6MmLGa%2Biv690%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:11.8755906","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A11Z&sr=b&sp=r&sig=x2RM0l1A3JDRTnXnnECD2z9%2BzoF6%2BxD95AKGb13YDMg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:11.8749738","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A11Z&sr=b&sp=r&sig=KRJAsiz42%2FeTbQY3dzgzak90U%2BnNkl0tK%2BADT5dJ5O8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:11.8756518","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.783Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3144'
+      - '3152'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:48 GMT
+      - Mon, 09 Oct 2023 19:24:12 GMT
       location:
-      - https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+      - https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - d7f59e9a-a47d-4576-a395-aa9f3d78a652
+      - b01617c0-4f7f-4b8b-9883-20006647a85a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A49Z&sr=b&sp=r&sig=ndBszNSYNEJ%2FRcBKOvZ7oNtAiffEYgRWOcT1vxVUZ3o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:49.0196522","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A49Z&sr=b&sp=r&sig=9gfWy8SDGFxYmvqqpLRkwo3XtA7retTLeC%2BS48%2B1rxo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:49.019587","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A49Z&sr=b&sp=r&sig=V2imVxmtl0c9YfV5aqpwgVeTJNpLYiNCFWYyEUvDtek%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:49.0196895","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:48.952Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A12Z&sr=b&sp=r&sig=uYqL7M%2F%2Byr6rjitQcO9moWJ90gTIWsysSYZwT5doq8Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:12.4659972","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A12Z&sr=b&sp=r&sig=F920c8B5IyIYxH1K%2F4ejwd7KoTpELybcRQRscDZM7tc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:12.4659126","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A12Z&sr=b&sp=r&sig=qqXj5a6Ww6z3AmHD5lvLmAhsuvzPLlLgbWhPTWizFWM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:12.4660178","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:12.295Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3188'
+      - '3189'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:17:49 GMT
+      - Mon, 09 Oct 2023 19:24:12 GMT
       mise-correlation-id:
-      - cff0095d-a73e-4cbb-9473-440928ccce54
+      - 985a90bd-5327-4737-8f29-d1c37ef4434a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,190 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A54Z&sr=b&sp=r&sig=Hcp6s%2BZhF%2BFyNKe%2F95wcHbxhHiMx9qnvk7fUO5t77gE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:54.3013288","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A54Z&sr=b&sp=r&sig=xC3TuN0rLPBNreeA1uq1oIEyeipXza0OmyzzHnAvYRE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:54.3012614","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A54Z&sr=b&sp=r&sig=HDuH8Hne0GcF94huH7QDMQy7sVuAgYB6N8JOwyhVUUc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:54.301345","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:49.146Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:54 GMT
-      mise-correlation-id:
-      - 7fc50e1a-77ac-4014-b3c3-437363115547
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A59Z&sr=b&sp=r&sig=ChmA0k33sf9%2BI5tRpuAHvnuEiPbqTvVhkC%2FUi66mcak%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:59.5927107","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A59Z&sr=b&sp=r&sig=%2BHp0WiQ9hY%2FcuPTG5r6c0Sz9uMvhZxnWJqPJlLAWBD4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:17:59.5926112","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A17%3A59Z&sr=b&sp=r&sig=sC6h%2FJgKjKxLtwaq6vSh2HAUMg5w125gTlR7yYw96HE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:17:59.592728","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:49.146Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:17:59 GMT
-      mise-correlation-id:
-      - 54f3de6f-4c0e-4eae-ac66-f0af4866fafa
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A04Z&sr=b&sp=r&sig=tWOfNaMdHS0N1xKxhCp3J3hHaiUB9sOIXtRTo%2FRMZeA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:04.887335","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A04Z&sr=b&sp=r&sig=RiI2lmMf8GiiVHQpyEyiXBJeglomYCotnCWS1N2Ee%2Bw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:04.8872654","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A04Z&sr=b&sp=r&sig=zOJr%2FEwuIQF%2Fyim9kb63xFSr9RsUJxVEmX%2BP4uedItA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:04.887349","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:49.146Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:04 GMT
-      mise-correlation-id:
-      - c21dd87f-44e4-48aa-8f18-b51ef5916da8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A10Z&sr=b&sp=r&sig=AFOaZsyZuDR6ZLRlqIUGoY3j3O1yLBXxB1C9tFQPkyA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:10.1611151","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A10Z&sr=b&sp=r&sig=c3z0TaN0ZsCaOq1FjyPvYiMpYDDUnBbwK7iWkFy0rug%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:10.161032","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A10Z&sr=b&sp=r&sig=QCFX2F1QnZral2O2TGt6vSF6XKi%2BBNJ7PSN11iYtqCA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:10.1611362","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:49.146Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:10 GMT
-      mise-correlation-id:
-      - 1b226c02-463e-464f-9002-88cb72747228
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A15Z&sr=b&sp=r&sig=RYR4aAouPXFK07tn5vojzONxAqhcjUBI4E2qvWHN1so%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:15.4874096","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A15Z&sr=b&sp=r&sig=IwDkYGjmVzbweEJEZmUDOrBOu2nCl9EQYfm0lbnKRG4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:15.4873423","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A15Z&sr=b&sp=r&sig=9U19MX6Nc4leflnq%2BPYaVHmS7elsqHWRVEjpDAEqaZY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:15.4874248","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:49.146Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:15 GMT
-      mise-correlation-id:
-      - 2cf609fb-a64e-4bb9-ba5d-32ca86060e9b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A20Z&sr=b&sp=r&sig=t7Uz5zixAeWmpYrgeBdaXN2jkeVMK02gBrphwQ6LdXI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:20.7725796","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A20Z&sr=b&sp=r&sig=9%2BlSLUsn%2Fg%2BuJFMJLbTIW2KHe2%2Figtr%2BVD8KPdVjQ2M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:20.7725081","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A20Z&sr=b&sp=r&sig=YWYHpJ%2B1K3yoHK55stwk4qWaqpArQ0LywBSssSxiYS8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:20.7725937","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:49.146Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A17Z&sr=b&sp=r&sig=jDn7hbBB86AfPItPNHrM%2Fs7xJeFKoITYMHL3YJJIvGE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:17.7818884","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A17Z&sr=b&sp=r&sig=45nPyEvDZO%2FTEusGW8vLxa2zrD1dr678fa7M1R2X6nE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:17.7818193","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A17Z&sr=b&sp=r&sig=%2BQvYY2OPoB%2BgoxVLRSv%2BoS7%2FmbOR7fw1mwJCOhqtHHc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:17.7819025","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:13.384Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -930,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:20 GMT
+      - Mon, 09 Oct 2023 19:24:17 GMT
       mise-correlation-id:
-      - 1c665132-1ed5-4bbd-9c77-e48d3c737917
+      - 26f10cbd-2422-44d6-8e3d-45ff35993ce0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -952,10 +772,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A26Z&sr=b&sp=r&sig=rBYTCVaNd7CvUlFmSQYdVPUBOvKnoza7y7QgN7hBfVI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:26.0397579","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A26Z&sr=b&sp=r&sig=fg90%2FfJjRkNh%2BBIYQ9u8HvRqDbIVdEM4lDJLVoSlBgE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:26.0396675","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A26Z&sr=b&sp=r&sig=ep8A3polpdcELDfCSSijmf2DWWJzUieE4QfR%2BWg4oSw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:26.0397736","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:17:49.146Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A23Z&sr=b&sp=r&sig=BcH78WBzD%2Fc7O%2FSyYdKXBD9pvJFhLdH9MUjyJvXiDCM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:23.0883427","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A23Z&sr=b&sp=r&sig=rwAaYGQuqDmm%2Ba%2BYh4%2FFb1uKP1o1vAe9r3eUx40c%2BJw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:23.088239","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A23Z&sr=b&sp=r&sig=xlu9Ydp1XVHByFkKKL8fiHmt5z0ehDwA5JKmxC1oOa8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:23.0883694","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:13.384Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:23 GMT
+      mise-correlation-id:
+      - bb10fe64-b74e-4c36-bc18-a7426715b7fa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A28Z&sr=b&sp=r&sig=ABkJHMRGVKPOyATlUCrTSfXrm2txC76JNeeBYGjIcRY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:28.4384914","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A28Z&sr=b&sp=r&sig=GmSbEve73ZtcQeNI499ZJVIanapg65B7ZBYujoWY4dI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:28.4383971","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A28Z&sr=b&sp=r&sig=eL6G5%2BNH3TbeLWzhFSsPZNGuHFsB%2Bt093%2FKzOP1xAnY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:28.4385176","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:13.384Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -966,9 +822,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:26 GMT
+      - Mon, 09 Oct 2023 19:24:28 GMT
       mise-correlation-id:
-      - edffe75a-08b2-4e45-bed3-86bddf2dab1c
+      - 3b3c07d0-61df-43bb-8edd-9279f6129f45
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -988,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A31Z&sr=b&sp=r&sig=gR9%2BQhlMLa46n3Q5Vw9QEloG9Ik7ytH267IYXlZkJXQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:31.3326446","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A31Z&sr=b&sp=r&sig=UppRaepW%2BNSoWQNaFQyzhgNFLEqedRRUjdjmTmktegc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:31.3325606","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A31Z&sr=b&sp=r&sig=CbaV4VYWPk%2B4OdFyFwZCxbek5PwgkvfkYQyGO%2B6csXs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:31.3326668","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:30.724Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A33Z&sr=b&sp=r&sig=WSr3LFxHLY1O%2FHbrHrjoSmHp584rB9S9G6Po3ThtgKg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:33.7304538","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A33Z&sr=b&sp=r&sig=xUxnPqHaxsk7wCGbOI4T1cwy2MIouIlXVZ3iwN092H4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:33.730369","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A33Z&sr=b&sp=r&sig=tBAmzgD78H1YyBuPOD3J%2FDhj7f4TjBsDZ3axKZAnYLs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:33.7304753","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:13.384Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3192'
+      - '3188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:31 GMT
+      - Mon, 09 Oct 2023 19:24:33 GMT
       mise-correlation-id:
-      - c31adb32-1305-41ff-abad-1a04f7f1f3ec
+      - 3580c5f5-04b7-4889-9cc4-62cd4e651987
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1024,23 +880,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A36Z&sr=b&sp=r&sig=7kyjyqAjL6ZObW1UpUKl9I9qyyS5%2FTax4pq3F37CycE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:36.6140815","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A36Z&sr=b&sp=r&sig=A05k6cqQxufEjh%2BafIWCrme%2Fnt1z3ck5KSSRcvfr97M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:36.6139857","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A36Z&sr=b&sp=r&sig=GF1%2FSAeYLpNkI9TzhsFXClVmmcdni%2BT9h1Mlvop1mLU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:36.6141001","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A39Z&sr=b&sp=r&sig=S6uAf2206ZIrh8%2BHVPC%2B7isTNkbB7It2xJpez5ixmnI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:39.0852928","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A39Z&sr=b&sp=r&sig=OhpdsEkd8mW5z%2BGU6dRBXp9juwOw1tTa2s9qYcc2IxQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:39.0851867","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A39Z&sr=b&sp=r&sig=4mYddFl123bfBtDQfwj2Hf2NSAScplu1l93JymA%2BHSY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:39.0853086","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:13.384Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3192'
+      - '3193'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:36 GMT
+      - Mon, 09 Oct 2023 19:24:39 GMT
       mise-correlation-id:
-      - d9049736-c4e4-4fb2-9e22-5256123ccffb
+      - e250acdb-060b-4e03-b571-0a38ecfe95d6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,10 +916,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A41Z&sr=b&sp=r&sig=i%2FpG9SaREjnQLB3IhTEbwjmqnOr2rkK34q98BgMUMqE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:41.8956617","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A41Z&sr=b&sp=r&sig=zcaC1jRsaEmEYZ4kaAuTkeDBjDreCTl%2F5e686MNEbGU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:41.8955771","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A41Z&sr=b&sp=r&sig=28imxF7GfpQyvQa3FPOhmKqJLZkEETPynhyzAHxEepA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:41.8956783","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A44Z&sr=b&sp=r&sig=mzBxQuh5Tj%2FfheO6lzgMUvHhLhpCx2xUTPj0hokGoNA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:44.4034047","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A44Z&sr=b&sp=r&sig=nzH8OzZp1nQv5RwutDOZw3nQyOtg9f6T0SyT16JdVnA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:44.4033282","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A44Z&sr=b&sp=r&sig=h2ur1s5vg1%2FYiTl61ttx2YekIi%2B2raeX1YCGB7lS%2FRI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:44.4034202","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:13.384Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:24:44 GMT
+      mise-correlation-id:
+      - d4fff7e4-cca8-4f69-8514-4d1688e09498
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A49Z&sr=b&sp=r&sig=Fr7MjedipvaAKZegcMd1txDRHHlrN3Kn4rHJdjtWNZo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:49.6804919","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A49Z&sr=b&sp=r&sig=GGnxqPzax68dgLYns2A5gGYvk1FVBXWKcxcznkD95%2F0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:49.6804212","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A49Z&sr=b&sp=r&sig=mKdKNPvjDNzosBGBUObcuC7dCUsxZoNx4mxG7usOOZw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:49.680507","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:13.384Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1074,9 +966,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:41 GMT
+      - Mon, 09 Oct 2023 19:24:49 GMT
       mise-correlation-id:
-      - 6bd6fd12-8cd3-4aec-9ed7-f3f57aa22481
+      - 577b68bf-7af3-49c3-ae15-ea404a55adde
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1096,23 +988,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A47Z&sr=b&sp=r&sig=735BNCw8%2BtwBtTc4sJ0C1k6WHy9EnbIQMniaPoKcE0k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:47.1764717","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A47Z&sr=b&sp=r&sig=DgYKIvb3NBWyqxhIhQvcrHvX%2FE0HM4xSJ9YFWH%2BYTf4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:47.176363","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A47Z&sr=b&sp=r&sig=5klnaXwJmF7BGa2sn2js9K%2By9gDLSLEhomfD7C9sYHA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:47.1764947","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A55Z&sr=b&sp=r&sig=TEAO3tZb7Fvr3%2Bu6jn9wwsLTgopwJ1u%2BsQwUCju1R5E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:55.8127531","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A55Z&sr=b&sp=r&sig=RQgXTwpR48Z4166OO0gqWRUaSrGq%2BMv2n7d3sPqchNc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:55.8126703","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A55Z&sr=b&sp=r&sig=i0dyaRanuWLEIPfVLPf5Vjs89Hlcy5LCNv232QRa7oM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:55.8127746","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:13.384Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3189'
+      - '3191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:47 GMT
+      - Mon, 09 Oct 2023 19:24:55 GMT
       mise-correlation-id:
-      - 1dbb5f9d-4a43-4392-9a11-5944c163ad4f
+      - cc131c91-550e-4047-88e9-8a37024eac78
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1132,23 +1024,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A52Z&sr=b&sp=r&sig=nLfP5n0%2B8p66r7TchaUKpkvCbXu0tXIjfXyosNMQzuY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:52.4655739","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A52Z&sr=b&sp=r&sig=YWh%2FkGPlI5AXizSVboLJcv8w%2FJ%2Bhnzsqp0mzBXfVpTU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:52.4654813","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A52Z&sr=b&sp=r&sig=JAt7Im%2Bj0B44zKCCkUG30yuVFE%2BaBuPtHkRRui0U9oA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:52.4655948","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A01Z&sr=b&sp=r&sig=ZMb2hbMlKsjlKsZOy296N7Fi4VEjjpxHPWMOXhdBFB8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:01.6958626","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A01Z&sr=b&sp=r&sig=8QWuhpxpaxgX%2F7mFqdfPb2t7MRB29mI2BzkD0UY1mx0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:01.6957722","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A01Z&sr=b&sp=r&sig=zUb0A1eauXHTeY96zjKVDrj%2Fp74TuxNpL041Cu1Mdz0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:01.6958843","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:58.642Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3194'
+      - '3188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:18:52 GMT
+      - Mon, 09 Oct 2023 19:25:01 GMT
       mise-correlation-id:
-      - 0511c4d4-be2a-4ed8-9c09-1fc99921c19e
+      - 548aa51c-bd0c-40cf-8b63-648d4067c31c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1168,46 +1060,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A57Z&sr=b&sp=r&sig=I8zUP9aA1nnHEKQuc9LWdcb5Q9dPXCAZidLgrTw48UM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:57.7353184","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A57Z&sr=b&sp=r&sig=2sli9g52yykY8hHBLLHVS8IeB0JqW3NsdIByDgZm5gA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:18:57.735229","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A18%3A57Z&sr=b&sp=r&sig=ZhnMFizfGHPhyKAL3zc7KNxDaQ9gQhYJtrAyk4FmMCk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:18:57.7353398","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3181'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:18:57 GMT
-      mise-correlation-id:
-      - 5a8b1f4a-96eb-4a2e-8bc4-ca1b86201f12
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A03Z&sr=b&sp=r&sig=6OcKaI27Wl003ZQZOoony3tXtu4ygnCS%2FZ2tKbVb9OA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:03.0325647","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A03Z&sr=b&sp=r&sig=4cThkcXPzXTrnG3%2BtAN6u3%2BVm1LkTBr6THxjC4mjSSA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:03.0324759","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A03Z&sr=b&sp=r&sig=hjH6RyW0noPyBaUVYRnn1m6ygoFDOltLmU5%2FvBrGj5c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:03.0325874","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A07Z&sr=b&sp=r&sig=oRgX6AxyUPYhv%2BH3BtKG7oPl6rTvvKtQkQXR27cqvOI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:07.0538627","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A07Z&sr=b&sp=r&sig=qB2RzjwGybsExACQ1YC%2BCGZuSX4Th1dS%2Fwh2p3imYMU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:07.0537923","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A07Z&sr=b&sp=r&sig=HOFb2cQgax7YvebWbuzePI9w9EXz%2BhPqHFgY6uNX2Kc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:07.0538771","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1218,9 +1074,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:19:03 GMT
+      - Mon, 09 Oct 2023 19:25:07 GMT
       mise-correlation-id:
-      - 07095c57-e5e8-4add-9b52-b956f69d6374
+      - a5169b12-f276-4efb-927e-32f4d136eb3a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1240,23 +1096,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A08Z&sr=b&sp=r&sig=EA4zgEx6PxIbtWXKQR%2BNR2bGToWPIpFD%2Fyx%2FrZcUpvk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:08.3126651","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A08Z&sr=b&sp=r&sig=J77oPtMR2Hc21GrXurNbIK5UA%2FsRRGmfmJg%2BhTsdYzk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:08.3125755","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A08Z&sr=b&sp=r&sig=n0%2FSh2cY2tLSus%2Byufm2Cn65SRmL8u1gfS3mhqcndkk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:08.3126864","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A12Z&sr=b&sp=r&sig=01jQEm7aBiTSkNbCkS5qu%2BAuhODRAaEICyq8mfK2UGM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:12.3659266","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A12Z&sr=b&sp=r&sig=sszdaEEGHGCbjQ0GDNhZjBkObLuBtzEFf%2BhABYbk6IA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:12.3658578","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A12Z&sr=b&sp=r&sig=W39ihSB9jD0Nn4O0GaE7idgThRyd8p2FmBzTcLpauLU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:12.3659407","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3196'
+      - '3186'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:19:08 GMT
+      - Mon, 09 Oct 2023 19:25:12 GMT
       mise-correlation-id:
-      - 4b7c94be-a8eb-45d5-9589-c3735f1f1a91
+      - 093acb31-54ea-40db-80c1-a2db83d1e055
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1276,10 +1132,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A13Z&sr=b&sp=r&sig=1nHOuBQg618HHH5afI2zv%2BAuo2sioAR3CVNJoZgfNm8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:13.5913403","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A13Z&sr=b&sp=r&sig=EhT5CPNxYJuuQOjgHspjsvbG5GM%2Bn%2F0Puj9kx5ObAmc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:13.5912589","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A13Z&sr=b&sp=r&sig=N9xKW1Ui3yFHpz6hJLDU2pbRLdeJfNkEuuZn1mizRVc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:13.591362","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A17Z&sr=b&sp=r&sig=JJke5z4bZFx93%2F0PfvHLwouwg1ZDwecltaYmq82BtYM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:17.6963065","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A17Z&sr=b&sp=r&sig=ZZH2q1Yy4CgHEgtSuwwMFYeCbULbDhL3bUmgjZm8wcs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:17.6962062","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A17Z&sr=b&sp=r&sig=jk%2FQx%2FG2puY7d6a3QZMDsxB5wXdOh%2B9wxnqzx9Ldrtc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:17.6963638","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:17 GMT
+      mise-correlation-id:
+      - 5ca3f0e7-b9a2-4aab-9e11-b1cb0cea2df5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A23Z&sr=b&sp=r&sig=rR%2BecSA%2BLuvq4ezVD6nWaUvF%2BUXEQocxZWI1wCV3VVI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:23.0156199","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A23Z&sr=b&sp=r&sig=Z3BybdFTyR8saRoqC8pLSa6LIlYTw9u9FdyQAL8kKJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:23.015514","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A23Z&sr=b&sp=r&sig=RuDj7N8b4uZedqYV1290dMBD7Ga3%2BejrNZpHu9tLY6M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:23.0156485","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:23 GMT
+      mise-correlation-id:
+      - 11379fe7-28fd-4e0a-8330-ad20f52f07ab
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A28Z&sr=b&sp=r&sig=LaB%2FQxdyQwtVPNbxOzMCpxtyyE9hVIOurtPgQ%2F3Fgn4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:28.3002165","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A28Z&sr=b&sp=r&sig=8xnsjsdh1L2Hj6UphQ9jgZAzipkzmA%2FLss8Wl9BtfI0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:28.3001394","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A28Z&sr=b&sp=r&sig=osWDOePwzbWmx%2BM%2BqaMEzLMhnvTQ1ZtgCu3w0Zgq%2BzU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:28.3002344","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:25:28 GMT
+      mise-correlation-id:
+      - 8a1d3300-f8d0-461b-897b-9e05682d29ec
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A33Z&sr=b&sp=r&sig=aQRlTlcGV8UufzoE22T%2FgL1CMtkfQCgGG52sBVuAcf0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:33.6588055","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A33Z&sr=b&sp=r&sig=1EFN0OOcd64Cxl%2FLvaZ4WEdWM6JAC4tLvFrfleLB7Ho%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:33.658755","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A33Z&sr=b&sp=r&sig=8LkzqEmtaVgdwipHfwJ2c3ZdrhHKMdSJ2gQ%2FmLV3qiQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:33.6588207","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1290,9 +1254,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:19:13 GMT
+      - Mon, 09 Oct 2023 19:25:33 GMT
       mise-correlation-id:
-      - ec30ca51-ceed-43c8-acfe-19196fd0dba8
+      - 66f26aa0-c55c-4998-bae5-650f860ebd97
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1312,23 +1276,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A18Z&sr=b&sp=r&sig=4HgAG9w7Dxbxn6OgBCIVK%2FPuyeQPIYU%2BXdw1OVtgxlg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:18.8688879","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A18Z&sr=b&sp=r&sig=cJB4d%2FoUKxQUbvW4%2FnN5td3FsnnDETp0o4USvtZF6KU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:18.8687715","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A18Z&sr=b&sp=r&sig=obRX0%2Fc4nUnfWdhMcrUYIW1R4iCg1v0g%2FYDWc%2FkzkdU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:18.8689116","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A38Z&sr=b&sp=r&sig=7WfBUOoGs5MqG2p1eCj1HRK5K8gkvdn83H2vOMK%2B668%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:38.9506443","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A38Z&sr=b&sp=r&sig=LU%2BX2Km64cxvfLE51t0Ap%2Fa0DSuXUZC3xZ6%2BCuHJSVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:38.9505713","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A38Z&sr=b&sp=r&sig=CKstRipqvOSUSv8qaQMyPtHs4UPdSbgc7tUxBI%2FX7BU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:38.950659","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3196'
+      - '3191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:19:18 GMT
+      - Mon, 09 Oct 2023 19:25:38 GMT
       mise-correlation-id:
-      - b20d14b0-becd-47ee-965d-0fb846ff3319
+      - 804933af-c34b-4db4-abef-fae0e0cd031f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1348,118 +1312,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A24Z&sr=b&sp=r&sig=jj5IlsQjE6lFdDuMpkOJRniLBGcDJeBv4PknABmYRa0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:24.1436127","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A24Z&sr=b&sp=r&sig=57bbjoMXWSUXUuDWG1uklwiSVeUev%2FXyzZ9pZnUsU%2BY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:24.1435408","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A24Z&sr=b&sp=r&sig=WyAa%2BBOt7tjVfhy0JxF%2FAumh5btFJQl8Wy%2FpaNqrMJc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:24.1436269","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:24 GMT
-      mise-correlation-id:
-      - 0f00f1a5-2315-40e7-9ad7-66f229013a03
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A29Z&sr=b&sp=r&sig=krWk5fi1u1IkmZKUDJjkUEN2NI1NgILv6e6J8d9a2VM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:29.4336672","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A29Z&sr=b&sp=r&sig=qgB6hjWXyK6i0iZgU7nX0rocgHqHJ3IDTE25ZHwodQ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:29.4335629","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A29Z&sr=b&sp=r&sig=fAQGOVfRo9aXpxGPHDnOiR97SkbZpCbuGUo5m%2B2%2BGEY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:29.4336925","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:29 GMT
-      mise-correlation-id:
-      - 5cb00304-83ab-4c40-a973-d806214b8788
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A34Z&sr=b&sp=r&sig=SSqfoXo1KjSuvVQB1fv5oRH5hCQSIs%2Bgr6CpbOAgEns%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:34.7106171","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A34Z&sr=b&sp=r&sig=4EPJ5AlLxJLLXzDyxmzAdx2gs7XmLXoWE9ZRdOzkB9A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:34.7105362","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A34Z&sr=b&sp=r&sig=JtWe7qNnRRfbEG6Bop07D43J%2FU4iFL65kDTu6X0Gyq4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:34.7106325","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:34 GMT
-      mise-correlation-id:
-      - 796223a0-4525-46ca-a2f4-94047fdc6880
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A39Z&sr=b&sp=r&sig=dTYMj40Ii3QwqFDDHIfYp7UsP%2Boxmb19a%2BJYdxxufrw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:39.9930844","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A39Z&sr=b&sp=r&sig=fuG%2F%2FmKgia1FWlQZjNsBcnDjYcm6l9UsarsHd9orwcc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:39.9930028","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A39Z&sr=b&sp=r&sig=7c4fmy3%2FiMDKsi2bw%2Bb0rRJjMb5m3fBf0Z22b4qnaW4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:39.9930986","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A44Z&sr=b&sp=r&sig=zHHC%2ByirPz6%2B6Ehji%2BZBjKmKiMR39zTOV%2BTw70UPCaM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:44.3119964","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A44Z&sr=b&sp=r&sig=QCouphbHUFzC8Yq9qIpeyq2OTl8Ngz3lvaYBJvRgiFM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:44.3119097","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A44Z&sr=b&sp=r&sig=5tbvMJnMKUMyMeNcVCNqLE%2BwD2eLZOCRIRO6Fq%2BseTs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:44.3120173","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1470,9 +1326,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:19:39 GMT
+      - Mon, 09 Oct 2023 19:25:44 GMT
       mise-correlation-id:
-      - c30bd6d4-bbdd-4aa1-ad64-21be5fe02f7f
+      - 1a019b7b-dc44-427c-aeed-ab9bc429381c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1492,118 +1348,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A45Z&sr=b&sp=r&sig=M5Re6M%2BEdig25knxctCoT0n%2FoT%2FuWIgzZd0mYT4NcA4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:45.2789308","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A45Z&sr=b&sp=r&sig=xlKseyv%2BYJQ4xb15BI0%2Fl0rcJFj%2FMp21HZBXS%2FJFyDE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:45.2788487","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A45Z&sr=b&sp=r&sig=OS8KZPcNgc0X%2FZabbnv0OhIPEu8IsKBaxi2Hbz1LolE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:45.2789484","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:45 GMT
-      mise-correlation-id:
-      - fe0333f4-1acb-4134-9f54-e01e5c934a78
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A50Z&sr=b&sp=r&sig=ZYXqiUvEM9e%2FbgH8co%2FZefcQs496P578Ic52vLml3iA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:50.5516804","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A50Z&sr=b&sp=r&sig=0K7UoqIspcHPVcXpbCGyL7gEffY7lrKenj6f1glhLrU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:50.5515881","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A50Z&sr=b&sp=r&sig=yRNJuH%2FGlQErvL8XNS7vgFnfUiYN7TDQnGfPLvWCiHI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:50.5516958","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:50 GMT
-      mise-correlation-id:
-      - 0ef964e9-ac3b-4f57-a1c6-6ef3173bdf2b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A55Z&sr=b&sp=r&sig=JOWL6ReT0qdR%2BjKNMIx3o7ghOo5Jg%2FbvLTIUSLT3A2k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:55.8434168","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A55Z&sr=b&sp=r&sig=mkwGEjKMvtXl%2Fcj5RVXrkrrTNWv3rPl954uMnGyj33c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:19:55.843338","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A19%3A55Z&sr=b&sp=r&sig=OFQ30kz5VbRABFLpmFwIdafGrgsa%2BLntUV1kyurQWVQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:19:55.8434332","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3189'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:19:55 GMT
-      mise-correlation-id:
-      - a533285b-abe7-4b57-9ece-c162bd36f244
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A01Z&sr=b&sp=r&sig=rtCsXekTNWzKuUtF4qS93zmqKKGjXADePwcQ%2BJhyZJ8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:01.1323863","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A01Z&sr=b&sp=r&sig=rQtQANxC1nVwR4IG8o7vSGSxExBTvsqp4tgWDWUqT%2Bk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:01.1322646","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A01Z&sr=b&sp=r&sig=Ja3Re%2FQrdwmDgHy0HiFkwBGbj0%2ByEgRRkWglzZq1Qv8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:01.1324127","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A49Z&sr=b&sp=r&sig=DCQiCgz0f%2BgcgikUvEdVmfDLQjDc0wjZ1%2FEyIw%2FQ4sE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:49.6394928","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A49Z&sr=b&sp=r&sig=okozcaYO3wOlFTvPE5k%2BnsOXfQjoDoPoK7NA1Y1ZoKc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:49.6393999","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A49Z&sr=b&sp=r&sig=KyDa6JaZIGmMum49AO7WvHq7wWHHr7ymrnYuDIvYfgE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:49.6395144","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1614,9 +1362,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:01 GMT
+      - Mon, 09 Oct 2023 19:25:49 GMT
       mise-correlation-id:
-      - f2ebbf0a-e969-46b6-9052-5f2ebf190daa
+      - 58dfd1d8-02a2-4b19-ab36-71da964871d7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,23 +1384,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A06Z&sr=b&sp=r&sig=LtrKPLJa7XtBTrY9kIOwocZWTUfOFPSjVyk9mpDSARw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:06.4252927","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A06Z&sr=b&sp=r&sig=vRxVsqwQgIMdFvCoizqK58donpjGxl%2F3V4lzM1s6MRY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:06.4252188","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A06Z&sr=b&sp=r&sig=DRygAdALrPm8My9eQtsNIth1I0QPsmWQEryMOHrUms4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:06.4253103","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A54Z&sr=b&sp=r&sig=kzk7xTjFyTG2oxtf3jUUJtNlfHiBAZS0lTNLivAWj5Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:54.9675512","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A54Z&sr=b&sp=r&sig=r9ljfMFtgY341DCmkt26tRpWF7TwCm1prw5Ubb3ImiY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:54.967483","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A54Z&sr=b&sp=r&sig=FoCYrDbQ8sH5PMOEN3Mq6QWAMO6d24h3zLLcAC6XmXI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:54.9675814","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3184'
+      - '3181'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:06 GMT
+      - Mon, 09 Oct 2023 19:25:54 GMT
       mise-correlation-id:
-      - 01f485b9-b908-4c66-a272-edba270bb182
+      - 47769597-275b-4ad9-aa3c-007d25905c60
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,23 +1420,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A11Z&sr=b&sp=r&sig=7JjG4216CfK7Ijq9ueeYP%2FbPyZGrHsGxdTV4whn%2B1vM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:11.7053015","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A11Z&sr=b&sp=r&sig=Brz6%2F9aQxVO5RUYwWapEgD%2FaC4bfEYQ4QaHMIoLVVNU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:11.7052341","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A11Z&sr=b&sp=r&sig=MfaoFPhKwBq0EuKMRFa%2Bug%2Fk886XcR%2FqHOBR7f8489U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:11.7053168","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A00Z&sr=b&sp=r&sig=i62b5TVbE3jFA1vuqOsmzz2fym69qYs%2BZ9niH%2BIC5nI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:00.2795368","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A00Z&sr=b&sp=r&sig=llSb1zNHQH%2F12onzxGvh0d95z4T4XEV%2BezMBcLGGVRs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:00.2794648","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A00Z&sr=b&sp=r&sig=9iSPy4sFmzzkiutOkYoeKatGBieNqkwwhkBxnl2Zhgg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:00.2795523","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3196'
+      - '3190'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:11 GMT
+      - Mon, 09 Oct 2023 19:26:00 GMT
       mise-correlation-id:
-      - 48dfc1e1-c14f-4b59-a2e9-da93ab14f85c
+      - 4d40bdbb-2188-4007-aaa5-e32cd5ca62d4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,23 +1456,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A17Z&sr=b&sp=r&sig=snj%2BEH%2F44BFmOearB7X3%2FJmN9RcFQ7ZOOlx7VHD28S4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:17.0027858","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A17Z&sr=b&sp=r&sig=bsuwHOLQ%2FRLUR4HPDUKvWyVZNjs83TyhE3aU7qXyzP4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:17.0026836","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A17Z&sr=b&sp=r&sig=oYfTHl%2BYa43ZMx%2Bwr%2Fq4fNL6EkAjM1NEUq4ZXNpYDwk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:17.0028295","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A05Z&sr=b&sp=r&sig=z%2FXwyWr9SPjxwIWUUcMS3ApLhTCxlE5kXahhBcnvDsc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:05.557416","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A05Z&sr=b&sp=r&sig=Eqd8j5b3RKp%2BrP8HX2JQ8NmQFJMYufDDbQ%2Bob0fVbL0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:05.5573282","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A05Z&sr=b&sp=r&sig=h7pr2EoDjMvpamg08CO4MwJndkTeRhBBDBWVcj0hGvE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:05.5574392","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3196'
+      - '3187'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:17 GMT
+      - Mon, 09 Oct 2023 19:26:05 GMT
       mise-correlation-id:
-      - f4bc1bbc-7b30-4ce4-929c-25217ff37d14
+      - fbf13b05-8351-4f5e-b9e7-8c66bf646122
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,10 +1492,154 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A22Z&sr=b&sp=r&sig=K9bcbB3HWwrqqAqbAz%2F1ZINQBnHJN2Kjnqike4U%2Bv6g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:22.2902919","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A22Z&sr=b&sp=r&sig=4G5QKO2noHanfRuPfBrbGW47kUjsUeeV4zyVxhv1hCU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:22.2902183","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A22Z&sr=b&sp=r&sig=l%2F7SojRFiUSEru3JHlKePjPFTZ7w4cIA7QrVbwZAVwQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:22.2903064","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:17:48.952Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:18:34.725Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A10Z&sr=b&sp=r&sig=XfFAiMvwRpoNZKO3qpXI%2F%2FT1TOuYOTNJP5lRtQpnF14%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:10.8365854","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A10Z&sr=b&sp=r&sig=eyvB5%2BwlR39hBGgRQuHRRLm00%2Fn2UOQSOnzDOzKpjAk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:10.8365017","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A10Z&sr=b&sp=r&sig=kPLGNS2OY4eEPhK55SMXICfioBY%2Fj5AW1f7a6EcOxJs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:10.836603","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:10 GMT
+      mise-correlation-id:
+      - c7a38607-1359-4870-ae24-3ed9a40da9bf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A16Z&sr=b&sp=r&sig=AjKEpCz50RA%2B6E6FAGqyUMIAR1szGGR2sw5%2BWbYNXSc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:16.1816773","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A16Z&sr=b&sp=r&sig=T4NknlGNrZZqW7Puve3zTuigYOvaVPZl9rpQk9d3OrM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:16.1815717","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A16Z&sr=b&sp=r&sig=B9CyoZU4lBWOe4%2BAbMf5M0yixDIMRD8XfEA6jVP%2FrW8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:16.181703","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:16 GMT
+      mise-correlation-id:
+      - 8c256b7c-c665-4a6c-8906-056e57a923f5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A21Z&sr=b&sp=r&sig=%2BUdIqNY4p3IIPfFEtUTarA966JjkrtxUPzgNMN6qI2U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:21.4694403","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A21Z&sr=b&sp=r&sig=AsLyf32AL4F9cBmSEvsG5%2Fo%2BaUYNvueGHWAtJcgik9I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:21.469369","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A21Z&sr=b&sp=r&sig=cv0L6IRjQpki6TstF0r0%2FV%2BPzg5hUXfThMC9m6I223M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:21.4694562","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:21 GMT
+      mise-correlation-id:
+      - 93675a5e-e624-4f34-9882-971bf47cedb6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A26Z&sr=b&sp=r&sig=keGzBQQxSMIFQdC3f7%2Fnu3QkymZ34oSTRWDq65vC7Gc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:26.8187954","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A26Z&sr=b&sp=r&sig=CLpwtNZrZ6I%2BOfBchTJZhAcqzWL0Hub%2BsH3zjauc0lQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:26.8187098","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A26Z&sr=b&sp=r&sig=2oMdDbS8BwnnFjRsNasbsSMQB%2FM0%2BDsnpqKNMf9Dxro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:26.8188167","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:26 GMT
+      mise-correlation-id:
+      - c2222415-28e2-410c-ac11-560392f60339
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A32Z&sr=b&sp=r&sig=6SvDXECcKI3z3rZi2M7kCXwtZ8iKDELCnAzILrahGG0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:32.4686245","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A32Z&sr=b&sp=r&sig=M39v5Kw0RjslYEAjGspq%2Bsp%2F9dblFA1h7sfWwDPVfec%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:32.4685679","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A32Z&sr=b&sp=r&sig=lUbUQCsBa0odkJKIJNGEjtDvsBK%2BMV3qtzFsPygCsMM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:32.4686381","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +1650,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:22 GMT
+      - Mon, 09 Oct 2023 19:26:32 GMT
       mise-correlation-id:
-      - aa16d1c5-25e5-452c-b94d-3e7fc5b6c15e
+      - a54b1d4a-4bad-41d3-a1b8-5c3b5365156d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,24 +1672,168 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A27Z&sr=b&sp=r&sig=cKLGtuVgDVBA2nNCfnYOO9yK0GZzYcCEh9w6cqSa8Gw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:27.5609908","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A27Z&sr=b&sp=r&sig=8DYo5utKU1sDDJQaGhHs1w8B1FfjUVG4oG8Lu6sUOe8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:27.5609051","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A27Z&sr=b&sp=r&sig=BOIFqdExAuOjBuh1q7%2FsAbTNE51cuF%2BVzA%2BZxXqrenI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:27.5610137","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-09T16:17:48.952Z","endDateTime":"2023-10-09T16:20:24.146Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:24.237Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A37Z&sr=b&sp=r&sig=QDnQDFB%2B54Jm%2FC%2FNuomEsfRZRUlobUP52aZXJahsDRc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:37.7484107","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A37Z&sr=b&sp=r&sig=Vq%2FNtv5hgXULBwcLtqyc5BeYbduEnqQAfhNhfzDTVU4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:37.7482909","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A37Z&sr=b&sp=r&sig=5MSQinR8w7wcvwb%2FmnCsbNCDH368H1fR%2BhngImQ9of0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:37.7484386","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3323'
+      - '3194'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:27 GMT
+      - Mon, 09 Oct 2023 19:26:37 GMT
       mise-correlation-id:
-      - 9ef6c13d-b316-479a-9213-8ec1cf9f5f75
+      - dbb9556c-79e7-46bf-ac09-037034e2c231
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A43Z&sr=b&sp=r&sig=23Ij7CA6Nnhr8HmWXrhKEnvEEqQLH2UA2ttM4gq5Nf4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:43.0927914","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A43Z&sr=b&sp=r&sig=bjnmjb651C3Gj5wRK2Gp%2BcUJy9SCmGpvW0lnwcRySvA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:43.0927151","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A43Z&sr=b&sp=r&sig=c%2BI0HHd9TOfeNk1T7YgWxcZ888KKe8wj8IX%2BC9ZgWsY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:43.0928056","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:43 GMT
+      mise-correlation-id:
+      - e8408b85-026d-4a32-9e05-c7a7f7221e60
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A48Z&sr=b&sp=r&sig=r9tdU%2Fmp15G6pi0%2B4BxmHReNeJXKH6JEyVbTYy69n2k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:48.4071402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A48Z&sr=b&sp=r&sig=FjdMFxGfVwaStRIbQ8BrQDcUyWODoSJkQw7e9i7cH5c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:48.4070455","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A48Z&sr=b&sp=r&sig=0BIZQBGoEGX7nmKh7jaJZgT2CRw6WaevBOPDlPlv%2Bcw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:48.407162","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:48 GMT
+      mise-correlation-id:
+      - 105adc65-402f-47cf-9930-171531126828
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A53Z&sr=b&sp=r&sig=QQLRgPtYxd%2BRbBDUkY0vjFjBIFKbgjtthucGokIywcA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:53.7352676","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A53Z&sr=b&sp=r&sig=PunhaMIUh1wWA%2FKKL%2F47ViB5wOmaIb6l2uXPb3EyJEw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:53.7351822","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A53Z&sr=b&sp=r&sig=OoGPboakiCtxm6Bix%2Bgd%2FKTSdwCOXpbcCrJtJQdopHg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:53.7352887","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:53 GMT
+      mise-correlation-id:
+      - 18d403c9-e21f-4342-b6f6-f4540ff03424
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A59Z&sr=b&sp=r&sig=QiZP9BdSyr62Cjl96cVNv0BmtJakzzanoKx070M7Smo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:59.022234","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A59Z&sr=b&sp=r&sig=EnTAUthtgWoMi6j9U5i%2BIfWd5ky4SjenJcXjX7n8bJg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:59.0219819","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A59Z&sr=b&sp=r&sig=Rx9JJItp8ej3OcztS4kybdJ%2Bnj4%2FtzYOtq7gSs99AlM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:59.0222734","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-09T19:24:12.295Z","endDateTime":"2023-10-09T19:26:56.807Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:26:56.887Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3322'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:26:59 GMT
+      mise-correlation-id:
+      - 92ae38e1-5953-4ee6-bc69-e3ddd19e9dae
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,7 +1856,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:48.0691178Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:48.0691178Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:11.7118206Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:11.7118206Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1829,9 +1865,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:27 GMT
+      - Mon, 09 Oct 2023 19:27:00 GMT
       etag:
-      - '"9201d1da-0000-0100-0000-652427710000"'
+      - '"56002ea3-0000-0100-0000-652453210000"'
       expires:
       - '-1'
       pragma:
@@ -1861,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=show-test-case&api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=show-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A29Z&sr=b&sp=r&sig=TKuIHznSIkVBEq%2FFtH6VPXyzE22HvtWnn5bSZnl2q%2Bc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:29.5317097","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A29Z&sr=b&sp=r&sig=WeKgRDps83M4NYIgds%2BsNf68mQbqLsCpPcPbVbBr5m0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:29.5316424","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A29Z&sr=b&sp=r&sig=dN%2BCJGk22CkiezNi1QU7HzAyu1nzwPcMZBr307EAnaE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:29.5317247","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-09T16:17:48.952Z","endDateTime":"2023-10-09T16:20:24.146Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:24.237Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A01Z&sr=b&sp=r&sig=eFKaHOdYK7YXAKOp8GiUZTc2N76taC1vjeXxXdPIJ3U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:01.4689579","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A01Z&sr=b&sp=r&sig=xEsOXDz%2FiObRKdZURfAlenrM7Tr7UpUBLBcOlEtLn1o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:01.46888","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A01Z&sr=b&sp=r&sig=%2FxjiV4bLWl1GBPagDFG4BIRtAKpwht0KMcjDEbg6eJY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:01.4689722","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-09T19:24:12.295Z","endDateTime":"2023-10-09T19:26:56.807Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:26:56.887Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3337'
+      - '3331'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:29 GMT
+      - Mon, 09 Oct 2023 19:27:01 GMT
       mise-correlation-id:
-      - c3680749-a68c-4fdc-9c73-17a53e89a860
+      - 93e6efd8-3094-40a3-bd3b-1a8a588b5089
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1901,7 +1937,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:16:48.0691178Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:16:48.0691178Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:11.7118206Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:11.7118206Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1910,9 +1946,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:30 GMT
+      - Mon, 09 Oct 2023 19:27:02 GMT
       etag:
-      - '"9201d1da-0000-0100-0000-652427710000"'
+      - '"56002ea3-0000-0100-0000-652453210000"'
       expires:
       - '-1'
       pragma:
@@ -1942,24 +1978,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://402606af-10c5-435b-a5de-3cd55be7f953.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c3a745bb-a584-45d1-9754-d1648cc87359":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9873454c-3b04-494f-8b78-517d55640068":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"230c0ec6-69bb-45b4-9c47-cc0c852d42ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/68e0d89b-36c6-4234-aa03-c2a5b4b3131f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A31Z&sr=b&sp=r&sig=%2FCHdMZExqYpDgojr39d7RNO1rnuCfcG6lzYX7HVa5Us%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:31.7806341","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/e1bb0b6d-d4a2-4fe4-9e64-72031667184f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A31Z&sr=b&sp=r&sig=dyLE2dVtB2iixN33XuGjTbjdNxYYZ3SW0Z%2BMIzymIfI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:31.7805411","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a1d9bc8e-1d5d-4104-a666-5d23e194ab01/308323f2-9956-42f9-8a79-1d0cd1239a5b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A31Z&sr=b&sp=r&sig=vif2ga%2BbYFEbVWKmfcqiDrzNe0XC4UahcTqig1yUhY0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:31.7806562","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-09T16:17:48.952Z","endDateTime":"2023-10-09T16:20:24.146Z","executedDateTime":"2023-10-09T16:17:47.327Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T16:17:48.493Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:30.178Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A03Z&sr=b&sp=r&sig=3lN475lA0%2BjGYwiUWL%2BKi8TWnS57Bt%2Fo5Obmvn6GHAg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:03.9173717","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A03Z&sr=b&sp=r&sig=BzVpc9HZCBtLPU2bVyENOtIUbpmhffYPqQoT2ttB4IQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:03.9172651","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A03Z&sr=b&sp=r&sig=yI59hYXMvsK0ljDd6tRuj4byXQOZMLNByeVAHk8%2BgXE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:03.9173983","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-09T19:24:12.295Z","endDateTime":"2023-10-09T19:26:56.807Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:26:56.887Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3323'
+      - '3325'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:31 GMT
+      - Mon, 09 Oct 2023 19:27:03 GMT
       mise-correlation-id:
-      - dde2b486-c2fd-4f94-9324-832820af3dd8
+      - 76ae4b9d-f1cd-46e2-bf4b-0abca552530a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_show.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_show.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:11.7118206Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:11.7118206Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:30.3512589Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:30.3512589Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:46 GMT
+      - Fri, 13 Oct 2023 13:57:04 GMT
       etag:
-      - '"56002ea3-0000-0100-0000-652453210000"'
+      - '"d901923f-0000-0100-0000-65294c900000"'
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:23:47 GMT
+      - Fri, 13 Oct 2023 13:57:05 GMT
       mise-correlation-id:
-      - 93483d6c-35c8-4cb3-b3ef-6e5b4a29fdcf
+      - 4e9d9fa6-5f32-4a9f-9106-78327a3e18c0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"2d828163-cd89-43a0-82e8-45ff414c793f": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "198a8c96-1fdf-43a5-953e-4365b55e501f":
+      {"passFailMetrics": {"4accade2-1b0b-43e5-8323-7ba7081159f6": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "bc389940-a451-48ba-8d83-d9239fa07b46":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "e156d481-b9a9-4175-8796-aa08651643f1": {"aggregate": "avg", "clientMetric":
+      "50"}, "c7b16299-1892-43ab-ac63-bd00f2172567": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -104,13 +104,13 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:23:47.577Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:23:47.577Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:57:06.036Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:06.036Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:47 GMT
+      - Fri, 13 Oct 2023 13:57:06 GMT
       location:
-      - https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+      - https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 70c8bb7f-efd3-4f1f-9f0f-4e33bc931021
+      - 612d13ef-bd61-4eb6-94a2-4cce81a7ab45
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -143,9 +143,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:47 GMT
+      - Fri, 13 Oct 2023 13:57:06 GMT
       mise-correlation-id:
-      - 33e0388b-d966-44a5-912f-7edbd6c290ef
+      - bc8d6bb2-bdca-499b-8ca9-ca659f090617
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -273,12 +273,12 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A48Z&sr=b&sp=r&sig=8YqKmg55PfJPpv14ffxscnCdsfFkvMtlWbvrPdUzV3g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:48.4772332","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A07Z&sr=b&sp=r&sig=qGrTPVF7XU4LOHSeZ7RpPxRpkMGwoeP1ycUTZAP0iPk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:07.6522284","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -289,11 +289,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:48 GMT
+      - Fri, 13 Oct 2023 13:57:07 GMT
       location:
-      - https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 83aaca1c-8ed4-48f1-8b9c-836a98049d77
+      - 5fd8882c-9143-4a92-8743-dcf8311c9eb7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -311,12 +311,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A48Z&sr=b&sp=r&sig=BJxGadcN7PkbWlPPf0U4J3phTfSah3JDu9f6aI6k5y4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:48.8107275","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A07Z&sr=b&sp=r&sig=2VcW8qP3QFUDdqZi7lEzG9ucrWKT5lyPmFTqKNcZQXE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:07.8604235","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:48 GMT
+      - Fri, 13 Oct 2023 13:57:07 GMT
       mise-correlation-id:
-      - 5ea5e815-3fbf-40f5-97d2-f1f6ea3d6e45
+      - 65739f34-dfc9-44d3-aa59-748c2d33218f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -347,25 +347,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A54Z&sr=b&sp=r&sig=vC8pdLJ0ejuwk8KK0sQzQIzldr0ZfWOh9vvgKRWF570%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:54.1310637","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A13Z&sr=b&sp=r&sig=uIgeZRIwRPGPZLYOa3DRgZeqM%2FbanIbK7uzEqonTq6c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:13.1796698","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:54 GMT
+      - Fri, 13 Oct 2023 13:57:13 GMT
       mise-correlation-id:
-      - c63982d4-da87-4682-92ce-7d170ac40c63
+      - 46b588f5-a941-45aa-8de2-6d6e2a98241d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -383,25 +383,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A33%3A59Z&sr=b&sp=r&sig=myVIa%2BH5eiRw13OOZrRvZEu71ClQzMF%2BT8RkrFwi2iM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:33:59.4155517","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A18Z&sr=b&sp=r&sig=1DAzX%2BAfNGDLcS%2FJo%2FCZwfHE2O4Pe8N3Zb18jCwT2qU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:18.4211043","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:23:59 GMT
+      - Fri, 13 Oct 2023 13:57:18 GMT
       mise-correlation-id:
-      - 7c31eaac-a019-4887-854e-043c57949a33
+      - 993d119c-afd0-4e95-885e-30dbf6179896
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -419,25 +419,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A34%3A04Z&sr=b&sp=r&sig=91ROY4MUzrOmqZcYsc%2BVMQ1iA4TLpK248Ze2j4zVCSM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:34:04.7718565","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A07%3A23Z&sr=b&sp=r&sig=c18vr9WsfxW9JVpBFyyGKdNv0DWoh5tGyJjnApBIk8M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:07:23.6681103","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:04 GMT
+      - Fri, 13 Oct 2023 13:57:23 GMT
       mise-correlation-id:
-      - 397c2752-de79-49ce-bc5c-256549214d90
+      - c0621080-9847-427f-ad24-e61f2dc3cf3a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -455,26 +455,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A05Z&sr=b&sp=r&sig=EqiwpzRKf53%2BDlLadN4c9P%2BmU1GCcd%2FYKx70jaB8oxo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:05.100397","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:23:47.577Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:02.442Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A23Z&sr=b&sp=r&sig=746zdQCyKloqvgatpKZ7yji2wMvVLMhcPOvpUmQW7Gs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:23.9448416","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:57:06.036Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:22.422Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1580'
+      - '1575'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:05 GMT
+      - Fri, 13 Oct 2023 13:57:23 GMT
       mise-correlation-id:
-      - a8b33bd2-ab44-484a-9447-1f5eabbcbf06
+      - 94ce4c86-75d9-4137-bd7f-5052abdd5d95
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:11.7118206Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:11.7118206Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:30.3512589Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:30.3512589Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:06 GMT
+      - Fri, 13 Oct 2023 13:57:24 GMT
       etag:
-      - '"56002ea3-0000-0100-0000-652453210000"'
+      - '"d901923f-0000-0100-0000-65294c900000"'
       expires:
       - '-1'
       pragma:
@@ -536,26 +536,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A07Z&sr=b&sp=r&sig=T7QlpFIAU2hdIZsNeRf3ZdUYZq35cRrZqnERRIHvfaw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:07.8006197","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:23:47.577Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:02.442Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A26Z&sr=b&sp=r&sig=VwyAmnXxHHq%2FjaLZkatPATYovqLAgWsoTfBSUT4F1o4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:26.0235904","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:57:06.036Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:22.422Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1587'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:07 GMT
+      - Fri, 13 Oct 2023 13:57:26 GMT
       mise-correlation-id:
-      - ae3246df-b44c-4bcb-99d6-6fd9265feced
+      - 4f7d3370-1b9c-4314-9716-3f4417e1bb35
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:11.7118206Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:11.7118206Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:30.3512589Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:30.3512589Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:09 GMT
+      - Fri, 13 Oct 2023 13:57:26 GMT
       etag:
-      - '"56002ea3-0000-0100-0000-652453210000"'
+      - '"d901923f-0000-0100-0000-65294c900000"'
       expires:
       - '-1'
       pragma:
@@ -617,9 +617,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:24:10 GMT
+      - Fri, 13 Oct 2023 13:57:28 GMT
       mise-correlation-id:
-      - c3ea32d0-bdfc-487b-afeb-b641709b395e
+      - d3ff6c44-63c6-48d3-919d-ef1608110128
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -660,27 +660,27 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A11Z&sr=b&sp=r&sig=8yTpkVBptonhlEid1KcZyLW8PMJNuE%2B6MmLGa%2Biv690%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:11.8755906","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A11Z&sr=b&sp=r&sig=x2RM0l1A3JDRTnXnnECD2z9%2BzoF6%2BxD95AKGb13YDMg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:11.8749738","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A11Z&sr=b&sp=r&sig=KRJAsiz42%2FeTbQY3dzgzak90U%2BnNkl0tK%2BADT5dJ5O8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:11.8756518","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:11.783Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A29Z&sr=b&sp=r&sig=WRVt7Dul%2BJtvr0qVr0W6shf8vNte68QWDLHYFXNms4Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:29.5188096","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A29Z&sr=b&sp=r&sig=wtTrFSxTlgb7FVm9K159Jz0iLHbNQ3J3%2FCsX%2BgPNhW8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:29.5187067","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A29Z&sr=b&sp=r&sig=NIOB3kvDWhmVBYcjwaNiZH8pbuegKVzbq%2FG8%2FSSJvFY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:29.5188358","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:29.437Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3152'
+      - '3147'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:12 GMT
+      - Fri, 13 Oct 2023 13:57:29 GMT
       location:
-      - https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+      - https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - b01617c0-4f7f-4b8b-9883-20006647a85a
+      - 51209dfc-75a7-47f3-99f2-89f83e08d079
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -698,25 +698,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A12Z&sr=b&sp=r&sig=uYqL7M%2F%2Byr6rjitQcO9moWJ90gTIWsysSYZwT5doq8Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:12.4659972","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A12Z&sr=b&sp=r&sig=F920c8B5IyIYxH1K%2F4ejwd7KoTpELybcRQRscDZM7tc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:12.4659126","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A12Z&sr=b&sp=r&sig=qqXj5a6Ww6z3AmHD5lvLmAhsuvzPLlLgbWhPTWizFWM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:12.4660178","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:12.295Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A30Z&sr=b&sp=r&sig=Uk4MRsJGcncX867A54kprM6prC%2B0mSCcJjsRCS67sIg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:30.0003536","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A30Z&sr=b&sp=r&sig=60YPcV2spZKw5%2BIKDZBlbOgz5bmO81anDa9S%2FUfHUuc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:30.0002152","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A30Z&sr=b&sp=r&sig=68b5E6Vt2CzSpFD0mZngK9QDw3phsjanZBJoczsVv5Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:30.0003758","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"NOTSTARTED","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:29.834Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3189'
+      - '3188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:12 GMT
+      - Fri, 13 Oct 2023 13:57:30 GMT
       mise-correlation-id:
-      - 985a90bd-5327-4737-8f29-d1c37ef4434a
+      - 61dfa004-a863-49f4-bd44-b49dfaee9e00
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -734,25 +734,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A17Z&sr=b&sp=r&sig=jDn7hbBB86AfPItPNHrM%2Fs7xJeFKoITYMHL3YJJIvGE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:17.7818884","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A17Z&sr=b&sp=r&sig=45nPyEvDZO%2FTEusGW8vLxa2zrD1dr678fa7M1R2X6nE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:17.7818193","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A17Z&sr=b&sp=r&sig=%2BQvYY2OPoB%2BgoxVLRSv%2BoS7%2FmbOR7fw1mwJCOhqtHHc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:17.7819025","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:13.384Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A35Z&sr=b&sp=r&sig=Ej6jTmae5zLpyHD0BSF8KN9W2ccTePOfysyFDIKvJVg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:35.331519","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A35Z&sr=b&sp=r&sig=SynfVr0%2F%2FTNBSAKgIPGNpeFJmP90ey4WJo%2B%2Bq2ztwbs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:35.331434","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A35Z&sr=b&sp=r&sig=tgNDUStaG8tFY3YTJ%2BxQQqdgh8Y4eqw0IVuTzka9vHQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:35.3315404","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:30.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3197'
+      - '3192'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:17 GMT
+      - Fri, 13 Oct 2023 13:57:35 GMT
       mise-correlation-id:
-      - 26f10cbd-2422-44d6-8e3d-45ff35993ce0
+      - ffce07c4-0c0e-47fd-93a5-988bb672dcd0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -770,12 +770,120 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A23Z&sr=b&sp=r&sig=BcH78WBzD%2Fc7O%2FSyYdKXBD9pvJFhLdH9MUjyJvXiDCM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:23.0883427","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A23Z&sr=b&sp=r&sig=rwAaYGQuqDmm%2Ba%2BYh4%2FFb1uKP1o1vAe9r3eUx40c%2BJw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:23.088239","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A23Z&sr=b&sp=r&sig=xlu9Ydp1XVHByFkKKL8fiHmt5z0ehDwA5JKmxC1oOa8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:23.0883694","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:13.384Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A40Z&sr=b&sp=r&sig=fYRdWbWYz7hmpe4KwSzg1AU12L0rxXIXjfoAgmPe%2BlA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:40.6387987","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A40Z&sr=b&sp=r&sig=LomCsukE0ibsWCqxlxPeCA%2BqlMaVrIIttXI%2FryyG4z4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:40.638715","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A40Z&sr=b&sp=r&sig=TF55v8YMMfRaegCVe3CUX%2BDCQrfPoPIKkRoICRMuv%2FU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:40.6388145","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:30.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:57:40 GMT
+      mise-correlation-id:
+      - b8819e2a-e2b9-4cc6-87fc-852f9a6fc369
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A45Z&sr=b&sp=r&sig=63vjX7AgSo33efpopF99J9P6sDsNqcEFs98RrhL4sJc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:45.9140817","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A45Z&sr=b&sp=r&sig=aS9AOyeEuVkELD85Y0cKvIaotIGdVaExeFnYksJyBa4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:45.9139995","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A45Z&sr=b&sp=r&sig=vuhsQVtLIyVhQiNTelVP2ziPIHgE2h7DJ09Nj%2FhcuoU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:45.9141009","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:30.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3186'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:57:45 GMT
+      mise-correlation-id:
+      - 867da1e4-a011-4378-b3cc-67223e9a2a6d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A51Z&sr=b&sp=r&sig=ns%2BQW5PBKeN7aJQ6MFYXDPavwPF7jP3qMVE315%2FHzFQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:51.1931899","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A51Z&sr=b&sp=r&sig=OGWhisNHol1t0LTWJoSCkzlpz3Qhubg6qZ7zcURKCgo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:51.1931233","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A51Z&sr=b&sp=r&sig=t1gWVymJ%2F0ODYWmeGPd6xf%2FbR0h4lRZA4%2Blltk6r5O4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:51.1932041","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:30.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:57:51 GMT
+      mise-correlation-id:
+      - d1e3a53a-5c62-4086-8bde-f130fb26df8f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A56Z&sr=b&sp=r&sig=ljHmSmmbEDu560jutMJFwZlpIvxMbwQYrKn1tfA8umQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:56.4481111","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A56Z&sr=b&sp=r&sig=ed63eho0xdK5%2F%2FpTZt%2Fv%2Fyw25Byi8gls1%2FS6HzygGlE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:57:56.4480405","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A57%3A56Z&sr=b&sp=r&sig=R0uKgY5yuLx0jvLhk6orEVgP7aVIl2ontjlio4J%2B7yI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:57:56.4481262","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:30.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -786,9 +894,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:24:23 GMT
+      - Fri, 13 Oct 2023 13:57:56 GMT
       mise-correlation-id:
-      - bb10fe64-b74e-4c36-bc18-a7426715b7fa
+      - d0d93a01-47b7-463c-9e6f-e993d1619dbb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -806,264 +914,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A28Z&sr=b&sp=r&sig=ABkJHMRGVKPOyATlUCrTSfXrm2txC76JNeeBYGjIcRY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:28.4384914","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A28Z&sr=b&sp=r&sig=GmSbEve73ZtcQeNI499ZJVIanapg65B7ZBYujoWY4dI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:28.4383971","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A28Z&sr=b&sp=r&sig=eL6G5%2BNH3TbeLWzhFSsPZNGuHFsB%2Bt093%2FKzOP1xAnY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:28.4385176","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:13.384Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:28 GMT
-      mise-correlation-id:
-      - 3b3c07d0-61df-43bb-8edd-9279f6129f45
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A33Z&sr=b&sp=r&sig=WSr3LFxHLY1O%2FHbrHrjoSmHp584rB9S9G6Po3ThtgKg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:33.7304538","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A33Z&sr=b&sp=r&sig=xUxnPqHaxsk7wCGbOI4T1cwy2MIouIlXVZ3iwN092H4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:33.730369","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A33Z&sr=b&sp=r&sig=tBAmzgD78H1YyBuPOD3J%2FDhj7f4TjBsDZ3axKZAnYLs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:33.7304753","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:13.384Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:33 GMT
-      mise-correlation-id:
-      - 3580c5f5-04b7-4889-9cc4-62cd4e651987
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A39Z&sr=b&sp=r&sig=S6uAf2206ZIrh8%2BHVPC%2B7isTNkbB7It2xJpez5ixmnI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:39.0852928","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A39Z&sr=b&sp=r&sig=OhpdsEkd8mW5z%2BGU6dRBXp9juwOw1tTa2s9qYcc2IxQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:39.0851867","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A39Z&sr=b&sp=r&sig=4mYddFl123bfBtDQfwj2Hf2NSAScplu1l93JymA%2BHSY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:39.0853086","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:13.384Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:39 GMT
-      mise-correlation-id:
-      - e250acdb-060b-4e03-b571-0a38ecfe95d6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A44Z&sr=b&sp=r&sig=mzBxQuh5Tj%2FfheO6lzgMUvHhLhpCx2xUTPj0hokGoNA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:44.4034047","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A44Z&sr=b&sp=r&sig=nzH8OzZp1nQv5RwutDOZw3nQyOtg9f6T0SyT16JdVnA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:44.4033282","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A44Z&sr=b&sp=r&sig=h2ur1s5vg1%2FYiTl61ttx2YekIi%2B2raeX1YCGB7lS%2FRI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:44.4034202","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:13.384Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:44 GMT
-      mise-correlation-id:
-      - d4fff7e4-cca8-4f69-8514-4d1688e09498
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A49Z&sr=b&sp=r&sig=Fr7MjedipvaAKZegcMd1txDRHHlrN3Kn4rHJdjtWNZo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:49.6804919","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A49Z&sr=b&sp=r&sig=GGnxqPzax68dgLYns2A5gGYvk1FVBXWKcxcznkD95%2F0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:49.6804212","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A49Z&sr=b&sp=r&sig=mKdKNPvjDNzosBGBUObcuC7dCUsxZoNx4mxG7usOOZw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:49.680507","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:13.384Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:49 GMT
-      mise-correlation-id:
-      - 577b68bf-7af3-49c3-ae15-ea404a55adde
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A55Z&sr=b&sp=r&sig=TEAO3tZb7Fvr3%2Bu6jn9wwsLTgopwJ1u%2BsQwUCju1R5E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:55.8127531","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A55Z&sr=b&sp=r&sig=RQgXTwpR48Z4166OO0gqWRUaSrGq%2BMv2n7d3sPqchNc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:24:55.8126703","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A24%3A55Z&sr=b&sp=r&sig=i0dyaRanuWLEIPfVLPf5Vjs89Hlcy5LCNv232QRa7oM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:24:55.8127746","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:13.384Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:24:55 GMT
-      mise-correlation-id:
-      - cc131c91-550e-4047-88e9-8a37024eac78
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A01Z&sr=b&sp=r&sig=ZMb2hbMlKsjlKsZOy296N7Fi4VEjjpxHPWMOXhdBFB8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:01.6958626","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A01Z&sr=b&sp=r&sig=8QWuhpxpaxgX%2F7mFqdfPb2t7MRB29mI2BzkD0UY1mx0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:01.6957722","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A01Z&sr=b&sp=r&sig=zUb0A1eauXHTeY96zjKVDrj%2Fp74TuxNpL041Cu1Mdz0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:01.6958843","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:24:58.642Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:25:01 GMT
-      mise-correlation-id:
-      - 548aa51c-bd0c-40cf-8b63-648d4067c31c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A07Z&sr=b&sp=r&sig=oRgX6AxyUPYhv%2BH3BtKG7oPl6rTvvKtQkQXR27cqvOI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:07.0538627","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A07Z&sr=b&sp=r&sig=qB2RzjwGybsExACQ1YC%2BCGZuSX4Th1dS%2Fwh2p3imYMU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:07.0537923","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A07Z&sr=b&sp=r&sig=HOFb2cQgax7YvebWbuzePI9w9EXz%2BhPqHFgY6uNX2Kc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:07.0538771","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A01Z&sr=b&sp=r&sig=pJ%2FrclRKEEq1EPvV3Zdi9ft7DcQEpGDXo6FMfPPFniI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:01.6661238","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A01Z&sr=b&sp=r&sig=BXptz7VBcZKg%2BFDwND4VCwC9bnGfaOMVXtfxX50tWvU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:01.6660371","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A01Z&sr=b&sp=r&sig=elR7qAuXELqcNxQJlO9b6zHyGANDHjB4HTmXv%2Foa5ZM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:01.6661456","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:30.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1074,9 +930,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:07 GMT
+      - Fri, 13 Oct 2023 13:58:01 GMT
       mise-correlation-id:
-      - a5169b12-f276-4efb-927e-32f4d136eb3a
+      - 907aa013-054c-4986-aa4b-1604b318169e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1094,25 +950,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A12Z&sr=b&sp=r&sig=01jQEm7aBiTSkNbCkS5qu%2BAuhODRAaEICyq8mfK2UGM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:12.3659266","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A12Z&sr=b&sp=r&sig=sszdaEEGHGCbjQ0GDNhZjBkObLuBtzEFf%2BhABYbk6IA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:12.3658578","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A12Z&sr=b&sp=r&sig=W39ihSB9jD0Nn4O0GaE7idgThRyd8p2FmBzTcLpauLU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:12.3659407","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A06Z&sr=b&sp=r&sig=hZjYmauG6xSquYhYuHFsI1hUV5MsvTcJ7U%2B%2BUou%2BqUc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:06.9515645","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A06Z&sr=b&sp=r&sig=jPXqe3XhKEa2uvmbtxNppPSXzF1uGVFtztrXxYBdvAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:06.9514974","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A06Z&sr=b&sp=r&sig=J8yHXrUArfOxGFA48L2zZ%2BM1NjE556JXfyHPWG981jo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:06.9515796","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:30.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3186'
+      - '3192'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:12 GMT
+      - Fri, 13 Oct 2023 13:58:06 GMT
       mise-correlation-id:
-      - 093acb31-54ea-40db-80c1-a2db83d1e055
+      - 5e5b47f6-f177-4ef9-a007-4586c4415d79
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1130,25 +986,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A17Z&sr=b&sp=r&sig=JJke5z4bZFx93%2F0PfvHLwouwg1ZDwecltaYmq82BtYM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:17.6963065","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A17Z&sr=b&sp=r&sig=ZZH2q1Yy4CgHEgtSuwwMFYeCbULbDhL3bUmgjZm8wcs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:17.6962062","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A17Z&sr=b&sp=r&sig=jk%2FQx%2FG2puY7d6a3QZMDsxB5wXdOh%2B9wxnqzx9Ldrtc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:17.6963638","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A12Z&sr=b&sp=r&sig=%2ByA8v1YDnlvo2DSikHculCKG431lmZ3HKfyQHikqaM0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:12.1940659","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A12Z&sr=b&sp=r&sig=%2FwGofsQfrtokOaSADBtEcCWCYqm%2BIIVQBVoh2ymSZcs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:12.1939953","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A12Z&sr=b&sp=r&sig=wycdyLQuIVIEtOys8cRQPNA%2B%2Fm2cAxJgqn%2FP9ygreV8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:12.1940822","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:57:30.092Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3190'
+      - '3196'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:17 GMT
+      - Fri, 13 Oct 2023 13:58:12 GMT
       mise-correlation-id:
-      - 5ca3f0e7-b9a2-4aab-9e11-b1cb0cea2df5
+      - d55a6856-fe5d-4012-878c-8b9d1d0b8eb2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1166,25 +1022,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A23Z&sr=b&sp=r&sig=rR%2BecSA%2BLuvq4ezVD6nWaUvF%2BUXEQocxZWI1wCV3VVI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:23.0156199","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A23Z&sr=b&sp=r&sig=Z3BybdFTyR8saRoqC8pLSa6LIlYTw9u9FdyQAL8kKJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:23.015514","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A23Z&sr=b&sp=r&sig=RuDj7N8b4uZedqYV1290dMBD7Ga3%2BejrNZpHu9tLY6M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:23.0156485","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A17Z&sr=b&sp=r&sig=wqzAVcrlJfmE%2Bi5bJcgTJPMX7rJqDdsFjcsLqkMYdUQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:17.5135787","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A17Z&sr=b&sp=r&sig=UsIKjZ4gCTX01g7ijjSFxsqhTb6ZJwSoPJWE95FVm8Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:17.5134915","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A17Z&sr=b&sp=r&sig=Cqsu9NUzKRjhyVpyJR2oSkbHYZg2sJLZyLMECQFVSQI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:17.5136006","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3189'
+      - '3183'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:23 GMT
+      - Fri, 13 Oct 2023 13:58:17 GMT
       mise-correlation-id:
-      - 11379fe7-28fd-4e0a-8330-ad20f52f07ab
+      - 038046b3-9497-4306-ba7b-7db1f2c638ae
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1202,25 +1058,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A28Z&sr=b&sp=r&sig=LaB%2FQxdyQwtVPNbxOzMCpxtyyE9hVIOurtPgQ%2F3Fgn4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:28.3002165","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A28Z&sr=b&sp=r&sig=8xnsjsdh1L2Hj6UphQ9jgZAzipkzmA%2FLss8Wl9BtfI0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:28.3001394","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A28Z&sr=b&sp=r&sig=osWDOePwzbWmx%2BM%2BqaMEzLMhnvTQ1ZtgCu3w0Zgq%2BzU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:28.3002344","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A22Z&sr=b&sp=r&sig=%2BZPB%2BpEKTxWQaINt6omJSq9gEKoI2GLebt2CMJ9TLs0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:22.7694557","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A22Z&sr=b&sp=r&sig=7YEFMmePLGjw0J6aCwqCNzoJtdsFx9a05NFDvefrQLk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:22.7693535","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A22Z&sr=b&sp=r&sig=Wr%2B6t6lVHZkInRHJ2E%2BMV%2FgpoJqLHrX2HFXQXCem%2Fnc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:22.7694784","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3194'
+      - '3193'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:28 GMT
+      - Fri, 13 Oct 2023 13:58:22 GMT
       mise-correlation-id:
-      - 8a1d3300-f8d0-461b-897b-9e05682d29ec
+      - ca705444-64e5-4e4a-a4dd-505f667e89ff
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1238,12 +1094,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A33Z&sr=b&sp=r&sig=aQRlTlcGV8UufzoE22T%2FgL1CMtkfQCgGG52sBVuAcf0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:33.6588055","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A33Z&sr=b&sp=r&sig=1EFN0OOcd64Cxl%2FLvaZ4WEdWM6JAC4tLvFrfleLB7Ho%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:33.658755","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A33Z&sr=b&sp=r&sig=8LkzqEmtaVgdwipHfwJ2c3ZdrhHKMdSJ2gQ%2FmLV3qiQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:33.6588207","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A28Z&sr=b&sp=r&sig=QrrILc7lnloa4jP5QrB5v8PA1t5f0t2Kw4p%2Bu3j%2Fbrk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:28.0777925","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A28Z&sr=b&sp=r&sig=lTNW4xQrVIU11FUpV8oE9LjAKkizY5%2F1g6ySRvRQYDw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:28.0777263","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A28Z&sr=b&sp=r&sig=LoibX5dUq7STuJ3XPvYta7M8wXSUwY3MXIP0Qrlzrso%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:28.0778077","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1254,9 +1110,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:33 GMT
+      - Fri, 13 Oct 2023 13:58:28 GMT
       mise-correlation-id:
-      - 66f26aa0-c55c-4998-bae5-650f860ebd97
+      - 01d929da-47b9-416a-b8f2-5c71f48bfbc2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1274,12 +1130,48 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A38Z&sr=b&sp=r&sig=7WfBUOoGs5MqG2p1eCj1HRK5K8gkvdn83H2vOMK%2B668%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:38.9506443","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A38Z&sr=b&sp=r&sig=LU%2BX2Km64cxvfLE51t0Ap%2Fa0DSuXUZC3xZ6%2BCuHJSVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:38.9505713","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A38Z&sr=b&sp=r&sig=CKstRipqvOSUSv8qaQMyPtHs4UPdSbgc7tUxBI%2FX7BU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:38.950659","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A33Z&sr=b&sp=r&sig=%2BvXWk7qeydVTd5%2FV%2BVm%2BRgS3zoWcJ%2FeYLfVv82Gxkfc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:33.3872383","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A33Z&sr=b&sp=r&sig=scbCuO4b6gZKh7pWLeXVSDV%2B4DtKwxJ6Gxd5WtDfQ0Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:33.3871589","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A33Z&sr=b&sp=r&sig=hN1XSlgUGsC%2FfSGUtA6DrzREsMasADm84WZ8Tv0wvT4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:33.3872555","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:58:33 GMT
+      mise-correlation-id:
+      - 5625f69e-e17e-4438-b6e5-991a4b057680
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A38Z&sr=b&sp=r&sig=C8QYcAlrcAplMa1%2F0H0C%2FFxcxV5o19GWbDxHgrS8PoE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:38.7008566","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A38Z&sr=b&sp=r&sig=XuNpwki%2FST9o6gtMb3PL926Rt%2Ffd1w6Ir7Tz14rOOGs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:38.7007924","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A38Z&sr=b&sp=r&sig=RLNqWcyjk%2BaRanxEc2ceyel653tkH8qgPNbBmJKm51o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:38.7008719","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1290,9 +1182,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:38 GMT
+      - Fri, 13 Oct 2023 13:58:38 GMT
       mise-correlation-id:
-      - 804933af-c34b-4db4-abef-fae0e0cd031f
+      - 2368e401-6e85-4b41-8e76-7b0f3c7cc4cc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1310,25 +1202,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A44Z&sr=b&sp=r&sig=zHHC%2ByirPz6%2B6Ehji%2BZBjKmKiMR39zTOV%2BTw70UPCaM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:44.3119964","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A44Z&sr=b&sp=r&sig=QCouphbHUFzC8Yq9qIpeyq2OTl8Ngz3lvaYBJvRgiFM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:44.3119097","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A44Z&sr=b&sp=r&sig=5tbvMJnMKUMyMeNcVCNqLE%2BwD2eLZOCRIRO6Fq%2BseTs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:44.3120173","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A44Z&sr=b&sp=r&sig=xLVdvHdIRZ%2BbwhX0MCBBuV7%2F91WwKEll3EV5MJIprvs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:44.0525587","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A44Z&sr=b&sp=r&sig=iC83GGbxABXHwOIFkLhRRGz2u1lB9Xd3bLm7rNLMikY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:44.0524802","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A44Z&sr=b&sp=r&sig=kYDtJa9oexSG3NJe5fr4pwIPsZmgGzz9te9TsgvWQ04%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:44.0525726","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3194'
+      - '3185'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:44 GMT
+      - Fri, 13 Oct 2023 13:58:44 GMT
       mise-correlation-id:
-      - 1a019b7b-dc44-427c-aeed-ab9bc429381c
+      - 20898465-7be3-4eb4-99ec-ac90b926f08a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1346,25 +1238,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A49Z&sr=b&sp=r&sig=DCQiCgz0f%2BgcgikUvEdVmfDLQjDc0wjZ1%2FEyIw%2FQ4sE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:49.6394928","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A49Z&sr=b&sp=r&sig=okozcaYO3wOlFTvPE5k%2BnsOXfQjoDoPoK7NA1Y1ZoKc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:49.6393999","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A49Z&sr=b&sp=r&sig=KyDa6JaZIGmMum49AO7WvHq7wWHHr7ymrnYuDIvYfgE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:49.6395144","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A49Z&sr=b&sp=r&sig=th2KS0boJzEsOdinS%2FJCXtu2p5%2BGNzbFVb7uQs8hgug%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:49.3117532","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A49Z&sr=b&sp=r&sig=mYSfGslDh90voff%2BdWQ2edk7aE2akiBzQJ0XGRKQCCk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:49.3116897","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A49Z&sr=b&sp=r&sig=dZxAnaf2vnAxnLFE2u6aIff4bY%2FLP2Wxsao3GqKA9sQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:49.3117685","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3190'
+      - '3189'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:49 GMT
+      - Fri, 13 Oct 2023 13:58:49 GMT
       mise-correlation-id:
-      - 58dfd1d8-02a2-4b19-ab36-71da964871d7
+      - 97654ea3-96fa-4ccf-ad64-2a33b1831a2b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1382,12 +1274,408 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A54Z&sr=b&sp=r&sig=kzk7xTjFyTG2oxtf3jUUJtNlfHiBAZS0lTNLivAWj5Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:54.9675512","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A54Z&sr=b&sp=r&sig=r9ljfMFtgY341DCmkt26tRpWF7TwCm1prw5Ubb3ImiY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:25:54.967483","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A25%3A54Z&sr=b&sp=r&sig=FoCYrDbQ8sH5PMOEN3Mq6QWAMO6d24h3zLLcAC6XmXI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:25:54.9675814","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A54Z&sr=b&sp=r&sig=VPFhBh3kk2YlDNtBJRxZO0HwB8LEy%2Bn%2FQ2of4Mf0TI4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:54.5872505","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A54Z&sr=b&sp=r&sig=tT97WxAZV%2FwWbZBJuW8Fl5cBz00smlhDewdQmHCl7ZI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:54.5871647","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A54Z&sr=b&sp=r&sig=5giuoM0mfh3f%2FPsvsDyIJDvKpW%2BNwgxaUOYzeYcWSdI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:54.5872713","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:58:54 GMT
+      mise-correlation-id:
+      - b3460d3c-46dc-4d70-b510-290b6439ee1b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A59Z&sr=b&sp=r&sig=grWXwu4j0Zbkw%2BMHrAkNTwp81%2Fhl6pX16GvGmP0YMes%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:59.8166882","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A59Z&sr=b&sp=r&sig=zzkn1XIy0uf%2BrcmEg%2Btf0AdmglQ2H0o5rSB0nVj1DdE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:58:59.8166048","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A58%3A59Z&sr=b&sp=r&sig=5cmox8XXoGHDZ%2F6hUnnjyRsini7U51QcUkGVbfK0bH8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:58:59.8167089","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:58:59 GMT
+      mise-correlation-id:
+      - 59802a8d-adcc-484b-8781-647c40e803d9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A05Z&sr=b&sp=r&sig=BAo4rNmjgfbC2o0Raa5mZoMuyp3JI%2B95e1mwcELHRfw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:05.0849253","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A05Z&sr=b&sp=r&sig=00Me78E0k%2FmOCDHL%2BXbIAdJ4oLQWH8VQ6vNVIgLV1FY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:05.0848464","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A05Z&sr=b&sp=r&sig=6pbATAMdszYOaA8c16B9gC3futnbodSa3P1aqnaDxUo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:05.0849387","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:05 GMT
+      mise-correlation-id:
+      - 0944834c-7a64-42c9-890a-03f3be42e027
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A10Z&sr=b&sp=r&sig=ZAF0WyGtW15Tvkas7iwzkXgX6KLQicev6vsM6pUANYw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:10.3420075","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A10Z&sr=b&sp=r&sig=8Rj%2FfTwToeUiX7HEMeDt8VeSBF6mLdZNN6dLMUKx2%2B4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:10.3419052","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A10Z&sr=b&sp=r&sig=qMnpBefX%2BeeNykPETH5rcCTOmgv4259xs4eNJm%2F2s3Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:10.3420286","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:10 GMT
+      mise-correlation-id:
+      - b31d7cfd-c709-412c-ac84-bb14b5d04098
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A15Z&sr=b&sp=r&sig=Q9pmbg8q3uK0mOkbZNEPwzG%2B4nR45%2FeVuYV6CZ01z2g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:15.6216745","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A15Z&sr=b&sp=r&sig=0uTo2r8SgqNJhbVk0qlnO82cUYmmPsIAuDOQWIYoz1c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:15.6216054","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A15Z&sr=b&sp=r&sig=tsXxVcC5W0ij9K4MquwwHTUbKSAUUashsTlZdyIIkxE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:15.6216894","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3185'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:15 GMT
+      mise-correlation-id:
+      - 8f6bc995-99d8-445c-a2dc-e2e5493b219f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A20Z&sr=b&sp=r&sig=%2BvZeiElB8uObEbwZ7iQk0gvK%2FsrhsTdOyPPaIxhFrxk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:20.8957537","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A20Z&sr=b&sp=r&sig=kv%2BhC2Zs9JTCvyurfmlY9i6r1e3TJsB2cmU9N00DcXE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:20.8956885","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A20Z&sr=b&sp=r&sig=voGFzOPgoTmzmFvmiCWdGCDE26CHov5UTFZUD%2B3aVSQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:20.8957689","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:20 GMT
+      mise-correlation-id:
+      - 7d053ec8-42bf-48a6-9c56-0dac6e8bd5cf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A26Z&sr=b&sp=r&sig=HHXJT56sh%2FZVzmc6AE0uPXXAaqjYVdYTC9oFTDIR9Vc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:26.2162761","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A26Z&sr=b&sp=r&sig=%2FH%2FRykPc50ELn%2FWWfgli90abc6Y19CdDogNTZmXvIqM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:26.2161909","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A26Z&sr=b&sp=r&sig=H%2FsPufp1EUYEHGmDn5Ag122OefjFNCSZtSj%2Bs2yT0w8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:26.2162975","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:26 GMT
+      mise-correlation-id:
+      - e125927d-7f3c-4806-9dfc-466e4cb2c2d2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A31Z&sr=b&sp=r&sig=4zjFB0OID4EQbfvYMy8Q9aahThqGvA%2FnrHmjqmB9hQU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:31.4295167","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A31Z&sr=b&sp=r&sig=Bwdoie%2B4Vz2v0sLpwD1D4NjJV3f9VlC%2BJDqhrD%2BCNbA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:31.4294361","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A31Z&sr=b&sp=r&sig=IHYv5dSx%2FHjubfmAjgexiBp0FeQrcswNxUacuUz32EA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:31.4295376","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:31 GMT
+      mise-correlation-id:
+      - cc1b4b93-3d1b-4fda-b32d-64789c775eac
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A36Z&sr=b&sp=r&sig=oWcA1DT8%2BXQCt7rgFY7KSZJBUkvy8oDsOWVlbCMZ1ic%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:36.6963889","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A36Z&sr=b&sp=r&sig=os6cNeJgsitz1hwr4fKrTfcuh4fWKjUsB8OnFLCfHJ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:36.6962619","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A36Z&sr=b&sp=r&sig=KoVhZlZvNsjN2dDqi%2BQt1HMrifRvx9hSAsGWc1AtlGE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:36.6964169","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3185'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:36 GMT
+      mise-correlation-id:
+      - be60b465-50ec-4f5c-b8e8-48657658f84e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A41Z&sr=b&sp=r&sig=sC3i7dpO5%2B9CPp9wfvSvEUpeLlTXarsYm1nuH2hQXOQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:41.995049","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A41Z&sr=b&sp=r&sig=6DgIoUirkyOqqprMCGBGe7wwhM6PgPmYJv1N0EdcmaM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:41.9949844","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A41Z&sr=b&sp=r&sig=%2F7sY8%2F12xkL0wA5rkhp6GedZ%2FO64lF1B%2BnbDDRWj3SE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:41.995064","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:42 GMT
+      mise-correlation-id:
+      - e21aa116-15cb-4e8c-bb7a-a5c2599a8649
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A48Z&sr=b&sp=r&sig=xeIYZYbIZHpQRNCfZwuJnGSybyVxGh8%2FhQ18zzdEYiI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:48.1718543","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A48Z&sr=b&sp=r&sig=UsCRBqeA9bkxpA%2BdgmGBGBDWLN2kvNged1xcZS%2Bumhs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:48.1717858","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A48Z&sr=b&sp=r&sig=z5Y0fBA9FzXi04FLk0Oi%2BgivUt28210BEOe13fBgEIE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:48.1718689","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:59:48 GMT
+      mise-correlation-id:
+      - d940c02d-5573-4444-af5b-3be43f0ace7e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A54Z&sr=b&sp=r&sig=Ix2Fr9MEbQWNaaUh7lRNOoDEBsaEroA22iL84EuFHfk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:54.1565528","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A54Z&sr=b&sp=r&sig=FSYI0aYdqdVOlRb3SysdMXmQNYLIOriIe8ygR6LbbA8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:54.15647","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A54Z&sr=b&sp=r&sig=9Wov23lNUgF9Ap8luyKRM%2F6MBuJH3Svajm3sMSW20pI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:54.1565667","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1398,9 +1686,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:25:54 GMT
+      - Fri, 13 Oct 2023 13:59:54 GMT
       mise-correlation-id:
-      - 47769597-275b-4ad9-aa3c-007d25905c60
+      - b4097db7-19b4-4440-a5d0-e8216c67ae8f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1418,25 +1706,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A00Z&sr=b&sp=r&sig=i62b5TVbE3jFA1vuqOsmzz2fym69qYs%2BZ9niH%2BIC5nI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:00.2795368","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A00Z&sr=b&sp=r&sig=llSb1zNHQH%2F12onzxGvh0d95z4T4XEV%2BezMBcLGGVRs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:00.2794648","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A00Z&sr=b&sp=r&sig=9iSPy4sFmzzkiutOkYoeKatGBieNqkwwhkBxnl2Zhgg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:00.2795523","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A59Z&sr=b&sp=r&sig=gKgUPpTRIvGaOkcGJeL6H23eLjOLBFol8UWOeDwU2rA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:59.3938058","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A59Z&sr=b&sp=r&sig=vG6xn9UVvVCXFce0IcuMZymIsqDrmgujeQsE7aMWfLA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:59:59.3937125","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A59%3A59Z&sr=b&sp=r&sig=EHNt4tN8xhsWqBRr0lcoIbclb4MGx%2B6PZafbvDuKlMM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T14:59:59.3938278","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3190'
+      - '3183'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:26:00 GMT
+      - Fri, 13 Oct 2023 13:59:59 GMT
       mise-correlation-id:
-      - 4d40bdbb-2188-4007-aaa5-e32cd5ca62d4
+      - dcf32c66-f318-458c-8221-9b3e1154d43c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1454,48 +1742,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A05Z&sr=b&sp=r&sig=z%2FXwyWr9SPjxwIWUUcMS3ApLhTCxlE5kXahhBcnvDsc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:05.557416","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A05Z&sr=b&sp=r&sig=Eqd8j5b3RKp%2BrP8HX2JQ8NmQFJMYufDDbQ%2Bob0fVbL0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:05.5573282","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A05Z&sr=b&sp=r&sig=h7pr2EoDjMvpamg08CO4MwJndkTeRhBBDBWVcj0hGvE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:05.5574392","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:05 GMT
-      mise-correlation-id:
-      - fbf13b05-8351-4f5e-b9e7-8c66bf646122
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A10Z&sr=b&sp=r&sig=XfFAiMvwRpoNZKO3qpXI%2F%2FT1TOuYOTNJP5lRtQpnF14%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:10.8365854","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A10Z&sr=b&sp=r&sig=eyvB5%2BwlR39hBGgRQuHRRLm00%2Fn2UOQSOnzDOzKpjAk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:10.8365017","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A10Z&sr=b&sp=r&sig=kPLGNS2OY4eEPhK55SMXICfioBY%2Fj5AW1f7a6EcOxJs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:10.836603","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A04Z&sr=b&sp=r&sig=SUJr70Rj4bePbPEF%2BSkvVA0SlfiWAzMZV6mBhgJOjGQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:04.6901565","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A04Z&sr=b&sp=r&sig=juTcwZs6VZWO3cDv9N%2FJsyut3TIEJm7Z8Ha%2Fr1PuLJ8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:04.6900814","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A04Z&sr=b&sp=r&sig=FX24hPOVSAAJHmKryvxYNkgGD7TC1kAT5EmkFO%2BH%2FrQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:04.6901712","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-13T13:57:29.834Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:58:16.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1506,9 +1758,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:26:10 GMT
+      - Fri, 13 Oct 2023 14:00:04 GMT
       mise-correlation-id:
-      - c7a38607-1359-4870-ae24-3ed9a40da9bf
+      - e26c4e21-5bf8-4772-a6c0-e2fa8ebcf38b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1526,314 +1778,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A16Z&sr=b&sp=r&sig=AjKEpCz50RA%2B6E6FAGqyUMIAR1szGGR2sw5%2BWbYNXSc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:16.1816773","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A16Z&sr=b&sp=r&sig=T4NknlGNrZZqW7Puve3zTuigYOvaVPZl9rpQk9d3OrM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:16.1815717","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A16Z&sr=b&sp=r&sig=B9CyoZU4lBWOe4%2BAbMf5M0yixDIMRD8XfEA6jVP%2FrW8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:16.181703","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A10Z&sr=b&sp=r&sig=krk5Ws34xj0rL7l0y4cTP3TmZa3BXtyLXdT42%2BrFtd8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:10.6789066","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A10Z&sr=b&sp=r&sig=jkZHAWYrwsytUsh4adqAko9iM68Z25gsibB14Do25sQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:10.6787867","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A10Z&sr=b&sp=r&sig=HzUMsjinoQZSZ7piz5POW5INDiC03vlWDZ655WDbG2E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:10.6789337","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-13T13:57:29.834Z","endDateTime":"2023-10-13T14:00:09.464Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:10.415Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3189'
+      - '3318'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:26:16 GMT
+      - Fri, 13 Oct 2023 14:00:10 GMT
       mise-correlation-id:
-      - 8c256b7c-c665-4a6c-8906-056e57a923f5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A21Z&sr=b&sp=r&sig=%2BUdIqNY4p3IIPfFEtUTarA966JjkrtxUPzgNMN6qI2U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:21.4694403","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A21Z&sr=b&sp=r&sig=AsLyf32AL4F9cBmSEvsG5%2Fo%2BaUYNvueGHWAtJcgik9I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:21.469369","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A21Z&sr=b&sp=r&sig=cv0L6IRjQpki6TstF0r0%2FV%2BPzg5hUXfThMC9m6I223M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:21.4694562","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:21 GMT
-      mise-correlation-id:
-      - 93675a5e-e624-4f34-9882-971bf47cedb6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A26Z&sr=b&sp=r&sig=keGzBQQxSMIFQdC3f7%2Fnu3QkymZ34oSTRWDq65vC7Gc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:26.8187954","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A26Z&sr=b&sp=r&sig=CLpwtNZrZ6I%2BOfBchTJZhAcqzWL0Hub%2BsH3zjauc0lQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:26.8187098","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A26Z&sr=b&sp=r&sig=2oMdDbS8BwnnFjRsNasbsSMQB%2FM0%2BDsnpqKNMf9Dxro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:26.8188167","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:26 GMT
-      mise-correlation-id:
-      - c2222415-28e2-410c-ac11-560392f60339
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A32Z&sr=b&sp=r&sig=6SvDXECcKI3z3rZi2M7kCXwtZ8iKDELCnAzILrahGG0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:32.4686245","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A32Z&sr=b&sp=r&sig=M39v5Kw0RjslYEAjGspq%2Bsp%2F9dblFA1h7sfWwDPVfec%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:32.4685679","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A32Z&sr=b&sp=r&sig=lUbUQCsBa0odkJKIJNGEjtDvsBK%2BMV3qtzFsPygCsMM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:32.4686381","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:32 GMT
-      mise-correlation-id:
-      - a54b1d4a-4bad-41d3-a1b8-5c3b5365156d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A37Z&sr=b&sp=r&sig=QDnQDFB%2B54Jm%2FC%2FNuomEsfRZRUlobUP52aZXJahsDRc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:37.7484107","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A37Z&sr=b&sp=r&sig=Vq%2FNtv5hgXULBwcLtqyc5BeYbduEnqQAfhNhfzDTVU4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:37.7482909","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A37Z&sr=b&sp=r&sig=5MSQinR8w7wcvwb%2FmnCsbNCDH368H1fR%2BhngImQ9of0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:37.7484386","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:37 GMT
-      mise-correlation-id:
-      - dbb9556c-79e7-46bf-ac09-037034e2c231
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A43Z&sr=b&sp=r&sig=23Ij7CA6Nnhr8HmWXrhKEnvEEqQLH2UA2ttM4gq5Nf4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:43.0927914","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A43Z&sr=b&sp=r&sig=bjnmjb651C3Gj5wRK2Gp%2BcUJy9SCmGpvW0lnwcRySvA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:43.0927151","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A43Z&sr=b&sp=r&sig=c%2BI0HHd9TOfeNk1T7YgWxcZ888KKe8wj8IX%2BC9ZgWsY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:43.0928056","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:43 GMT
-      mise-correlation-id:
-      - e8408b85-026d-4a32-9e05-c7a7f7221e60
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A48Z&sr=b&sp=r&sig=r9tdU%2Fmp15G6pi0%2B4BxmHReNeJXKH6JEyVbTYy69n2k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:48.4071402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A48Z&sr=b&sp=r&sig=FjdMFxGfVwaStRIbQ8BrQDcUyWODoSJkQw7e9i7cH5c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:48.4070455","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A48Z&sr=b&sp=r&sig=0BIZQBGoEGX7nmKh7jaJZgT2CRw6WaevBOPDlPlv%2Bcw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:48.407162","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:48 GMT
-      mise-correlation-id:
-      - 105adc65-402f-47cf-9930-171531126828
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A53Z&sr=b&sp=r&sig=QQLRgPtYxd%2BRbBDUkY0vjFjBIFKbgjtthucGokIywcA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:53.7352676","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A53Z&sr=b&sp=r&sig=PunhaMIUh1wWA%2FKKL%2F47ViB5wOmaIb6l2uXPb3EyJEw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:53.7351822","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A53Z&sr=b&sp=r&sig=OoGPboakiCtxm6Bix%2Bgd%2FKTSdwCOXpbcCrJtJQdopHg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:53.7352887","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:24:12.295Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:25:04.529Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:53 GMT
-      mise-correlation-id:
-      - 18d403c9-e21f-4342-b6f6-f4540ff03424
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A59Z&sr=b&sp=r&sig=QiZP9BdSyr62Cjl96cVNv0BmtJakzzanoKx070M7Smo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:59.022234","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A59Z&sr=b&sp=r&sig=EnTAUthtgWoMi6j9U5i%2BIfWd5ky4SjenJcXjX7n8bJg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:26:59.0219819","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A26%3A59Z&sr=b&sp=r&sig=Rx9JJItp8ej3OcztS4kybdJ%2Bnj4%2FtzYOtq7gSs99AlM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:26:59.0222734","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-09T19:24:12.295Z","endDateTime":"2023-10-09T19:26:56.807Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:26:56.887Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3322'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:26:59 GMT
-      mise-correlation-id:
-      - 92ae38e1-5953-4ee6-bc69-e3ddd19e9dae
+      - d505ca77-00b4-4b92-a4f7-73b81f1ef682
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1856,7 +1820,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:11.7118206Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:11.7118206Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:30.3512589Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:30.3512589Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1865,9 +1829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:00 GMT
+      - Fri, 13 Oct 2023 14:00:11 GMT
       etag:
-      - '"56002ea3-0000-0100-0000-652453210000"'
+      - '"d901923f-0000-0100-0000-65294c900000"'
       expires:
       - '-1'
       pragma:
@@ -1895,26 +1859,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=show-test-case&api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=show-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A01Z&sr=b&sp=r&sig=eFKaHOdYK7YXAKOp8GiUZTc2N76taC1vjeXxXdPIJ3U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:01.4689579","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A01Z&sr=b&sp=r&sig=xEsOXDz%2FiObRKdZURfAlenrM7Tr7UpUBLBcOlEtLn1o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:01.46888","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A01Z&sr=b&sp=r&sig=%2FxjiV4bLWl1GBPagDFG4BIRtAKpwht0KMcjDEbg6eJY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:01.4689722","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-09T19:24:12.295Z","endDateTime":"2023-10-09T19:26:56.807Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:26:56.887Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A12Z&sr=b&sp=r&sig=r9gUyVLYDjN4CO0W9e6lZQYHKW5ov5Kofsj2w5zYAGk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:12.7609866","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A12Z&sr=b&sp=r&sig=Kq8euYTmRS%2FFUuUviTE9qhG1K4Ev8%2B4BWvovBmsQBvY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:12.7609178","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A12Z&sr=b&sp=r&sig=pJXt%2B8E2vdtkkN56G4GFM6DQB5N5M47p2ONpxBJsBjU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:12.7610001","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-13T13:57:29.834Z","endDateTime":"2023-10-13T14:00:09.464Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:10.415Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3331'
+      - '3334'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:01 GMT
+      - Fri, 13 Oct 2023 14:00:12 GMT
       mise-correlation-id:
-      - 93e6efd8-3094-40a3-bd3b-1a8a588b5089
+      - 848a24ea-e1d5-4691-b043-e46106bd1f7f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1937,7 +1901,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:23:11.7118206Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:23:11.7118206Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:56:30.3512589Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:56:30.3512589Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1946,9 +1910,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:02 GMT
+      - Fri, 13 Oct 2023 14:00:13 GMT
       etag:
-      - '"56002ea3-0000-0100-0000-652453210000"'
+      - '"d901923f-0000-0100-0000-65294c900000"'
       expires:
       - '-1'
       pragma:
@@ -1976,26 +1940,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://af03a673-7b41-4593-97aa-83229e80b07e.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://18b9cae5-45b1-43d2-8eac-ad2ce5be300f.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"2d828163-cd89-43a0-82e8-45ff414c793f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"198a8c96-1fdf-43a5-953e-4365b55e501f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e156d481-b9a9-4175-8796-aa08651643f1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/01ffbd1e-8d0d-43cb-9cba-dca67f47a1b7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A03Z&sr=b&sp=r&sig=3lN475lA0%2BjGYwiUWL%2BKi8TWnS57Bt%2Fo5Obmvn6GHAg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:03.9173717","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/91f74be7-3f84-46da-abfd-2286476bf8a6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A03Z&sr=b&sp=r&sig=BzVpc9HZCBtLPU2bVyENOtIUbpmhffYPqQoT2ttB4IQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:03.9172651","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ce6c61ba-3850-4c52-8d60-0aa595c3c841/32c45238-5a4d-4eb1-a0fe-25ed93efd169?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A03Z&sr=b&sp=r&sig=yI59hYXMvsK0ljDd6tRuj4byXQOZMLNByeVAHk8%2BgXE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:03.9173983","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-09T19:24:12.295Z","endDateTime":"2023-10-09T19:26:56.807Z","executedDateTime":"2023-10-09T19:24:11.489Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-09T19:24:11.783Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:26:56.887Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4accade2-1b0b-43e5-8323-7ba7081159f6":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"bc389940-a451-48ba-8d83-d9239fa07b46":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c7b16299-1892-43ab-ac63-bd00f2172567":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/14f2eade-33e2-4ac6-ba45-0ae6b062a52b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A14Z&sr=b&sp=r&sig=NidWx%2BINAR0cXqTY574cxv1Hu%2Bewe7MRHb9UEwU0ykA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:14.8169255","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/c6295a56-4b5e-4b6c-9756-8578c661778d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A14Z&sr=b&sp=r&sig=dpvN5K4ZrLasm1SnuVUCYnb2mknrVW0i92Ct0rCO0D8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:00:14.81685","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9a6c7ac6-949a-4a8c-970d-d28461fce420/54280d60-6687-419a-a3d0-f120900f2ca2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A00%3A14Z&sr=b&sp=r&sig=TsX1H8cfyqvAT1lLEf4CQn3F5SmhWrhD17DQEUNRVCg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:00:14.8169406","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-13T13:57:29.834Z","endDateTime":"2023-10-13T14:00:09.464Z","executedDateTime":"2023-10-13T13:57:28.53Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-13T13:57:29.437Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:10.415Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3325'
+      - '3318'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:03 GMT
+      - Fri, 13 Oct 2023 14:00:14 GMT
       mise-correlation-id:
-      - 76ae4b9d-f1cd-46e2-bf4b-0abca552530a
+      - 7a7b8f73-d887-4152-9a72-c5ffaf675238
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_show.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_show.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:33:04.2189798Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:33:04.2189798Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:26:24.0632488Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:26:24.0632488Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:37 GMT
+      - Sun, 29 Oct 2023 22:26:58 GMT
       etag:
-      - '"d300094a-0000-0100-0000-6537b9820000"'
+      - '"3c005c31-0000-0100-0000-653edc120000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:33:38 GMT
+      - Sun, 29 Oct 2023 22:26:59 GMT
       mise-correlation-id:
-      - 95501169-de93-4728-9b45-c6ec58edee0f
+      - 819a4517-8a6b-4a44-9c05-5eeaf39f814c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"f8ee81d5-6518-43ad-9a4e-b9700d69e096": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "d1604977-5345-4f60-ada4-93691cd760f1":
+      {"passFailMetrics": {"4baa0483-5376-4dd0-b0d0-62320513018f": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "811593e5-691c-4840-9970-9165295eeb75":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "363ef462-9754-481e-98ac-f0093447de46": {"aggregate": "avg", "clientMetric":
+      "50"}, "f9a7c530-55ea-478d-ab6c-095e020abbfd": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:33:39.566Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:39.566Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:27:00.304Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:00.304Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:39 GMT
+      - Sun, 29 Oct 2023 22:27:00 GMT
       location:
-      - https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+      - https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - f0764e68-aae9-4b46-a2ab-f45f6ae086e0
+      - 517e70ec-4a45-4681-b5b7-7b01f3bab5ae
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:39 GMT
+      - Sun, 29 Oct 2023 22:27:00 GMT
       mise-correlation-id:
-      - 52a721c4-428c-40ed-b3dc-1617406293be
+      - 2718fa7e-eb15-49c4-9230-62267aa16bd9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A40Z&sr=b&sp=r&sig=aM4VDHMQXyNjpX6bv%2FgQYjkN36y6vEgw0y1t%2B1dIrPc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:40.5858898","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A37%3A01Z&sr=b&sp=r&sig=y2YtCZrMCMenWVHRWiYxVsutiabuYqR01Q5X3iTMkqA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:37:01.1598011","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:40 GMT
+      - Sun, 29 Oct 2023 22:27:01 GMT
       location:
-      - https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - e17e3014-00d5-43c3-b750-fd13e2166258
+      - 601e711d-3464-4aaa-8da1-38cc9de5f4e4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A40Z&sr=b&sp=r&sig=F9ufS0jVy0gKS2VNU26I%2BaA97KlUZcDfG6cjEUcRt0E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:40.9358879","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A37%3A01Z&sr=b&sp=r&sig=heCrjU0oxtG%2FSu%2BIisp9Y6u6dy9%2B7CWBmgEjLi4DUVs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:37:01.5333623","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:40 GMT
+      - Sun, 29 Oct 2023 22:27:01 GMT
       mise-correlation-id:
-      - d5622301-4f58-4b08-b421-7c9deb4c73d9
+      - 2a23efaa-f20b-463e-85c0-778a2a208aac
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,82 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A46Z&sr=b&sp=r&sig=z79%2F%2BGpza0xThcv4pvJutW44WmeHsSYwWSYGKBlBWU0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:46.2264304","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:33:46 GMT
-      mise-correlation-id:
-      - 2c167aba-df92-4c3d-9070-8ced1f69d12d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A51Z&sr=b&sp=r&sig=dRy0ZieM9sTuGPmc2jg5blQEsY%2B1ml3prdTdXZZ3dfg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:51.5012162","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:33:51 GMT
-      mise-correlation-id:
-      - 2e1a7dd6-a7f3-4b67-b439-2abfdfa9ecaa
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A43%3A56Z&sr=b&sp=r&sig=qf0oJ33PAq5koiiC0%2BWkLPgoIqYV7dyuJILkkhqphK0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:43:56.7691944","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A37%3A07Z&sr=b&sp=r&sig=EkJ56rPmWrB3huxdETuWfsx4q1w5AzaKmG4oPen9dQU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:37:07.4929721","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:56 GMT
+      - Sun, 29 Oct 2023 22:27:07 GMT
       mise-correlation-id:
-      - 6f157c76-94b9-446b-bb7d-6cce89069cc9
+      - 792fbd36-a30d-45e5-8987-5f1b9b725073
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +385,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A57Z&sr=b&sp=r&sig=kbdN%2F%2FWLM28uU3wR51PXYn85wNjagUHEnxTe6p8RuDI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:57.0057418","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:33:39.566Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:53.443Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A37%3A12Z&sr=b&sp=r&sig=eoAVlvseM05NfG63xaew9lPSRSEFmr%2FShx0LyZCiihI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:37:12.7471957","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1579'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:57 GMT
+      - Sun, 29 Oct 2023 22:27:12 GMT
       mise-correlation-id:
-      - 7dd282c5-6e7e-433b-8874-51fb1062d344
+      - 235b252f-f1a0-4089-8dbc-799a6a72fa31
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A37%3A18Z&sr=b&sp=r&sig=71gFzxQDFZIjYOL04WTTwDVvR1X5kYyNG0wO3ll8drc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:37:18.0527548","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '547'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:27:18 GMT
+      mise-correlation-id:
+      - a834c322-ade9-4323-9daf-00580e75d3af
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A18Z&sr=b&sp=r&sig=CQ%2BBZ0L8PXBWOe70KavM9VM8KDoBP6IdKaYj764g6TM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:18.3131914","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:27:00.304Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:13.229Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1577'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:27:18 GMT
+      mise-correlation-id:
+      - 3f7c8732-464b-4f10-b3fb-fb79eb7fe785
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:33:04.2189798Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:33:04.2189798Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:26:24.0632488Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:26:24.0632488Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:57 GMT
+      - Sun, 29 Oct 2023 22:27:19 GMT
       etag:
-      - '"d300094a-0000-0100-0000-6537b9820000"'
+      - '"3c005c31-0000-0100-0000-653edc120000"'
       expires:
       - '-1'
       pragma:
@@ -538,11 +538,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A33%3A58Z&sr=b&sp=r&sig=NSyn596lUAwROcvfU8hV52VFbEZtU3SS22MNfo94N%2Bk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:33:58.5839333","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:33:39.566Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:33:53.443Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A20Z&sr=b&sp=r&sig=2zD9fYkY%2BtSpZNDRxhAu0Zbc49ZLlSZHCSsrpJbCCSs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:20.5748943","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:27:00.304Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:13.229Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:58 GMT
+      - Sun, 29 Oct 2023 22:27:20 GMT
       mise-correlation-id:
-      - b858fe85-933e-4d25-8d6b-2483be42e64b
+      - e631f29d-3ade-4e2b-908e-419ae0a89fa9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:33:04.2189798Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:33:04.2189798Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:26:24.0632488Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:26:24.0632488Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:33:58 GMT
+      - Sun, 29 Oct 2023 22:27:21 GMT
       etag:
-      - '"d300094a-0000-0100-0000-6537b9820000"'
+      - '"3c005c31-0000-0100-0000-653edc120000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:34:00 GMT
+      - Sun, 29 Oct 2023 22:27:22 GMT
       mise-correlation-id:
-      - 531d387a-4ebb-447d-adf7-e484fae444f8
+      - 2a359599-33e8-4940-bce7-e3ee07787bed
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A00Z&sr=b&sp=r&sig=5iI%2FhPEZIcwrOMB9OGtzxwDt4M4fDMeUvqMyW1cbb%2BM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:00.8837233","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A00Z&sr=b&sp=r&sig=%2BqHtFwBgQm%2Fx1eK812b16MlIfoWNX1UWReHugBxQFJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:00.8836243","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A00Z&sr=b&sp=r&sig=XInDjlyqTbO6FhL6BOUSbdmLTruDgRvaTI31wxklX8s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:00.8837572","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:00.795Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A23Z&sr=b&sp=r&sig=1TgbKQKhsc6qcsQAlpZLRv8Owl0u4E5q33xc7nQ095k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:23.5671602","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A23Z&sr=b&sp=r&sig=C4%2B2BowHt1bVQVtoNlpAGwmJuzwVZUxhrAj4Iwfg6vU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:23.5670596","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A23Z&sr=b&sp=r&sig=rAmATosRhTUHJEbNOV5udPP%2F9aLoRPQK1saFOTn6cXo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:23.5671834","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:23.474Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3146'
+      - '3142'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:34:01 GMT
+      - Sun, 29 Oct 2023 22:27:23 GMT
       location:
-      - https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+      - https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - ac0af053-b61b-4f6f-99a7-60d9e09b74ff
+      - 8a4c975e-113e-480b-9ee4-64a5c2615ddd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,46 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A01Z&sr=b&sp=r&sig=OGcHVakYc6jESrKPLLMkLKziA9nCw%2FVEKVRlCRautUQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:01.4235434","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A01Z&sr=b&sp=r&sig=PxLWGsiQV%2FRMMn3xhLEZzqSupi5AP33XB0CL0WWK%2Bv0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:01.423437","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A01Z&sr=b&sp=r&sig=Zc2qrmhT9ALwvh2mDCNPKtjFfO1hfuBwoEJV%2BUmK70A%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:01.4235673","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:01.349Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:01 GMT
-      mise-correlation-id:
-      - 67f1bfcb-d082-4b54-a885-a095e6d27f01
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A06Z&sr=b&sp=r&sig=GabkuGt3Ks2dOCbalR2y63bSrFcZbQm3CAgqJ9BKMf8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:06.7499919","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A06Z&sr=b&sp=r&sig=%2BsKrGNH2UQsN47fPCA1VUXmrcSeHzmzbgMmoDFm1H0s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:06.7499124","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A06Z&sr=b&sp=r&sig=OCdGW7Y%2FRK3Q5kCa6Xn2f2uylRPmv0sdJSYGEQBpX0k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:06.7500096","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:01.349Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A24Z&sr=b&sp=r&sig=L4SiOem9NozloRAFxCge90fB2KkkHyp0NLpN2wutq5I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:24.0078672","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A24Z&sr=b&sp=r&sig=pZswC6yAHWVpv2ib%2FN5rWybdPrCRBitaEehmn%2BY95QU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:24.0077967","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A24Z&sr=b&sp=r&sig=DegIpmuSadXjaDoC36miCGMHFvhcP%2FTmIZ9ZBxT4ulI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:24.0078822","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"NOTSTARTED","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:23.963Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -750,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:34:06 GMT
+      - Sun, 29 Oct 2023 22:27:24 GMT
       mise-correlation-id:
-      - 0f444c27-6372-474d-87ed-05967c67ee21
+      - 709fddd2-990f-439c-9712-8620f535dc18
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,118 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A12Z&sr=b&sp=r&sig=tY2WJtrPDV7oGfgJsj7KDfdROXDcvVF120hIqGlSFJc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:12.0334418","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A12Z&sr=b&sp=r&sig=hEiTl1IcTpvsU8Y1I6z7ptCJhW%2FwNIqdZbyIMlHE0iI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:12.0333698","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A12Z&sr=b&sp=r&sig=H%2BE%2BO8LiT8%2FTdFxJKSUpno%2B4Z4ydW4EveaoXM1ef91w%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:12.0334559","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:01.349Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3195'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:12 GMT
-      mise-correlation-id:
-      - b255cf68-de0e-4f7f-8e29-621ead3cbe39
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A17Z&sr=b&sp=r&sig=bvC%2FjEvm7RQVqjgk%2FLadRqVTO%2FNiMr81yZHnLWmPuB0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:17.2784257","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A17Z&sr=b&sp=r&sig=psf%2FjVx6ZNmplUcg%2FO70u1lcq9ayzHZDtDawe3fC050%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:17.2783395","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A17Z&sr=b&sp=r&sig=2THt7cKEZLHJ1RdQBBXDiZ9ciLJa922tSwOd7JROC5M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:17.2784409","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:01.349Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3195'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:17 GMT
-      mise-correlation-id:
-      - 46e9aa8c-ca74-4153-b0cd-f2ba91e7e5a6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A22Z&sr=b&sp=r&sig=vuX9YAlAcFboLqyKAFdevfLzBHcdzu3486dcu%2FFHuLM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:22.5698773","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A22Z&sr=b&sp=r&sig=yC1oevi0HxZ9nsQMcG%2BnPoLvLWNb4ATmGegIP3nTIj0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:22.5697658","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A22Z&sr=b&sp=r&sig=UBvRdt8UlDuwcMWyWcfaJKIX2kOFhke6C6hGCAU2d7o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:22.5699018","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:01.349Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3189'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:22 GMT
-      mise-correlation-id:
-      - 54cf0416-1635-4991-a2ae-1649e6fb45d8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A27Z&sr=b&sp=r&sig=229B0Ta%2Fvbo6CwQxbtlf3bU2av8VzBtIhxrsbchT%2FIo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:27.8536129","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A27Z&sr=b&sp=r&sig=6Dmbp9KRCMndOxqLblhI93zo%2B2BYNw3zk4kTtrlIxLU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:27.8535105","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A27Z&sr=b&sp=r&sig=J6Rre12pa7GQx0Zi0qZBQ3NahceQ2uwwHkM%2BFof4OSs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:27.8536353","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:01.349Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A29Z&sr=b&sp=r&sig=WgLOuO4%2BF%2F4qDr9zVbqtvDuAzPfN1C07xW%2BueE5mB0Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:29.2810135","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A29Z&sr=b&sp=r&sig=cJdd73gmvWAe0NDT8%2BPb8EtLjXhiRJuwez8LDgn037k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:29.280929","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A29Z&sr=b&sp=r&sig=EGnKXo2%2BXpoaS9XuLOldFeJAYIZL9Nkq2bJtHddnciU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:29.281035","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:24.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -894,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:34:27 GMT
+      - Sun, 29 Oct 2023 22:27:29 GMT
       mise-correlation-id:
-      - 11f5ab12-cde3-4797-87b3-a471db503ac9
+      - 67606bb9-19cc-4af9-b1f2-79063b086337
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -916,82 +772,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A33Z&sr=b&sp=r&sig=XvexfLaJiNScpQpUOifGoNZxIodxTXi122GgcVLx2Bk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:33.1152152","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A33Z&sr=b&sp=r&sig=ATKPxCRAjUFx%2BG%2Fw6NCMwpd%2BYS%2FcuCmCaodzLSghkak%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:33.115116","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A33Z&sr=b&sp=r&sig=%2FlsK67Z0WoKi5P9rS4kcQI9BvCJ414JNdeogSsyLnf4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:33.1152414","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:01.349Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:33 GMT
-      mise-correlation-id:
-      - b506bf9e-09c1-4c49-bb3e-1cacd6d1a6a9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A38Z&sr=b&sp=r&sig=GAIQCoAj%2Bh7kgFfZj%2FNPeeDyBZQaYrrxcp9FT1Newlk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:38.3791825","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A38Z&sr=b&sp=r&sig=bPdh74aLfFlbgNI9XPBoGgLy0PKFLNQ8sSKc4Hkym6o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:38.3791122","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A38Z&sr=b&sp=r&sig=4lyVP5B0ZF4Bky858%2BidnH2gRUkGYAujvKjeZHiZuUk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:38.3791963","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:01.349Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:38 GMT
-      mise-correlation-id:
-      - b6b253b8-0d78-4543-9c63-78fdf2dba2ed
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A43Z&sr=b&sp=r&sig=8Qf5rP29F4U2er6PL7jQwr3skrA9%2FEInd6qmMYE75z4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:43.6607729","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A43Z&sr=b&sp=r&sig=me9qgBCOy9kthHir97KY3NgjtxOjG3l0P60JVu02vw8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:43.6607025","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A43Z&sr=b&sp=r&sig=9XxkReZKL9IMlm%2FitBUU8rzps65zTfoAy7SMTeeSoME%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:43.6607867","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:01.349Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A34Z&sr=b&sp=r&sig=BD42119LpnxxqaXfrzaHuhjG11BSGC1oZgLjccHtUuk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:34.5605395","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A34Z&sr=b&sp=r&sig=atJV8NhuRx2yg9mIJUhLz18Eri0DN9q1p2KUHI9Dpug%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:34.5604529","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A34Z&sr=b&sp=r&sig=2%2BGOKo1lsQqr4F2QhiQ4%2FsEZ82IjgawWtx90GeXruYk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:34.5605613","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:24.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1002,9 +786,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:34:43 GMT
+      - Sun, 29 Oct 2023 22:27:34 GMT
       mise-correlation-id:
-      - 4d63310b-9efe-4a70-89cd-ef32d53567c7
+      - adda895b-e7da-4d07-a579-b67dab277ea0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1024,82 +808,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A48Z&sr=b&sp=r&sig=J0%2BkcPf18FHWTn1ZCNc03PH6wz8Ax%2FY5oeh2tIqSAiI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:48.9058954","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A48Z&sr=b&sp=r&sig=V7rp5ApbwYrtxhXjG4gSqKqP85SG%2BNJgNpvcmGFLgoM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:48.9058103","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A48Z&sr=b&sp=r&sig=Vheo3W%2BXwiHE3yuYV%2FfYNsG6p3eanf7Ius93o%2BiCBQE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:48.905911","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:48 GMT
-      mise-correlation-id:
-      - 0bbd537a-287a-4984-b1a4-113c16f45055
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A54Z&sr=b&sp=r&sig=71%2B67HRKxgOWqPjSJAe6u5jiCZKZIxH1PfSUaVOjKLs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:54.9646518","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A54Z&sr=b&sp=r&sig=54H6iriFtCFZlisVWmNggu6DudhUrAVpm9D6eyQMe%2B8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:34:54.9645715","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A34%3A54Z&sr=b&sp=r&sig=q1pHI05uKgIDGrzi4KZsKRYXZf%2Fj3kl%2BuD1pORPNRi4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:34:54.9646657","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:34:54 GMT
-      mise-correlation-id:
-      - f5d1f12b-3de2-4497-9bfe-19ec74d92f22
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A00Z&sr=b&sp=r&sig=f2TKnV6pNPi8lkCsZV%2FK62y6r2Fmn2t0fprZ%2BslDSTY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:00.2972422","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A00Z&sr=b&sp=r&sig=qCtZYwnkl1V2YIp7K0OFiGMWzCig3veF532rZjYeU0o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:00.2971753","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A00Z&sr=b&sp=r&sig=osZjTP2Td%2BRmnjlxauujW1SPMFj537Wf0BldzzwkJ7c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:00.2972567","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A39Z&sr=b&sp=r&sig=cTxIOM%2BI4vQ8EovmSpw1C9vPdkRZ8vvjWIxdo55Adyw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:39.8395151","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A39Z&sr=b&sp=r&sig=jPllPqWQlHBH5SgkKhFGXJoJTrv6EZHqf0SJMus0n4Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:39.839427","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A39Z&sr=b&sp=r&sig=LG3yHtf%2FEXjtMqEzsHFOsvFeHruLQHbtw4WZhWDiipI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:39.8395373","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:24.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1110,9 +822,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:00 GMT
+      - Sun, 29 Oct 2023 22:27:39 GMT
       mise-correlation-id:
-      - 26bb13b0-f366-4d7f-9dc9-001be9e1db20
+      - 9c3e2805-7a71-4c1d-8fde-86ffefffa275
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1132,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A05Z&sr=b&sp=r&sig=08F8yXiKxmrGW8wokpd0tKtNzcdSWCx1Em8YCP7lVNI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:05.6195356","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A05Z&sr=b&sp=r&sig=%2FV%2BfxR6bqwKy5cVxfZNSR2pZMnweoTdkVtBM7o6HKpI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:05.6194583","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A05Z&sr=b&sp=r&sig=EwD%2B77P9xJGUEAh0z2DfQdLcRt1SMEkpjMktdeyU8uc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:05.6195496","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A45Z&sr=b&sp=r&sig=LnyT%2BN2HMsQQ4%2FozKEXCZdVQuAeSgUY67rKM4mACD1I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:45.1504608","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A45Z&sr=b&sp=r&sig=wogLVXgEJaiAbnT4%2FowVBT%2F7meolMg8g7ty%2FZsxptis%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:45.1502779","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A45Z&sr=b&sp=r&sig=cQ4kQH6xW96cYhallTYOifr5o1LVoy6yMqwo7d%2FCjD8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:45.1504833","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:24.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3188'
+      - '3197'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:05 GMT
+      - Sun, 29 Oct 2023 22:27:45 GMT
       mise-correlation-id:
-      - 181af0d8-0d0f-4fd2-b12a-ff3550931ad9
+      - c64fbaf7-7549-48c7-9294-469699a08d24
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1168,334 +880,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A10Z&sr=b&sp=r&sig=0SWypKVOlciYB%2B%2Bgs2p4PhWPURGAeNFuhl1yI0MatvI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:10.9309656","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A10Z&sr=b&sp=r&sig=xDmBduCsBdTz4arMNfzmM992W2WxNOVFEUGB565GLGc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:10.9308856","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A10Z&sr=b&sp=r&sig=m22sKmE9bxqyd4HT6sVHPe4VClW3uDIVbnbtYO1FE4s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:10.9309811","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:10 GMT
-      mise-correlation-id:
-      - 5b92a49d-a0a0-40bc-b2ed-0ebfd10e4cc8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A16Z&sr=b&sp=r&sig=zUlr2f7YUyMuKTDTCamacaDRbjSl6zNSmUFFBoBFXHA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:16.2632645","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A16Z&sr=b&sp=r&sig=2F4WK%2BjYAW0OYUIZzhWcecYwKm72DMEex2Uh4Wx5E4s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:16.2631954","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A16Z&sr=b&sp=r&sig=laTRtA4Jj7aOyclOQ9zgQ0BpPjwJetzDqdy1edJSogk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:16.2632783","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3184'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:16 GMT
-      mise-correlation-id:
-      - 09818514-4a8d-4e7e-8b78-456649c059aa
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A21Z&sr=b&sp=r&sig=0cDgXMb8kWTCZKvWcg7ghvUItTWqK8DNU16qQGYdFXs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:21.5677544","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A21Z&sr=b&sp=r&sig=wSGUefHk7pnLaEX5NtjP5LR1WYfJhs8woro%2F%2B7HW6pk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:21.5676684","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A21Z&sr=b&sp=r&sig=Tf9mZ8wAeQSD9BWT6npKL%2B5tw2mVBkkivK1Hg2Gj8kY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:21.5677763","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:21 GMT
-      mise-correlation-id:
-      - 590dc300-b2fc-499f-8e05-6a4a429970a2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A26Z&sr=b&sp=r&sig=8hH9R1kz7qcdgDN0giViTVYq5S9l6bz60cmeos34e04%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:26.9103319","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A26Z&sr=b&sp=r&sig=TKk34bjFuDI37yDiu5Pco6QX8us2h3tdLDY0k2GAc%2Bk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:26.9102249","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A26Z&sr=b&sp=r&sig=YjZxq2iMhFDq9VfiP71qE3h4oqUz2J19%2BBitHrDVZtE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:26.9103466","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:26 GMT
-      mise-correlation-id:
-      - 6776ae65-68f9-4ece-b84a-c8ab7364a920
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A32Z&sr=b&sp=r&sig=IooXMLIZvFwzn5vNzXy%2FwCoq5ZBL4jPJaJm4MqAi%2F0A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:32.182662","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A32Z&sr=b&sp=r&sig=UFRqMi082bcx%2BPwnMUaX5AXKx4T3182BaLOOf2mnDAs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:32.1825781","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A32Z&sr=b&sp=r&sig=PeEWX3YwzzyvNnp9SA%2FZZNecxz5YTUJ52c%2FRazP4WNM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:32.182682","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:32 GMT
-      mise-correlation-id:
-      - 8fc67ad4-16c1-4dbb-926c-5e3e809e0c04
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A37Z&sr=b&sp=r&sig=1i3uUDK7a00szwjjSV5XZO7PzxVKwUo%2F2yr6wPdl89A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:37.4717536","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A37Z&sr=b&sp=r&sig=hClWpusnLr8%2BZd6cvgixvLmLQdXn%2BWAT%2FbWYC5X8Ppg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:37.4716743","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A37Z&sr=b&sp=r&sig=cWazmP%2FjkNHlIr65RGX4zD1ltCV9k8etDOxJNuot7is%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:37.4717687","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:37 GMT
-      mise-correlation-id:
-      - e0ceb6bc-6f8e-4bca-b50a-d10f351951c5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A42Z&sr=b&sp=r&sig=zSTb8U4tKWiioh8uIOpA6u3hhReLsaipEuMVTrTFEmk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:42.7662548","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A42Z&sr=b&sp=r&sig=ZSlQvGcZv42teV1TogZcpefckwlCg6R3iSQKtiBr%2BR0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:42.7661096","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A42Z&sr=b&sp=r&sig=d8aQ9s6wf9rgUBnLPejXjxmhyx7hb9vu%2BN8tiwyyuPM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:42.7662806","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3186'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:42 GMT
-      mise-correlation-id:
-      - 60a18e42-a49a-4ceb-b2e2-a0e4a76db138
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A48Z&sr=b&sp=r&sig=rMaij2qK1rFkq4xOIAgEB5tsnWPPCNoxSvchdBF3BPI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:48.0258152","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A48Z&sr=b&sp=r&sig=8L0KN%2F3jPAHEPQS%2B%2FrgfK%2BQsCoUvTNrOA6YIyp5NDpA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:48.0257443","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A48Z&sr=b&sp=r&sig=TeVN2J7tudrPnR9SLN0sj5LRBlR5Nnyv7Azmtzpb%2BDM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:48.025829","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:48 GMT
-      mise-correlation-id:
-      - 1aed1475-0cf5-4acc-a55e-d0751172a73d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A53Z&sr=b&sp=r&sig=bedLLGUhUfIq6NESM%2B8BFEDUn%2B0yP%2FR0rXKYjdcgjlI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:53.3791045","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A53Z&sr=b&sp=r&sig=Hp5oCMQIloKXLxlGjD2o1WQJlVHtTg1or5ZcOBYstL0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:53.3790193","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A53Z&sr=b&sp=r&sig=AcJ%2FuRASkS6M5byYZTb2246T%2FLrnB9f9e%2FgbNYKxyAM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:53.3791257","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:35:53 GMT
-      mise-correlation-id:
-      - d4847993-bc98-486a-a134-bcfcf15b76b7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A58Z&sr=b&sp=r&sig=81AJ4R8gpRbLzmK%2BHzFX9iUeIH%2FYD%2FUHUpHjBu9sVLs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:58.6542911","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A58Z&sr=b&sp=r&sig=son%2BHdbIKvVd5XOdltdYm5REYVLJIoZJR%2FKDmWzcFUc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:35:58.6542257","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A35%3A58Z&sr=b&sp=r&sig=X%2BI1HRv7D%2BQMhFHErfWhZfQNDSD7y3zzbALUtNYwvDw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:35:58.6543054","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A50Z&sr=b&sp=r&sig=2AkkUWvLk8n%2BzqmRzUUKWDsLLrF%2FPtuKWyXilGPCoRg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:50.7965019","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A50Z&sr=b&sp=r&sig=Z1DPt6LE8GITygr0qF7jc65BGBAhmY24zc7Sml5e10g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:50.7964238","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A50Z&sr=b&sp=r&sig=Ujw0%2FhjBM%2FeAHtE8W7UFT2vs%2B4adX97%2FCxguDz5rbzI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:50.796516","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:24.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1506,9 +894,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:35:58 GMT
+      - Sun, 29 Oct 2023 22:27:50 GMT
       mise-correlation-id:
-      - 5890ab62-8310-4552-a92c-d2cf41988d19
+      - f2e8d17a-e44d-4945-82fe-5f766e98720e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1528,10 +916,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A03Z&sr=b&sp=r&sig=uyVg%2FTpGFn6wBli7u%2FMeNPIF2G8pCHoZz9zHsjSAKJM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:03.9042792","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A03Z&sr=b&sp=r&sig=UwkvHJAK7XcTMeiFUGQX%2F9VQMOp79eFDq6udj2T1dOk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:03.9041913","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A03Z&sr=b&sp=r&sig=er%2BQy2f2SxYHNQWSY5o3YTlliCNfS6gCfffLtAoslJA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:03.9042948","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A56Z&sr=b&sp=r&sig=lRyD96W%2FpYS02Bdkx8dpGTNbNRuDbne7FXpBrJ6nkPI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:56.1270944","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A56Z&sr=b&sp=r&sig=gfTOqWyM7wgGR53nfKirYQ4IMiYtjjjEc9KQUHwl1Dk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:27:56.1270171","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A27%3A56Z&sr=b&sp=r&sig=HgfrolMDN36T3nY%2FW%2B3yv0R4opYK89emulxCRFe6bfw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:27:56.127109","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:24.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1542,9 +930,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:03 GMT
+      - Sun, 29 Oct 2023 22:27:56 GMT
       mise-correlation-id:
-      - 72082be2-f0f3-46a6-a31e-79e2f9a5e013
+      - 2c6ba059-1afb-43a7-8eac-01e4b201e1ff
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,23 +952,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A09Z&sr=b&sp=r&sig=9roINJyZH0kiC8TClgpcs3s0uQx4niGW5f8gC%2FCpceo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:09.1945831","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A09Z&sr=b&sp=r&sig=f7TtUXVahCKFDiquqpVCPh0lCEdKHFGzyqizU4IJBko%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:09.1945078","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A09Z&sr=b&sp=r&sig=PipQqs6g0quCo6nKQ4jKqKTz6jeKxMUR0l7FZ8RFLIE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:09.1946072","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A01Z&sr=b&sp=r&sig=7e5QFevBdekZjksFWH2DQ7rvZlJ%2F%2BiTENzmuPsut7Qw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:01.4374628","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A01Z&sr=b&sp=r&sig=8hIRPJMlIP4m1tjOVrGDVdE1xEFktZ0FVI8kgaPJH9A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:01.4373987","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A01Z&sr=b&sp=r&sig=nfAxis69YTL3f2YyKCa5djY2Sb6LW9BZm8MRFX%2B2n6g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:01.4374831","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:24.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3184'
+      - '3191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:09 GMT
+      - Sun, 29 Oct 2023 22:28:01 GMT
       mise-correlation-id:
-      - 9e4be7e0-8fe1-47cb-bf3a-4e054d431209
+      - 27fbfa67-14ba-4306-afdd-50031949718e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,23 +988,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A14Z&sr=b&sp=r&sig=hnjlX3fE7g7JuAwr1wO6lRedmtwmIEZXn5gE5gMBt9g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:14.476862","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A14Z&sr=b&sp=r&sig=yNwSfiRkKhR1KmvBnX58atOSsR4nmM95lPWa64%2Fqhtw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:14.4767642","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A14Z&sr=b&sp=r&sig=LSnKirz3o6%2FeCztUC0cGzjtSW6lE7eLp5F4%2BudTQhdo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:14.476884","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A06Z&sr=b&sp=r&sig=MwNfbGKke6ctfoVM6UZoUbiStg8Dura2mnacICiZacc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:06.7097626","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A06Z&sr=b&sp=r&sig=yb%2FvvbrhEk%2BRCaKOK3XmGrMHyYBUkpkIeaxRD6CMeRY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:06.7097108","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A06Z&sr=b&sp=r&sig=tgnrk%2ByxXO5mkhQP3xRep55gb5BTR%2F7sSYP2rTMLfFo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:06.7097764","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:27:24.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3186'
+      - '3193'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:14 GMT
+      - Sun, 29 Oct 2023 22:28:06 GMT
       mise-correlation-id:
-      - 46b90387-f050-447a-8748-0091986b234c
+      - 9abf8b53-e972-4545-8d6c-9620bb9c0fe5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,23 +1024,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A19Z&sr=b&sp=r&sig=6xkFO92budn73KdLgWLx5IPB5kV1%2FPoK1pNS0ufUtbM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:19.7720703","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A19Z&sr=b&sp=r&sig=yGmN5EhFbpD5RH%2Fe5%2Btx%2BVFo878BqRCw%2F8V73a6cHVk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:19.7719774","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A19Z&sr=b&sp=r&sig=645es%2F9TSsP9v6i3GQfzQr3lm5OCyxIMotdEvZCZMV0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:19.7720858","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A12Z&sr=b&sp=r&sig=uvuqL6pkuKOAag7awWHvbsNtXqrbGE69w3XyS1IJBYE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:12.0424761","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A12Z&sr=b&sp=r&sig=mCm8BPOh4QLMpjAOZGsbddcZGCrPQ9m0RwBhjwyIQd0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:12.0424074","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A12Z&sr=b&sp=r&sig=%2BhOcQTw569Llko%2B5rlzNqg4ASqXQ%2FytmTbmy7JJ0wro%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:12.0424899","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3194'
+      - '3188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:19 GMT
+      - Sun, 29 Oct 2023 22:28:12 GMT
       mise-correlation-id:
-      - e0712a1c-2dbd-4c67-9cb8-9f1e327c825e
+      - beb22685-77c3-496d-a30b-3e191b0348f7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,10 +1060,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A25Z&sr=b&sp=r&sig=rSB45mRZREFW65aWncPdyTNtfk9f9W2cXtdNh0lEIbI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:25.0940874","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A25Z&sr=b&sp=r&sig=N7Pk%2BXj4GiQpOG%2FqWJHasV7pMx7mH1SH1N2pz5jTIBo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:25.0940103","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A25Z&sr=b&sp=r&sig=UqWd5ikm8ZiNbzvbTk9WZwZAwWl%2BAmITi7W0tx%2BcKHU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:25.0941013","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A17Z&sr=b&sp=r&sig=dioH9ylQpl11so5WfsAFEo%2F7mXoX%2B3ZEFxvAdw1pv9o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:17.3488055","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A17Z&sr=b&sp=r&sig=VRc1Zdcz1bKyAL4GYOYt1efbztX1QvXsmlvMV8qbXg8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:17.348739","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A17Z&sr=b&sp=r&sig=xAcwT7hHasEpa5oj%2FCJAtSk%2B2g0W6yvaz57GsPYVPU4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:17.34882","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:17 GMT
+      mise-correlation-id:
+      - ef96309a-b75e-43d9-9c81-43b361c5d265
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A23Z&sr=b&sp=r&sig=F0gUpCQALNB5KtZvIdol3DOCt%2Fzii%2BI5%2BRvf26HfvDU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:23.0615341","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A23Z&sr=b&sp=r&sig=TlNSw0dderQ5Jrg%2BrtITqeuiyuhpQ77hUhsI1HYHG%2FM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:23.0614658","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A23Z&sr=b&sp=r&sig=2AVIZkx0F0ejs13pZMNnPLRygNVbPaRlnFEQRiHrcNc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:23.0615489","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:23 GMT
+      mise-correlation-id:
+      - 05f8dcf7-8b10-4c5b-9397-fb0009ecb91b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A28Z&sr=b&sp=r&sig=K4HagAKmUfTzLfNhvFvUHt7W4u1VjoIH4p7%2FNxR9LRM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:28.3163849","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A28Z&sr=b&sp=r&sig=M2tRLzdKeC5bbzRrpR%2BTasf8%2FiMSB69IjRdD2n0q5MY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:28.3163082","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A28Z&sr=b&sp=r&sig=Q%2Fpwy0EBtAGwxmFQ8s1m85KutfnnaeFL3f6UvBhdJ58%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:28.3163984","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1686,9 +1146,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:25 GMT
+      - Sun, 29 Oct 2023 22:28:28 GMT
       mise-correlation-id:
-      - 8c535545-3baf-478f-ad48-350b4f8c5475
+      - e8143ff6-b496-418c-8b24-47ced0ac4b90
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,10 +1168,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A30Z&sr=b&sp=r&sig=qOnOLRu37OsbHic4REWMp33yaFXjDhcIjSoi6S8bb%2Bw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:30.4607278","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A30Z&sr=b&sp=r&sig=ZBEsvjwMcXkIujugShPJVd%2BIvnss2Qzclx4sJQM4FZI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:30.4606606","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A30Z&sr=b&sp=r&sig=%2BMxsdTabgXS1NmKdgZ2NBncTcWEWx52SS1GUElLQ%2FiQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:30.4607413","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A33Z&sr=b&sp=r&sig=AcdYyT85fx1x9FzHMYMmb9wvI2FRTM0ngvhyH0DOmus%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:33.5590193","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A33Z&sr=b&sp=r&sig=nBTqntuSik96satC%2F5a7xx%2FNZD0ZFW5elxDm0riiIzI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:33.5589459","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A33Z&sr=b&sp=r&sig=41r8DjcDQ9UgL0hB7sWjHrIm4vi2klyez3yNw%2Fk%2FhJo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:33.5590357","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1722,9 +1182,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:30 GMT
+      - Sun, 29 Oct 2023 22:28:33 GMT
       mise-correlation-id:
-      - 2b49565e-2bbc-400c-8da8-36eb63024dca
+      - 0b31d14c-5a16-4753-8ec9-43c111fceebe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,10 +1204,262 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A35Z&sr=b&sp=r&sig=y%2BV5CYXYeB0JuJyOBfncWN%2FYLpehnCBDTZFqrUgpO%2B0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:35.7200037","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A35Z&sr=b&sp=r&sig=AbQYxd7y5NIuLvYnz35FqvSqszwJjidDBZQkIbPnuOI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:35.7199118","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A35Z&sr=b&sp=r&sig=h4whPQDlVTgLR5izsiR6Srq6r0x4RG4cMMw2dy%2FueQY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:35.7200252","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:34:01.194Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:34:48.398Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A38Z&sr=b&sp=r&sig=ka9SjDzm3baWwjtd0rHRMvqP085pf6hkOjBdu41QfKw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:38.806574","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A38Z&sr=b&sp=r&sig=xlA8zQCs11pFlzOE9xijO59a9zpmSSLB233lPzeXtbE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:38.8064857","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A38Z&sr=b&sp=r&sig=UyTq230o%2FjgELZJGxB6Gp%2FYVh7Sh78%2Btr6sY6cMG9Qc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:38.8065969","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:38 GMT
+      mise-correlation-id:
+      - 84efa710-ed7b-4f33-a029-76f56afd71b5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A44Z&sr=b&sp=r&sig=B3txgzQY1vWUj1ZBS20M8GbSgEcOKoA3992QFYL9diU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:44.0504619","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A44Z&sr=b&sp=r&sig=ipuIU%2FHRPodJPXKPoeA7AUvqhQHVNVbJuovWQzYX5fA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:44.0503661","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A44Z&sr=b&sp=r&sig=9SrvjEh3zsCr5jYxlCCl%2F3TnjfUFnou12o%2FLgeoDDV8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:44.0504783","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:44 GMT
+      mise-correlation-id:
+      - 4f036402-1c56-44a0-84ec-3ed9740bd930
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A49Z&sr=b&sp=r&sig=v3EEm6yM0h%2FbRX7tqBa37BUsx8LsdUFQwV3VUJVbtPo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:49.4861432","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A49Z&sr=b&sp=r&sig=xulFvHeKeTZ6Gd34N90RYX0a5lu8g3Mfc8OBIEi3XoA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:49.486059","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A49Z&sr=b&sp=r&sig=5%2BCq4lqv97z82VNgwd9q83TlZkFIMom6VEwR1HBnmnI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:49.4861658","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3185'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:49 GMT
+      mise-correlation-id:
+      - 5ced5978-507b-4bf5-80ea-353e36159323
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A54Z&sr=b&sp=r&sig=3O0q%2FrGgUvyzJHdKqUC0kno3B5EGgOO1rCKJP0Ld%2BUU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:54.7828343","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A54Z&sr=b&sp=r&sig=lhnrgeK8akW5HHcN8igjttAAkSm0ltRk5ICxV9DtFFU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:28:54.7827597","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A28%3A54Z&sr=b&sp=r&sig=jUF9x1INV036iIPZzF%2FVf%2BhBf%2BxxJcjWdctzqy1xMvI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:28:54.7828491","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:28:54 GMT
+      mise-correlation-id:
+      - 08486d18-5c4b-4735-ade0-e5907afbcd21
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A00Z&sr=b&sp=r&sig=BfjqIvYGRtZDidFPWaEKt%2BSuF%2FnH9MA1qiqaQ%2B4cgFw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:00.0331543","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A00Z&sr=b&sp=r&sig=8rGd2a7WEULBcSeGEmb0dR4jXIidxQDSvgCIyDLGq6A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:00.033046","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A00Z&sr=b&sp=r&sig=4%2BrTP3aAGGjyj91H9HjdDP8QoYvKyvZwzYoCyj9AqDo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:00.0331789","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:00 GMT
+      mise-correlation-id:
+      - db1630fe-9b3d-4ca1-9f77-4b35b5e0b477
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A05Z&sr=b&sp=r&sig=QUE3sRhy%2F6675cR67u8yUJ7wJp5hLoAQmwIKwKGO7h4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:05.3183947","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A05Z&sr=b&sp=r&sig=4zbjb%2BrtTKSKzIsO2GWS3QiZ4rz5azlf6%2Bn9qeLCdgw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:05.3183251","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A05Z&sr=b&sp=r&sig=PPLHu7ydbgvsd1tC3TZpPLmWQGSGCXuC7DoEiJRJ2eo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:05.3184146","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:05 GMT
+      mise-correlation-id:
+      - 8e32df7b-5211-46b7-ab3b-fc3359a1810f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A10Z&sr=b&sp=r&sig=lkjJJwfscU%2B9JW%2FOTOucvs6Xz69fa1VPqSLBUNymtCU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:10.6705709","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A10Z&sr=b&sp=r&sig=ZJxsMhNwfcYQWPY344FgoRULeU69J9tqL2pHj4dEa58%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:10.6704819","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A10Z&sr=b&sp=r&sig=g%2FxLbReTH27HRTamVy4KPNM4elQc5vveV774oiA2oK4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:10.670593","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:10 GMT
+      mise-correlation-id:
+      - a0a27f38-5390-495d-b23c-d92678de9821
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A15Z&sr=b&sp=r&sig=HzEYo6GD91fp8PHaMcv6RRwZbsMKx%2Bc%2FrnZeHR8iqJs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:15.9177812","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A15Z&sr=b&sp=r&sig=KCpvAXJKBrVeIe2xs4Uirijt4WICEiNROHZsjNEzs5o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:15.9177097","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A15Z&sr=b&sp=r&sig=ZBLMWyW%2Fz4lwiX1Nmjnen73Tv5LDJYIcXf%2Bu7IJIXIk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:15.9177951","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +1470,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:35 GMT
+      - Sun, 29 Oct 2023 22:29:15 GMT
       mise-correlation-id:
-      - 050061d0-7584-4d90-8042-1ca6f992ad91
+      - 6a80edee-b861-4701-8f14-a12dda9efa50
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,24 +1492,312 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A41Z&sr=b&sp=r&sig=LC2NrrU3aGDNMQHT0m8j6zsuc1OjelqY%2BFsoIVfZ1pk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:41.0277121","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A41Z&sr=b&sp=r&sig=03PzGN9ck9KQJLrcpT7LQZDYFAiSjfRnoTdoyU7Yrlc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:41.0276262","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A41Z&sr=b&sp=r&sig=0LWSnhaHPA%2FsJOjukvcjO3YtjekKOGBnUMwWW5vs6mo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:41.0277353","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-24T12:34:01.194Z","endDateTime":"2023-10-24T12:36:40.471Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:36:40.685Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A21Z&sr=b&sp=r&sig=LxDaLvmVw%2FzRfgBJZSJSVOVGiUisug42jxUTcTovdI0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:21.2065765","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A21Z&sr=b&sp=r&sig=GI9hdowbq8tm7528ZZ2N2TBHX4DqljnVei9d%2FcjmmhA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:21.2065089","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A21Z&sr=b&sp=r&sig=3fpBYbctwSL0lSB5T1awEUHTsJrdCIzjcmOwtuw8R2o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:21.206591","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3321'
+      - '3185'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:41 GMT
+      - Sun, 29 Oct 2023 22:29:21 GMT
       mise-correlation-id:
-      - 87d84ac4-2d10-4939-9d20-e31f5fae33a5
+      - 623eae70-cbf9-438b-9226-8d7948675a07
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A26Z&sr=b&sp=r&sig=twPmjrRbnadMUBMrYZ5AjmAhFw41fRwTJ6iVnZl7HIE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:26.552734","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A26Z&sr=b&sp=r&sig=TnPSov6%2FRsyk%2BH6TcTeLtSbUOj7nsdMiPfOLXtSSItA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:26.5526648","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A26Z&sr=b&sp=r&sig=sa5qshrZgc1I8X%2Fh2%2Fp%2BSxxmD7RRtfwQP%2FTkAtMY0HQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:26.5527488","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:26 GMT
+      mise-correlation-id:
+      - fa269303-aaa0-4912-841b-8ff4a5f8e11f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A31Z&sr=b&sp=r&sig=df6RvVXmmSH1RXhA4uOJlXE0UThGTa7gxEAx2R75BYg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:31.8472969","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A31Z&sr=b&sp=r&sig=2eUGYNoY2tKg8kbdgJlBMTAKD1D20DdO%2FwJLw8NOrf8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:31.8472274","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A31Z&sr=b&sp=r&sig=MzBLi9%2F8cdFrtPSH0Pg7YrEQ37rJKkyl7YxBvn%2B2bgc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:31.8473109","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:31 GMT
+      mise-correlation-id:
+      - fed12f95-510d-413a-b325-4a5e8d49a11a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A37Z&sr=b&sp=r&sig=LgYteABW1vVEa%2FpNN8L7qr7HDFkQrMYSYMr70LWs%2Bws%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:37.0958108","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A37Z&sr=b&sp=r&sig=5CBS8VON6dY%2BsgBGE9OuthyPm%2BdZV3cd6bcIX0p3mUc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:37.0957423","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A37Z&sr=b&sp=r&sig=k9XTFnAmb4w1nPJBaDbZ0sT0nulWFlMtwkfUxoG2%2Bxk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:37.0958247","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:37 GMT
+      mise-correlation-id:
+      - 73876809-f040-4acf-9363-17ff9280d3c4
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A42Z&sr=b&sp=r&sig=yPvMOiD6DEfb0CdEcNIvpG90tbUcjez7AjOCcKynRWs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:42.3509463","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A42Z&sr=b&sp=r&sig=URpEH8rjJJjksoRTr7qm2Vuyyqckelt9%2Bb6%2BEojJwSk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:42.3508786","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A42Z&sr=b&sp=r&sig=i6D%2BV%2F%2F3W6mJie1PrE6DcRMNZffqLSJSBH1DbroeMT8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:42.3509611","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:42 GMT
+      mise-correlation-id:
+      - f05711c7-1e72-4879-b4dd-f2801e71d7e8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A47Z&sr=b&sp=r&sig=Jyrb%2BBy2LXVeI0Z3htzDgJy74EnsUYCb0LYZKwB0bG4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:47.6049756","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A47Z&sr=b&sp=r&sig=5q6I4DFTcrOLT0FvqriTHQY2a%2BybGWwl%2FabKuaN55O0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:47.6048791","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A47Z&sr=b&sp=r&sig=DvQHjXX7hDKKRlSoOHsJo%2ByME5ntY7GXZoFBoh11VFA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:47.6049913","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:47 GMT
+      mise-correlation-id:
+      - 8f3cd646-d027-40ee-b873-7563027dac4b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A52Z&sr=b&sp=r&sig=XVToJkn4BN0x4t%2BWd9dZus4UnnYBG9W%2Fm6fGiyvt1Hg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:52.8498142","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A52Z&sr=b&sp=r&sig=gpuWWqXejleXRNh7vzBXFmQzBaSeB880qFumYWNiIuQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:52.8497304","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A52Z&sr=b&sp=r&sig=32F1wL%2FOBXzAt33%2BLCIb6X5hxcYEJMerFdVelDkiyzA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:52.8498348","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:52 GMT
+      mise-correlation-id:
+      - 16715bf2-b00a-4d89-bcff-84541b2343a5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A58Z&sr=b&sp=r&sig=de3DOUm8I1p5AZHhfOlvyMDlPivxI68fXXbOFvnbR3E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:58.1149621","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A58Z&sr=b&sp=r&sig=g90EcpXSI75ncxXZD6awhuGuDoldoMrNlbO8ggm5NWA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:58.1148904","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A58Z&sr=b&sp=r&sig=34DdUHRHx6cW4tLDs7l11vJjqEkZjKsqvmGGJozYuto%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:58.1149788","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:27:23.963Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:28:10.707Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3182'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:58 GMT
+      mise-correlation-id:
+      - e3d27b0a-8262-4428-a269-4bbeae0d3a05
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A03Z&sr=b&sp=r&sig=aNuF3bTKcV5qM624IgmeLh2e9lkknGtUq2ZEBPLk4vk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:03.8078766","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A03Z&sr=b&sp=r&sig=bCyDOlJfPE6Q6xv8SwPHyD%2FXLDwUIK%2BNLbUCrXreJb8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:03.8078054","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A03Z&sr=b&sp=r&sig=9msRlilu8WzEn336mpTMVNesbMp1HToMkksoa6U%2BlN4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:03.8078919","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-29T22:27:23.963Z","endDateTime":"2023-10-29T22:29:59.602Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:59.754Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3323'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:30:03 GMT
+      mise-correlation-id:
+      - 919fd0a3-8045-418e-9b07-7a41c3af3684
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,18 +1820,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:33:04.2189798Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:33:04.2189798Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:26:24.0632488Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:26:24.0632488Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:42 GMT
+      - Sun, 29 Oct 2023 22:30:04 GMT
       etag:
-      - '"d300094a-0000-0100-0000-6537b9820000"'
+      - '"3c005c31-0000-0100-0000-653edc120000"'
       expires:
       - '-1'
       pragma:
@@ -1861,11 +1861,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=show-test-case&api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=show-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A43Z&sr=b&sp=r&sig=kGZApBu9PThKm7SPrJ02BotObWZ4Qcqz%2BVyWldfOP%2Fk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:43.6820447","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A43Z&sr=b&sp=r&sig=%2FlKIfJJr6rdAoII%2B0uKzmxDNDK5rOtbJHseSF0XF760%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:43.6819553","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A43Z&sr=b&sp=r&sig=qYlZnuWtnFJ3JR3wbW1FlsfRjN4Wp3Fglo%2BGVv0OS7U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:43.6820675","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-24T12:34:01.194Z","endDateTime":"2023-10-24T12:36:40.471Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:36:43.573Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A06Z&sr=b&sp=r&sig=FNBQJnpFEr3AyyNTWhXz%2FgKTTdGgt8AsB5YupyNCQIU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:06.077065","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A06Z&sr=b&sp=r&sig=X9%2BXCds8SSC1rXTZlyMeKkHOD7YuWf3N1z%2BSAL2cHKE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:06.0769821","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A06Z&sr=b&sp=r&sig=6YDH%2BQ%2FvGAD2PWrmf2%2BKQ5BP22JOtfmRgfXd4uzOvJ4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:06.077086","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-29T22:27:23.963Z","endDateTime":"2023-10-29T22:29:59.602Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:30:05.784Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1876,9 +1876,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:43 GMT
+      - Sun, 29 Oct 2023 22:30:06 GMT
       mise-correlation-id:
-      - 48dca7a7-b8e5-4a8f-a582-5fbb96b5d55e
+      - 97761943-1214-4761-83a4-5bba23c40434
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1901,18 +1901,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:33:04.2189798Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:33:04.2189798Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:26:24.0632488Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:26:24.0632488Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:44 GMT
+      - Sun, 29 Oct 2023 22:30:06 GMT
       etag:
-      - '"d300094a-0000-0100-0000-6537b9820000"'
+      - '"3c005c31-0000-0100-0000-653edc120000"'
       expires:
       - '-1'
       pragma:
@@ -1942,24 +1942,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://df9c799d-ae82-41ed-9f31-add280edb9fd.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
+    uri: https://284637f4-ede3-4354-9877-4051ec3a3952.eastus.cnt-prod.loadtesting.azure.com/test-runs/show-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f8ee81d5-6518-43ad-9a4e-b9700d69e096":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d1604977-5345-4f60-ada4-93691cd760f1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"363ef462-9754-481e-98ac-f0093447de46":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/2f197796-403a-4c6a-ab55-71803cf580f3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A46Z&sr=b&sp=r&sig=%2BbHqvl8wzAxJje2ST6XTqu%2FKCdVg7MoXkY9mUpXQ92s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:46.8190766","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/55b5d490-501f-478f-ad91-5909b988c382?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A46Z&sr=b&sp=r&sig=kv%2F777qUwBbbdjrH8EKKV4XCc0wFZy8xjfdxfqZYX6I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:36:46.8189867","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b6b20f96-85ae-47e8-8206-2ea99543c749/100c5df6-bd08-4840-a18e-5fcd0ff18e83?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A36%3A46Z&sr=b&sp=r&sig=Rl3TVsGDAf2RlS6GkNCata5M1oQsZG%2BUA99PsF97gc4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:36:46.8190915","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-24T12:34:01.194Z","endDateTime":"2023-10-24T12:36:40.471Z","executedDateTime":"2023-10-24T12:34:00.509Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-24T12:34:00.795Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:36:43.573Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4baa0483-5376-4dd0-b0d0-62320513018f":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"811593e5-691c-4840-9970-9165295eeb75":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f9a7c530-55ea-478d-ab6c-095e020abbfd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/b37679f8-c968-4006-b3c9-472111059b92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A08Z&sr=b&sp=r&sig=Z9M8GZRXQ8nG9w3bEnclkr2%2F3T3eml12Qmw2p9%2B%2B4Vc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:08.4332433","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/0c749f7a-6493-41c1-8e7c-d3a83f777666?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A08Z&sr=b&sp=r&sig=cBTgOwyaOsJsSYQzl6Bxt1bKY2oVJKdCqvRPUtMFqXU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:08.4331467","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6a5437fa-c3f7-4ce3-80d5-2b25d538bae7/2158bbd5-b233-47c1-8a38-0b4b0804d431?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A08Z&sr=b&sp=r&sig=JUyCdm1TV9qf0fiFtXEQdYNtxrVf9xSVYEZzSuV73dY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:08.4332662","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"show-test-run-case","displayName":"show-test-run-case","testId":"show-test-case","status":"FAILED","startDateTime":"2023-10-29T22:27:23.963Z","endDateTime":"2023-10-29T22:29:59.602Z","executedDateTime":"2023-10-29T22:27:23.215Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/show-test-case/testRunId/show-test-run-case","createdDateTime":"2023-10-29T22:27:23.474Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:30:05.784Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3325'
+      - '3323'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:46 GMT
+      - Sun, 29 Oct 2023 22:30:08 GMT
       mise-correlation-id:
-      - 2cbb0b3c-ef16-4552-832e-2a9b0bbe39ae
+      - f21cb2f9-58e8-45e2-9e34-5d54c7a78583
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_stop.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_stop.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:19:48.2259316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:19:48.2259316Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:26:26.8851856Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:26:26.8851856Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:22 GMT
+      - Mon, 09 Oct 2023 19:27:01 GMT
       etag:
-      - '"92017df2-0000-0100-0000-652428260000"'
+      - '"57006d01-0000-0100-0000-652453e40000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:20:23 GMT
+      - Mon, 09 Oct 2023 19:27:03 GMT
       mise-correlation-id:
-      - 6fdcd67e-c43c-441d-8ba5-d4d29fc6cac7
+      - b1d9cec4-e2a3-45ce-8d39-370865314c83
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "120"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"cf9cd94b-d2be-4d52-85be-7ec69ce37051": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "a560898a-ce75-40de-a3d5-e0812ff7c059":
+      {"passFailMetrics": {"dbded5ef-34b0-4728-bc8f-849d496aa3b4": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "fa150ae5-6a9d-4a0f-b153-124db50a32c3":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d": {"aggregate": "avg", "clientMetric":
+      "50"}, "3a1c074c-53c2-47c6-9c50-5b386db38e6c": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:20:24.538Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:24.538Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:27:04.123Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:04.123Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:24 GMT
+      - Mon, 09 Oct 2023 19:27:04 GMT
       location:
-      - https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+      - https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 82c29ac7-d1dc-4024-aeae-69cb420fe3dd
+      - 2184e401-26ed-4a8f-96f4-0d2af8cce0b2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:24 GMT
+      - Mon, 09 Oct 2023 19:27:04 GMT
       mise-correlation-id:
-      - e4353f33-fc41-43bd-93da-2f60c914b64c
+      - 380ed850-d640-4fa3-a8b1-12a69ef6cfc5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A30%3A25Z&sr=b&sp=r&sig=VWFS9jbAergJhylUE4Qk4OfomPFPjXIJy%2BUtT8z0GcQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:30:25.3786681","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A37%3A06Z&sr=b&sp=r&sig=PUUEr2grqOtm76eOqIOd0CdAtDRTWErkBCQPorTLD8E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:37:06.060112","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '548'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:25 GMT
+      - Mon, 09 Oct 2023 19:27:06 GMT
       location:
-      - https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 8e25ca06-314f-416c-84fe-32abc9e3515b
+      - 7ef79057-646c-4121-81fa-46287d17aebd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A30%3A25Z&sr=b&sp=r&sig=4Oppm3aYzkrARxrrwRq010ND4EDCuJgcx01ppgPABH8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:30:25.6453328","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A37%3A06Z&sr=b&sp=r&sig=8ejoamPOopLjJVj8TbisjIwnhmj%2FZ7E0iydH9Bi5UGk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:37:06.3457749","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:25 GMT
+      - Mon, 09 Oct 2023 19:27:06 GMT
       mise-correlation-id:
-      - bbf86a45-ea99-4636-914e-663fd58115c0
+      - d1d2ed24-6313-4221-b57f-136e2842d05b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,10 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A30%3A30Z&sr=b&sp=r&sig=jJOWRumCxxUEM8y7ys3CTmpKaF%2BuGM9FxXrQi%2F0sYVk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:30:30.9256272","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A37%3A11Z&sr=b&sp=r&sig=khwkHT4kemiXH%2FWLtuHuF%2F93h7Hy4pVCwSKb3dyhCk4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:37:11.6202489","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:30 GMT
+      - Mon, 09 Oct 2023 19:27:11 GMT
       mise-correlation-id:
-      - d6468085-f6a8-4628-b864-ceceb23d02f6
+      - 837ee2e4-dd74-4403-9bb2-93d960f54d74
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A30%3A36Z&sr=b&sp=r&sig=DjefxEn5oQ4flFgs0m3sleyC6zjNevBZ%2BCeWwQVHPRc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:30:36.2082684","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A37%3A16Z&sr=b&sp=r&sig=XLNTlHaIHvveUgIjulHqLf5mlywDOdCMN%2F%2FIZCNvL70%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:37:16.8950567","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:36 GMT
+      - Mon, 09 Oct 2023 19:27:16 GMT
       mise-correlation-id:
-      - 3ed82090-1c9b-456b-bd4a-1066cc406849
+      - c80dcc07-917f-423d-aab1-fb8999cb890d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A30%3A41Z&sr=b&sp=r&sig=bsC6XsYpN7iuZFro6XEe%2BDCFgWbCpJKkKo5y4oqT%2Bks%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:30:41.4822856","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A37%3A22Z&sr=b&sp=r&sig=o%2FVV2gVIqT4zoEcS0TGZSzkpt%2BlEwmmkSLS2i7c%2BSL4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:37:22.2171346","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:41 GMT
+      - Mon, 09 Oct 2023 19:27:22 GMT
       mise-correlation-id:
-      - 0d44f442-e9ec-468f-96e0-4360d6f663ab
+      - 61cd00ea-0d3e-4cc6-b629-2d1750563c9b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A41Z&sr=b&sp=r&sig=FlStQ69hdCsy%2Bj0zWdAfa928sSsoYCkZMyNoUDe5wUQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:41.7922736","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:20:24.538Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:40.34Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A22Z&sr=b&sp=r&sig=lmoSuXF6XBtMDfCQh1MA7yXpM%2FKBI%2BBP486ly6LwHt0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:22.5192796","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:27:04.123Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:18.464Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1578'
+      - '1581'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:41 GMT
+      - Mon, 09 Oct 2023 19:27:22 GMT
       mise-correlation-id:
-      - cfdf5928-78db-4b0f-9c03-50378e199758
+      - 7670e549-aa1d-43ae-918d-7de845d54569
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:19:48.2259316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:19:48.2259316Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:26:26.8851856Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:26:26.8851856Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:42 GMT
+      - Mon, 09 Oct 2023 19:27:23 GMT
       etag:
-      - '"92017df2-0000-0100-0000-652428260000"'
+      - '"57006d01-0000-0100-0000-652453e40000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A43Z&sr=b&sp=r&sig=quDagn%2BG5zLFPMVQH2D%2BY%2BJlMiIb0TA%2FlXmPGjokpq0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:43.3522687","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:20:24.538Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:40.34Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A25Z&sr=b&sp=r&sig=vi63YPxehDzULfszvRvLYe%2FKoRDMglHGrUvj1UbIYB8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:25.1177444","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:27:04.123Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:18.464Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1596'
+      - '1591'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:43 GMT
+      - Mon, 09 Oct 2023 19:27:25 GMT
       mise-correlation-id:
-      - eb6e2c45-8cc9-4cb5-8208-32cfde9adfb0
+      - 3e8b5be8-65ae-4f3d-b96b-525e96cee996
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:19:48.2259316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:19:48.2259316Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:26:26.8851856Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:26:26.8851856Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:44 GMT
+      - Mon, 09 Oct 2023 19:27:26 GMT
       etag:
-      - '"92017df2-0000-0100-0000-652428260000"'
+      - '"57006d01-0000-0100-0000-652453e40000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:20:45 GMT
+      - Mon, 09 Oct 2023 19:27:27 GMT
       mise-correlation-id:
-      - 8f7da6a2-ce1f-4a28-ac8a-96b3c83c4cb7
+      - 32f4853c-c2dc-418b-9f9b-a0027c14767e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/c652a322-260a-44cd-a54b-ec211f7065a1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A46Z&sr=b&sp=r&sig=b3EgzEKaSojILWwSCtDLM7n6H4YbwlA29sZYY4GiOuA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:46.5206057","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A46Z&sr=b&sp=r&sig=H%2B1Prf%2BhI%2Bf0lUKusWbEeucx2s4it6DCFgk35Hd2ZhE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:46.5204609","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/90fc8a6c-4700-4ac2-9e12-bbe5a07f8974?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A46Z&sr=b&sp=r&sig=Snu%2F2u1p%2FWGCsHzBaHIW8BVsQw9FABwv5GJ7cc2MOa8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:46.5206289","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:20:46.167Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T16:20:46.453Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:46.453Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/fee43389-b960-42eb-b332-811e1036e5b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A28Z&sr=b&sp=r&sig=WgcONUZxGACuCRoQPNyNQILQw9NuZDZmbGFNk1QOzxU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:28.3537305","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A28Z&sr=b&sp=r&sig=MRXGgX14YbOXhtKxFXYL%2FhT%2F3ylfKXga7%2BQQbeXQZ4A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:28.3536563","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/e1352333-328d-4b12-99dc-41f2b144b689?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A28Z&sr=b&sp=r&sig=b8ntM6UhGKII7ZJYzlGdKA%2F8m9gIsWRMbVFSUoeSqto%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:28.353749","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T19:27:28.027Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T19:27:28.282Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:28.282Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3150'
+      - '3147'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:46 GMT
+      - Mon, 09 Oct 2023 19:27:28 GMT
       location:
-      - https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+      - https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 6fe2b899-1221-49c2-ba37-728d4a87ef90
+      - 6e293774-de81-4b7d-ac11-bf256269a364
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,10 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/c652a322-260a-44cd-a54b-ec211f7065a1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A46Z&sr=b&sp=r&sig=7jRfYWTuztXRXB9XKfJtj5Ie1znDKkkYjQDPB6tD5PU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:46.9660049","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A46Z&sr=b&sp=r&sig=7XNILeL4cQrjT2p%2Fqbi3rM2LuzB0iJmggwT5Zb8oNl0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:46.9659128","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/90fc8a6c-4700-4ac2-9e12-bbe5a07f8974?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A46Z&sr=b&sp=r&sig=gLwfqpkQ9y8y7AsSNkKxSID0ZCGhKuAGwCoge2rnQ5g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:46.9660288","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T16:20:46.852Z","executedDateTime":"2023-10-09T16:20:46.167Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T16:20:46.453Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:46.852Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/fee43389-b960-42eb-b332-811e1036e5b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A28Z&sr=b&sp=r&sig=jDuTnJ8otTwPckK7FAzq2x7sq4yoCymlB8BoiBVTccE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:28.8833134","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A28Z&sr=b&sp=r&sig=8tpZ4FG%2F6Chh0MZuw5CDfHQuC0ijRxcJJqMovVDSzDA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:28.8832206","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/e1352333-328d-4b12-99dc-41f2b144b689?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A28Z&sr=b&sp=r&sig=VNCwd63pyqrpDJUOjgoPQ9qvonVDcUwvmPbMsHsMnAM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:28.8833342","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T19:27:28.662Z","executedDateTime":"2023-10-09T19:27:28.027Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T19:27:28.282Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:28.662Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -714,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:46 GMT
+      - Mon, 09 Oct 2023 19:27:28 GMT
       mise-correlation-id:
-      - 05c1eeca-d73f-4ebd-b421-e4db4609a706
+      - 1ddc8679-8eaa-45ac-8ae1-aad72d58da02
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/c652a322-260a-44cd-a54b-ec211f7065a1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A52Z&sr=b&sp=r&sig=NN9JWY%2F%2BUQR%2F%2BFOvSEbPKacmWtiRtKaZzuT5aGcp%2FqM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:52.2404693","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A52Z&sr=b&sp=r&sig=c9I258U2OgxgLj8eLi0ecWpW7iiSKteZ0zi3mF8ASiQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:52.240403","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/90fc8a6c-4700-4ac2-9e12-bbe5a07f8974?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A52Z&sr=b&sp=r&sig=ADkkBTROz1mpCJkH0AIzqWjuDSAUlbNtynWrulGx2dA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:52.2404843","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:20:46.852Z","executedDateTime":"2023-10-09T16:20:46.167Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T16:20:46.453Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:47.122Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/fee43389-b960-42eb-b332-811e1036e5b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A34Z&sr=b&sp=r&sig=RNW6nYOk91MPYxgKhYSyGwgiv8fBug0te3FtB0eVyEs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:34.2574887","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A34Z&sr=b&sp=r&sig=D%2FAUd34YYVJ7OiJore1RqAxdI3Y74r7vhfo3XFtj0Z8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:34.257393","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/e1352333-328d-4b12-99dc-41f2b144b689?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A34Z&sr=b&sp=r&sig=9az%2BTEcbQ6btyKxpc6ugpN0b9cV5Grmgx3Gx9Brga1s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:34.25751","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:27:28.662Z","executedDateTime":"2023-10-09T19:27:28.027Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T19:27:28.282Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:28.925Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3196'
+      - '3188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:52 GMT
+      - Mon, 09 Oct 2023 19:27:34 GMT
       mise-correlation-id:
-      - d63008b7-0b78-41a3-8118-1531a9977072
+      - 5ef2fb3a-179b-44b9-8f10-1731a2ab6cb2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/c652a322-260a-44cd-a54b-ec211f7065a1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A57Z&sr=b&sp=r&sig=6yImYf%2FAK8kqLfPDnC0%2BlkEIBNLjUdnwVDrfvgzYElI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:57.5283022","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A57Z&sr=b&sp=r&sig=j3e5ESAkZ88uWa09o4TgHM5e4RiY%2BKglLX9bffD3GYI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:57.5282184","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/90fc8a6c-4700-4ac2-9e12-bbe5a07f8974?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A57Z&sr=b&sp=r&sig=ntvo7iL%2BLjhdYdOUxGV6CIxTruJKW%2FyHBoqV2ZwarV0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:57.5283628","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:20:46.852Z","executedDateTime":"2023-10-09T16:20:46.167Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T16:20:46.453Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:47.122Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/fee43389-b960-42eb-b332-811e1036e5b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A39Z&sr=b&sp=r&sig=MnxHCNPmfanSlMs4nOPxLEKfUYjrqmd57l%2FYYJdIaqw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:39.5409172","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A39Z&sr=b&sp=r&sig=kqP8Ee7sff5qd1sNRGvb0A0ejpIRSz73NA1kV0dLg%2Fw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:39.5408268","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/e1352333-328d-4b12-99dc-41f2b144b689?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A39Z&sr=b&sp=r&sig=RMRWUN2AM8Vmf06t8MaRtAlIYTrzRM1PL19s5ozy6Sg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:39.5409393","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:27:28.662Z","executedDateTime":"2023-10-09T19:27:28.027Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T19:27:28.282Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:28.925Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3197'
+      - '3191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:20:57 GMT
+      - Mon, 09 Oct 2023 19:27:39 GMT
       mise-correlation-id:
-      - f7f40804-4bad-4f38-930d-aabe599ae4a3
+      - da3898b9-50fe-4ef4-b5e1-7dc448fdeaae
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/c652a322-260a-44cd-a54b-ec211f7065a1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A02Z&sr=b&sp=r&sig=kgEF4ESRVA0zzMKHyIEOGai202%2Fj%2FHjRxet9hvyItKM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:02.8194338","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A02Z&sr=b&sp=r&sig=haXzjN%2FVnWk%2FpUSmnsOgfn4lldLgaEEqu0Jeqf9NyAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:02.8193344","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/90fc8a6c-4700-4ac2-9e12-bbe5a07f8974?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A02Z&sr=b&sp=r&sig=dmaiYqt1vmTKI9wxVwlwD6Liph5o3Cmuln44Rcf8jEU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:02.8194599","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:20:46.852Z","executedDateTime":"2023-10-09T16:20:46.167Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T16:20:46.453Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:47.122Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/fee43389-b960-42eb-b332-811e1036e5b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A44Z&sr=b&sp=r&sig=EaKHxX5Uw62m8WwDDlBbH0iNnQsSp%2BwHx5s3jWeLb0w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:44.8390367","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A44Z&sr=b&sp=r&sig=RT1u%2FLQzc196eecZhQwp8Wxrag2vOq78XxBQNeuuHX8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:44.8389366","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/e1352333-328d-4b12-99dc-41f2b144b689?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A44Z&sr=b&sp=r&sig=djqSLp0J1Qd4EV5yByjE%2FaDyt2c9rVQwnAmQTsMJFug%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:44.8390758","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:27:28.662Z","executedDateTime":"2023-10-09T19:27:28.027Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T19:27:28.282Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:28.925Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3195'
+      - '3193'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:02 GMT
+      - Mon, 09 Oct 2023 19:27:44 GMT
       mise-correlation-id:
-      - 33333397-1ec5-416d-8696-9bf995631f29
+      - 44b9514e-065a-4e73-94db-9932aafe4168
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/c652a322-260a-44cd-a54b-ec211f7065a1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A08Z&sr=b&sp=r&sig=k1fhVhd8UmWpi%2BEUqK6yeDsrdv5gObaglhSaTAzFDU0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:08.10443","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A08Z&sr=b&sp=r&sig=ij3J8G5xnEAnnUgO9B4qgrBRDRAed1GbfUElNH8ujMg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:08.1043538","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/90fc8a6c-4700-4ac2-9e12-bbe5a07f8974?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A08Z&sr=b&sp=r&sig=tvqeD9KIpxZMITSA%2FCHbcC9ZJRTvBTkv0keR5bg0TDM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:08.1044466","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:20:46.852Z","executedDateTime":"2023-10-09T16:20:46.167Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T16:20:46.453Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:47.122Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/fee43389-b960-42eb-b332-811e1036e5b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A50Z&sr=b&sp=r&sig=BNiG%2FF7ztrFdLAzuzL1aJqaglK14fYkXehYnE0Cbtk8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:50.1260248","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A50Z&sr=b&sp=r&sig=qd314G1az7MYvoQCxWC5dI5yXELCi7zjFnLRZm3N6ZY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:50.1259151","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/e1352333-328d-4b12-99dc-41f2b144b689?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A50Z&sr=b&sp=r&sig=3tl%2BmIFqIuUgsufojVOOu1BYkDoaN3m0a0AbCYfEKJU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:50.1260499","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:27:28.662Z","executedDateTime":"2023-10-09T19:27:28.027Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T19:27:28.282Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:28.925Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3189'
+      - '3191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:08 GMT
+      - Mon, 09 Oct 2023 19:27:50 GMT
       mise-correlation-id:
-      - fd3b50ae-c420-4b54-908c-818f2cbe14f9
+      - 40bca65e-c2d9-44a9-bfb4-c1d6c9a5a6df
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -883,7 +883,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:19:48.2259316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:19:48.2259316Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:26:26.8851856Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:26:26.8851856Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -892,9 +892,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:08 GMT
+      - Mon, 09 Oct 2023 19:27:49 GMT
       etag:
-      - '"92017df2-0000-0100-0000-652428260000"'
+      - '"57006d01-0000-0100-0000-652453e40000"'
       expires:
       - '-1'
       pragma:
@@ -926,23 +926,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case:stop?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case:stop?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/c652a322-260a-44cd-a54b-ec211f7065a1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A09Z&sr=b&sp=r&sig=3nuVUPVUxMJdceiPDfHYou9Oq3ySJbR7oJIt0r3D%2BRc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:09.0618151","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A09Z&sr=b&sp=r&sig=Q4novf%2BXg5MnZ2V998%2FbURtYeVnGdBcNXi0G8mcpXSM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:09.0617413","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/90fc8a6c-4700-4ac2-9e12-bbe5a07f8974?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A09Z&sr=b&sp=r&sig=rUucMrlFMFj9kEDWi%2BnvSVRt3w7cR61mMkWBZKAS3tM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:09.0618321","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:20:46.852Z","executedDateTime":"2023-10-09T16:20:46.167Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T16:20:46.453Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:47.122Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/fee43389-b960-42eb-b332-811e1036e5b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A51Z&sr=b&sp=r&sig=fZoueKGgLN%2FHn07Ottk5t0d1k%2BUX1eoQQ1%2BwjmGmu0s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:51.1886863","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A51Z&sr=b&sp=r&sig=7GXlrTPPZ5pLQlen%2BrgmoHCkHW7A%2BykU3WNHLeJoPpY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:51.1886101","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/e1352333-328d-4b12-99dc-41f2b144b689?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A51Z&sr=b&sp=r&sig=OQuUQw5Ah6SOOb6q%2BSmvTcFOjJvDObh5d%2B5KevWSo0Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:51.1887018","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:27:28.662Z","executedDateTime":"2023-10-09T19:27:28.027Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T19:27:28.282Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:28.925Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3136'
+      - '3142'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:09 GMT
+      - Mon, 09 Oct 2023 19:27:51 GMT
       mise-correlation-id:
-      - 5c748f13-3c03-47a7-8ede-23d14e9738c7
+      - fc02cd6a-356a-4eca-8287-e78efa037b76
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -962,23 +962,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/c652a322-260a-44cd-a54b-ec211f7065a1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A13Z&sr=b&sp=r&sig=0MvplmItiLnuwL57Sy4jlwpeaWnza8K3JgpF0z4Kgb8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:13.3667752","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A13Z&sr=b&sp=r&sig=6WsrPdaRaAxPhU79B3HRIcxTT18QHZXQJdiYmLlzkBY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:13.3666877","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/90fc8a6c-4700-4ac2-9e12-bbe5a07f8974?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A13Z&sr=b&sp=r&sig=goA4Zq%2F4dupoftsruhD8kxmRtmwQTkey%2BOScQLw7MkE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:13.3667922","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-09T16:20:46.852Z","endDateTime":"2023-10-09T16:21:09.189Z","executedDateTime":"2023-10-09T16:20:46.167Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T16:20:46.453Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:21:09.499Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/fee43389-b960-42eb-b332-811e1036e5b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A55Z&sr=b&sp=r&sig=fnZImz3qYM4Xmr3LQd6xlqzq6mGFtYa%2B%2Bxaa9COUtDQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:55.4949241","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A55Z&sr=b&sp=r&sig=l%2BncBZkeymQa%2Fsw%2FOUWq8mylSS2BRbnHUE6tF%2BajNA8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:55.4948564","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/e1352333-328d-4b12-99dc-41f2b144b689?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A55Z&sr=b&sp=r&sig=GnE7tjRAeJBgJBVmIGp6xmNe1E4ncmzeo1AZ4vjB9eY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:55.49494","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-09T19:27:28.662Z","endDateTime":"2023-10-09T19:27:51.328Z","executedDateTime":"2023-10-09T19:27:28.027Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T19:27:28.282Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:51.616Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3229'
+      - '3235'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:13 GMT
+      - Mon, 09 Oct 2023 19:27:55 GMT
       mise-correlation-id:
-      - 3d66310e-ff39-46c0-8b17-29ae0bbb67d3
+      - 40d9c58a-848a-4250-b9a8-52bdc22f306e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1001,7 +1001,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:19:48.2259316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:19:48.2259316Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:26:26.8851856Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:26:26.8851856Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1010,9 +1010,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:30 GMT
+      - Mon, 09 Oct 2023 19:28:11 GMT
       etag:
-      - '"92017df2-0000-0100-0000-652428260000"'
+      - '"57006d01-0000-0100-0000-652453e40000"'
       expires:
       - '-1'
       pragma:
@@ -1042,23 +1042,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/c652a322-260a-44cd-a54b-ec211f7065a1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A31Z&sr=b&sp=r&sig=tVcmJxaAWH03OrHrC%2FdPNuJ8aGY%2Ftwn4gRQoGHFbDOU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:31.2650054","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A31Z&sr=b&sp=r&sig=CeQEkl6jU4Om7PeK9TZDI%2FKdEm4NzuFP1bHtxchHKBM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:31.2649393","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/90fc8a6c-4700-4ac2-9e12-bbe5a07f8974?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A31Z&sr=b&sp=r&sig=Klaes9pgNGw4J56PdvxScVIidCbWf1sXEYZifDCyIzQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:31.2650208","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-09T16:20:46.852Z","endDateTime":"2023-10-09T16:21:09.189Z","executedDateTime":"2023-10-09T16:20:46.167Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T16:20:46.453Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:21:28.837Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/fee43389-b960-42eb-b332-811e1036e5b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A14Z&sr=b&sp=r&sig=LpnuDUexCjpVAeiytnImeihlkIbNyp%2BRqxtfWteg2NQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:14.4763198","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A14Z&sr=b&sp=r&sig=yendjol8jNNtH48%2FaNmv%2FyHh%2BJ3nlvYZ4DMORIHlpCg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:14.4762472","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/e1352333-328d-4b12-99dc-41f2b144b689?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A14Z&sr=b&sp=r&sig=5l4EFMq%2BLlSnUs8ixE264qTlVUpVeTwwCsHmXfKtxBc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:14.4763344","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-09T19:27:28.662Z","endDateTime":"2023-10-09T19:27:51.328Z","executedDateTime":"2023-10-09T19:27:28.027Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T19:27:28.282Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:10.402Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3231'
+      - '3235'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:21:31 GMT
+      - Mon, 09 Oct 2023 19:28:14 GMT
       mise-correlation-id:
-      - 9a609690-37b7-417a-9d7b-73cfa41bead7
+      - bf413cb6-7dc7-42dc-87a0-f407774c9ef4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_stop.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_stop.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:28:34.4962316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:28:34.4962316Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:28:59.9332104Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:28:59.9332104Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:07 GMT
+      - Mon, 30 Oct 2023 07:29:33 GMT
       etag:
-      - '"3c00aa34-0000-0100-0000-653edc940000"'
+      - '"3f000478-0000-0100-0000-653f5b3e0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:29:09 GMT
+      - Mon, 30 Oct 2023 07:29:34 GMT
       mise-correlation-id:
-      - 72bc612e-1d6d-412b-aedc-ee194e80833d
+      - bfc51d65-a092-4db6-bd8d-c192269ccdb7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "120"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"3810ff1d-02df-4067-bfda-ca3a9289e0a3": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "2b650d86-bee1-4f6a-925b-2c2511dac183":
+      {"passFailMetrics": {"de972c60-9061-4eda-a122-4a3b09cbdd3b": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "8b931bab-5502-4ef7-ab5d-4eaa50dbcd33":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "4f14afaa-3c61-4295-84b1-625054f134ad": {"aggregate": "avg", "clientMetric":
+      "50"}, "0aee50fd-99b5-4fe0-803f-3c9a6825c0c6": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,26 +106,26 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:29:09.654Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:09.654Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"de972c60-9061-4eda-a122-4a3b09cbdd3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8b931bab-5502-4ef7-ab5d-4eaa50dbcd33":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0aee50fd-99b5-4fe0-803f-3c9a6825c0c6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:29:35.37Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:35.37Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1008'
+      - '1006'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:09 GMT
+      - Mon, 30 Oct 2023 07:29:35 GMT
       location:
-      - https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+      - https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - cd2e17e4-cee6-4002-a07d-7695c1f103b0
+      - 56830791-755f-406c-a43e-4f764778f1e6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files?api-version=2022-11-01
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:10 GMT
+      - Mon, 30 Oct 2023 07:29:35 GMT
       mise-correlation-id:
-      - e48251d7-61cd-411f-bde7-cf25c6acabb2
+      - 9b07199e-0ec6-4b58-88fb-115ba5fbed0f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A39%3A10Z&sr=b&sp=r&sig=j4GW6M2ox1HslVDP0z8vshae7XU2IkDQ3cDTOyJUShY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:39:10.5550048","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/69891730-41e2-4807-9ae3-08b246aba421?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A39%3A37Z&sr=b&sp=r&sig=4iU5KJNNZ1HPsCfGbe9uAw2IdlP6uZNOHlz6Z26P3jQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:39:37.737291","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '548'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:10 GMT
+      - Mon, 30 Oct 2023 07:29:37 GMT
       location:
-      - https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 8216fe10-f863-47e2-8be7-93155f0dbcd5
+      - 4ad9d12b-911d-48ae-b0b6-9eea7a1b21d3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A39%3A10Z&sr=b&sp=r&sig=zAIg8kqEZsDN1FpJvib1V9k5Xl%2Bk3ohsEZV%2B8JYPi44%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:39:10.8678005","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:29:10 GMT
-      mise-correlation-id:
-      - 49891983-cf05-4e6a-a11f-6c91d118d995
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A39%3A16Z&sr=b&sp=r&sig=lCdmq%2FabGpbmaObWPDE5G3Secq9C%2Fw%2BcHqEg3jzDPms%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:39:16.1845476","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:29:16 GMT
-      mise-correlation-id:
-      - fdebe457-23d0-4424-9d33-66e6c7fe3e8f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A39%3A21Z&sr=b&sp=r&sig=bz05qorftU1X7jMAjsI1vC81F3VWBqYSCp7QDQ%2F8x4U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:39:21.5101071","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/69891730-41e2-4807-9ae3-08b246aba421?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A39%3A37Z&sr=b&sp=r&sig=KSKLF5xbgtYSYDpIsr6mw5wwmQ%2BMCCcHCOdXk1UvNSY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:39:37.9742776","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:21 GMT
+      - Mon, 30 Oct 2023 07:29:37 GMT
       mise-correlation-id:
-      - d27b4ac1-a6e1-4e39-85c6-c0dda1339d7e
+      - b7376239-e031-4abe-a49b-1479af1dbb46
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A39%3A26Z&sr=b&sp=r&sig=WZXmOk6y5W0yGcvNtkWD2x4O0%2BAvTTvety3CAMnXXYU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:39:26.7657029","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/69891730-41e2-4807-9ae3-08b246aba421?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A39%3A43Z&sr=b&sp=r&sig=dpvjEqvo403K%2Fn0oYA1xlEMLCLTg1TWkg7D95OF2b6A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:39:43.2214904","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:26 GMT
+      - Mon, 30 Oct 2023 07:29:43 GMT
       mise-correlation-id:
-      - 0336454a-4119-4a28-a61e-691a70231398
+      - 0674ec1c-134e-4921-a3ab-fe89025ddaa8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +385,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A27Z&sr=b&sp=r&sig=whYkEd52%2FhYqlOUH%2BfvrX4PcHni%2BCJ%2FwlfHL7GLXzv0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:27.0422683","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:29:09.654Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:22.923Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/69891730-41e2-4807-9ae3-08b246aba421?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A39%3A48Z&sr=b&sp=r&sig=9qx7g76P21z8wcgKInu%2BCKEgbmiQmocJzkQpdss75hM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:39:48.4745332","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1585'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:27 GMT
+      - Mon, 30 Oct 2023 07:29:48 GMT
       mise-correlation-id:
-      - 1a89240a-eb37-455d-bb58-6da909cc456c
+      - 520dde73-9821-434c-8486-7497264d4c09
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/69891730-41e2-4807-9ae3-08b246aba421?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A39%3A53Z&sr=b&sp=r&sig=Isp9oOj8Sf4ihhe6oq%2B73MmHrFpQFZT6qGk48B%2BLXXw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:39:53.7158429","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:29:53 GMT
+      mise-correlation-id:
+      - 015885ae-a9aa-4555-b34c-17366db96b69
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"de972c60-9061-4eda-a122-4a3b09cbdd3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8b931bab-5502-4ef7-ab5d-4eaa50dbcd33":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0aee50fd-99b5-4fe0-803f-3c9a6825c0c6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/69891730-41e2-4807-9ae3-08b246aba421?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A53Z&sr=b&sp=r&sig=cZDkinJYc3xcdRUccRaUf8NTavq8V8eRiFTHM7%2FkHtQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:53.9824168","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:29:35.37Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:50.718Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1578'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:29:54 GMT
+      mise-correlation-id:
+      - c559aae8-ce78-4368-b708-de8d167cc314
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:28:34.4962316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:28:34.4962316Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:28:59.9332104Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:28:59.9332104Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:28 GMT
+      - Mon, 30 Oct 2023 07:29:55 GMT
       etag:
-      - '"3c00aa34-0000-0100-0000-653edc940000"'
+      - '"3f000478-0000-0100-0000-653f5b3e0000"'
       expires:
       - '-1'
       pragma:
@@ -538,11 +538,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A30Z&sr=b&sp=r&sig=yj0ADg5giOfwrIrPaXVSoyCkpBW2LpxiRjaVZSZQRgE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:30.160354","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:29:09.654Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:22.923Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"de972c60-9061-4eda-a122-4a3b09cbdd3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8b931bab-5502-4ef7-ab5d-4eaa50dbcd33":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0aee50fd-99b5-4fe0-803f-3c9a6825c0c6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/69891730-41e2-4807-9ae3-08b246aba421?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A56Z&sr=b&sp=r&sig=zPz43xHp19VBZLFoBFlYEHEhCkgnIm9NmjIVJ8Tq7hQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:56.2341116","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:29:35.37Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:50.718Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:30 GMT
+      - Mon, 30 Oct 2023 07:29:56 GMT
       mise-correlation-id:
-      - f31113d6-8741-4d38-8db9-09c8d3e63b67
+      - fecdc2cc-1567-4537-8b60-b7a9d8a49777
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:28:34.4962316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:28:34.4962316Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:28:59.9332104Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:28:59.9332104Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:31 GMT
+      - Mon, 30 Oct 2023 07:29:56 GMT
       etag:
-      - '"3c00aa34-0000-0100-0000-653edc940000"'
+      - '"3f000478-0000-0100-0000-653f5b3e0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:29:32 GMT
+      - Mon, 30 Oct 2023 07:29:58 GMT
       mise-correlation-id:
-      - 3f3c22c8-0fb9-43e4-9d78-8923239a2ca4
+      - 17f58098-d2a0-4fa6-b4fd-09083a82f6c3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/64491ab8-5d2b-49f5-815e-80bbd634ca92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A34Z&sr=b&sp=r&sig=lqz3H6TIo624wp0vtYAx4sSJB8L3jU6x6U%2FoLWuamGo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:34.0483742","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A34Z&sr=b&sp=r&sig=X6hTI4oNAahDhoQnkWc0dAnIwGRnQ4ucBYq7QrGUzkU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:34.04827","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/36a0e41e-54c4-4871-ad27-d89277960570?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A34Z&sr=b&sp=r&sig=MaqJ%2FSiNVMGV4smxqj0PcRYUjfB7dr3V7108X1mGcoM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:34.0483968","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:29:33.086Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-29T22:29:33.966Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:33.966Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"de972c60-9061-4eda-a122-4a3b09cbdd3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8b931bab-5502-4ef7-ab5d-4eaa50dbcd33":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0aee50fd-99b5-4fe0-803f-3c9a6825c0c6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/571b857b-c84d-4b8d-b203-6b69d8c303d9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A59Z&sr=b&sp=r&sig=vTvDBpT05cqQlueVn1njcA7ZktQ5DdvHjKm6jVuIKnQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:59.2174504","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/69891730-41e2-4807-9ae3-08b246aba421?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A59Z&sr=b&sp=r&sig=W1IPKEEN%2B7czmRPUu2RUNqHe%2Frs7Fj8OXX8AeoXrhVo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:59.2172605","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/cade7a36-cb55-4c1e-89d7-3eda94950f4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A59Z&sr=b&sp=r&sig=MMylcy8nqbzHEpvhsBpnqTFOi54ohSOZn6PtyRsiLcA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:59.2174821","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"ACCEPTED","executedDateTime":"2023-10-30T07:29:58.868Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-30T07:29:59.122Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:59.122Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3142'
+      - '3144'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:34 GMT
+      - Mon, 30 Oct 2023 07:29:59 GMT
       location:
-      - https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+      - https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 658a8903-8abd-4e0b-bfba-ed869b9d6471
+      - 1b42649f-94dd-47ff-ae66-def1aac8dac6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/64491ab8-5d2b-49f5-815e-80bbd634ca92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A34Z&sr=b&sp=r&sig=JJO1yErw3MNrlSnUVpFgTFAsnZ8YjmeaevoeLxpjsL8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:34.5413932","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A34Z&sr=b&sp=r&sig=Kvrk8V7SZCMNHYHJJjcHqHtsegof3walbZeizboutKM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:34.5413307","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/36a0e41e-54c4-4871-ad27-d89277960570?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A34Z&sr=b&sp=r&sig=wmdQ1fvVBH1TyWnLAZGrJSbsoEcZQXqyI2XtL5bq1Q4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:34.5414085","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:29:34.34Z","executedDateTime":"2023-10-29T22:29:33.086Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-29T22:29:33.966Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:34.527Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"de972c60-9061-4eda-a122-4a3b09cbdd3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8b931bab-5502-4ef7-ab5d-4eaa50dbcd33":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0aee50fd-99b5-4fe0-803f-3c9a6825c0c6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/571b857b-c84d-4b8d-b203-6b69d8c303d9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A59Z&sr=b&sp=r&sig=bZtvsoT3nisY0f%2BUgClA1jMpaYj0V0%2F23cnEG66tyKA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:59.7532007","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/69891730-41e2-4807-9ae3-08b246aba421?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A59Z&sr=b&sp=r&sig=AbumgjkeE3HSdKbTsiT0%2BHqrkdEI2RHct%2BwFmxBwJJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:29:59.7531166","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/cade7a36-cb55-4c1e-89d7-3eda94950f4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A29%3A59Z&sr=b&sp=r&sig=uIWt1x6y9gsYdqYHGw2bO8wxlg6TD%2F8djYgEhhtj4So%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:29:59.7532229","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"NOTSTARTED","startDateTime":"2023-10-30T07:29:59.582Z","executedDateTime":"2023-10-30T07:29:58.868Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-30T07:29:59.122Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:59.582Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3186'
+      - '3195'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:34 GMT
+      - Mon, 30 Oct 2023 07:29:59 GMT
       mise-correlation-id:
-      - 6502750a-2fff-4342-9839-bf6d63068977
+      - b4687578-2eb5-4ddd-9ab6-dfaeb3e52fa5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/64491ab8-5d2b-49f5-815e-80bbd634ca92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A39Z&sr=b&sp=r&sig=LOfSm0NNL%2FXXUteiUmBAgXggFQ9oRdnt6xmzdLS7j%2Fw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:39.8586306","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A39Z&sr=b&sp=r&sig=e%2FTQiuwCLnHW3Dssthhm95J1oawUt3O%2BnBzXhzs7cnM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:39.8585596","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/36a0e41e-54c4-4871-ad27-d89277960570?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A39Z&sr=b&sp=r&sig=YgqXwD40jCuQC%2Bc5RY861BZp6vk00lMnJumnaksGbSA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:39.8586449","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:29:34.34Z","executedDateTime":"2023-10-29T22:29:33.086Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-29T22:29:33.966Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:34.527Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"de972c60-9061-4eda-a122-4a3b09cbdd3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8b931bab-5502-4ef7-ab5d-4eaa50dbcd33":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0aee50fd-99b5-4fe0-803f-3c9a6825c0c6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/571b857b-c84d-4b8d-b203-6b69d8c303d9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A05Z&sr=b&sp=r&sig=HnJuFlVYsf02UBqpeW9pqQ6YqohI4TfJrWiI428k2gY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:05.0596817","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/69891730-41e2-4807-9ae3-08b246aba421?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A05Z&sr=b&sp=r&sig=j0YneT6haKzNTud4%2FOtNXuZC2%2Fq2yjGgdBZASISYkrg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:30:05.0595962","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/cade7a36-cb55-4c1e-89d7-3eda94950f4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A05Z&sr=b&sp=r&sig=X9a7opmkxMNYEEXNgm9oXtSYu9qLOzsvFooo0Up5VXQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:05.0596977","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:29:59.582Z","executedDateTime":"2023-10-30T07:29:58.868Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-30T07:29:59.122Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:59.783Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3196'
+      - '3191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:39 GMT
+      - Mon, 30 Oct 2023 07:30:05 GMT
       mise-correlation-id:
-      - 076823a6-a77e-449a-8550-2d59f9710b30
+      - 98b77bef-3a51-42c5-9db7-000a5b7b70af
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/64491ab8-5d2b-49f5-815e-80bbd634ca92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A45Z&sr=b&sp=r&sig=85p8B%2Bes9BkjLbccJ7Srl0RuPp48pGsuqOqiYyYCuZc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:45.1069669","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A45Z&sr=b&sp=r&sig=EKHgW2Q3%2FmOmuV53nkhmA8phk7kupNx52gOM4yzRG2k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:45.1068972","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/36a0e41e-54c4-4871-ad27-d89277960570?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A45Z&sr=b&sp=r&sig=MnKbbICWXKmV8%2F3IEatcncKCCh4mZMCSa5fYRuGuD8I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:45.1069811","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:29:34.34Z","executedDateTime":"2023-10-29T22:29:33.086Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-29T22:29:33.966Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:34.527Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"de972c60-9061-4eda-a122-4a3b09cbdd3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8b931bab-5502-4ef7-ab5d-4eaa50dbcd33":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0aee50fd-99b5-4fe0-803f-3c9a6825c0c6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/571b857b-c84d-4b8d-b203-6b69d8c303d9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A10Z&sr=b&sp=r&sig=l9ghcQ9DiirI23a1qP3Q%2BKCm16wYjQZJPxZxxyzppwU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:10.3014107","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/69891730-41e2-4807-9ae3-08b246aba421?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A10Z&sr=b&sp=r&sig=EYDGdgxIfGDDs9Po8djalZBRXVugqy%2FHEuQ3gSroeKw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:30:10.301344","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/cade7a36-cb55-4c1e-89d7-3eda94950f4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A10Z&sr=b&sp=r&sig=6IDKeKwQcvaUYs0Ghb%2B3OebS1%2Fe0R1fj6Pox5218yD8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:10.3014245","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:29:59.582Z","executedDateTime":"2023-10-30T07:29:58.868Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-30T07:29:59.122Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:59.783Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3192'
+      - '3194'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:45 GMT
+      - Mon, 30 Oct 2023 07:30:10 GMT
       mise-correlation-id:
-      - 272345ce-918d-45e4-8158-b6a844b2066b
+      - 44e252ca-64b2-426f-9a53-13647a965e39
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,23 +808,59 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/64491ab8-5d2b-49f5-815e-80bbd634ca92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A50Z&sr=b&sp=r&sig=YCkmO3WmnCcvzBg6OwhHY5ES20DkYOeCVFfGgtbWlcE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:50.4117978","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A50Z&sr=b&sp=r&sig=zpC3SCl%2FYb0iqikp13UTOjz2a2PvlnMDYGQI1GWCxIo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:50.4117101","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/36a0e41e-54c4-4871-ad27-d89277960570?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A50Z&sr=b&sp=r&sig=dmV0kgCSj2yQpAj8OrAra7HVt9iYUd%2B17g%2FzVkSvvnY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:50.4118226","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:29:34.34Z","executedDateTime":"2023-10-29T22:29:33.086Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-29T22:29:33.966Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:34.527Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"de972c60-9061-4eda-a122-4a3b09cbdd3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8b931bab-5502-4ef7-ab5d-4eaa50dbcd33":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0aee50fd-99b5-4fe0-803f-3c9a6825c0c6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/571b857b-c84d-4b8d-b203-6b69d8c303d9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A15Z&sr=b&sp=r&sig=ZZnrNaZ4X1kFxHOaB%2FKpVIxEnKuzoLP%2Bb7JNAR7bi14%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:15.5370338","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/69891730-41e2-4807-9ae3-08b246aba421?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A15Z&sr=b&sp=r&sig=x3OoAU6w%2BZiJULuVN3QG8banilAtDo1svoG%2FpeZHEQ8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:30:15.5369497","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/cade7a36-cb55-4c1e-89d7-3eda94950f4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A15Z&sr=b&sp=r&sig=Eg88R09CpgwegmJYM%2FVpnG8OIhY0q8v7GfdsX5CAsMI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:15.5370554","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:29:59.582Z","executedDateTime":"2023-10-30T07:29:58.868Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-30T07:29:59.122Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:59.783Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3192'
+      - '3197'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:50 GMT
+      - Mon, 30 Oct 2023 07:30:15 GMT
       mise-correlation-id:
-      - 5faba3a4-615c-4180-9b97-f8476150e924
+      - 8d435939-aaa0-41b5-bded-57780c1fe035
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"de972c60-9061-4eda-a122-4a3b09cbdd3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8b931bab-5502-4ef7-ab5d-4eaa50dbcd33":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0aee50fd-99b5-4fe0-803f-3c9a6825c0c6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/571b857b-c84d-4b8d-b203-6b69d8c303d9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A20Z&sr=b&sp=r&sig=kIoyHvARL3zVAtnBHr1HS%2BZhUcdu%2F4gDOYTv4L2uYB0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:20.8093367","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/69891730-41e2-4807-9ae3-08b246aba421?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A20Z&sr=b&sp=r&sig=LpaYS8iTclt%2FIE4fpBiBL%2BDdXVm7lZaKH6eBI8QIxBY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:30:20.8092489","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/cade7a36-cb55-4c1e-89d7-3eda94950f4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A20Z&sr=b&sp=r&sig=20wVHAahCU37auX2LdImS3UALac7qbymXEPL5tXgRMU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:20.8093586","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:29:59.582Z","executedDateTime":"2023-10-30T07:29:58.868Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-30T07:29:59.122Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:59.783Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:30:20 GMT
+      mise-correlation-id:
+      - f223dc72-4e85-4d44-98ce-8c0d457af25d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -847,7 +883,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:28:34.4962316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:28:34.4962316Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:28:59.9332104Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:28:59.9332104Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -856,9 +892,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:55 GMT
+      - Mon, 30 Oct 2023 07:30:20 GMT
       etag:
-      - '"3c00aa34-0000-0100-0000-653edc940000"'
+      - '"3f000478-0000-0100-0000-653f5b3e0000"'
       expires:
       - '-1'
       pragma:
@@ -873,42 +909,6 @@ interactions:
       - nosniff
       x-ms-providerhub-traffic:
       - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/64491ab8-5d2b-49f5-815e-80bbd634ca92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A55Z&sr=b&sp=r&sig=zvexsmZc3qqatpiHs7R3NY443hHDBxbzGSif31RIftk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:55.7140849","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A55Z&sr=b&sp=r&sig=IL4gdTRjRwSq0xPQkbtkWKLNeaHHqyNmf7vFnGTdbPw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:55.7140002","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/36a0e41e-54c4-4871-ad27-d89277960570?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A55Z&sr=b&sp=r&sig=R%2F%2FgGCeOfDnB67rCDdW3wViRFmFEZ4P58LOulqGJBxY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:55.7141061","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:29:34.34Z","executedDateTime":"2023-10-29T22:29:33.086Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-29T22:29:33.966Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:34.527Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:29:55 GMT
-      mise-correlation-id:
-      - 33455520-d3fd-4924-86af-506913c21cde
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
     status:
       code: 200
       message: OK
@@ -926,23 +926,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case:stop?api-version=2022-11-01
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case:stop?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/64491ab8-5d2b-49f5-815e-80bbd634ca92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A56Z&sr=b&sp=r&sig=ZCT%2B76VL2Wq4uRCOnq3MNxM7%2BBdQ1CUYUIUGJecefLU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:56.5249408","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A56Z&sr=b&sp=r&sig=VVUysPPQYQejK2nEoOXxkk4wgEmiSYsZcQXnBFidZdg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:56.5248644","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/36a0e41e-54c4-4871-ad27-d89277960570?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A56Z&sr=b&sp=r&sig=CtH9bJIr7eH9yNkwpR7JCpQry7fn8oIrGiyc8X8AiFE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:56.5249559","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:29:34.34Z","executedDateTime":"2023-10-29T22:29:33.086Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-29T22:29:33.966Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:34.527Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"de972c60-9061-4eda-a122-4a3b09cbdd3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8b931bab-5502-4ef7-ab5d-4eaa50dbcd33":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0aee50fd-99b5-4fe0-803f-3c9a6825c0c6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/571b857b-c84d-4b8d-b203-6b69d8c303d9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A22Z&sr=b&sp=r&sig=NqJfbtRf%2FB2kdUu9ZPTiLuxg8xToDzd5A%2FQJqc0SbPc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:22.3837076","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/69891730-41e2-4807-9ae3-08b246aba421?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A22Z&sr=b&sp=r&sig=JoreyG9RYARxBxXnR4739G3VOz32hqlo0jpO%2BqMUheM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:30:22.3836106","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/cade7a36-cb55-4c1e-89d7-3eda94950f4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A22Z&sr=b&sp=r&sig=QuW2xNgE69TkUVqASmpYHyuVm%2BkSEbRFj986AJqQjds%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:22.3837299","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:29:59.582Z","executedDateTime":"2023-10-30T07:29:58.868Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-30T07:29:59.122Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:29:59.783Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3131'
+      - '3136'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:29:56 GMT
+      - Mon, 30 Oct 2023 07:30:22 GMT
       mise-correlation-id:
-      - c4d2ba9c-b947-4013-8836-1dbbd3faae17
+      - 110ce9c7-b1a2-411f-af11-575b8d629288
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -962,23 +962,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/64491ab8-5d2b-49f5-815e-80bbd634ca92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A01Z&sr=b&sp=r&sig=wU81XrH3mswIbkf6U7S9rYzmn1gDt5UWLhCoJpp6UmE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:01.0361815","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A01Z&sr=b&sp=r&sig=nD%2Frp%2FI2z6FerzNAk%2Bh3lS5w2%2F7DCJq72CAoVy0VrKA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:01.0361127","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/36a0e41e-54c4-4871-ad27-d89277960570?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A01Z&sr=b&sp=r&sig=HWKp3y4PXfSfMZiw4FBu1dB%2F67q46wHKxnNu1X7v13E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:01.0361957","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-29T22:29:34.34Z","endDateTime":"2023-10-29T22:29:56.663Z","executedDateTime":"2023-10-29T22:29:33.086Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-29T22:29:33.966Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:57.812Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"de972c60-9061-4eda-a122-4a3b09cbdd3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8b931bab-5502-4ef7-ab5d-4eaa50dbcd33":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0aee50fd-99b5-4fe0-803f-3c9a6825c0c6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/571b857b-c84d-4b8d-b203-6b69d8c303d9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A26Z&sr=b&sp=r&sig=EZ3k0sNUxxN3M8tOPpPeo0bHl2K9SWWfz1N9C6%2Bd0LU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:26.048327","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/69891730-41e2-4807-9ae3-08b246aba421?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A26Z&sr=b&sp=r&sig=4kgQjmMaOj9vNlAex61PWZ7Gy3hUxqfBzp%2BoRL9LCes%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:30:26.0482378","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/cade7a36-cb55-4c1e-89d7-3eda94950f4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A26Z&sr=b&sp=r&sig=gzaBen0b3b6wNdQ1v6PJIkSLvjZ%2FVUvDRu5urYAF6G4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:26.0483429","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-30T07:29:59.582Z","endDateTime":"2023-10-30T07:30:22.703Z","executedDateTime":"2023-10-30T07:29:58.868Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-30T07:29:59.122Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:30:23Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3234'
+      - '3226'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:30:01 GMT
+      - Mon, 30 Oct 2023 07:30:26 GMT
       mise-correlation-id:
-      - 079c8cbe-a155-4595-8a61-b16feb4f1e5e
+      - ea586046-2c63-462e-b676-17f640c0d68a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1001,7 +1001,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:28:34.4962316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:28:34.4962316Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:28:59.9332104Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:28:59.9332104Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1010,9 +1010,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:30:17 GMT
+      - Mon, 30 Oct 2023 07:30:43 GMT
       etag:
-      - '"3c00aa34-0000-0100-0000-653edc940000"'
+      - '"3f000478-0000-0100-0000-653f5b3e0000"'
       expires:
       - '-1'
       pragma:
@@ -1042,10 +1042,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://a471d960-ed9a-4097-8a84-1f68ea5e0ac3.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/64491ab8-5d2b-49f5-815e-80bbd634ca92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A18Z&sr=b&sp=r&sig=M4IqZiswbTlc5H8KGwhtcSWQXyHIpSdioW4FnrixEdg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:18.6489094","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A18Z&sr=b&sp=r&sig=n0g4OM%2Fa%2Fa%2B%2BCjQI5PeFlLmQ53e7ati5fcZw6fapabU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:18.6488171","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/36a0e41e-54c4-4871-ad27-d89277960570?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A18Z&sr=b&sp=r&sig=v0Y5R9DsYUcgeb%2FzTKZ194mF6IJs%2FXDSrg5JbtQ90%2BM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:18.6489326","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-29T22:29:34.34Z","endDateTime":"2023-10-29T22:29:56.663Z","executedDateTime":"2023-10-29T22:29:33.086Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-29T22:29:33.966Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:30:15.797Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"de972c60-9061-4eda-a122-4a3b09cbdd3b":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"8b931bab-5502-4ef7-ab5d-4eaa50dbcd33":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0aee50fd-99b5-4fe0-803f-3c9a6825c0c6":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/571b857b-c84d-4b8d-b203-6b69d8c303d9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A44Z&sr=b&sp=r&sig=L%2F94NTuSkKo%2FK8ryl1aoR71kl%2B2DnCRTz5nsBZYCkbU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:44.7107726","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/69891730-41e2-4807-9ae3-08b246aba421?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A44Z&sr=b&sp=r&sig=kzufxTqwKqcdSfX6GXE%2FDjlRbP3Dk4h0EzSc9H1SGSc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:30:44.7107044","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1e5171f0-cb0b-4f6d-9c62-6fb5d182ec70/cade7a36-cb55-4c1e-89d7-3eda94950f4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A30%3A44Z&sr=b&sp=r&sig=7v%2Bq%2Fej8FbCpID95KYUdax1i3LS8AvHnTq%2BI4Cc0tPg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:30:44.710787","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-30T07:29:59.582Z","endDateTime":"2023-10-30T07:30:22.703Z","executedDateTime":"2023-10-30T07:29:58.868Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-30T07:29:59.122Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:30:41.777Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1056,9 +1056,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:30:18 GMT
+      - Mon, 30 Oct 2023 07:30:44 GMT
       mise-correlation-id:
-      - 4732cb3e-1e25-418a-b64d-fa1f2f63df77
+      - f0578511-705a-4790-bb19-0adc178d1333
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_stop.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_stop.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:01:54.5481168Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:01:54.5481168Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:01:44.1948751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:01:44.1948751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:02:29 GMT
+      - Wed, 18 Oct 2023 21:02:17 GMT
       etag:
-      - '"d901949d-0000-0100-0000-65294dd40000"'
+      - '"75000892-0000-0100-0000-653047ba0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 14:02:30 GMT
+      - Wed, 18 Oct 2023 21:02:19 GMT
       mise-correlation-id:
-      - 3158d4d8-82cc-463d-82c1-6674276610b8
+      - db2e78e8-ae79-4c16-a4fe-dc95a03dbd45
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "120"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"37f49a3d-c667-4a76-a547-264b549534e0": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":
+      {"passFailMetrics": {"9e244c8e-6625-42fb-a9d9-bd734cfd3542": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "1dcc06dc-8177-4958-80ba-d42a263fdd3b":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "ae3478dd-3466-44e8-8077-b1374fc762fd": {"aggregate": "avg", "clientMetric":
+      "50"}, "9ab2ee93-2bf9-47be-98f4-e5a8139114ff": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,26 +106,26 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T14:02:31.168Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:31.168Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T21:02:19.67Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:19.67Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1008'
+      - '1006'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:02:31 GMT
+      - Wed, 18 Oct 2023 21:02:19 GMT
       location:
-      - https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+      - https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 60c5aaaa-ffcf-418d-9635-73c1353af710
+      - 6cb2f316-39c8-4078-9176-c37c1e02464b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files?api-version=2022-11-01
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:02:31 GMT
+      - Wed, 18 Oct 2023 21:02:19 GMT
       mise-correlation-id:
-      - 20fa80a8-d0ed-44ff-b7e9-23a18bc8c93c
+      - 3b53504b-dfac-45cb-adf2-ae8ce895cc4a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A12%3A32Z&sr=b&sp=r&sig=GuzVcPYuOis4J3M%2FRwmgQfnWAP1xuwVWS02y%2FE5wgos%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:12:32.8833547","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A12%3A20Z&sr=b&sp=r&sig=lgRW5ORlQkD9I9nObcTBXuIvSAh8C5R1PU5wJNyV4Es%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:12:20.5592956","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:02:32 GMT
+      - Wed, 18 Oct 2023 21:02:20 GMT
       location:
-      - https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - d749cb4e-a376-4e68-89b4-ddbef18a5b8e
+      - 1e3159cc-0bda-4f20-b7a0-4a8783690da8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,118 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A12%3A33Z&sr=b&sp=r&sig=TB%2B7nijmIXfUvYe7rpWAw66JOneYk4MeDE9u4bXGF7E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:12:33.2106693","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:02:33 GMT
-      mise-correlation-id:
-      - 8dd8de24-e9b0-41e6-a7d6-a2d05d78475f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A12%3A38Z&sr=b&sp=r&sig=cC%2BOHJTdx81RxzTU6I3unL6gK4hQxhe3f9YvBQIZwdA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:12:38.5168662","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:02:38 GMT
-      mise-correlation-id:
-      - 925d0550-38ae-4d1f-9345-ed1bb7d93f5a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A12%3A43Z&sr=b&sp=r&sig=KNu0rLRou%2Bi%2FG5iVtlZKv090wghJqip01YXf98uysJs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:12:43.8551727","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:02:43 GMT
-      mise-correlation-id:
-      - a97edf5a-08c1-4945-bce2-6bed34a4ec1a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A12%3A49Z&sr=b&sp=r&sig=iUIwJDEnXhBF0FrU6tdGEm%2Fg4JRHQEoAIJYgitUkYyg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:12:49.1828508","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A12%3A20Z&sr=b&sp=r&sig=tXxSO8jmRHEhYnd2moNPAwQGZft0kiyqEc62JGoiTMQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:12:20.8542562","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:02:49 GMT
+      - Wed, 18 Oct 2023 21:02:20 GMT
       mise-correlation-id:
-      - c01b4ab7-2cd8-4c35-b8d3-0d4b396e5c79
+      - e8437ee4-72dc-420f-9a33-95c784a4b2eb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +349,132 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A49Z&sr=b&sp=r&sig=FkhC5cetTvwwfHOp5d4Ly8iC9ZkDJWuPch1iDXP94pM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:49.4358255","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T14:02:31.168Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:45.35Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A12%3A26Z&sr=b&sp=r&sig=Ja2wikvSTnJ19ztgFUW0e1GJUe0gdDSKCJmHI7HJjys%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:12:26.1630369","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1576'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:02:49 GMT
+      - Wed, 18 Oct 2023 21:02:26 GMT
       mise-correlation-id:
-      - ec01f41f-5412-4de2-8ea2-7a270ed467c7
+      - b1a7f144-178c-4e17-8c6b-9b6a8413b114
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A12%3A31Z&sr=b&sp=r&sig=E7LmBJXlb%2FwwqLc8tVv9fhSbmmWMqSAVY8z%2Fmu1fkzM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:12:31.5168171","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:02:31 GMT
+      mise-correlation-id:
+      - 825fe52e-ca38-40af-8b37-31250ed8a067
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A12%3A36Z&sr=b&sp=r&sig=lqVmPgrUCMuR9PbhCC5Fb6DGVr7CO8G2JZ%2FceXVBveU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:12:36.821911","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '548'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:02:36 GMT
+      mise-correlation-id:
+      - 6a4deb65-0627-41d8-8da8-3be689a45466
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A37Z&sr=b&sp=r&sig=JKoZj6%2FHXImIH%2FeXaYKQJ4FpIQLuVr1eC9MHRj761Zg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:37.0720259","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T21:02:19.67Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:33.201Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1580'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:02:37 GMT
+      mise-correlation-id:
+      - 575df35e-6c3f-4b92-b3a2-8351459e768f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:01:54.5481168Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:01:54.5481168Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:01:44.1948751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:01:44.1948751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:02:51 GMT
+      - Wed, 18 Oct 2023 21:02:38 GMT
       etag:
-      - '"d901949d-0000-0100-0000-65294dd40000"'
+      - '"75000892-0000-0100-0000-653047ba0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A52Z&sr=b&sp=r&sig=ug8FvH14s8TeaNLvv%2BsiZ3cUDXbv5w5gHYM%2Byq9peAw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:52.3888321","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T14:02:31.168Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:45.35Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A39Z&sr=b&sp=r&sig=vh6PcgDAU8r6JguJ4GxmlcJ5TUno8Krjva%2BMeoLRMfw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:39.4922579","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T21:02:19.67Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:33.201Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1592'
+      - '1590'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:02:52 GMT
+      - Wed, 18 Oct 2023 21:02:39 GMT
       mise-correlation-id:
-      - e09e6b18-97f1-4228-89ca-8444d163b7fe
+      - ed8e05af-2df2-42f5-af29-8c12292ade90
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:01:54.5481168Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:01:54.5481168Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:01:44.1948751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:01:44.1948751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:02:53 GMT
+      - Wed, 18 Oct 2023 21:02:40 GMT
       etag:
-      - '"d901949d-0000-0100-0000-65294dd40000"'
+      - '"75000892-0000-0100-0000-653047ba0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 14:02:54 GMT
+      - Wed, 18 Oct 2023 21:02:41 GMT
       mise-correlation-id:
-      - 025e4a45-de33-4c9f-973e-daeca80b5b43
+      - f4342ef1-6a49-4a33-a212-d073044738de
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/bb0b53c3-1deb-414c-af7f-089d0df602e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A55Z&sr=b&sp=r&sig=2FA%2B3VcFrmhPC0zHAv3l7uY5vrM4WtwAqUpLX0MYxrI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:55.2775787","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A55Z&sr=b&sp=r&sig=91EVcWaCVqFMqhe5YfOCbAiUiHJnqeJbxTm2cdN%2F5Hg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:55.277457","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/abdee8de-563c-403a-bd36-b98706414f9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A55Z&sr=b&sp=r&sig=ITkftB%2BZ9XDNNfmIxD6mVjkn5ySzDuW920xSJexK1sI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:55.2776075","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T14:02:54.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-13T14:02:55.173Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:55.173Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/0585e19d-7e04-4093-a821-4cb8c2dbe9e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A42Z&sr=b&sp=r&sig=E9KVeda%2FnJIrva1IUcSqfp4R%2BWTWTfjmoZX6kMY4a5E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:42.6479683","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A42Z&sr=b&sp=r&sig=7DMAim5EUih0kxkHqYsXYmNFYxmZLvCplpRmhV3FGy0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:42.6478617","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/4529b81b-fbd8-403a-8996-90f31931f55e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A42Z&sr=b&sp=r&sig=TUQpoKFPN49lj8BYXBlXFFofxqgasREuGYLwXVKSVYk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:42.6479945","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T21:02:42.303Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-18T21:02:42.574Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:42.574Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3145'
+      - '3144'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:02:56 GMT
+      - Wed, 18 Oct 2023 21:02:42 GMT
       location:
-      - https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+      - https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 12de8ae5-bb40-43f5-964f-99162b26f70b
+      - f79a7d0c-f3d6-4c45-94c6-3e175759be54
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/bb0b53c3-1deb-414c-af7f-089d0df602e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A56Z&sr=b&sp=r&sig=Y1XiidzxTW1S4EWypfd9xP1svH9QQlX7AhTxupXy5e0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:56.3677922","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A56Z&sr=b&sp=r&sig=Lc%2FAnVX8SGrQnm%2FCAJD92oW75OQeuBhDvlgq52DXH9Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:56.367741","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/abdee8de-563c-403a-bd36-b98706414f9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A56Z&sr=b&sp=r&sig=ctt4KuaXp3HTRjoac%2B%2FQR0bKjmgO0hQz3O9vZIGzelo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:56.3678076","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"NOTSTARTED","startDateTime":"2023-10-13T14:02:56.275Z","executedDateTime":"2023-10-13T14:02:54.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-13T14:02:55.173Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:56.275Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/0585e19d-7e04-4093-a821-4cb8c2dbe9e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A43Z&sr=b&sp=r&sig=XQI4bU0bMgI%2Buz2oIpPHM6Gx3P6t0%2FHm816IvDalDrI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:43.1773836","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A43Z&sr=b&sp=r&sig=uYwAXE6C3CmZUxXoGVeN9hbwUBcdQBU5Zmh%2Ffqzeo7c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:43.1772916","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/4529b81b-fbd8-403a-8996-90f31931f55e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A43Z&sr=b&sp=r&sig=RgegzRwo2EQwLcCByI2LvmIuG62p21t7iux%2BgW4%2B0Kk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:43.1774049","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:02:42.965Z","executedDateTime":"2023-10-18T21:02:42.303Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-18T21:02:42.574Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:43.154Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3192'
+      - '3197'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:02:56 GMT
+      - Wed, 18 Oct 2023 21:02:43 GMT
       mise-correlation-id:
-      - 28dd1675-11dd-4e0e-9b48-7d84697368a1
+      - bc62d798-915a-4559-94e0-a922612c14e2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/bb0b53c3-1deb-414c-af7f-089d0df602e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A01Z&sr=b&sp=r&sig=vlaqmmrUkXpgUQF%2FtE5GkrAtFgmAG4ceScohI0CGtuA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:01.6805143","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A01Z&sr=b&sp=r&sig=kfSpwmiQ%2Bxesf9k8ec0fS4GxFncIEpIiTfuaKAUyvCk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:01.6804262","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/abdee8de-563c-403a-bd36-b98706414f9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A01Z&sr=b&sp=r&sig=Uks9g5RNwT8%2FA26AOP8JqmogdEQs7GdfgzI7u4IUZyc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:01.6805347","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:02:56.275Z","executedDateTime":"2023-10-13T14:02:54.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-13T14:02:55.173Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:57.108Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/0585e19d-7e04-4093-a821-4cb8c2dbe9e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A48Z&sr=b&sp=r&sig=Zz8qp9NJgYZxu0DYVgzSqYctipfp%2Bt%2Fnt4pvHbzfyio%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:48.5144849","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A48Z&sr=b&sp=r&sig=IVBHpIFW3OJkoKc3tSm5DgWPkXGgl3qqy%2FuyGpJl%2Fgs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:48.5144082","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/4529b81b-fbd8-403a-8996-90f31931f55e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A48Z&sr=b&sp=r&sig=ypEF6tX1NWLGx21L%2BIgKzHlTBRXLvz%2BLvfghGLWiJfA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:48.514499","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:02:42.965Z","executedDateTime":"2023-10-18T21:02:42.303Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-18T21:02:42.574Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:43.154Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3193'
+      - '3198'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:03:01 GMT
+      - Wed, 18 Oct 2023 21:02:48 GMT
       mise-correlation-id:
-      - bad1912b-e81f-4b3c-a8b5-2034be5a41de
+      - 08ef85ea-4a37-41fa-8ebc-72075aa9cb78
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,10 +772,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/bb0b53c3-1deb-414c-af7f-089d0df602e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A06Z&sr=b&sp=r&sig=aPN2Yz4q3FcR6ulcsIyGGE1ZymGIRmWDwhZCkt1khEA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:06.9782659","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A06Z&sr=b&sp=r&sig=oQLRF%2FdCxEalWyYR5uxsEeLF3Vh04osAIZV2%2BVZmoNY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:06.9781644","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/abdee8de-563c-403a-bd36-b98706414f9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A06Z&sr=b&sp=r&sig=rgispvKAtY9i5yEF5M4cjgz5EWx2FC5kN6XLByH505k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:06.9782841","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:02:56.275Z","executedDateTime":"2023-10-13T14:02:54.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-13T14:02:55.173Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:57.108Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/0585e19d-7e04-4093-a821-4cb8c2dbe9e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A53Z&sr=b&sp=r&sig=bf4lIWmxo%2FCD2UMnoaPWseltAX9RVUTtrLJMNJXoLsk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:53.8322566","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A53Z&sr=b&sp=r&sig=Qrn4CO%2FY%2Bc2yLSpL6VDRwXBJnA1pYtefRDLQKiaq3HE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:53.8321554","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/4529b81b-fbd8-403a-8996-90f31931f55e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A53Z&sr=b&sp=r&sig=mPE64oTYVU3%2F6O8WeIp7qz0ewIfp0dMHRlE2SkzEHk0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:53.8322817","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:02:42.965Z","executedDateTime":"2023-10-18T21:02:42.303Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-18T21:02:42.574Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:43.154Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:02:53 GMT
+      mise-correlation-id:
+      - 1e8c9ea0-f125-4ff4-82c0-0fef9d0c7406
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/0585e19d-7e04-4093-a821-4cb8c2dbe9e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A59Z&sr=b&sp=r&sig=kzoPCT574wt%2BFdWpIKKV6rEZ%2BL5EC5Gbi1eqhxyYWfI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:59.1716902","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A59Z&sr=b&sp=r&sig=Lj1wLdGksnu7Sd8ykeu2qgT1hoBLp1KHLqvnSKdLNaA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:59.1715903","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/4529b81b-fbd8-403a-8996-90f31931f55e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A59Z&sr=b&sp=r&sig=qNKvrYN0qMWav5m8D33t9VZlm2ANOVCI7oZuOhH7Xns%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:59.1717123","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:02:42.965Z","executedDateTime":"2023-10-18T21:02:42.303Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-18T21:02:42.574Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:43.154Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -786,45 +822,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:03:06 GMT
+      - Wed, 18 Oct 2023 21:02:59 GMT
       mise-correlation-id:
-      - f609895e-077a-41dd-9d76-e68497980d19
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/bb0b53c3-1deb-414c-af7f-089d0df602e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A12Z&sr=b&sp=r&sig=AfrNk8pKJti%2FewJJlO%2Fv24fepx5ndoya%2FJLfxvqLhRg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:12.273276","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A12Z&sr=b&sp=r&sig=cQcyad0giHgCxZlvutNKcXNB7mGV7sm6eUm5nFLRGpA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:12.2731933","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/abdee8de-563c-403a-bd36-b98706414f9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A12Z&sr=b&sp=r&sig=ExbqfoSnG16SlT6nRPSdyP5AKZqFBdK6WhLkbMRXaKI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:12.2732968","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:02:56.275Z","executedDateTime":"2023-10-13T14:02:54.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-13T14:02:55.173Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:57.108Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:03:12 GMT
-      mise-correlation-id:
-      - 91780761-68cc-4022-b93c-62abc43607b0
+      - 49c573f9-10d0-4906-b923-65b826624753
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -847,7 +847,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:01:54.5481168Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:01:54.5481168Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:01:44.1948751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:01:44.1948751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -856,9 +856,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:03:17 GMT
+      - Wed, 18 Oct 2023 21:03:03 GMT
       etag:
-      - '"d901949d-0000-0100-0000-65294dd40000"'
+      - '"75000892-0000-0100-0000-653047ba0000"'
       expires:
       - '-1'
       pragma:
@@ -888,23 +888,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/bb0b53c3-1deb-414c-af7f-089d0df602e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A17Z&sr=b&sp=r&sig=ClmL9%2BZPd7gBodbRggaLQ%2Fzq2uY2wQKVttqwR3d8sVw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:17.6076686","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A17Z&sr=b&sp=r&sig=J2myKNa%2F42tAgSlfvL2US5MDcRGqDHe0jbedLZ0e7sg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:17.6075717","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/abdee8de-563c-403a-bd36-b98706414f9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A17Z&sr=b&sp=r&sig=AML8adIIXpdPryazDUmbFKsgwUWmLWvvlYVxNfyj6a8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:17.6076926","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:02:56.275Z","executedDateTime":"2023-10-13T14:02:54.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-13T14:02:55.173Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:57.108Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/0585e19d-7e04-4093-a821-4cb8c2dbe9e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A04Z&sr=b&sp=r&sig=XmeQOpBdT8T5yEDFVAKBGhaSiyAE6MqDl%2B0oNFEAHdE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:04.4795763","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A04Z&sr=b&sp=r&sig=jhHbfBBu5CCIpkmII07njacIipcvSYthdJwDWdoj%2BOk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:04.4794789","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/4529b81b-fbd8-403a-8996-90f31931f55e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A04Z&sr=b&sp=r&sig=vUoKqYWEnAwUxX4OBQhZ3kryxDbQOhhismxaGzLSrFw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:04.479598","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:02:42.965Z","executedDateTime":"2023-10-18T21:02:42.303Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-18T21:02:42.574Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:43.154Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3193'
+      - '3190'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:03:17 GMT
+      - Wed, 18 Oct 2023 21:03:04 GMT
       mise-correlation-id:
-      - a8a2482d-1558-4c52-988f-85d3e67feee1
+      - 6b4b1b2e-00bc-4a54-9f51-62b76b5bb13d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -926,23 +926,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case:stop?api-version=2022-11-01
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case:stop?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/bb0b53c3-1deb-414c-af7f-089d0df602e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A18Z&sr=b&sp=r&sig=%2Fj3oyWg86%2B%2Bwe2%2BXRN3OwAjSrecoh25pQ7PXBypeSuw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:18.3067638","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A18Z&sr=b&sp=r&sig=BpYslxSdhQC0Wuqx0Em3aWNMNrG3kPVvqtXikhChyAk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:18.3066947","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/abdee8de-563c-403a-bd36-b98706414f9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A18Z&sr=b&sp=r&sig=RcqwfKRyIVEFbI0YQD%2B7dOPa3IcxAvLKOdi3i%2Fn3WJM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:18.3067782","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:02:56.275Z","executedDateTime":"2023-10-13T14:02:54.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-13T14:02:55.173Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:57.108Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/0585e19d-7e04-4093-a821-4cb8c2dbe9e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A05Z&sr=b&sp=r&sig=paKiW5vgoKXNCZl8Fwdp0%2BO4%2BofMoPIA58UMvtndL%2FY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:05.3819061","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A05Z&sr=b&sp=r&sig=Fy8eQDaT7Lp%2F0HUksZEYDc7Ibb286zlXvyp8LB6HlHM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:05.3818065","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/4529b81b-fbd8-403a-8996-90f31931f55e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A05Z&sr=b&sp=r&sig=Y6tslgu05Nhs24gHM80lshxcNnpikUXKX3qpB4zyDeg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:05.3819276","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:02:42.965Z","executedDateTime":"2023-10-18T21:02:42.303Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-18T21:02:42.574Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:43.154Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3140'
+      - '3136'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:03:18 GMT
+      - Wed, 18 Oct 2023 21:03:05 GMT
       mise-correlation-id:
-      - f175d26f-e439-471d-8c61-1d9d08ddcefb
+      - 31ead3e6-ad70-42f5-a741-b42281c8fbb1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -962,23 +962,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/bb0b53c3-1deb-414c-af7f-089d0df602e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A22Z&sr=b&sp=r&sig=%2F6%2Bom%2B4piSDkTtlF4v8EqqMeVAGl3CPqOEbsVWgcZcQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:22.9328436","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A22Z&sr=b&sp=r&sig=ZUHp3Y4PNRQYGMJtc2hHTedsuJUPQ6je3hZGvk0yDXE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:22.9327548","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/abdee8de-563c-403a-bd36-b98706414f9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A22Z&sr=b&sp=r&sig=Osh5PomVI1JDtajFJRd7BFDfgyK9gTC5IrOZ6Bl5rg4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:22.9328659","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-13T14:02:56.275Z","endDateTime":"2023-10-13T14:03:18.426Z","executedDateTime":"2023-10-13T14:02:54.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-13T14:02:55.173Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:03:18.726Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/0585e19d-7e04-4093-a821-4cb8c2dbe9e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A09Z&sr=b&sp=r&sig=nvpjcySundmvszJ8MFcDv1Y3rX7MAIIxIn94SB0Vk9I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:09.8182312","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A09Z&sr=b&sp=r&sig=ZNy5Em6bR4lYcGFaQt7nROh19xmWIZnBWO9019uQEeQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:09.8181632","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/4529b81b-fbd8-403a-8996-90f31931f55e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A09Z&sr=b&sp=r&sig=kk0ZyD8XANc%2BPOb2C8%2FOAQGCzaxrKk6P7D8IFxloYA8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:09.8182475","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-18T21:02:42.965Z","endDateTime":"2023-10-18T21:03:05.509Z","executedDateTime":"2023-10-18T21:02:42.303Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-18T21:02:42.574Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:03:05.781Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3231'
+      - '3229'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:03:22 GMT
+      - Wed, 18 Oct 2023 21:03:09 GMT
       mise-correlation-id:
-      - 607f21db-4712-4e96-b3cf-8e0c51d17daa
+      - df60d4ba-c706-4751-8554-4137cfc35394
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1001,7 +1001,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:01:54.5481168Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:01:54.5481168Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:01:44.1948751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:01:44.1948751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1010,9 +1010,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:03:39 GMT
+      - Wed, 18 Oct 2023 21:03:26 GMT
       etag:
-      - '"d901949d-0000-0100-0000-65294dd40000"'
+      - '"75000892-0000-0100-0000-653047ba0000"'
       expires:
       - '-1'
       pragma:
@@ -1042,23 +1042,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/bb0b53c3-1deb-414c-af7f-089d0df602e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A40Z&sr=b&sp=r&sig=s8YanVaBBfaSk748%2F54dRK4%2BLZ9Ts4oHs5w8uUM5H7w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:40.3801787","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A40Z&sr=b&sp=r&sig=T7M293wkpXzGAPPtP%2BLImgH202exli7tNoDuGzhHONg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:40.3801145","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/abdee8de-563c-403a-bd36-b98706414f9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A40Z&sr=b&sp=r&sig=%2BV7sh9K%2FwWnqBvLi0pt4JTA19dwiKi7BiCHYzcw9gOs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:40.3801948","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-13T14:02:56.275Z","endDateTime":"2023-10-13T14:03:18.426Z","executedDateTime":"2023-10-13T14:02:54.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-13T14:02:55.173Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:03:37.062Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/0585e19d-7e04-4093-a821-4cb8c2dbe9e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A27Z&sr=b&sp=r&sig=va29lWrq9Q2M7J3A8D1ZJ8PHRNPlu1FvQRHz6SHLPjw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:27.7232899","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A27Z&sr=b&sp=r&sig=UZYpPN5cUlm94hH7j35FpBYXoOXGk7eisQMN2ZK%2BYRc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:27.7231884","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/4529b81b-fbd8-403a-8996-90f31931f55e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A27Z&sr=b&sp=r&sig=H6ZzQFLFx1NQOTqindxkvE2PjRnlv2S%2Fhi9B86ETLuk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:27.7233123","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-18T21:02:42.965Z","endDateTime":"2023-10-18T21:03:05.509Z","executedDateTime":"2023-10-18T21:02:42.303Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-18T21:02:42.574Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:03:25.243Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3235'
+      - '3229'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:03:40 GMT
+      - Wed, 18 Oct 2023 21:03:27 GMT
       mise-correlation-id:
-      - 23d8c5cc-32d8-4d75-9db0-d49864ebad93
+      - 5fdb2544-1a0e-43dc-b00a-049fe4593d7b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_stop.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_stop.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:01:44.1948751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:01:44.1948751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:36:11.1310639Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:36:11.1310639Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:02:17 GMT
+      - Tue, 24 Oct 2023 12:36:45 GMT
       etag:
-      - '"75000892-0000-0100-0000-653047ba0000"'
+      - '"d3006b52-0000-0100-0000-6537ba3d0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 21:02:19 GMT
+      - Tue, 24 Oct 2023 12:36:47 GMT
       mise-correlation-id:
-      - db2e78e8-ae79-4c16-a4fe-dc95a03dbd45
+      - 3905c87b-d4eb-47ac-8135-2f0d6842589b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "120"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"9e244c8e-6625-42fb-a9d9-bd734cfd3542": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "1dcc06dc-8177-4958-80ba-d42a263fdd3b":
+      {"passFailMetrics": {"21ed0892-e9fb-4777-b96a-1914e19055e4": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "ae20c3a3-c077-4d49-8223-d6919f9015d6":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "9ab2ee93-2bf9-47be-98f4-e5a8139114ff": {"aggregate": "avg", "clientMetric":
+      "50"}, "daa78e6e-16b3-4685-aaa9-b2f4deabf60c": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,26 +106,26 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T21:02:19.67Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:19.67Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:36:48.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:36:48.324Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1006'
+      - '1008'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:02:19 GMT
+      - Tue, 24 Oct 2023 12:36:48 GMT
       location:
-      - https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+      - https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 6cb2f316-39c8-4078-9176-c37c1e02464b
+      - 94cd0733-f584-4500-b7f2-8c6c97b05a49
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files?api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:02:19 GMT
+      - Tue, 24 Oct 2023 12:36:48 GMT
       mise-correlation-id:
-      - 3b53504b-dfac-45cb-adf2-ae8ce895cc4a
+      - 0fbab025-19aa-4912-8469-4d80ab640f9f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A12%3A20Z&sr=b&sp=r&sig=lgRW5ORlQkD9I9nObcTBXuIvSAh8C5R1PU5wJNyV4Es%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:12:20.5592956","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A46%3A49Z&sr=b&sp=r&sig=SUceVHH4UgWyhDastt3g6MJXsk1b1a6%2FTFmqfI5YA7c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:46:49.1127581","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:02:20 GMT
+      - Tue, 24 Oct 2023 12:36:49 GMT
       location:
-      - https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 1e3159cc-0bda-4f20-b7a0-4a8783690da8
+      - a786d90a-2a39-4e93-9bcf-11cae5857896
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A12%3A20Z&sr=b&sp=r&sig=tXxSO8jmRHEhYnd2moNPAwQGZft0kiyqEc62JGoiTMQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:12:20.8542562","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A46%3A49Z&sr=b&sp=r&sig=ynhoZ55uL4PPteMNFeXwXsTw5VKhPuy386yL1FOjV8k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:46:49.3676782","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:02:20 GMT
+      - Tue, 24 Oct 2023 12:36:49 GMT
       mise-correlation-id:
-      - e8437ee4-72dc-420f-9a33-95c784a4b2eb
+      - 0eb75908-25e6-48a8-8849-ab0315a7d771
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,46 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A12%3A26Z&sr=b&sp=r&sig=Ja2wikvSTnJ19ztgFUW0e1GJUe0gdDSKCJmHI7HJjys%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:12:26.1630369","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:02:26 GMT
-      mise-correlation-id:
-      - b1a7f144-178c-4e17-8c6b-9b6a8413b114
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A12%3A31Z&sr=b&sp=r&sig=E7LmBJXlb%2FwwqLc8tVv9fhSbmmWMqSAVY8z%2Fmu1fkzM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:12:31.5168171","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A46%3A54Z&sr=b&sp=r&sig=SMRI3oiHiMY5OdNBLUlxDyU3N2PBMP%2BSCMtOh1Ucn%2FI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:46:54.6743245","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:02:31 GMT
+      - Tue, 24 Oct 2023 12:36:54 GMT
       mise-correlation-id:
-      - 825fe52e-ca38-40af-8b37-31250ed8a067
+      - 59c63430-1aca-4da4-9bf8-ce4851723ef3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A12%3A36Z&sr=b&sp=r&sig=lqVmPgrUCMuR9PbhCC5Fb6DGVr7CO8G2JZ%2FceXVBveU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:12:36.821911","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A47%3A00Z&sr=b&sp=r&sig=W%2F7LpvdnoVjiijVnX8IMIl8F4t%2FYGac3fl3pwRTNOvo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:47:00.034642","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '548'
+      - '552'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:02:36 GMT
+      - Tue, 24 Oct 2023 12:37:00 GMT
       mise-correlation-id:
-      - 6a4deb65-0627-41d8-8da8-3be689a45466
+      - a374f30a-f5b5-4634-9336-642dbf25d1d0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +421,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A37Z&sr=b&sp=r&sig=JKoZj6%2FHXImIH%2FeXaYKQJ4FpIQLuVr1eC9MHRj761Zg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:37.0720259","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T21:02:19.67Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:33.201Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A47%3A05Z&sr=b&sp=r&sig=HQgtFKHZcmMMNL2vo3hXJ0f84f0qx9qF%2FVdzkW%2BpzdY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:47:05.3576116","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1580'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:02:37 GMT
+      - Tue, 24 Oct 2023 12:37:05 GMT
       mise-correlation-id:
-      - 575df35e-6c3f-4b92-b3a2-8351459e768f
+      - 42357862-6bdd-4d20-8c47-85f01f2c56db
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A05Z&sr=b&sp=r&sig=jeXtNvQOx%2B2e%2BLkBPIHlSh4Q%2B6bLHrkA3en18g3e8mE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:05.6615865","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:36:48.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:01.355Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1583'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:37:05 GMT
+      mise-correlation-id:
+      - 899a2435-9b95-42e0-a817-2ad634cbcc66
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:01:44.1948751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:01:44.1948751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:36:11.1310639Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:36:11.1310639Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:02:38 GMT
+      - Tue, 24 Oct 2023 12:37:06 GMT
       etag:
-      - '"75000892-0000-0100-0000-653047ba0000"'
+      - '"d3006b52-0000-0100-0000-6537ba3d0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A39Z&sr=b&sp=r&sig=vh6PcgDAU8r6JguJ4GxmlcJ5TUno8Krjva%2BMeoLRMfw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:39.4922579","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T21:02:19.67Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:33.201Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A08Z&sr=b&sp=r&sig=6VB27l0E0O6lhQzVFpu318ovlWlL0%2B2papwapNRZG74%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:08.3224899","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:36:48.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:01.355Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1590'
+      - '1591'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:02:39 GMT
+      - Tue, 24 Oct 2023 12:37:08 GMT
       mise-correlation-id:
-      - ed8e05af-2df2-42f5-af29-8c12292ade90
+      - c2cfeec9-74e4-4a4c-8a72-260af848c3d2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:01:44.1948751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:01:44.1948751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:36:11.1310639Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:36:11.1310639Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:02:40 GMT
+      - Tue, 24 Oct 2023 12:37:09 GMT
       etag:
-      - '"75000892-0000-0100-0000-653047ba0000"'
+      - '"d3006b52-0000-0100-0000-6537ba3d0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 21:02:41 GMT
+      - Tue, 24 Oct 2023 12:37:10 GMT
       mise-correlation-id:
-      - f4342ef1-6a49-4a33-a212-d073044738de
+      - 19ad9c08-32d7-4e45-b1ea-c57ea9ab625c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/0585e19d-7e04-4093-a821-4cb8c2dbe9e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A42Z&sr=b&sp=r&sig=E9KVeda%2FnJIrva1IUcSqfp4R%2BWTWTfjmoZX6kMY4a5E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:42.6479683","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A42Z&sr=b&sp=r&sig=7DMAim5EUih0kxkHqYsXYmNFYxmZLvCplpRmhV3FGy0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:42.6478617","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/4529b81b-fbd8-403a-8996-90f31931f55e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A42Z&sr=b&sp=r&sig=TUQpoKFPN49lj8BYXBlXFFofxqgasREuGYLwXVKSVYk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:42.6479945","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T21:02:42.303Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-18T21:02:42.574Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:42.574Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/fa15535a-e219-4355-b977-1e94946ca110?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A12Z&sr=b&sp=r&sig=P8UaJ%2FO%2Fn6jZHxRoSujYVGhesEcaAgtLJPYdxSl%2BgGQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:12.4067694","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A12Z&sr=b&sp=r&sig=fF1Mt3a78CqlP57THmxouuFrkUlP2c%2FQsNAE6FneXzQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:12.4066317","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/f2fc4209-9c01-49cd-ad06-b9f736a6542c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A12Z&sr=b&sp=r&sig=AvHe6UFJu2sMZqrAGPkShkKKxRHt%2BDE%2B6pWFNn2Hn%2B0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:12.4067972","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:37:11.511Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-24T12:37:12.313Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:12.313Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3144'
+      - '3154'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:02:42 GMT
+      - Tue, 24 Oct 2023 12:37:12 GMT
       location:
-      - https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+      - https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - f79a7d0c-f3d6-4c45-94c6-3e175759be54
+      - e3244343-eb14-4bc4-8c6b-42ca0855d3e7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/0585e19d-7e04-4093-a821-4cb8c2dbe9e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A43Z&sr=b&sp=r&sig=XQI4bU0bMgI%2Buz2oIpPHM6Gx3P6t0%2FHm816IvDalDrI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:43.1773836","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A43Z&sr=b&sp=r&sig=uYwAXE6C3CmZUxXoGVeN9hbwUBcdQBU5Zmh%2Ffqzeo7c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:43.1772916","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/4529b81b-fbd8-403a-8996-90f31931f55e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A43Z&sr=b&sp=r&sig=RgegzRwo2EQwLcCByI2LvmIuG62p21t7iux%2BgW4%2B0Kk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:43.1774049","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:02:42.965Z","executedDateTime":"2023-10-18T21:02:42.303Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-18T21:02:42.574Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:43.154Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/fa15535a-e219-4355-b977-1e94946ca110?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A12Z&sr=b&sp=r&sig=CEW0LTV2jtZgRYHV9ptu90%2BleCjr%2BAY3hBT3kZOAmNw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:12.8164608","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A12Z&sr=b&sp=r&sig=4P%2Fgd1xORSJcvckNTkeVJymFuQye3VTO2dTx6uTY4Xg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:12.8163931","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/f2fc4209-9c01-49cd-ad06-b9f736a6542c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A12Z&sr=b&sp=r&sig=%2BGtC7WpAXl%2Bll1%2BmyGOk%2Fv%2B6BdyoXvH5e9BWKgForT0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:12.8164745","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:37:11.511Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-24T12:37:12.313Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:12.313Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3197'
+      - '3156'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:02:43 GMT
+      - Tue, 24 Oct 2023 12:37:12 GMT
       mise-correlation-id:
-      - bc62d798-915a-4559-94e0-a922612c14e2
+      - 4b65ac66-2933-4d6d-a406-aaa084387d84
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/0585e19d-7e04-4093-a821-4cb8c2dbe9e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A48Z&sr=b&sp=r&sig=Zz8qp9NJgYZxu0DYVgzSqYctipfp%2Bt%2Fnt4pvHbzfyio%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:48.5144849","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A48Z&sr=b&sp=r&sig=IVBHpIFW3OJkoKc3tSm5DgWPkXGgl3qqy%2FuyGpJl%2Fgs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:48.5144082","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/4529b81b-fbd8-403a-8996-90f31931f55e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A48Z&sr=b&sp=r&sig=ypEF6tX1NWLGx21L%2BIgKzHlTBRXLvz%2BLvfghGLWiJfA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:48.514499","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:02:42.965Z","executedDateTime":"2023-10-18T21:02:42.303Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-18T21:02:42.574Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:43.154Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/fa15535a-e219-4355-b977-1e94946ca110?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A18Z&sr=b&sp=r&sig=inXqGTz8rKCdCJM6quAYHGioRfR%2FGhOcaCMDwACByf4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:18.1453612","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A18Z&sr=b&sp=r&sig=Jepgu1GiSao2XbgLlM94UNrJTg3cbO8b2dhIrvvhWBU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:18.1452914","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/f2fc4209-9c01-49cd-ad06-b9f736a6542c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A18Z&sr=b&sp=r&sig=3P03%2B9mO0JL0bjV2aHPFYw1qY6D1jo%2BdaQ72o%2BBtPPY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:18.1453747","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:37:13.99Z","executedDateTime":"2023-10-24T12:37:11.511Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-24T12:37:12.313Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:14.129Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3198'
+      - '3194'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:02:48 GMT
+      - Tue, 24 Oct 2023 12:37:18 GMT
       mise-correlation-id:
-      - 08ef85ea-4a37-41fa-8ebc-72075aa9cb78
+      - 393bfd93-9548-4efd-88bd-225e67f2fbae
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/0585e19d-7e04-4093-a821-4cb8c2dbe9e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A53Z&sr=b&sp=r&sig=bf4lIWmxo%2FCD2UMnoaPWseltAX9RVUTtrLJMNJXoLsk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:53.8322566","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A53Z&sr=b&sp=r&sig=Qrn4CO%2FY%2Bc2yLSpL6VDRwXBJnA1pYtefRDLQKiaq3HE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:53.8321554","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/4529b81b-fbd8-403a-8996-90f31931f55e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A53Z&sr=b&sp=r&sig=mPE64oTYVU3%2F6O8WeIp7qz0ewIfp0dMHRlE2SkzEHk0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:53.8322817","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:02:42.965Z","executedDateTime":"2023-10-18T21:02:42.303Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-18T21:02:42.574Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:43.154Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/fa15535a-e219-4355-b977-1e94946ca110?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A23Z&sr=b&sp=r&sig=6PPdbMvqlDz%2F6ohyGPjqLhU7KZEX4FdfxsHvz9aBjtg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:23.4827271","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A23Z&sr=b&sp=r&sig=LObPVcMLbY4IVsxmZID%2FchJVcnHmRw3HbDmZg8GH5dg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:23.4826575","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/f2fc4209-9c01-49cd-ad06-b9f736a6542c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A23Z&sr=b&sp=r&sig=emIC9%2FiXGWeydjAOxl5noS6zsP0DhApYwFDfdq4efxo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:23.4827409","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:37:13.99Z","executedDateTime":"2023-10-24T12:37:11.511Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-24T12:37:12.313Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:14.129Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3195'
+      - '3192'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:02:53 GMT
+      - Tue, 24 Oct 2023 12:37:23 GMT
       mise-correlation-id:
-      - 1e8c9ea0-f125-4ff4-82c0-0fef9d0c7406
+      - 0ec6f0ed-32fd-4424-83a1-b6072a746373
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/0585e19d-7e04-4093-a821-4cb8c2dbe9e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A59Z&sr=b&sp=r&sig=kzoPCT574wt%2BFdWpIKKV6rEZ%2BL5EC5Gbi1eqhxyYWfI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:59.1716902","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A59Z&sr=b&sp=r&sig=Lj1wLdGksnu7Sd8ykeu2qgT1hoBLp1KHLqvnSKdLNaA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:59.1715903","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/4529b81b-fbd8-403a-8996-90f31931f55e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A59Z&sr=b&sp=r&sig=qNKvrYN0qMWav5m8D33t9VZlm2ANOVCI7oZuOhH7Xns%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:59.1717123","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:02:42.965Z","executedDateTime":"2023-10-18T21:02:42.303Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-18T21:02:42.574Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:43.154Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/fa15535a-e219-4355-b977-1e94946ca110?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A29Z&sr=b&sp=r&sig=Z802XO%2BltGgDpNnhSnRzJspmwjedrwfgUImOWg%2FrYNM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:29.5721868","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A29Z&sr=b&sp=r&sig=hfV7X57S9Qm2MpqU25DPLIRHRU2JqjXxVnslb4zMjUQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:29.5720847","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/f2fc4209-9c01-49cd-ad06-b9f736a6542c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A29Z&sr=b&sp=r&sig=j8ZmVPU4Yuaweh00qvKNSz%2BWO%2FrwLT9ujxRAJAGjR%2Fs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:29.5722101","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:37:13.99Z","executedDateTime":"2023-10-24T12:37:11.511Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-24T12:37:12.313Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:14.129Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3191'
+      - '3196'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:02:59 GMT
+      - Tue, 24 Oct 2023 12:37:29 GMT
       mise-correlation-id:
-      - 49c573f9-10d0-4906-b923-65b826624753
+      - c2b6db5c-8f1f-40c4-8dde-a0f10acfa286
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -847,7 +847,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:01:44.1948751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:01:44.1948751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:36:11.1310639Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:36:11.1310639Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -856,9 +856,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:03:03 GMT
+      - Tue, 24 Oct 2023 12:37:33 GMT
       etag:
-      - '"75000892-0000-0100-0000-653047ba0000"'
+      - '"d3006b52-0000-0100-0000-6537ba3d0000"'
       expires:
       - '-1'
       pragma:
@@ -888,23 +888,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/0585e19d-7e04-4093-a821-4cb8c2dbe9e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A04Z&sr=b&sp=r&sig=XmeQOpBdT8T5yEDFVAKBGhaSiyAE6MqDl%2B0oNFEAHdE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:04.4795763","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A04Z&sr=b&sp=r&sig=jhHbfBBu5CCIpkmII07njacIipcvSYthdJwDWdoj%2BOk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:04.4794789","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/4529b81b-fbd8-403a-8996-90f31931f55e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A04Z&sr=b&sp=r&sig=vUoKqYWEnAwUxX4OBQhZ3kryxDbQOhhismxaGzLSrFw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:04.479598","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:02:42.965Z","executedDateTime":"2023-10-18T21:02:42.303Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-18T21:02:42.574Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:43.154Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/fa15535a-e219-4355-b977-1e94946ca110?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A34Z&sr=b&sp=r&sig=gwQoqh8oexIvoFrKuloQeV01xTZHz3lCo8yGySeAVW0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:34.950449","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A34Z&sr=b&sp=r&sig=SKctbopfjzE29lPBj6td7wSKlqOXV%2FPDTSUyWa7QIgI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:34.9503628","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/f2fc4209-9c01-49cd-ad06-b9f736a6542c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A34Z&sr=b&sp=r&sig=sJSEhJdw2mOtrns83%2FnUO96h8XXiB5GXH3QmHvBFREE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:34.95047","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:37:13.99Z","executedDateTime":"2023-10-24T12:37:11.511Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-24T12:37:12.313Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:14.129Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3190'
+      - '3187'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:03:04 GMT
+      - Tue, 24 Oct 2023 12:37:34 GMT
       mise-correlation-id:
-      - 6b4b1b2e-00bc-4a54-9f51-62b76b5bb13d
+      - e7b3945d-36c4-4864-8bab-929553edbd8f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -926,23 +926,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case:stop?api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case:stop?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/0585e19d-7e04-4093-a821-4cb8c2dbe9e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A05Z&sr=b&sp=r&sig=paKiW5vgoKXNCZl8Fwdp0%2BO4%2BofMoPIA58UMvtndL%2FY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:05.3819061","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A05Z&sr=b&sp=r&sig=Fy8eQDaT7Lp%2F0HUksZEYDc7Ibb286zlXvyp8LB6HlHM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:05.3818065","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/4529b81b-fbd8-403a-8996-90f31931f55e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A05Z&sr=b&sp=r&sig=Y6tslgu05Nhs24gHM80lshxcNnpikUXKX3qpB4zyDeg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:05.3819276","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:02:42.965Z","executedDateTime":"2023-10-18T21:02:42.303Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-18T21:02:42.574Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:02:43.154Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/fa15535a-e219-4355-b977-1e94946ca110?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A35Z&sr=b&sp=r&sig=TtjmqzRCqAKICru%2B7py1YSyrT1r%2B0vkNJKMnR2kL%2Bvs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:35.2443537","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A35Z&sr=b&sp=r&sig=dqaF7aPJISS6Tlc1soqNgWVosw1xnKIqeCRpuRQd3WE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:35.2442523","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/f2fc4209-9c01-49cd-ad06-b9f736a6542c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A35Z&sr=b&sp=r&sig=h4Jwv0tnO5fXmjRpRS8d1NtmxTFxuzsNPM5ofqjIt0Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:35.24437","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:37:13.99Z","executedDateTime":"2023-10-24T12:37:11.511Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-24T12:37:12.313Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:14.129Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3136'
+      - '3131'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:03:05 GMT
+      - Tue, 24 Oct 2023 12:37:35 GMT
       mise-correlation-id:
-      - 31ead3e6-ad70-42f5-a741-b42281c8fbb1
+      - f1b09f05-40d8-4c91-a5e3-6559152be295
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -962,23 +962,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/0585e19d-7e04-4093-a821-4cb8c2dbe9e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A09Z&sr=b&sp=r&sig=nvpjcySundmvszJ8MFcDv1Y3rX7MAIIxIn94SB0Vk9I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:09.8182312","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A09Z&sr=b&sp=r&sig=ZNy5Em6bR4lYcGFaQt7nROh19xmWIZnBWO9019uQEeQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:09.8181632","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/4529b81b-fbd8-403a-8996-90f31931f55e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A09Z&sr=b&sp=r&sig=kk0ZyD8XANc%2BPOb2C8%2FOAQGCzaxrKk6P7D8IFxloYA8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:09.8182475","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-18T21:02:42.965Z","endDateTime":"2023-10-18T21:03:05.509Z","executedDateTime":"2023-10-18T21:02:42.303Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-18T21:02:42.574Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:03:05.781Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/fa15535a-e219-4355-b977-1e94946ca110?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A40Z&sr=b&sp=r&sig=8yLxwfwXOkRbcJqprEMd1tc4F5znTlhHdhCPXzeMosM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:40.2399787","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A40Z&sr=b&sp=r&sig=LwwFP7QLY%2FX02iRQcwZ%2FLFfffLRAZ9NAaNRJu0a638I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:40.2399032","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/f2fc4209-9c01-49cd-ad06-b9f736a6542c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A40Z&sr=b&sp=r&sig=WOdTOp%2FLViRISdeemrEy3s3A1%2BwFqR5doFh5LrOxh50%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:40.2399926","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-24T12:37:13.99Z","endDateTime":"2023-10-24T12:37:35.411Z","executedDateTime":"2023-10-24T12:37:11.511Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-24T12:37:12.313Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:35.681Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3229'
+      - '3232'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:03:09 GMT
+      - Tue, 24 Oct 2023 12:37:40 GMT
       mise-correlation-id:
-      - df60d4ba-c706-4751-8554-4137cfc35394
+      - 90318d36-5480-4819-bb7b-3ba233072f52
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1001,7 +1001,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:01:44.1948751Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:01:44.1948751Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:36:11.1310639Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:36:11.1310639Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1010,9 +1010,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:03:26 GMT
+      - Tue, 24 Oct 2023 12:37:56 GMT
       etag:
-      - '"75000892-0000-0100-0000-653047ba0000"'
+      - '"d3006b52-0000-0100-0000-6537ba3d0000"'
       expires:
       - '-1'
       pragma:
@@ -1042,10 +1042,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0eb3723e-c8b7-46aa-b51e-023a4396f872.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9e244c8e-6625-42fb-a9d9-bd734cfd3542":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1dcc06dc-8177-4958-80ba-d42a263fdd3b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9ab2ee93-2bf9-47be-98f4-e5a8139114ff":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/0585e19d-7e04-4093-a821-4cb8c2dbe9e1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A27Z&sr=b&sp=r&sig=va29lWrq9Q2M7J3A8D1ZJ8PHRNPlu1FvQRHz6SHLPjw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:27.7232899","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/da03deef-4d08-41e3-9714-2e66268d58ca?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A27Z&sr=b&sp=r&sig=UZYpPN5cUlm94hH7j35FpBYXoOXGk7eisQMN2ZK%2BYRc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:27.7231884","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/b7c4a2da-8e31-4279-a94c-480a63ddb57e/4529b81b-fbd8-403a-8996-90f31931f55e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A27Z&sr=b&sp=r&sig=H6ZzQFLFx1NQOTqindxkvE2PjRnlv2S%2Fhi9B86ETLuk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:27.7233123","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-18T21:02:42.965Z","endDateTime":"2023-10-18T21:03:05.509Z","executedDateTime":"2023-10-18T21:02:42.303Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-18T21:02:42.574Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:03:25.243Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/fa15535a-e219-4355-b977-1e94946ca110?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A57Z&sr=b&sp=r&sig=EBQQj1pbuaL8a67pVIGSYtKNLixURl2LWD6vNMTm%2F50%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:57.7196982","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A57Z&sr=b&sp=r&sig=3rjzRfjvqy2Lawwe9ZoulnW%2FmbAEVXVec6zp8HUDIwA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:57.7196032","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/f2fc4209-9c01-49cd-ad06-b9f736a6542c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A57Z&sr=b&sp=r&sig=7fTCdGuedYByywzCS8Ld7f2y8XYJvcsyLay%2BwRnbgDA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:57.7197225","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-24T12:37:13.99Z","endDateTime":"2023-10-24T12:37:35.411Z","executedDateTime":"2023-10-24T12:37:11.511Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-24T12:37:12.313Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:57.12Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1056,9 +1056,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:03:27 GMT
+      - Tue, 24 Oct 2023 12:37:57 GMT
       mise-correlation-id:
-      - 5fdb2544-1a0e-43dc-b00a-049fe4593d7b
+      - 1eb77850-02b4-46a8-8311-7b8b75bcb588
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_stop.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_stop.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:26:26.8851856Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:26:26.8851856Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:01:54.5481168Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:01:54.5481168Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:01 GMT
+      - Fri, 13 Oct 2023 14:02:29 GMT
       etag:
-      - '"57006d01-0000-0100-0000-652453e40000"'
+      - '"d901949d-0000-0100-0000-65294dd40000"'
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:27:03 GMT
+      - Fri, 13 Oct 2023 14:02:30 GMT
       mise-correlation-id:
-      - b1d9cec4-e2a3-45ce-8d39-370865314c83
+      - 3158d4d8-82cc-463d-82c1-6674276610b8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "120"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"dbded5ef-34b0-4728-bc8f-849d496aa3b4": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "fa150ae5-6a9d-4a0f-b153-124db50a32c3":
+      {"passFailMetrics": {"37f49a3d-c667-4a76-a547-264b549534e0": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "3a1c074c-53c2-47c6-9c50-5b386db38e6c": {"aggregate": "avg", "clientMetric":
+      "50"}, "ae3478dd-3466-44e8-8077-b1374fc762fd": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -104,13 +104,13 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:27:04.123Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:04.123Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T14:02:31.168Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:31.168Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:04 GMT
+      - Fri, 13 Oct 2023 14:02:31 GMT
       location:
-      - https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+      - https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 2184e401-26ed-4a8f-96f4-0d2af8cce0b2
+      - 60c5aaaa-ffcf-418d-9635-73c1353af710
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -143,9 +143,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files?api-version=2022-11-01
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:04 GMT
+      - Fri, 13 Oct 2023 14:02:31 GMT
       mise-correlation-id:
-      - 380ed850-d640-4fa3-a8b1-12a69ef6cfc5
+      - 20fa80a8-d0ed-44ff-b7e9-23a18bc8c93c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -273,27 +273,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A37%3A06Z&sr=b&sp=r&sig=PUUEr2grqOtm76eOqIOd0CdAtDRTWErkBCQPorTLD8E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:37:06.060112","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A12%3A32Z&sr=b&sp=r&sig=GuzVcPYuOis4J3M%2FRwmgQfnWAP1xuwVWS02y%2FE5wgos%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:12:32.8833547","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '548'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:06 GMT
+      - Fri, 13 Oct 2023 14:02:32 GMT
       location:
-      - https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 7ef79057-646c-4121-81fa-46287d17aebd
+      - d749cb4e-a376-4e68-89b4-ddbef18a5b8e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -311,12 +311,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A37%3A06Z&sr=b&sp=r&sig=8ejoamPOopLjJVj8TbisjIwnhmj%2FZ7E0iydH9Bi5UGk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:37:06.3457749","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A12%3A33Z&sr=b&sp=r&sig=TB%2B7nijmIXfUvYe7rpWAw66JOneYk4MeDE9u4bXGF7E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:12:33.2106693","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:06 GMT
+      - Fri, 13 Oct 2023 14:02:33 GMT
       mise-correlation-id:
-      - d1d2ed24-6313-4221-b57f-136e2842d05b
+      - 8dd8de24-e9b0-41e6-a7d6-a2d05d78475f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -347,12 +347,48 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A37%3A11Z&sr=b&sp=r&sig=khwkHT4kemiXH%2FWLtuHuF%2F93h7Hy4pVCwSKb3dyhCk4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:37:11.6202489","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A12%3A38Z&sr=b&sp=r&sig=cC%2BOHJTdx81RxzTU6I3unL6gK4hQxhe3f9YvBQIZwdA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:12:38.5168662","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:02:38 GMT
+      mise-correlation-id:
+      - 925d0550-38ae-4d1f-9345-ed1bb7d93f5a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A12%3A43Z&sr=b&sp=r&sig=KNu0rLRou%2Bi%2FG5iVtlZKv090wghJqip01YXf98uysJs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:12:43.8551727","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:11 GMT
+      - Fri, 13 Oct 2023 14:02:43 GMT
       mise-correlation-id:
-      - 837ee2e4-dd74-4403-9bb2-93d960f54d74
+      - a97edf5a-08c1-4945-bce2-6bed34a4ec1a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -383,25 +419,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A37%3A16Z&sr=b&sp=r&sig=XLNTlHaIHvveUgIjulHqLf5mlywDOdCMN%2F%2FIZCNvL70%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:37:16.8950567","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A12%3A49Z&sr=b&sp=r&sig=iUIwJDEnXhBF0FrU6tdGEm%2Fg4JRHQEoAIJYgitUkYyg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:12:49.1828508","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:16 GMT
+      - Fri, 13 Oct 2023 14:02:49 GMT
       mise-correlation-id:
-      - c80dcc07-917f-423d-aab1-fb8999cb890d
+      - c01b4ab7-2cd8-4c35-b8d3-0d4b396e5c79
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -419,62 +455,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A37%3A22Z&sr=b&sp=r&sig=o%2FVV2gVIqT4zoEcS0TGZSzkpt%2BlEwmmkSLS2i7c%2BSL4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:37:22.2171346","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A49Z&sr=b&sp=r&sig=FkhC5cetTvwwfHOp5d4Ly8iC9ZkDJWuPch1iDXP94pM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:49.4358255","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T14:02:31.168Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:45.35Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '1576'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:22 GMT
+      - Fri, 13 Oct 2023 14:02:49 GMT
       mise-correlation-id:
-      - 61cd00ea-0d3e-4cc6-b629-2d1750563c9b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A22Z&sr=b&sp=r&sig=lmoSuXF6XBtMDfCQh1MA7yXpM%2FKBI%2BBP486ly6LwHt0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:22.5192796","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:27:04.123Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:18.464Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1581'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:27:22 GMT
-      mise-correlation-id:
-      - 7670e549-aa1d-43ae-918d-7de845d54569
+      - ec01f41f-5412-4de2-8ea2-7a270ed467c7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:26:26.8851856Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:26:26.8851856Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:01:54.5481168Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:01:54.5481168Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:23 GMT
+      - Fri, 13 Oct 2023 14:02:51 GMT
       etag:
-      - '"57006d01-0000-0100-0000-652453e40000"'
+      - '"d901949d-0000-0100-0000-65294dd40000"'
       expires:
       - '-1'
       pragma:
@@ -536,26 +536,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A25Z&sr=b&sp=r&sig=vi63YPxehDzULfszvRvLYe%2FKoRDMglHGrUvj1UbIYB8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:25.1177444","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:27:04.123Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:18.464Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A52Z&sr=b&sp=r&sig=ug8FvH14s8TeaNLvv%2BsiZ3cUDXbv5w5gHYM%2Byq9peAw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:52.3888321","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T14:02:31.168Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:45.35Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1591'
+      - '1592'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:25 GMT
+      - Fri, 13 Oct 2023 14:02:52 GMT
       mise-correlation-id:
-      - 3e8b5be8-65ae-4f3d-b96b-525e96cee996
+      - e09e6b18-97f1-4228-89ca-8444d163b7fe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:26:26.8851856Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:26:26.8851856Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:01:54.5481168Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:01:54.5481168Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:26 GMT
+      - Fri, 13 Oct 2023 14:02:53 GMT
       etag:
-      - '"57006d01-0000-0100-0000-652453e40000"'
+      - '"d901949d-0000-0100-0000-65294dd40000"'
       expires:
       - '-1'
       pragma:
@@ -617,9 +617,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:27:27 GMT
+      - Fri, 13 Oct 2023 14:02:54 GMT
       mise-correlation-id:
-      - 32f4853c-c2dc-418b-9f9b-a0027c14767e
+      - 025e4a45-de33-4c9f-973e-daeca80b5b43
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -660,27 +660,27 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/fee43389-b960-42eb-b332-811e1036e5b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A28Z&sr=b&sp=r&sig=WgcONUZxGACuCRoQPNyNQILQw9NuZDZmbGFNk1QOzxU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:28.3537305","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A28Z&sr=b&sp=r&sig=MRXGgX14YbOXhtKxFXYL%2FhT%2F3ylfKXga7%2BQQbeXQZ4A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:28.3536563","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/e1352333-328d-4b12-99dc-41f2b144b689?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A28Z&sr=b&sp=r&sig=b8ntM6UhGKII7ZJYzlGdKA%2F8m9gIsWRMbVFSUoeSqto%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:28.353749","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T19:27:28.027Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T19:27:28.282Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:28.282Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/bb0b53c3-1deb-414c-af7f-089d0df602e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A55Z&sr=b&sp=r&sig=2FA%2B3VcFrmhPC0zHAv3l7uY5vrM4WtwAqUpLX0MYxrI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:55.2775787","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A55Z&sr=b&sp=r&sig=91EVcWaCVqFMqhe5YfOCbAiUiHJnqeJbxTm2cdN%2F5Hg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:55.277457","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/abdee8de-563c-403a-bd36-b98706414f9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A55Z&sr=b&sp=r&sig=ITkftB%2BZ9XDNNfmIxD6mVjkn5ySzDuW920xSJexK1sI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:55.2776075","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T14:02:54.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-13T14:02:55.173Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:55.173Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3147'
+      - '3145'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:28 GMT
+      - Fri, 13 Oct 2023 14:02:56 GMT
       location:
-      - https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+      - https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 6e293774-de81-4b7d-ac11-bf256269a364
+      - 12de8ae5-bb40-43f5-964f-99162b26f70b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -698,25 +698,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/fee43389-b960-42eb-b332-811e1036e5b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A28Z&sr=b&sp=r&sig=jDuTnJ8otTwPckK7FAzq2x7sq4yoCymlB8BoiBVTccE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:28.8833134","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A28Z&sr=b&sp=r&sig=8tpZ4FG%2F6Chh0MZuw5CDfHQuC0ijRxcJJqMovVDSzDA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:28.8832206","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/e1352333-328d-4b12-99dc-41f2b144b689?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A28Z&sr=b&sp=r&sig=VNCwd63pyqrpDJUOjgoPQ9qvonVDcUwvmPbMsHsMnAM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:28.8833342","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T19:27:28.662Z","executedDateTime":"2023-10-09T19:27:28.027Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T19:27:28.282Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:28.662Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/bb0b53c3-1deb-414c-af7f-089d0df602e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A56Z&sr=b&sp=r&sig=Y1XiidzxTW1S4EWypfd9xP1svH9QQlX7AhTxupXy5e0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:56.3677922","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A56Z&sr=b&sp=r&sig=Lc%2FAnVX8SGrQnm%2FCAJD92oW75OQeuBhDvlgq52DXH9Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:56.367741","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/abdee8de-563c-403a-bd36-b98706414f9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A56Z&sr=b&sp=r&sig=ctt4KuaXp3HTRjoac%2B%2FQR0bKjmgO0hQz3O9vZIGzelo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:56.3678076","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"NOTSTARTED","startDateTime":"2023-10-13T14:02:56.275Z","executedDateTime":"2023-10-13T14:02:54.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-13T14:02:55.173Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:56.275Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3187'
+      - '3192'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:28 GMT
+      - Fri, 13 Oct 2023 14:02:56 GMT
       mise-correlation-id:
-      - 1ddc8679-8eaa-45ac-8ae1-aad72d58da02
+      - 28dd1675-11dd-4e0e-9b48-7d84697368a1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -734,84 +734,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/fee43389-b960-42eb-b332-811e1036e5b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A34Z&sr=b&sp=r&sig=RNW6nYOk91MPYxgKhYSyGwgiv8fBug0te3FtB0eVyEs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:34.2574887","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A34Z&sr=b&sp=r&sig=D%2FAUd34YYVJ7OiJore1RqAxdI3Y74r7vhfo3XFtj0Z8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:34.257393","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/e1352333-328d-4b12-99dc-41f2b144b689?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A34Z&sr=b&sp=r&sig=9az%2BTEcbQ6btyKxpc6ugpN0b9cV5Grmgx3Gx9Brga1s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:34.25751","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:27:28.662Z","executedDateTime":"2023-10-09T19:27:28.027Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T19:27:28.282Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:28.925Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:27:34 GMT
-      mise-correlation-id:
-      - 5ef2fb3a-179b-44b9-8f10-1731a2ab6cb2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/fee43389-b960-42eb-b332-811e1036e5b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A39Z&sr=b&sp=r&sig=MnxHCNPmfanSlMs4nOPxLEKfUYjrqmd57l%2FYYJdIaqw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:39.5409172","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A39Z&sr=b&sp=r&sig=kqP8Ee7sff5qd1sNRGvb0A0ejpIRSz73NA1kV0dLg%2Fw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:39.5408268","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/e1352333-328d-4b12-99dc-41f2b144b689?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A39Z&sr=b&sp=r&sig=RMRWUN2AM8Vmf06t8MaRtAlIYTrzRM1PL19s5ozy6Sg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:39.5409393","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:27:28.662Z","executedDateTime":"2023-10-09T19:27:28.027Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T19:27:28.282Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:28.925Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:27:39 GMT
-      mise-correlation-id:
-      - da3898b9-50fe-4ef4-b5e1-7dc448fdeaae
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/fee43389-b960-42eb-b332-811e1036e5b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A44Z&sr=b&sp=r&sig=EaKHxX5Uw62m8WwDDlBbH0iNnQsSp%2BwHx5s3jWeLb0w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:44.8390367","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A44Z&sr=b&sp=r&sig=RT1u%2FLQzc196eecZhQwp8Wxrag2vOq78XxBQNeuuHX8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:44.8389366","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/e1352333-328d-4b12-99dc-41f2b144b689?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A44Z&sr=b&sp=r&sig=djqSLp0J1Qd4EV5yByjE%2FaDyt2c9rVQwnAmQTsMJFug%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:44.8390758","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:27:28.662Z","executedDateTime":"2023-10-09T19:27:28.027Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T19:27:28.282Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:28.925Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/bb0b53c3-1deb-414c-af7f-089d0df602e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A01Z&sr=b&sp=r&sig=vlaqmmrUkXpgUQF%2FtE5GkrAtFgmAG4ceScohI0CGtuA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:01.6805143","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A01Z&sr=b&sp=r&sig=kfSpwmiQ%2Bxesf9k8ec0fS4GxFncIEpIiTfuaKAUyvCk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:01.6804262","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/abdee8de-563c-403a-bd36-b98706414f9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A01Z&sr=b&sp=r&sig=Uks9g5RNwT8%2FA26AOP8JqmogdEQs7GdfgzI7u4IUZyc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:01.6805347","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:02:56.275Z","executedDateTime":"2023-10-13T14:02:54.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-13T14:02:55.173Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:57.108Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -822,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:44 GMT
+      - Fri, 13 Oct 2023 14:03:01 GMT
       mise-correlation-id:
-      - 44b9514e-065a-4e73-94db-9932aafe4168
+      - bad1912b-e81f-4b3c-a8b5-2034be5a41de
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -842,12 +770,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/fee43389-b960-42eb-b332-811e1036e5b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A50Z&sr=b&sp=r&sig=BNiG%2FF7ztrFdLAzuzL1aJqaglK14fYkXehYnE0Cbtk8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:50.1260248","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A50Z&sr=b&sp=r&sig=qd314G1az7MYvoQCxWC5dI5yXELCi7zjFnLRZm3N6ZY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:50.1259151","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/e1352333-328d-4b12-99dc-41f2b144b689?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A50Z&sr=b&sp=r&sig=3tl%2BmIFqIuUgsufojVOOu1BYkDoaN3m0a0AbCYfEKJU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:50.1260499","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:27:28.662Z","executedDateTime":"2023-10-09T19:27:28.027Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T19:27:28.282Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:28.925Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/bb0b53c3-1deb-414c-af7f-089d0df602e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A06Z&sr=b&sp=r&sig=aPN2Yz4q3FcR6ulcsIyGGE1ZymGIRmWDwhZCkt1khEA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:06.9782659","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A06Z&sr=b&sp=r&sig=oQLRF%2FdCxEalWyYR5uxsEeLF3Vh04osAIZV2%2BVZmoNY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:06.9781644","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/abdee8de-563c-403a-bd36-b98706414f9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A06Z&sr=b&sp=r&sig=rgispvKAtY9i5yEF5M4cjgz5EWx2FC5kN6XLByH505k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:06.9782841","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:02:56.275Z","executedDateTime":"2023-10-13T14:02:54.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-13T14:02:55.173Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:57.108Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -858,9 +786,45 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:50 GMT
+      - Fri, 13 Oct 2023 14:03:06 GMT
       mise-correlation-id:
-      - 40bca65e-c2d9-44a9-bfb4-c1d6c9a5a6df
+      - f609895e-077a-41dd-9d76-e68497980d19
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/bb0b53c3-1deb-414c-af7f-089d0df602e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A12Z&sr=b&sp=r&sig=AfrNk8pKJti%2FewJJlO%2Fv24fepx5ndoya%2FJLfxvqLhRg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:12.273276","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A12Z&sr=b&sp=r&sig=cQcyad0giHgCxZlvutNKcXNB7mGV7sm6eUm5nFLRGpA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:12.2731933","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/abdee8de-563c-403a-bd36-b98706414f9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A12Z&sr=b&sp=r&sig=ExbqfoSnG16SlT6nRPSdyP5AKZqFBdK6WhLkbMRXaKI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:12.2732968","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:02:56.275Z","executedDateTime":"2023-10-13T14:02:54.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-13T14:02:55.173Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:57.108Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:03:12 GMT
+      mise-correlation-id:
+      - 91780761-68cc-4022-b93c-62abc43607b0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -883,7 +847,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:26:26.8851856Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:26:26.8851856Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:01:54.5481168Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:01:54.5481168Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -892,9 +856,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:49 GMT
+      - Fri, 13 Oct 2023 14:03:17 GMT
       etag:
-      - '"57006d01-0000-0100-0000-652453e40000"'
+      - '"d901949d-0000-0100-0000-65294dd40000"'
       expires:
       - '-1'
       pragma:
@@ -909,6 +873,42 @@ interactions:
       - nosniff
       x-ms-providerhub-traffic:
       - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/bb0b53c3-1deb-414c-af7f-089d0df602e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A17Z&sr=b&sp=r&sig=ClmL9%2BZPd7gBodbRggaLQ%2Fzq2uY2wQKVttqwR3d8sVw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:17.6076686","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A17Z&sr=b&sp=r&sig=J2myKNa%2F42tAgSlfvL2US5MDcRGqDHe0jbedLZ0e7sg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:17.6075717","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/abdee8de-563c-403a-bd36-b98706414f9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A17Z&sr=b&sp=r&sig=AML8adIIXpdPryazDUmbFKsgwUWmLWvvlYVxNfyj6a8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:17.6076926","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:02:56.275Z","executedDateTime":"2023-10-13T14:02:54.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-13T14:02:55.173Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:57.108Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:03:17 GMT
+      mise-correlation-id:
+      - a8a2482d-1558-4c52-988f-85d3e67feee1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
     status:
       code: 200
       message: OK
@@ -924,25 +924,25 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case:stop?api-version=2022-11-01
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case:stop?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/fee43389-b960-42eb-b332-811e1036e5b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A51Z&sr=b&sp=r&sig=fZoueKGgLN%2FHn07Ottk5t0d1k%2BUX1eoQQ1%2BwjmGmu0s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:51.1886863","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A51Z&sr=b&sp=r&sig=7GXlrTPPZ5pLQlen%2BrgmoHCkHW7A%2BykU3WNHLeJoPpY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:51.1886101","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/e1352333-328d-4b12-99dc-41f2b144b689?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A51Z&sr=b&sp=r&sig=OQuUQw5Ah6SOOb6q%2BSmvTcFOjJvDObh5d%2B5KevWSo0Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:51.1887018","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:27:28.662Z","executedDateTime":"2023-10-09T19:27:28.027Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T19:27:28.282Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:28.925Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/bb0b53c3-1deb-414c-af7f-089d0df602e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A18Z&sr=b&sp=r&sig=%2Fj3oyWg86%2B%2Bwe2%2BXRN3OwAjSrecoh25pQ7PXBypeSuw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:18.3067638","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A18Z&sr=b&sp=r&sig=BpYslxSdhQC0Wuqx0Em3aWNMNrG3kPVvqtXikhChyAk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:18.3066947","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/abdee8de-563c-403a-bd36-b98706414f9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A18Z&sr=b&sp=r&sig=RcqwfKRyIVEFbI0YQD%2B7dOPa3IcxAvLKOdi3i%2Fn3WJM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:18.3067782","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:02:56.275Z","executedDateTime":"2023-10-13T14:02:54.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-13T14:02:55.173Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:02:57.108Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3142'
+      - '3140'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:51 GMT
+      - Fri, 13 Oct 2023 14:03:18 GMT
       mise-correlation-id:
-      - fc02cd6a-356a-4eca-8287-e78efa037b76
+      - f175d26f-e439-471d-8c61-1d9d08ddcefb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -960,25 +960,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/fee43389-b960-42eb-b332-811e1036e5b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A55Z&sr=b&sp=r&sig=fnZImz3qYM4Xmr3LQd6xlqzq6mGFtYa%2B%2Bxaa9COUtDQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:55.4949241","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A55Z&sr=b&sp=r&sig=l%2BncBZkeymQa%2Fsw%2FOUWq8mylSS2BRbnHUE6tF%2BajNA8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:27:55.4948564","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/e1352333-328d-4b12-99dc-41f2b144b689?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A27%3A55Z&sr=b&sp=r&sig=GnE7tjRAeJBgJBVmIGp6xmNe1E4ncmzeo1AZ4vjB9eY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:27:55.49494","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-09T19:27:28.662Z","endDateTime":"2023-10-09T19:27:51.328Z","executedDateTime":"2023-10-09T19:27:28.027Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T19:27:28.282Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:51.616Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/bb0b53c3-1deb-414c-af7f-089d0df602e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A22Z&sr=b&sp=r&sig=%2F6%2Bom%2B4piSDkTtlF4v8EqqMeVAGl3CPqOEbsVWgcZcQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:22.9328436","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A22Z&sr=b&sp=r&sig=ZUHp3Y4PNRQYGMJtc2hHTedsuJUPQ6je3hZGvk0yDXE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:22.9327548","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/abdee8de-563c-403a-bd36-b98706414f9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A22Z&sr=b&sp=r&sig=Osh5PomVI1JDtajFJRd7BFDfgyK9gTC5IrOZ6Bl5rg4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:22.9328659","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-13T14:02:56.275Z","endDateTime":"2023-10-13T14:03:18.426Z","executedDateTime":"2023-10-13T14:02:54.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-13T14:02:55.173Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:03:18.726Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3235'
+      - '3231'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:55 GMT
+      - Fri, 13 Oct 2023 14:03:22 GMT
       mise-correlation-id:
-      - 40d9c58a-848a-4250-b9a8-52bdc22f306e
+      - 607f21db-4712-4e96-b3cf-8e0c51d17daa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1001,7 +1001,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:26:26.8851856Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:26:26.8851856Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:01:54.5481168Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:01:54.5481168Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1010,9 +1010,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:11 GMT
+      - Fri, 13 Oct 2023 14:03:39 GMT
       etag:
-      - '"57006d01-0000-0100-0000-652453e40000"'
+      - '"d901949d-0000-0100-0000-65294dd40000"'
       expires:
       - '-1'
       pragma:
@@ -1040,12 +1040,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://0193c7af-1689-4497-a71e-6882d25d6377.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://71ad226e-7a5e-4994-a04b-2adb1ab4296e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"dbded5ef-34b0-4728-bc8f-849d496aa3b4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fa150ae5-6a9d-4a0f-b153-124db50a32c3":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3a1c074c-53c2-47c6-9c50-5b386db38e6c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/fee43389-b960-42eb-b332-811e1036e5b3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A14Z&sr=b&sp=r&sig=LpnuDUexCjpVAeiytnImeihlkIbNyp%2BRqxtfWteg2NQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:14.4763198","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/4328f02a-2341-4458-b929-32965630a434?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A14Z&sr=b&sp=r&sig=yendjol8jNNtH48%2FaNmv%2FyHh%2BJ3nlvYZ4DMORIHlpCg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:14.4762472","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bb9e91e3-b2b1-4483-b502-a24ed96c36ae/e1352333-328d-4b12-99dc-41f2b144b689?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A14Z&sr=b&sp=r&sig=5l4EFMq%2BLlSnUs8ixE264qTlVUpVeTwwCsHmXfKtxBc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:14.4763344","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-09T19:27:28.662Z","endDateTime":"2023-10-09T19:27:51.328Z","executedDateTime":"2023-10-09T19:27:28.027Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T19:27:28.282Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:10.402Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"37f49a3d-c667-4a76-a547-264b549534e0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2f5e3af2-8a2b-4214-994e-8e7f66cc1bce":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ae3478dd-3466-44e8-8077-b1374fc762fd":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/bb0b53c3-1deb-414c-af7f-089d0df602e9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A40Z&sr=b&sp=r&sig=s8YanVaBBfaSk748%2F54dRK4%2BLZ9Ts4oHs5w8uUM5H7w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:40.3801787","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/4e3bdadd-b36f-47b1-8a9f-a88788e70c6a?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A40Z&sr=b&sp=r&sig=T7M293wkpXzGAPPtP%2BLImgH202exli7tNoDuGzhHONg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:40.3801145","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c7b98523-6e11-468c-8bf4-3ff4cdf3be56/abdee8de-563c-403a-bd36-b98706414f9b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A40Z&sr=b&sp=r&sig=%2BV7sh9K%2FwWnqBvLi0pt4JTA19dwiKi7BiCHYzcw9gOs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:40.3801948","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-13T14:02:56.275Z","endDateTime":"2023-10-13T14:03:18.426Z","executedDateTime":"2023-10-13T14:02:54.922Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-13T14:02:55.173Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:03:37.062Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1056,9 +1056,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:14 GMT
+      - Fri, 13 Oct 2023 14:03:40 GMT
       mise-correlation-id:
-      - bf413cb6-7dc7-42dc-87a0-f407774c9ef4
+      - 23d8c5cc-32d8-4d75-9db0-d49864ebad93
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_stop.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_stop.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:36:11.1310639Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:36:11.1310639Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:28:34.4962316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:28:34.4962316Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:45 GMT
+      - Sun, 29 Oct 2023 22:29:07 GMT
       etag:
-      - '"d3006b52-0000-0100-0000-6537ba3d0000"'
+      - '"3c00aa34-0000-0100-0000-653edc940000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:36:47 GMT
+      - Sun, 29 Oct 2023 22:29:09 GMT
       mise-correlation-id:
-      - 3905c87b-d4eb-47ac-8135-2f0d6842589b
+      - 72bc612e-1d6d-412b-aedc-ee194e80833d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "120"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"21ed0892-e9fb-4777-b96a-1914e19055e4": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "ae20c3a3-c077-4d49-8223-d6919f9015d6":
+      {"passFailMetrics": {"3810ff1d-02df-4067-bfda-ca3a9289e0a3": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "2b650d86-bee1-4f6a-925b-2c2511dac183":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "daa78e6e-16b3-4685-aaa9-b2f4deabf60c": {"aggregate": "avg", "clientMetric":
+      "50"}, "4f14afaa-3c61-4295-84b1-625054f134ad": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:36:48.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:36:48.324Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:29:09.654Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:09.654Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:48 GMT
+      - Sun, 29 Oct 2023 22:29:09 GMT
       location:
-      - https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+      - https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 94cd0733-f584-4500-b7f2-8c6c97b05a49
+      - cd2e17e4-cee6-4002-a07d-7695c1f103b0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files?api-version=2022-11-01
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:48 GMT
+      - Sun, 29 Oct 2023 22:29:10 GMT
       mise-correlation-id:
-      - 0fbab025-19aa-4912-8469-4d80ab640f9f
+      - e48251d7-61cd-411f-bde7-cf25c6acabb2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A46%3A49Z&sr=b&sp=r&sig=SUceVHH4UgWyhDastt3g6MJXsk1b1a6%2FTFmqfI5YA7c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:46:49.1127581","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A39%3A10Z&sr=b&sp=r&sig=j4GW6M2ox1HslVDP0z8vshae7XU2IkDQ3cDTOyJUShY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:39:10.5550048","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:49 GMT
+      - Sun, 29 Oct 2023 22:29:10 GMT
       location:
-      - https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - a786d90a-2a39-4e93-9bcf-11cae5857896
+      - 8216fe10-f863-47e2-8be7-93155f0dbcd5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,46 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A46%3A49Z&sr=b&sp=r&sig=ynhoZ55uL4PPteMNFeXwXsTw5VKhPuy386yL1FOjV8k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:46:49.3676782","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:36:49 GMT
-      mise-correlation-id:
-      - 0eb75908-25e6-48a8-8849-ab0315a7d771
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A46%3A54Z&sr=b&sp=r&sig=SMRI3oiHiMY5OdNBLUlxDyU3N2PBMP%2BSCMtOh1Ucn%2FI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:46:54.6743245","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A39%3A10Z&sr=b&sp=r&sig=zAIg8kqEZsDN1FpJvib1V9k5Xl%2Bk3ohsEZV%2B8JYPi44%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:39:10.8678005","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:36:54 GMT
+      - Sun, 29 Oct 2023 22:29:10 GMT
       mise-correlation-id:
-      - 59c63430-1aca-4da4-9bf8-ce4851723ef3
+      - 49891983-cf05-4e6a-a11f-6c91d118d995
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A47%3A00Z&sr=b&sp=r&sig=W%2F7LpvdnoVjiijVnX8IMIl8F4t%2FYGac3fl3pwRTNOvo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:47:00.034642","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A39%3A16Z&sr=b&sp=r&sig=lCdmq%2FabGpbmaObWPDE5G3Secq9C%2Fw%2BcHqEg3jzDPms%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:39:16.1845476","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '552'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:00 GMT
+      - Sun, 29 Oct 2023 22:29:16 GMT
       mise-correlation-id:
-      - a374f30a-f5b5-4634-9336-642dbf25d1d0
+      - fdebe457-23d0-4424-9d33-66e6c7fe3e8f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,10 +385,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A47%3A05Z&sr=b&sp=r&sig=HQgtFKHZcmMMNL2vo3hXJ0f84f0qx9qF%2FVdzkW%2BpzdY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:47:05.3576116","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A39%3A21Z&sr=b&sp=r&sig=bz05qorftU1X7jMAjsI1vC81F3VWBqYSCp7QDQ%2F8x4U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:39:21.5101071","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:05 GMT
+      - Sun, 29 Oct 2023 22:29:21 GMT
       mise-correlation-id:
-      - 42357862-6bdd-4d20-8c47-85f01f2c56db
+      - d27b4ac1-a6e1-4e39-85c6-c0dda1339d7e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +421,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A05Z&sr=b&sp=r&sig=jeXtNvQOx%2B2e%2BLkBPIHlSh4Q%2B6bLHrkA3en18g3e8mE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:05.6615865","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:36:48.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:01.355Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A39%3A26Z&sr=b&sp=r&sig=WZXmOk6y5W0yGcvNtkWD2x4O0%2BAvTTvety3CAMnXXYU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:39:26.7657029","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1583'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:05 GMT
+      - Sun, 29 Oct 2023 22:29:26 GMT
       mise-correlation-id:
-      - 899a2435-9b95-42e0-a817-2ad634cbcc66
+      - 0336454a-4119-4a28-a61e-691a70231398
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A27Z&sr=b&sp=r&sig=whYkEd52%2FhYqlOUH%2BfvrX4PcHni%2BCJ%2FwlfHL7GLXzv0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:27.0422683","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:29:09.654Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:22.923Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1585'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:27 GMT
+      mise-correlation-id:
+      - 1a89240a-eb37-455d-bb58-6da909cc456c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:36:11.1310639Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:36:11.1310639Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:28:34.4962316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:28:34.4962316Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:06 GMT
+      - Sun, 29 Oct 2023 22:29:28 GMT
       etag:
-      - '"d3006b52-0000-0100-0000-6537ba3d0000"'
+      - '"3c00aa34-0000-0100-0000-653edc940000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A08Z&sr=b&sp=r&sig=6VB27l0E0O6lhQzVFpu318ovlWlL0%2B2papwapNRZG74%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:08.3224899","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:36:48.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:01.355Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A30Z&sr=b&sp=r&sig=yj0ADg5giOfwrIrPaXVSoyCkpBW2LpxiRjaVZSZQRgE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:30.160354","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:29:09.654Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:22.923Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1591'
+      - '1588'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:08 GMT
+      - Sun, 29 Oct 2023 22:29:30 GMT
       mise-correlation-id:
-      - c2cfeec9-74e4-4a4c-8a72-260af848c3d2
+      - f31113d6-8741-4d38-8db9-09c8d3e63b67
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:36:11.1310639Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:36:11.1310639Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:28:34.4962316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:28:34.4962316Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:09 GMT
+      - Sun, 29 Oct 2023 22:29:31 GMT
       etag:
-      - '"d3006b52-0000-0100-0000-6537ba3d0000"'
+      - '"3c00aa34-0000-0100-0000-653edc940000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:37:10 GMT
+      - Sun, 29 Oct 2023 22:29:32 GMT
       mise-correlation-id:
-      - 19ad9c08-32d7-4e45-b1ea-c57ea9ab625c
+      - 3f3c22c8-0fb9-43e4-9d78-8923239a2ca4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/fa15535a-e219-4355-b977-1e94946ca110?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A12Z&sr=b&sp=r&sig=P8UaJ%2FO%2Fn6jZHxRoSujYVGhesEcaAgtLJPYdxSl%2BgGQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:12.4067694","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A12Z&sr=b&sp=r&sig=fF1Mt3a78CqlP57THmxouuFrkUlP2c%2FQsNAE6FneXzQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:12.4066317","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/f2fc4209-9c01-49cd-ad06-b9f736a6542c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A12Z&sr=b&sp=r&sig=AvHe6UFJu2sMZqrAGPkShkKKxRHt%2BDE%2B6pWFNn2Hn%2B0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:12.4067972","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:37:11.511Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-24T12:37:12.313Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:12.313Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/64491ab8-5d2b-49f5-815e-80bbd634ca92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A34Z&sr=b&sp=r&sig=lqz3H6TIo624wp0vtYAx4sSJB8L3jU6x6U%2FoLWuamGo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:34.0483742","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A34Z&sr=b&sp=r&sig=X6hTI4oNAahDhoQnkWc0dAnIwGRnQ4ucBYq7QrGUzkU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:34.04827","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/36a0e41e-54c4-4871-ad27-d89277960570?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A34Z&sr=b&sp=r&sig=MaqJ%2FSiNVMGV4smxqj0PcRYUjfB7dr3V7108X1mGcoM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:34.0483968","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:29:33.086Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-29T22:29:33.966Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:33.966Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3154'
+      - '3142'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:12 GMT
+      - Sun, 29 Oct 2023 22:29:34 GMT
       location:
-      - https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+      - https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - e3244343-eb14-4bc4-8c6b-42ca0855d3e7
+      - 658a8903-8abd-4e0b-bfba-ed869b9d6471
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/fa15535a-e219-4355-b977-1e94946ca110?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A12Z&sr=b&sp=r&sig=CEW0LTV2jtZgRYHV9ptu90%2BleCjr%2BAY3hBT3kZOAmNw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:12.8164608","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A12Z&sr=b&sp=r&sig=4P%2Fgd1xORSJcvckNTkeVJymFuQye3VTO2dTx6uTY4Xg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:12.8163931","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/f2fc4209-9c01-49cd-ad06-b9f736a6542c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A12Z&sr=b&sp=r&sig=%2BGtC7WpAXl%2Bll1%2BmyGOk%2Fv%2B6BdyoXvH5e9BWKgForT0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:12.8164745","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:37:11.511Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-24T12:37:12.313Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:12.313Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/64491ab8-5d2b-49f5-815e-80bbd634ca92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A34Z&sr=b&sp=r&sig=JJO1yErw3MNrlSnUVpFgTFAsnZ8YjmeaevoeLxpjsL8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:34.5413932","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A34Z&sr=b&sp=r&sig=Kvrk8V7SZCMNHYHJJjcHqHtsegof3walbZeizboutKM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:34.5413307","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/36a0e41e-54c4-4871-ad27-d89277960570?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A34Z&sr=b&sp=r&sig=wmdQ1fvVBH1TyWnLAZGrJSbsoEcZQXqyI2XtL5bq1Q4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:34.5414085","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:29:34.34Z","executedDateTime":"2023-10-29T22:29:33.086Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-29T22:29:33.966Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:34.527Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3156'
+      - '3186'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:12 GMT
+      - Sun, 29 Oct 2023 22:29:34 GMT
       mise-correlation-id:
-      - 4b65ac66-2933-4d6d-a406-aaa084387d84
+      - 6502750a-2fff-4342-9839-bf6d63068977
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,82 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/fa15535a-e219-4355-b977-1e94946ca110?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A18Z&sr=b&sp=r&sig=inXqGTz8rKCdCJM6quAYHGioRfR%2FGhOcaCMDwACByf4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:18.1453612","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A18Z&sr=b&sp=r&sig=Jepgu1GiSao2XbgLlM94UNrJTg3cbO8b2dhIrvvhWBU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:18.1452914","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/f2fc4209-9c01-49cd-ad06-b9f736a6542c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A18Z&sr=b&sp=r&sig=3P03%2B9mO0JL0bjV2aHPFYw1qY6D1jo%2BdaQ72o%2BBtPPY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:18.1453747","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:37:13.99Z","executedDateTime":"2023-10-24T12:37:11.511Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-24T12:37:12.313Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:14.129Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:37:18 GMT
-      mise-correlation-id:
-      - 393bfd93-9548-4efd-88bd-225e67f2fbae
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/fa15535a-e219-4355-b977-1e94946ca110?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A23Z&sr=b&sp=r&sig=6PPdbMvqlDz%2F6ohyGPjqLhU7KZEX4FdfxsHvz9aBjtg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:23.4827271","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A23Z&sr=b&sp=r&sig=LObPVcMLbY4IVsxmZID%2FchJVcnHmRw3HbDmZg8GH5dg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:23.4826575","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/f2fc4209-9c01-49cd-ad06-b9f736a6542c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A23Z&sr=b&sp=r&sig=emIC9%2FiXGWeydjAOxl5noS6zsP0DhApYwFDfdq4efxo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:23.4827409","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:37:13.99Z","executedDateTime":"2023-10-24T12:37:11.511Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-24T12:37:12.313Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:14.129Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:37:23 GMT
-      mise-correlation-id:
-      - 0ec6f0ed-32fd-4424-83a1-b6072a746373
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/fa15535a-e219-4355-b977-1e94946ca110?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A29Z&sr=b&sp=r&sig=Z802XO%2BltGgDpNnhSnRzJspmwjedrwfgUImOWg%2FrYNM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:29.5721868","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A29Z&sr=b&sp=r&sig=hfV7X57S9Qm2MpqU25DPLIRHRU2JqjXxVnslb4zMjUQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:29.5720847","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/f2fc4209-9c01-49cd-ad06-b9f736a6542c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A29Z&sr=b&sp=r&sig=j8ZmVPU4Yuaweh00qvKNSz%2BWO%2FrwLT9ujxRAJAGjR%2Fs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:29.5722101","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:37:13.99Z","executedDateTime":"2023-10-24T12:37:11.511Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-24T12:37:12.313Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:14.129Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/64491ab8-5d2b-49f5-815e-80bbd634ca92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A39Z&sr=b&sp=r&sig=LOfSm0NNL%2FXXUteiUmBAgXggFQ9oRdnt6xmzdLS7j%2Fw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:39.8586306","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A39Z&sr=b&sp=r&sig=e%2FTQiuwCLnHW3Dssthhm95J1oawUt3O%2BnBzXhzs7cnM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:39.8585596","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/36a0e41e-54c4-4871-ad27-d89277960570?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A39Z&sr=b&sp=r&sig=YgqXwD40jCuQC%2Bc5RY861BZp6vk00lMnJumnaksGbSA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:39.8586449","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:29:34.34Z","executedDateTime":"2023-10-29T22:29:33.086Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-29T22:29:33.966Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:34.527Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -822,9 +750,81 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:29 GMT
+      - Sun, 29 Oct 2023 22:29:39 GMT
       mise-correlation-id:
-      - c2b6db5c-8f1f-40c4-8dde-a0f10acfa286
+      - 076823a6-a77e-449a-8550-2d59f9710b30
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/64491ab8-5d2b-49f5-815e-80bbd634ca92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A45Z&sr=b&sp=r&sig=85p8B%2Bes9BkjLbccJ7Srl0RuPp48pGsuqOqiYyYCuZc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:45.1069669","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A45Z&sr=b&sp=r&sig=EKHgW2Q3%2FmOmuV53nkhmA8phk7kupNx52gOM4yzRG2k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:45.1068972","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/36a0e41e-54c4-4871-ad27-d89277960570?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A45Z&sr=b&sp=r&sig=MnKbbICWXKmV8%2F3IEatcncKCCh4mZMCSa5fYRuGuD8I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:45.1069811","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:29:34.34Z","executedDateTime":"2023-10-29T22:29:33.086Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-29T22:29:33.966Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:34.527Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:45 GMT
+      mise-correlation-id:
+      - 272345ce-918d-45e4-8158-b6a844b2066b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/64491ab8-5d2b-49f5-815e-80bbd634ca92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A50Z&sr=b&sp=r&sig=YCkmO3WmnCcvzBg6OwhHY5ES20DkYOeCVFfGgtbWlcE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:50.4117978","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A50Z&sr=b&sp=r&sig=zpC3SCl%2FYb0iqikp13UTOjz2a2PvlnMDYGQI1GWCxIo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:50.4117101","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/36a0e41e-54c4-4871-ad27-d89277960570?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A50Z&sr=b&sp=r&sig=dmV0kgCSj2yQpAj8OrAra7HVt9iYUd%2B17g%2FzVkSvvnY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:50.4118226","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:29:34.34Z","executedDateTime":"2023-10-29T22:29:33.086Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-29T22:29:33.966Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:34.527Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:29:50 GMT
+      mise-correlation-id:
+      - 5faba3a4-615c-4180-9b97-f8476150e924
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -847,18 +847,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:36:11.1310639Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:36:11.1310639Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:28:34.4962316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:28:34.4962316Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:33 GMT
+      - Sun, 29 Oct 2023 22:29:55 GMT
       etag:
-      - '"d3006b52-0000-0100-0000-6537ba3d0000"'
+      - '"3c00aa34-0000-0100-0000-653edc940000"'
       expires:
       - '-1'
       pragma:
@@ -888,23 +888,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/fa15535a-e219-4355-b977-1e94946ca110?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A34Z&sr=b&sp=r&sig=gwQoqh8oexIvoFrKuloQeV01xTZHz3lCo8yGySeAVW0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:34.950449","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A34Z&sr=b&sp=r&sig=SKctbopfjzE29lPBj6td7wSKlqOXV%2FPDTSUyWa7QIgI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:34.9503628","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/f2fc4209-9c01-49cd-ad06-b9f736a6542c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A34Z&sr=b&sp=r&sig=sJSEhJdw2mOtrns83%2FnUO96h8XXiB5GXH3QmHvBFREE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:34.95047","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:37:13.99Z","executedDateTime":"2023-10-24T12:37:11.511Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-24T12:37:12.313Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:14.129Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/64491ab8-5d2b-49f5-815e-80bbd634ca92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A55Z&sr=b&sp=r&sig=zvexsmZc3qqatpiHs7R3NY443hHDBxbzGSif31RIftk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:55.7140849","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A55Z&sr=b&sp=r&sig=IL4gdTRjRwSq0xPQkbtkWKLNeaHHqyNmf7vFnGTdbPw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:55.7140002","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/36a0e41e-54c4-4871-ad27-d89277960570?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A55Z&sr=b&sp=r&sig=R%2F%2FgGCeOfDnB67rCDdW3wViRFmFEZ4P58LOulqGJBxY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:55.7141061","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:29:34.34Z","executedDateTime":"2023-10-29T22:29:33.086Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-29T22:29:33.966Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:34.527Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3187'
+      - '3190'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:34 GMT
+      - Sun, 29 Oct 2023 22:29:55 GMT
       mise-correlation-id:
-      - e7b3945d-36c4-4864-8bab-929553edbd8f
+      - 33455520-d3fd-4924-86af-506913c21cde
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -926,10 +926,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case:stop?api-version=2022-11-01
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case:stop?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/fa15535a-e219-4355-b977-1e94946ca110?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A35Z&sr=b&sp=r&sig=TtjmqzRCqAKICru%2B7py1YSyrT1r%2B0vkNJKMnR2kL%2Bvs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:35.2443537","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A35Z&sr=b&sp=r&sig=dqaF7aPJISS6Tlc1soqNgWVosw1xnKIqeCRpuRQd3WE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:35.2442523","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/f2fc4209-9c01-49cd-ad06-b9f736a6542c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A35Z&sr=b&sp=r&sig=h4Jwv0tnO5fXmjRpRS8d1NtmxTFxuzsNPM5ofqjIt0Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:35.24437","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:37:13.99Z","executedDateTime":"2023-10-24T12:37:11.511Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-24T12:37:12.313Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:14.129Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/64491ab8-5d2b-49f5-815e-80bbd634ca92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A56Z&sr=b&sp=r&sig=ZCT%2B76VL2Wq4uRCOnq3MNxM7%2BBdQ1CUYUIUGJecefLU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:56.5249408","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A56Z&sr=b&sp=r&sig=VVUysPPQYQejK2nEoOXxkk4wgEmiSYsZcQXnBFidZdg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:29:56.5248644","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/36a0e41e-54c4-4871-ad27-d89277960570?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A29%3A56Z&sr=b&sp=r&sig=CtH9bJIr7eH9yNkwpR7JCpQry7fn8oIrGiyc8X8AiFE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:29:56.5249559","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:29:34.34Z","executedDateTime":"2023-10-29T22:29:33.086Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-29T22:29:33.966Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:34.527Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -940,9 +940,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:35 GMT
+      - Sun, 29 Oct 2023 22:29:56 GMT
       mise-correlation-id:
-      - f1b09f05-40d8-4c91-a5e3-6559152be295
+      - c4d2ba9c-b947-4013-8836-1dbbd3faae17
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -962,23 +962,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/fa15535a-e219-4355-b977-1e94946ca110?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A40Z&sr=b&sp=r&sig=8yLxwfwXOkRbcJqprEMd1tc4F5znTlhHdhCPXzeMosM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:40.2399787","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A40Z&sr=b&sp=r&sig=LwwFP7QLY%2FX02iRQcwZ%2FLFfffLRAZ9NAaNRJu0a638I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:40.2399032","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/f2fc4209-9c01-49cd-ad06-b9f736a6542c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A40Z&sr=b&sp=r&sig=WOdTOp%2FLViRISdeemrEy3s3A1%2BwFqR5doFh5LrOxh50%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:40.2399926","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-24T12:37:13.99Z","endDateTime":"2023-10-24T12:37:35.411Z","executedDateTime":"2023-10-24T12:37:11.511Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-24T12:37:12.313Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:35.681Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/64491ab8-5d2b-49f5-815e-80bbd634ca92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A01Z&sr=b&sp=r&sig=wU81XrH3mswIbkf6U7S9rYzmn1gDt5UWLhCoJpp6UmE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:01.0361815","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A01Z&sr=b&sp=r&sig=nD%2Frp%2FI2z6FerzNAk%2Bh3lS5w2%2F7DCJq72CAoVy0VrKA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:01.0361127","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/36a0e41e-54c4-4871-ad27-d89277960570?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A01Z&sr=b&sp=r&sig=HWKp3y4PXfSfMZiw4FBu1dB%2F67q46wHKxnNu1X7v13E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:01.0361957","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-29T22:29:34.34Z","endDateTime":"2023-10-29T22:29:56.663Z","executedDateTime":"2023-10-29T22:29:33.086Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-29T22:29:33.966Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:29:57.812Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3232'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:40 GMT
+      - Sun, 29 Oct 2023 22:30:01 GMT
       mise-correlation-id:
-      - 90318d36-5480-4819-bb7b-3ba233072f52
+      - 079c8cbe-a155-4595-8a61-b16feb4f1e5e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1001,18 +1001,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:36:11.1310639Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:36:11.1310639Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:28:34.4962316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:28:34.4962316Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:56 GMT
+      - Sun, 29 Oct 2023 22:30:17 GMT
       etag:
-      - '"d3006b52-0000-0100-0000-6537ba3d0000"'
+      - '"3c00aa34-0000-0100-0000-653edc940000"'
       expires:
       - '-1'
       pragma:
@@ -1042,23 +1042,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://171ae8cd-bcc7-4879-a639-2595cb7b9340.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://1a986ee5-8396-47d7-bbea-ae825491a8a2.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"21ed0892-e9fb-4777-b96a-1914e19055e4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ae20c3a3-c077-4d49-8223-d6919f9015d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"daa78e6e-16b3-4685-aaa9-b2f4deabf60c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/fa15535a-e219-4355-b977-1e94946ca110?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A57Z&sr=b&sp=r&sig=EBQQj1pbuaL8a67pVIGSYtKNLixURl2LWD6vNMTm%2F50%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:57.7196982","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/74802bfc-d5b5-4caf-80d3-fd99ad3a40bd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A57Z&sr=b&sp=r&sig=3rjzRfjvqy2Lawwe9ZoulnW%2FmbAEVXVec6zp8HUDIwA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:37:57.7196032","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af43858a-6fe4-4af1-ae14-0cfcf49edcc1/f2fc4209-9c01-49cd-ad06-b9f736a6542c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A37%3A57Z&sr=b&sp=r&sig=7fTCdGuedYByywzCS8Ld7f2y8XYJvcsyLay%2BwRnbgDA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:37:57.7197225","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-24T12:37:13.99Z","endDateTime":"2023-10-24T12:37:35.411Z","executedDateTime":"2023-10-24T12:37:11.511Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-24T12:37:12.313Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:37:57.12Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3810ff1d-02df-4067-bfda-ca3a9289e0a3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2b650d86-bee1-4f6a-925b-2c2511dac183":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"4f14afaa-3c61-4295-84b1-625054f134ad":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/64491ab8-5d2b-49f5-815e-80bbd634ca92?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A18Z&sr=b&sp=r&sig=M4IqZiswbTlc5H8KGwhtcSWQXyHIpSdioW4FnrixEdg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:18.6489094","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/96d9d232-15f8-4b4c-9286-413b346ce3c4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A18Z&sr=b&sp=r&sig=n0g4OM%2Fa%2Fa%2B%2BCjQI5PeFlLmQ53e7ati5fcZw6fapabU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:30:18.6488171","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/580dce4c-6ced-44ff-b2e8-238966117038/36a0e41e-54c4-4871-ad27-d89277960570?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A30%3A18Z&sr=b&sp=r&sig=v0Y5R9DsYUcgeb%2FzTKZ194mF6IJs%2FXDSrg5JbtQ90%2BM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:30:18.6489326","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-29T22:29:34.34Z","endDateTime":"2023-10-29T22:29:56.663Z","executedDateTime":"2023-10-29T22:29:33.086Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-29T22:29:33.966Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:30:15.797Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3229'
+      - '3238'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:37:57 GMT
+      - Sun, 29 Oct 2023 22:30:18 GMT
       mise-correlation-id:
-      - 1eb77850-02b4-46a8-8311-7b8b75bcb588
+      - 4732cb3e-1e25-418a-b64d-fa1f2f63df77
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_stop.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_stop.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:17:57.7796793Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:17:57.7796793Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:19:48.2259316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:19:48.2259316Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:35 GMT
+      - Mon, 09 Oct 2023 16:20:22 GMT
       etag:
-      - '"1a0a25f8-0000-0100-0000-64af0a780000"'
+      - '"92017df2-0000-0100-0000-652428260000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:18:36 GMT
+      - Mon, 09 Oct 2023 16:20:23 GMT
       mise-correlation-id:
-      - 89d94acd-0ff7-4454-8653-73171dc6eb95
+      - 6fdcd67e-c43c-441d-8ba5-d4d29fc6cac7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -85,12 +85,12 @@ interactions:
 - request:
     body: '{"displayName": "CLI-Test", "description": "Test created from az load test
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
-      {"rps": 1, "duration_in_sec": "120"}, "secrets": {}, "loadTestConfiguration":
+      {"rps": 1, "duration_in_sec": "120"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"743e9290-c352-4ffe-90ae-022a37d70919": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "b750cb73-5dfb-4dd5-a4c3-3dbd9c429f3f":
+      {"passFailMetrics": {"cf9cd94b-d2be-4d52-85be-7ec69ce37051": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "a560898a-ce75-40de-a3d5-e0812ff7c059":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "dbe50de3-4195-4e0e-a548-709557927477": {"aggregate": "avg", "clientMetric":
+      "50"}, "6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -100,32 +100,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '770'
+      - '791'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"743e9290-c352-4ffe-90ae-022a37d70919":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"b750cb73-5dfb-4dd5-a4c3-3dbd9c429f3f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"dbe50de3-4195-4e0e-a548-709557927477":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:18:37.352Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:18:37.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:20:24.538Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:24.538Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1062'
+      - '1008'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:37 GMT
+      - Mon, 09 Oct 2023 16:20:24 GMT
       location:
-      - https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+      - https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - b1f5833b-5bec-4736-8287-c286212a3255
+      - 82c29ac7-d1dc-4024-aeae-69cb420fe3dd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files?api-version=2022-11-01
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:37 GMT
+      - Mon, 09 Oct 2023 16:20:24 GMT
       mise-correlation-id:
-      - bf4900c2-fc5d-475c-a33c-5e2d052ca853
+      - e4353f33-fc41-43bd-93da-2f60c914b64c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/4416eb77-0995-474e-9174-28fc6f29f83e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A28%3A39Z&sr=b&sp=r&sig=99VTrDWNgSM8cyHjr3pAgOe8MXxgeL2Eqh2BLdsbOC0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:28:39.0953146","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A30%3A25Z&sr=b&sp=r&sig=VWFS9jbAergJhylUE4Qk4OfomPFPjXIJy%2BUtT8z0GcQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:30:25.3786681","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:39 GMT
+      - Mon, 09 Oct 2023 16:20:25 GMT
       location:
-      - https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 97450b5a-9958-48c5-b519-bd09690f7392
+      - 8e25ca06-314f-416c-84fe-32abc9e3515b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/4416eb77-0995-474e-9174-28fc6f29f83e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A28%3A39Z&sr=b&sp=r&sig=jlXtSZFgyHObA0%2FfMXr8cA0kC%2F8MaUeLMqFfDt8QsnA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:28:39.3579055","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:18:39 GMT
-      mise-correlation-id:
-      - 17def579-a3a4-4bc7-b768-23b1c355936c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/4416eb77-0995-474e-9174-28fc6f29f83e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A28%3A45Z&sr=b&sp=r&sig=94SRA9WRvZiJFCZC9NO4A6fASPsa2J3ac%2BPmUOAJbIw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:28:45.4165588","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:18:45 GMT
-      mise-correlation-id:
-      - f9c453b0-b240-4498-9c26-f7678ee8cce7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/4416eb77-0995-474e-9174-28fc6f29f83e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A28%3A50Z&sr=b&sp=r&sig=r9M6PIK0XHwobHlFqddVdsTKFrVt7H0Xm52HJqGwSrg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:28:50.8021147","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A30%3A25Z&sr=b&sp=r&sig=4Oppm3aYzkrARxrrwRq010ND4EDCuJgcx01ppgPABH8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:30:25.6453328","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:50 GMT
+      - Mon, 09 Oct 2023 16:20:25 GMT
       mise-correlation-id:
-      - 28c2fd16-1fe6-46a9-bdbd-6ce3c1e12120
+      - bbf86a45-ea99-4636-914e-663fd58115c0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,10 +349,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/4416eb77-0995-474e-9174-28fc6f29f83e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A28%3A56Z&sr=b&sp=r&sig=E2D0qz6fUwUp%2FmQnJJOu%2BibHJeV7oaAwjJOPVzA9wa4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:28:56.1364633","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A30%3A30Z&sr=b&sp=r&sig=jJOWRumCxxUEM8y7ys3CTmpKaF%2BuGM9FxXrQi%2F0sYVk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:30:30.9256272","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:30 GMT
+      mise-correlation-id:
+      - d6468085-f6a8-4628-b864-ceceb23d02f6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A30%3A36Z&sr=b&sp=r&sig=DjefxEn5oQ4flFgs0m3sleyC6zjNevBZ%2BCeWwQVHPRc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:30:36.2082684","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:56 GMT
+      - Mon, 09 Oct 2023 16:20:36 GMT
       mise-correlation-id:
-      - 64e24d5b-e7d4-426a-ad3a-a7a1777e60a9
+      - 3ed82090-1c9b-456b-bd4a-1066cc406849
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +421,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"743e9290-c352-4ffe-90ae-022a37d70919":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"b750cb73-5dfb-4dd5-a4c3-3dbd9c429f3f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"dbe50de3-4195-4e0e-a548-709557927477":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/4416eb77-0995-474e-9174-28fc6f29f83e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A56Z&sr=b&sp=r&sig=Bqh%2F6wedz6cSYPsXW6Z%2Fs8tkBM5JINtNkxEx%2Bb80n5s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:56.455695","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:18:37.352Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:18:52.586Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A30%3A41Z&sr=b&sp=r&sig=bsC6XsYpN7iuZFro6XEe%2BDCFgWbCpJKkKo5y4oqT%2Bks%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:30:41.4822856","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1636'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:56 GMT
+      - Mon, 09 Oct 2023 16:20:41 GMT
       mise-correlation-id:
-      - b5cd8dcc-a7a7-46dd-bb49-223e695454bf
+      - 0d44f442-e9ec-468f-96e0-4360d6f663ab
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests/stop-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A41Z&sr=b&sp=r&sig=FlStQ69hdCsy%2Bj0zWdAfa928sSsoYCkZMyNoUDe5wUQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:41.7922736","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:20:24.538Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:40.34Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1578'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:20:41 GMT
+      mise-correlation-id:
+      - cfdf5928-78db-4b0f-9c03-50378e199758
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:17:57.7796793Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:17:57.7796793Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:19:48.2259316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:19:48.2259316Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:57 GMT
+      - Mon, 09 Oct 2023 16:20:42 GMT
       etag:
-      - '"1a0a25f8-0000-0100-0000-64af0a780000"'
+      - '"92017df2-0000-0100-0000-652428260000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"743e9290-c352-4ffe-90ae-022a37d70919":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"b750cb73-5dfb-4dd5-a4c3-3dbd9c429f3f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"dbe50de3-4195-4e0e-a548-709557927477":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/4416eb77-0995-474e-9174-28fc6f29f83e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A59Z&sr=b&sp=r&sig=UJyzokRMHXLII9J2mBMtOMdnLuAEPnO9Nu%2Bf9UvKnU4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:59.0949946","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:18:37.352Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:18:52.586Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A43Z&sr=b&sp=r&sig=quDagn%2BG5zLFPMVQH2D%2BY%2BJlMiIb0TA%2FlXmPGjokpq0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:43.3522687","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"stop-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:20:24.538Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:40.34Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1645'
+      - '1596'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:59 GMT
+      - Mon, 09 Oct 2023 16:20:43 GMT
       mise-correlation-id:
-      - 56da7699-0686-486e-a33c-b6bc5fe83f2f
+      - eb6e2c45-8cc9-4cb5-8208-32cfde9adfb0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:17:57.7796793Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:17:57.7796793Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:19:48.2259316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:19:48.2259316Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:00 GMT
+      - Mon, 09 Oct 2023 16:20:44 GMT
       etag:
-      - '"1a0a25f8-0000-0100-0000-64af0a780000"'
+      - '"92017df2-0000-0100-0000-652428260000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:19:01 GMT
+      - Mon, 09 Oct 2023 16:20:45 GMT
       mise-correlation-id:
-      - 87812286-61b7-47c7-9127-4f6cfe13b16d
+      - 8f7da6a2-ce1f-4a28-ac8a-96b3c83c4cb7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"743e9290-c352-4ffe-90ae-022a37d70919":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"b750cb73-5dfb-4dd5-a4c3-3dbd9c429f3f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"dbe50de3-4195-4e0e-a548-709557927477":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/f2a05038-dcaf-4bd9-a413-1d3b57381e40?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A02Z&sr=b&sp=r&sig=q19rhCzlxbVRRcsmErSAcU%2BICKL9mHrTQ2di%2FAj1O%2Fk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:02.3742515","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/4416eb77-0995-474e-9174-28fc6f29f83e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A02Z&sr=b&sp=r&sig=d%2FE04qkvzvaVwgFbO2DoBLB0sEdh80%2FSEFQOvfSMz9k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:02.3741233","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/9dbc38f6-e424-4783-84eb-81ea04473936?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A02Z&sr=b&sp=r&sig=7RjIH%2BvUkYEdiEYj6HFBXb5zSS3PvoM9Yc6P3KXp7%2BA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:02.3742807","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","testId":"stop-test-case","status":"ACCEPTED","executedDateTime":"2023-07-12T20:19:02.182Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-07-12T20:19:02.739Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:02.739Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/c652a322-260a-44cd-a54b-ec211f7065a1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A46Z&sr=b&sp=r&sig=b3EgzEKaSojILWwSCtDLM7n6H4YbwlA29sZYY4GiOuA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:46.5206057","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A46Z&sr=b&sp=r&sig=H%2B1Prf%2BhI%2Bf0lUKusWbEeucx2s4it6DCFgk35Hd2ZhE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:46.5204609","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/90fc8a6c-4700-4ac2-9e12-bbe5a07f8974?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A46Z&sr=b&sp=r&sig=Snu%2F2u1p%2FWGCsHzBaHIW8BVsQw9FABwv5GJ7cc2MOa8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:46.5206289","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:20:46.167Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T16:20:46.453Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:46.453Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3191'
+      - '3150'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:02 GMT
+      - Mon, 09 Oct 2023 16:20:46 GMT
       location:
-      - https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+      - https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 3f2d989b-9076-43f7-9f3b-2ed02a6bda6f
+      - 6fe2b899-1221-49c2-ba37-728d4a87ef90
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"743e9290-c352-4ffe-90ae-022a37d70919":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"b750cb73-5dfb-4dd5-a4c3-3dbd9c429f3f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"dbe50de3-4195-4e0e-a548-709557927477":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/f2a05038-dcaf-4bd9-a413-1d3b57381e40?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A03Z&sr=b&sp=r&sig=WqO65SnQqED4nReCqFK8qxy0A3xJDyf%2FEtM2HEjc2FI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:03.0992928","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/4416eb77-0995-474e-9174-28fc6f29f83e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A03Z&sr=b&sp=r&sig=PaR2CHaws9kxDX1xNNq9HYISBJ%2F%2BMmDSKUffJciJmUo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:03.0992191","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/9dbc38f6-e424-4783-84eb-81ea04473936?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A03Z&sr=b&sp=r&sig=Z4Wi9K5TONN49alWgAsC5i7sVhgq%2FOwRFEmQDoaj4fQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:03.0993065","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","testId":"stop-test-case","status":"ACCEPTED","executedDateTime":"2023-07-12T20:19:02.182Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-07-12T20:19:02.739Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:02.739Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/c652a322-260a-44cd-a54b-ec211f7065a1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A46Z&sr=b&sp=r&sig=7jRfYWTuztXRXB9XKfJtj5Ie1znDKkkYjQDPB6tD5PU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:46.9660049","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A46Z&sr=b&sp=r&sig=7XNILeL4cQrjT2p%2Fqbi3rM2LuzB0iJmggwT5Zb8oNl0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:46.9659128","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/90fc8a6c-4700-4ac2-9e12-bbe5a07f8974?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A46Z&sr=b&sp=r&sig=gLwfqpkQ9y8y7AsSNkKxSID0ZCGhKuAGwCoge2rnQ5g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:46.9660288","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T16:20:46.852Z","executedDateTime":"2023-10-09T16:20:46.167Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T16:20:46.453Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:46.852Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3185'
+      - '3187'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:03 GMT
+      - Mon, 09 Oct 2023 16:20:46 GMT
       mise-correlation-id:
-      - 0382bf39-942f-413b-943f-3a58473eba84
+      - 05c1eeca-d73f-4ebd-b421-e4db4609a706
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"743e9290-c352-4ffe-90ae-022a37d70919":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"b750cb73-5dfb-4dd5-a4c3-3dbd9c429f3f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"dbe50de3-4195-4e0e-a548-709557927477":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/f2a05038-dcaf-4bd9-a413-1d3b57381e40?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A08Z&sr=b&sp=r&sig=aN5aEotKKrUA5B9QDXQKT%2FBafOwoDTMcmPNv3xJTtv0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:08.39849","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/4416eb77-0995-474e-9174-28fc6f29f83e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A08Z&sr=b&sp=r&sig=PWlVLgop01VNXZjo9AuJvLGqOoNyjUJ1liBELE5uKhk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:08.3984247","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/9dbc38f6-e424-4783-84eb-81ea04473936?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A08Z&sr=b&sp=r&sig=xpcvEIkksZ5Hk%2Fm6eJnHWu6mRR4HSzizy52Q4EwuNN8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:08.3985041","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:19:03.506Z","executedDateTime":"2023-07-12T20:19:02.182Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-07-12T20:19:02.739Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:03.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/c652a322-260a-44cd-a54b-ec211f7065a1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A52Z&sr=b&sp=r&sig=NN9JWY%2F%2BUQR%2F%2BFOvSEbPKacmWtiRtKaZzuT5aGcp%2FqM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:52.2404693","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A52Z&sr=b&sp=r&sig=c9I258U2OgxgLj8eLi0ecWpW7iiSKteZ0zi3mF8ASiQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:52.240403","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/90fc8a6c-4700-4ac2-9e12-bbe5a07f8974?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A52Z&sr=b&sp=r&sig=ADkkBTROz1mpCJkH0AIzqWjuDSAUlbNtynWrulGx2dA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:52.2404843","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:20:46.852Z","executedDateTime":"2023-10-09T16:20:46.167Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T16:20:46.453Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:47.122Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3226'
+      - '3196'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:08 GMT
+      - Mon, 09 Oct 2023 16:20:52 GMT
       mise-correlation-id:
-      - a88ced75-4ba6-4eca-95f0-bf6606632aad
+      - d63008b7-0b78-41a3-8118-1531a9977072
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"743e9290-c352-4ffe-90ae-022a37d70919":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"b750cb73-5dfb-4dd5-a4c3-3dbd9c429f3f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"dbe50de3-4195-4e0e-a548-709557927477":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/f2a05038-dcaf-4bd9-a413-1d3b57381e40?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A13Z&sr=b&sp=r&sig=oHaJWsSd8mp32MsDshVr%2BFDCkYu7qXG5ibUUH%2BGILDg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:13.6994004","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/4416eb77-0995-474e-9174-28fc6f29f83e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A13Z&sr=b&sp=r&sig=CM2ChZgUE5W2Uq%2F62tY2E8BQx5T6GYmyIcDcqJuW2RY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:13.6993415","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/9dbc38f6-e424-4783-84eb-81ea04473936?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A13Z&sr=b&sp=r&sig=P0wxVokqxP2IcCMcAecPtZ0BCRuxlUaM2ncqRIx64qo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:13.6994159","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:19:03.506Z","executedDateTime":"2023-07-12T20:19:02.182Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-07-12T20:19:02.739Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:03.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/c652a322-260a-44cd-a54b-ec211f7065a1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A57Z&sr=b&sp=r&sig=6yImYf%2FAK8kqLfPDnC0%2BlkEIBNLjUdnwVDrfvgzYElI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:57.5283022","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A57Z&sr=b&sp=r&sig=j3e5ESAkZ88uWa09o4TgHM5e4RiY%2BKglLX9bffD3GYI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:20:57.5282184","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/90fc8a6c-4700-4ac2-9e12-bbe5a07f8974?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A20%3A57Z&sr=b&sp=r&sig=ntvo7iL%2BLjhdYdOUxGV6CIxTruJKW%2FyHBoqV2ZwarV0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:20:57.5283628","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:20:46.852Z","executedDateTime":"2023-10-09T16:20:46.167Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T16:20:46.453Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:47.122Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3230'
+      - '3197'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:13 GMT
+      - Mon, 09 Oct 2023 16:20:57 GMT
       mise-correlation-id:
-      - a8267788-a016-44c9-8a89-5eed97047dc7
+      - f7f40804-4bad-4f38-930d-aabe599ae4a3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,23 +808,59 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"743e9290-c352-4ffe-90ae-022a37d70919":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"b750cb73-5dfb-4dd5-a4c3-3dbd9c429f3f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"dbe50de3-4195-4e0e-a548-709557927477":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/f2a05038-dcaf-4bd9-a413-1d3b57381e40?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A19Z&sr=b&sp=r&sig=nch0w3oUuCYOr645l7%2BRqFDSpdyjR5LrtqqwcjojXUY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:19.0001197","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/4416eb77-0995-474e-9174-28fc6f29f83e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A19Z&sr=b&sp=r&sig=JEHtCM%2FAd3pQQULpAX5lr%2BCkEQmFWmzA816uyXP2vvk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:19.000037","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/9dbc38f6-e424-4783-84eb-81ea04473936?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A19Z&sr=b&sp=r&sig=fGZyXwIXWGUjHgTEBp79WHGmQ49q1%2BkCg1a%2FTr2warU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:19.0001389","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:19:03.506Z","executedDateTime":"2023-07-12T20:19:02.182Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-07-12T20:19:02.739Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:03.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/c652a322-260a-44cd-a54b-ec211f7065a1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A02Z&sr=b&sp=r&sig=kgEF4ESRVA0zzMKHyIEOGai202%2Fj%2FHjRxet9hvyItKM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:02.8194338","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A02Z&sr=b&sp=r&sig=haXzjN%2FVnWk%2FpUSmnsOgfn4lldLgaEEqu0Jeqf9NyAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:02.8193344","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/90fc8a6c-4700-4ac2-9e12-bbe5a07f8974?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A02Z&sr=b&sp=r&sig=dmaiYqt1vmTKI9wxVwlwD6Liph5o3Cmuln44Rcf8jEU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:02.8194599","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:20:46.852Z","executedDateTime":"2023-10-09T16:20:46.167Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T16:20:46.453Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:47.122Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3233'
+      - '3195'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:18 GMT
+      - Mon, 09 Oct 2023 16:21:02 GMT
       mise-correlation-id:
-      - ebf3d31a-cc60-4c60-a8ab-3da0f7b6338e
+      - 33333397-1ec5-416d-8696-9bf995631f29
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/c652a322-260a-44cd-a54b-ec211f7065a1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A08Z&sr=b&sp=r&sig=k1fhVhd8UmWpi%2BEUqK6yeDsrdv5gObaglhSaTAzFDU0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:08.10443","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A08Z&sr=b&sp=r&sig=ij3J8G5xnEAnnUgO9B4qgrBRDRAed1GbfUElNH8ujMg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:08.1043538","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/90fc8a6c-4700-4ac2-9e12-bbe5a07f8974?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A08Z&sr=b&sp=r&sig=tvqeD9KIpxZMITSA%2FCHbcC9ZJRTvBTkv0keR5bg0TDM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:08.1044466","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:20:46.852Z","executedDateTime":"2023-10-09T16:20:46.167Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T16:20:46.453Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:47.122Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:21:08 GMT
+      mise-correlation-id:
+      - fd3b50ae-c420-4b54-908c-818f2cbe14f9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -847,7 +883,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:17:57.7796793Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:17:57.7796793Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:19:48.2259316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:19:48.2259316Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -856,9 +892,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:24 GMT
+      - Mon, 09 Oct 2023 16:21:08 GMT
       etag:
-      - '"1a0a25f8-0000-0100-0000-64af0a780000"'
+      - '"92017df2-0000-0100-0000-652428260000"'
       expires:
       - '-1'
       pragma:
@@ -873,42 +909,6 @@ interactions:
       - nosniff
       x-ms-providerhub-traffic:
       - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"743e9290-c352-4ffe-90ae-022a37d70919":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"b750cb73-5dfb-4dd5-a4c3-3dbd9c429f3f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"dbe50de3-4195-4e0e-a548-709557927477":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/f2a05038-dcaf-4bd9-a413-1d3b57381e40?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A24Z&sr=b&sp=r&sig=CVje9YMlngBnVSs9I%2B3bsJT9vLCYUEQNpHcRR0LmLYo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:24.5451678","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/4416eb77-0995-474e-9174-28fc6f29f83e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A24Z&sr=b&sp=r&sig=fYOh5FG5eON57dPJXfLhT1dp41vvkipC0HiOf0EHmhU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:24.5450991","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/9dbc38f6-e424-4783-84eb-81ea04473936?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A24Z&sr=b&sp=r&sig=TB7wRogOyWjSe%2BwiNU1tB5yckWy7wEqxMddf1%2FnwU2s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:24.5451817","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:19:03.506Z","executedDateTime":"2023-07-12T20:19:02.182Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-07-12T20:19:02.739Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:03.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3230'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:19:24 GMT
-      mise-correlation-id:
-      - a8ddf7de-ff1d-4c45-be0a-b1235483a844
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
     status:
       code: 200
       message: OK
@@ -926,23 +926,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case:stop?api-version=2022-11-01
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case:stop?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"743e9290-c352-4ffe-90ae-022a37d70919":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"b750cb73-5dfb-4dd5-a4c3-3dbd9c429f3f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"dbe50de3-4195-4e0e-a548-709557927477":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/f2a05038-dcaf-4bd9-a413-1d3b57381e40?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A25Z&sr=b&sp=r&sig=4cJCDXAoYSNL8YX0icZ7Xy%2FTQpeNsz9AyIWGmVAPV14%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:25.4701577","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/4416eb77-0995-474e-9174-28fc6f29f83e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A25Z&sr=b&sp=r&sig=2mYX%2F1%2BPNl7Y91rOshKS%2Bl5zoFi%2FmbMicE5FNjWd80A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:25.4700897","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/9dbc38f6-e424-4783-84eb-81ea04473936?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A25Z&sr=b&sp=r&sig=%2BMGkEQLRt7StjoAdR6PlfPqXkQ3Ts2MecmLj5ydDxh0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:25.4701715","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:19:03.506Z","executedDateTime":"2023-07-12T20:19:02.182Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-07-12T20:19:02.739Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:03.658Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/c652a322-260a-44cd-a54b-ec211f7065a1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A09Z&sr=b&sp=r&sig=3nuVUPVUxMJdceiPDfHYou9Oq3ySJbR7oJIt0r3D%2BRc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:09.0618151","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A09Z&sr=b&sp=r&sig=Q4novf%2BXg5MnZ2V998%2FbURtYeVnGdBcNXi0G8mcpXSM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:09.0617413","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/90fc8a6c-4700-4ac2-9e12-bbe5a07f8974?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A09Z&sr=b&sp=r&sig=rUucMrlFMFj9kEDWi%2BnvSVRt3w7cR61mMkWBZKAS3tM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:09.0618321","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:20:46.852Z","executedDateTime":"2023-10-09T16:20:46.167Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T16:20:46.453Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:20:47.122Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3177'
+      - '3136'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:25 GMT
+      - Mon, 09 Oct 2023 16:21:09 GMT
       mise-correlation-id:
-      - 4f57bf7e-707e-423b-926a-fb4ffba5f5ea
+      - 5c748f13-3c03-47a7-8ede-23d14e9738c7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -962,23 +962,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"743e9290-c352-4ffe-90ae-022a37d70919":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"b750cb73-5dfb-4dd5-a4c3-3dbd9c429f3f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"dbe50de3-4195-4e0e-a548-709557927477":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/f2a05038-dcaf-4bd9-a413-1d3b57381e40?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A30Z&sr=b&sp=r&sig=HrTXkPZh2a192LSxKZm9taCxpePigs%2Fm29YCY%2BS2z58%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:30.0922812","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/4416eb77-0995-474e-9174-28fc6f29f83e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A30Z&sr=b&sp=r&sig=nsqpKapmUprwUg6tcV%2BmyccgD1wsmyu1kOf9uvE4nlU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:30.0922067","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/9dbc38f6-e424-4783-84eb-81ea04473936?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A30Z&sr=b&sp=r&sig=AlOo1ZD7DfKON1z6OEBpMQDeNzqqVKPoOAmAo7aRAjQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:30.0922961","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-07-12T20:19:03.506Z","endDateTime":"2023-07-12T20:19:25.688Z","executedDateTime":"2023-07-12T20:19:02.182Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-07-12T20:19:02.739Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:25.987Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/c652a322-260a-44cd-a54b-ec211f7065a1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A13Z&sr=b&sp=r&sig=0MvplmItiLnuwL57Sy4jlwpeaWnza8K3JgpF0z4Kgb8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:13.3667752","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A13Z&sr=b&sp=r&sig=6WsrPdaRaAxPhU79B3HRIcxTT18QHZXQJdiYmLlzkBY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:13.3666877","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/90fc8a6c-4700-4ac2-9e12-bbe5a07f8974?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A13Z&sr=b&sp=r&sig=goA4Zq%2F4dupoftsruhD8kxmRtmwQTkey%2BOScQLw7MkE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:13.3667922","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-09T16:20:46.852Z","endDateTime":"2023-10-09T16:21:09.189Z","executedDateTime":"2023-10-09T16:20:46.167Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T16:20:46.453Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:21:09.499Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3268'
+      - '3229'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:30 GMT
+      - Mon, 09 Oct 2023 16:21:13 GMT
       mise-correlation-id:
-      - 7bbed474-0d7a-49af-a86b-911d1582a889
+      - 3d66310e-ff39-46c0-8b17-29ae0bbb67d3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1001,7 +1001,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:17:57.7796793Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:17:57.7796793Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:19:48.2259316Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:19:48.2259316Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1010,9 +1010,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:46 GMT
+      - Mon, 09 Oct 2023 16:21:30 GMT
       etag:
-      - '"1a0a25f8-0000-0100-0000-64af0a780000"'
+      - '"92017df2-0000-0100-0000-652428260000"'
       expires:
       - '-1'
       pragma:
@@ -1042,23 +1042,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5fb522da-0f01-4217-b6e5-7d9c11bb4089.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
+    uri: https://d60cd146-8e3d-4dc6-82c1-c55bf523e90e.eastus.cnt-prod.loadtesting.azure.com/test-runs/stop-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"743e9290-c352-4ffe-90ae-022a37d70919":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"b750cb73-5dfb-4dd5-a4c3-3dbd9c429f3f":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"dbe50de3-4195-4e0e-a548-709557927477":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/f2a05038-dcaf-4bd9-a413-1d3b57381e40?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A48Z&sr=b&sp=r&sig=Bs%2B0mxTdZuWKFiECUa7vLWr8JCfH0NiU8jDhLY9oo4o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:48.2482113","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/4416eb77-0995-474e-9174-28fc6f29f83e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A48Z&sr=b&sp=r&sig=U1ZcOco2CZGzBe11jSsxf7R%2B7uoDZleuuLUSBqy%2BVhQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:48.2481288","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fa95b5c7-25a2-4cca-aa7d-4245caef2ebe/9dbc38f6-e424-4783-84eb-81ea04473936?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A48Z&sr=b&sp=r&sig=8dCDDAcovfw9A0UusIfjmDyOWGFPuBFUtb6vLyuBpwU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:48.248234","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-07-12T20:19:03.506Z","endDateTime":"2023-07-12T20:19:25.688Z","executedDateTime":"2023-07-12T20:19:02.182Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-07-12T20:19:02.739Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:44.714Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"cf9cd94b-d2be-4d52-85be-7ec69ce37051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a560898a-ce75-40de-a3d5-e0812ff7c059":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6c5dde03-8dbd-4aa0-9592-3bf0d757cc9d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"120"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/c652a322-260a-44cd-a54b-ec211f7065a1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A31Z&sr=b&sp=r&sig=tVcmJxaAWH03OrHrC%2FdPNuJ8aGY%2Ftwn4gRQoGHFbDOU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:31.2650054","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/66e11f85-e69e-4462-8d6f-09427a08ffd4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A31Z&sr=b&sp=r&sig=CeQEkl6jU4Om7PeK9TZDI%2FKdEm4NzuFP1bHtxchHKBM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:21:31.2649393","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/43e76f36-0c1d-4d2a-bf7c-4d1bc87c6338/90fc8a6c-4700-4ac2-9e12-bbe5a07f8974?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A21%3A31Z&sr=b&sp=r&sig=Klaes9pgNGw4J56PdvxScVIidCbWf1sXEYZifDCyIzQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:21:31.2650208","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"stop-test-run-case","displayName":"stop-test-run-case","testId":"stop-test-case","status":"CANCELLED","startDateTime":"2023-10-09T16:20:46.852Z","endDateTime":"2023-10-09T16:21:09.189Z","executedDateTime":"2023-10-09T16:20:46.167Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/stop-test-case/testRunId/stop-test-run-case","createdDateTime":"2023-10-09T16:20:46.453Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:21:28.837Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3267'
+      - '3231'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:48 GMT
+      - Mon, 09 Oct 2023 16:21:31 GMT
       mise-correlation-id:
-      - f2d5fa2f-1560-49a7-9a60-e0281e3512d2
+      - 9a609690-37b7-417a-9d7b-73cfa41bead7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_update.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_update.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:00:05.4265706Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:00:05.4265706Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:37:32.8275879Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:37:32.8275879Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:00:39 GMT
+      - Tue, 24 Oct 2023 12:38:07 GMT
       etag:
-      - '"7500ab84-0000-0100-0000-653047570000"'
+      - '"d300a757-0000-0100-0000-6537ba8e0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 21:00:41 GMT
+      - Tue, 24 Oct 2023 12:38:08 GMT
       mise-correlation-id:
-      - e1710f88-c9d0-4d6a-8c93-4a653696f144
+      - e17b5d56-7bf7-4689-b48a-85fe6a7c4c24
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"d51e59fd-7da5-457d-9f97-b741816c8463": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "2c428843-c903-4c3f-9cff-097da70e820c":
+      {"passFailMetrics": {"43111ca2-0af0-47af-b425-5c4c79d0bd98": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "658dd14a-02d6-42b2-b43f-5b87e77480d6":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "f5da1b17-25ae-4efb-bf5f-7deb5066ed10": {"aggregate": "avg", "clientMetric":
+      "50"}, "0810b81b-3082-4e5b-95fe-9a40c26cd6d8": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T21:00:41.604Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:00:41.604Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:38:08.745Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:08.745Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:00:41 GMT
+      - Tue, 24 Oct 2023 12:38:08 GMT
       location:
-      - https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+      - https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 3f69cb7b-230c-4a32-a8ee-8b6b437a7b4e
+      - 5717ebe4-87bc-4d02-8b3a-015831c80258
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:00:41 GMT
+      - Tue, 24 Oct 2023 12:38:09 GMT
       mise-correlation-id:
-      - 6ff0671d-a1ca-4be8-9ed9-43fce1dcc281
+      - 35a2b741-e787-4861-b4ec-1e2892cb1cbf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A10%3A45Z&sr=b&sp=r&sig=HHXvsLlEL46jlTH4gdLLaJp0LNVQkGJxvePr8OsXjUo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:10:45.6319651","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A48%3A09Z&sr=b&sp=r&sig=Jz9TW4nYShkp2I20QQOrbpgrfKtf4bk0RTpTunhji%2Fs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:48:09.6325184","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:00:45 GMT
+      - Tue, 24 Oct 2023 12:38:09 GMT
       location:
-      - https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 236e98fe-10c5-4fe2-b15d-abdb2a245bb1
+      - e74c893b-b99d-49fd-b76f-efc591387de6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,118 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A10%3A45Z&sr=b&sp=r&sig=6llYXSscv3AZt%2F7XbFwwvMEnkVWlv5DlA5PVc%2FEKmOE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:10:45.9316804","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:00:45 GMT
-      mise-correlation-id:
-      - 9db9e66a-ecab-4bca-b146-bd56070a39ca
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A10%3A51Z&sr=b&sp=r&sig=501JtCqFUCw%2By6WS9eQPOTlQazsxWzdDAs80Xkk4%2FR0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:10:51.2517241","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:00:51 GMT
-      mise-correlation-id:
-      - 5b8fcdde-891f-4baa-bfbf-550d81e2fa23
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A10%3A56Z&sr=b&sp=r&sig=HQ00lte%2BJULqrgE4LgA%2Fs19Pnya772AfoTGyhhFhrJg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:10:56.5440011","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:00:56 GMT
-      mise-correlation-id:
-      - e8125eca-cf57-4c2f-9b8c-bf459f157ed6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A11%3A01Z&sr=b&sp=r&sig=G0HcAl39fj2Pf25394uiFUCnne1l%2Fj%2BGyNU1We3otEA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:11:01.8391517","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A48%3A09Z&sr=b&sp=r&sig=fG59pRyqLawfVo5HCtHD%2Bq9sXgrI4bxQmko3ijNlIXM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:48:09.9506007","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:01 GMT
+      - Tue, 24 Oct 2023 12:38:09 GMT
       mise-correlation-id:
-      - d76f4258-e6f2-4c87-a751-4f80d755cccf
+      - 018d572e-8212-4de1-ab16-f157a9bfa471
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +349,132 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A02Z&sr=b&sp=r&sig=j1bRQ%2F5y8%2BYCbEnM2fNC9FUUuUmkGoUFC9CrM6QnRU0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:02.15059","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T21:00:41.604Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:00:57.676Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A48%3A15Z&sr=b&sp=r&sig=J7NunEoN%2FWtq0scx7a2ZkaMWDV1IvUudBdGqLTMVWVI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:48:15.6520237","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1579'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:02 GMT
+      - Tue, 24 Oct 2023 12:38:15 GMT
       mise-correlation-id:
-      - e1674189-bf21-4abe-ad4a-aa46443f1276
+      - cfa499c5-e5c7-4ead-b78a-47ae6bbd3ea2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A48%3A21Z&sr=b&sp=r&sig=koZ75bpbAmqqBFiBGZ32GlI8w%2Bg%2Fn4HlQOigUxtOSvI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:48:21.0314396","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:38:21 GMT
+      mise-correlation-id:
+      - 3b41ec80-7bfb-4aca-9de3-a982ae350d7e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A48%3A26Z&sr=b&sp=r&sig=v1baoTa1WfhlzaWUfNoTzs1ztuNIM%2FnDglQrFeY1IJE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:48:26.3478811","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:38:26 GMT
+      mise-correlation-id:
+      - 06ebcf3b-f51a-41ef-a8c6-8423b0472a9e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A26Z&sr=b&sp=r&sig=tQ%2F%2BfcCWNI8iCuv1ma4oooB0ZtTHYVvK3O%2Fo7ocvo3o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:26.6636093","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:38:08.745Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:23.625Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1583'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:38:26 GMT
+      mise-correlation-id:
+      - e905a9b0-959f-41a2-aa6b-f184f42f7d17
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:00:05.4265706Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:00:05.4265706Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:37:32.8275879Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:37:32.8275879Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:03 GMT
+      - Tue, 24 Oct 2023 12:38:28 GMT
       etag:
-      - '"7500ab84-0000-0100-0000-653047570000"'
+      - '"d300a757-0000-0100-0000-6537ba8e0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A04Z&sr=b&sp=r&sig=h%2BgXul%2BKEbo3SQ6LG3IiaZbMG0TWL31B76%2FsglemSS4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:04.4564431","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T21:00:41.604Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:00:57.676Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A29Z&sr=b&sp=r&sig=8L2lQ0IdVvCRvgIYZqN8p90SNEibRJSh06KfXZ4kN%2BM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:29.221557","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:38:08.745Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:23.625Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1595'
+      - '1590'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:04 GMT
+      - Tue, 24 Oct 2023 12:38:29 GMT
       mise-correlation-id:
-      - b76eda63-ca61-4eb6-800c-8881ce3b7d2a
+      - 96b4ab91-ecab-477b-883e-c6bfdd8f236d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:00:05.4265706Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:00:05.4265706Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:37:32.8275879Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:37:32.8275879Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:05 GMT
+      - Tue, 24 Oct 2023 12:38:30 GMT
       etag:
-      - '"7500ab84-0000-0100-0000-653047570000"'
+      - '"d300a757-0000-0100-0000-6537ba8e0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 21:01:06 GMT
+      - Tue, 24 Oct 2023 12:38:31 GMT
       mise-correlation-id:
-      - 617822c6-557b-4369-93d8-87117e32bc59
+      - 7d549d94-bda5-4554-98b4-c7a3fdb8d940
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A07Z&sr=b&sp=r&sig=0bnJVIwuHfhlahYrRUpjVHQFCwsFI3K8p4kNdIZ0i84%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:07.7740297","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A07Z&sr=b&sp=r&sig=ujihJ1grP6OPzBvqH1Wizr66XNsEVEK3wkH29lT2JVk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:07.7738927","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A07Z&sr=b&sp=r&sig=g7%2FMn%2BAAtW3bTooXh6vCPcpb7pnCoFf%2BT5gLwG6rMmk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:07.7740612","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A32Z&sr=b&sp=r&sig=TIodo0hViUeqbZcnEi68RQSLB4J8R5RTQJKvtprSCjs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:32.76729","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A32Z&sr=b&sp=r&sig=irT2FZKig%2FKDbG4bzUo9ItaRXxYQCiEbVheYe0B%2FMwk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:32.7671914","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A32Z&sr=b&sp=r&sig=GqWdoDprI%2BHsVgNyevtMzdFEJ2gI%2FpJ9u78j5QTsXBw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:32.767315","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:32.69Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3154'
+      - '3151'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:07 GMT
+      - Tue, 24 Oct 2023 12:38:32 GMT
       location:
-      - https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+      - https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - d69ad249-0956-49a7-99b9-ef6fb87c3ecb
+      - 00fa1173-de27-4d87-8a34-78a4888f6d69
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A08Z&sr=b&sp=r&sig=oIy2gfU2djxp8FHVcfO0ojfoRJZq6fZOy1nnyV6fjlE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:08.239368","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A08Z&sr=b&sp=r&sig=GC83Be18XyG%2BiN9UxYpDFegVIf%2Fa%2FJIJ4ixQZ5R0%2BmQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:08.2392839","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A08Z&sr=b&sp=r&sig=T%2BfHRrf1c0%2FdrZlI4GYQKBRRjh6VKEabih%2BLcjIkhbY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:08.2393825","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"NOTSTARTED","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:08.118Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A33Z&sr=b&sp=r&sig=P6J7Papes8EvqPrhs87KO4sDr0FUhjAFAdkniZIhOeg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:33.3158056","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A33Z&sr=b&sp=r&sig=iVpcckNlsL2ezVg2RtKlNLjafWvJ7xzKPdsU9805JFk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:33.3157285","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A33Z&sr=b&sp=r&sig=BpyPEE9RL8DxntVzEoivWtokbKMmc%2BcI3nOWTOu73x8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:33.3158207","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"NOTSTARTED","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.174Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3206'
+      - '3194'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:01:08 GMT
+      - Tue, 24 Oct 2023 12:38:33 GMT
       mise-correlation-id:
-      - b817a5f0-eaf8-491c-a9d5-28b27de475c9
+      - f4cda962-0894-496b-85d1-9eeaae039fe3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,730 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A13Z&sr=b&sp=r&sig=9pYMkRnlqwqTuBhs4d9ik5mlDG8DsP9Zp4%2BuPR46iAE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:13.6181635","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A13Z&sr=b&sp=r&sig=Sw7Cqdv4oMba4i3RnGN2QmZq7XVl23IIUV3fznWGueA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:13.6180911","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A13Z&sr=b&sp=r&sig=5mE4HB1N%2FWn%2BEe3aGBe7ztE7lXr8T%2BUKfixiVH6LoN4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:13.6181786","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:08.335Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:01:13 GMT
-      mise-correlation-id:
-      - 24278a74-e6b5-4696-a11e-42def4dd8e19
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A18Z&sr=b&sp=r&sig=PPkk6wn0U6S3Ug8Ckbj8YpAy%2BtYnZYWvFt5xDUokuQI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:18.8911943","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A18Z&sr=b&sp=r&sig=zhmi0JKjG4bwdWTzVAQdBorIKx%2F4WhvMu2sx6sRUj4o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:18.8911213","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A18Z&sr=b&sp=r&sig=4pyBgHBYC%2Frcg9FyFmGv9o3d%2Bn%2B%2FPpvVY%2F5v8HZdG%2Fo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:18.8912087","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:08.335Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3211'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:01:18 GMT
-      mise-correlation-id:
-      - 8ad9da36-58fb-4a2d-a107-8a2d1d0857b6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A24Z&sr=b&sp=r&sig=RTkAcspkcFEdfhmbAEXG9QFHd%2BD7%2B1NAuYT8TL1a1MI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:24.20183","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A24Z&sr=b&sp=r&sig=BIjVoOFfAe6V3kwziGxjZj2qdKKRPuTX1Tpg7%2FhIOWM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:24.2017619","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A24Z&sr=b&sp=r&sig=r5p%2Flu9QRBXRnhydLzdJH%2F2l4wJFQHDXFweK%2B9fzEns%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:24.2018445","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:08.335Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:01:24 GMT
-      mise-correlation-id:
-      - 5b01bffc-0ce7-49d2-aaa5-964a7acad87f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A29Z&sr=b&sp=r&sig=dEJdFHSYrbCMYSN7iA%2BeaueVoTJ3s0X7OUG3iz0Hv%2FQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:29.4575097","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A29Z&sr=b&sp=r&sig=%2BiWHcuoPaJXofQnB6PIXi%2FnfQ2zOaHbJC6MvFOzXRAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:29.457422","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A29Z&sr=b&sp=r&sig=MCCB%2BFgq9lUdHkMdHiMbANlX9JTwnkO4WCgVnH7bdGg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:29.4575321","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:08.335Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:01:29 GMT
-      mise-correlation-id:
-      - 817988e1-fb14-40e8-ac8f-f5cbfb69b34c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A34Z&sr=b&sp=r&sig=j5g38c03oXqJRUkzFh9voyOoJYsbw7%2FUDUsE0tGKH80%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:34.7601642","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A34Z&sr=b&sp=r&sig=BfZdaBqvdmEdmeKGSxtojHd24uhg%2F0o5PQh3mVicVKM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:34.7600691","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A34Z&sr=b&sp=r&sig=A9%2FinUdDtElNxAEN9A0ccvLF%2BrF5AniHSKJtriN40CI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:34.7601858","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:08.335Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:01:34 GMT
-      mise-correlation-id:
-      - 5b13592c-c3f8-4991-aab2-0783ce25656b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A40Z&sr=b&sp=r&sig=nwEQp03KBvSeGrctto5Tu6%2BBcGrwwtCHggFK%2BCV7bZ8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:40.0313942","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A40Z&sr=b&sp=r&sig=UhLROJVlXzycFSiEblQKJWYNaUCqvNSGBWY4S76MU48%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:40.031289","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A40Z&sr=b&sp=r&sig=KNN0hWA%2FaQFvVr5dzl%2BxcXZuIbXlR%2BmcfnVELTH1Gaw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:40.0314164","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:08.335Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:01:40 GMT
-      mise-correlation-id:
-      - a5f9c06d-8520-4b7c-9587-0e9b2e1cc4b0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A45Z&sr=b&sp=r&sig=vC5pqtegljKwSs%2FsNn%2B3CPIn6VkTCKAi2qTB0DfBZeA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:45.3760874","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A45Z&sr=b&sp=r&sig=vIWuoOhpKCCJebUUvMBVKid7v0GXfUPAO%2B0eevBM8vA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:45.3760021","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A45Z&sr=b&sp=r&sig=FlLlk5sfVxHRx8mOUsVQPwTbaNoo%2BQy30se95oWiJZ0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:45.3761093","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:08.335Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:01:45 GMT
-      mise-correlation-id:
-      - 9b421cfc-5527-4c99-bf3a-04dd855704b5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A50Z&sr=b&sp=r&sig=L7OejuNbfcrWxSR6Z8yOf6DHnya0a5WOyPRRxOjoX2M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:50.6759824","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A50Z&sr=b&sp=r&sig=x6AtzbdoQJG40fCfSzBTi6se8yVCl4d92qiT1tXzS%2Bw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:50.6758835","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A50Z&sr=b&sp=r&sig=Sgrt4ALyYQTUZlgno2X3Y%2FKTixCL4gqJq%2F6xKF7ilew%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:50.676003","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:08.335Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:01:50 GMT
-      mise-correlation-id:
-      - 597c707b-d9cf-4060-a32b-9a62296d5995
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A55Z&sr=b&sp=r&sig=TjIewHUwkHHI%2F3UFeA5hl9ZcMBNvrUV2CMqF2zK0qLQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:55.9662511","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A55Z&sr=b&sp=r&sig=p875GayKnp2JiLXaiPh4bSPpyVQe%2FJ6WXis5Mg%2Bp%2BBk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:55.9661286","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A55Z&sr=b&sp=r&sig=CHHHEOh5s9TD6YqRBTaOFakurbPvy9A7Pf%2FBl2O9A%2BA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:55.9662753","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"CONFIGURING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:52.047Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:01:55 GMT
-      mise-correlation-id:
-      - 01a91bf1-44dd-4cbc-b564-2ce797cc5d85
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A01Z&sr=b&sp=r&sig=1IRKFB1er78qFfBvsfHlMsL5YLdDMNRnnhKxigQNtHk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:01.3060451","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A01Z&sr=b&sp=r&sig=pdobFSRNdA%2B1%2Fxcd%2FX5i8e%2Bg%2Bi13zvdVSIkK%2FXDmLJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:01.3059303","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A01Z&sr=b&sp=r&sig=QP2i4FS6nXfKFQIslAQIE3iCa8RIxjlanNrV9Dc6Vgg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:01.306066","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:02:01 GMT
-      mise-correlation-id:
-      - 883e935b-fc9b-4dba-b970-ff7d916a6f85
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A07Z&sr=b&sp=r&sig=h7kNd5AV2%2Ftvh34umoYVma9q%2FaX2a1Xj2Uw0WYWECBw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:07.1179456","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A07Z&sr=b&sp=r&sig=9eSxlsAZ6xmog34I%2FEj5GRilH8CnJpoyPLQyQg6HyzQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:07.1178718","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A07Z&sr=b&sp=r&sig=wfeb7SM4AljmfvTyWIFWc%2BTBfrlubaB0bxzRcu10XsQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:07.1179611","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:02:07 GMT
-      mise-correlation-id:
-      - 8e33ff5d-aed5-4b57-ac96-ced3669451cc
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A12Z&sr=b&sp=r&sig=auHLPB1I8w0ytcWKT6yJUzuJRQYYVJSzQqid2dsZdMI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:12.4041594","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A12Z&sr=b&sp=r&sig=s%2B%2BLJE7V6uQyykaH7pIb89GSJZPuy2eHQUqsUVMqMsY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:12.4040844","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A12Z&sr=b&sp=r&sig=QO%2BXROwxdhYnorbAF1y6EZkOzr35oRrNYh88ENO%2FAHE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:12.4041749","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:02:12 GMT
-      mise-correlation-id:
-      - dc92ed33-48bc-44b9-9651-6db060596b72
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A17Z&sr=b&sp=r&sig=Y8Bpd9c1fpDtR06wevMXql9GBgxohCwZDdfCiMz0kA8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:17.675229","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A17Z&sr=b&sp=r&sig=vlnnXPdvGkCNmblajBzdfCZnwRfCHFQU5Oxztsrbtjc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:17.6751405","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A17Z&sr=b&sp=r&sig=PpBaD17EQUoEJlJnIOpsv8eV4ZjghlwU%2BUP9Uiws5Rg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:17.6752431","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:02:17 GMT
-      mise-correlation-id:
-      - fb5afa65-0a4c-4706-a7a0-23d16f9b1863
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A23Z&sr=b&sp=r&sig=FKNB0IFYGtI0x1B02JKusAtwnpQt9f9V1wxA%2B%2FaBf%2Fc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:23.0019523","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A23Z&sr=b&sp=r&sig=81KMg7Kp7M1nbydGVYOdbdDVBu0bklRvoPTOvKFnpB0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:23.0018822","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A23Z&sr=b&sp=r&sig=ZKd1I1q316NoHCCkpQwKEaFrvhIFnf0kaU%2BFUukYx9o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:23.001967","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:02:23 GMT
-      mise-correlation-id:
-      - 7ba6d1ec-5696-41c5-8435-4d23a34bca5c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A28Z&sr=b&sp=r&sig=IJfdt2b0GqRyS5y2RvT08TDxHJbZ6UHe6mrM0ZTCyBg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:28.34281","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A28Z&sr=b&sp=r&sig=C4uXiRrutGev1ss8DYtWqCunGMGWH%2F%2F3WlHmuF43HQU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:28.3427304","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A28Z&sr=b&sp=r&sig=87rOraMskimXrh5EatXeGFgoaeXyexTFhupWJGw%2BbLY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:28.3428246","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:02:28 GMT
-      mise-correlation-id:
-      - 75873ac8-18de-485b-be3d-6401fba2e9a8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A33Z&sr=b&sp=r&sig=nXfRQNjXRcF1c84taZr9xyI3dCNM1%2BV5aVR1zqSk%2BmI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:33.6680342","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A33Z&sr=b&sp=r&sig=lBUx5NX7zFZnh619vO6JmULbiwC0h7aD2IuqgDu4KuE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:33.6679663","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A33Z&sr=b&sp=r&sig=6eJgKGm6nDodeS6mjsdkKyKByX%2F8NjOhuwXUFfIsqh0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:33.6680477","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:02:33 GMT
-      mise-correlation-id:
-      - ba364eda-e230-4880-bb0d-ddc3d397562d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A38Z&sr=b&sp=r&sig=ARQPQLcHhJ9gKpd07qygGY%2BjajD%2Fdf6vrBHmAP4%2FM3E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:38.9674106","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A38Z&sr=b&sp=r&sig=ke1kMa5kQaqeS%2B8AfNfQwl8NOzw5vgfXxZ73XpO3nYU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:38.967323","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A38Z&sr=b&sp=r&sig=jCW4OZsqqfkeYhXvXNsFtPM8Gdl7BHH1S1VdHjo9Wm4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:38.9674277","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:02:38 GMT
-      mise-correlation-id:
-      - 1a523414-a840-41e6-a202-787d1264c2fa
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A44Z&sr=b&sp=r&sig=8yNZT2KnhseLgdc8Tt6JBjhaYcSLbC%2FM5UWl2x17r3I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:44.2317429","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A44Z&sr=b&sp=r&sig=%2BdtiKW%2B9jGWsZHmsMZbLEVTjss1CvwtlpTbA56B8Avs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:44.2315948","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A44Z&sr=b&sp=r&sig=tc686Gxrlvdg4JB6OY1X7WgwUNtbfp3pcZ6mGCl8EoE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:44.2317676","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:02:44 GMT
-      mise-correlation-id:
-      - 9b772465-3c22-44ac-8b8d-8eb5c34ea164
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A49Z&sr=b&sp=r&sig=zs3wkMfkgf8o7l%2BSogNmm2QBn1LAwAQZXhq%2BpaenItc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:49.5251403","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A49Z&sr=b&sp=r&sig=oc2SKsOSj4KgOv3FVFltrnT4SG6JbUB%2B4hTg59pBSno%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:49.5250659","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A49Z&sr=b&sp=r&sig=nGClf7DOWeu%2BJrqRLm2q8obCnRFOltbc4KXs7xP7j1Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:49.5251548","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:02:49 GMT
-      mise-correlation-id:
-      - 09e29155-173c-425b-bba4-2e293d1b5c5e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A54Z&sr=b&sp=r&sig=nu1Jasu7Ywl%2B5CKcfUP9fvRpCjnIKyvdlK%2FaNldDH8M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:54.8132376","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A54Z&sr=b&sp=r&sig=fHYig5A2DA4IDXnSygR0dtKtJFKhZ2hNHhzU1VYN1rU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:54.8131465","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A54Z&sr=b&sp=r&sig=tX%2F0hI4nBG2gn4TY3duqVmjkhRlzbX39ROLJEKt%2BvpU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:54.8132607","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:02:54 GMT
-      mise-correlation-id:
-      - 0c7f880e-b8b5-48d3-85c5-4dff743331d6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A00Z&sr=b&sp=r&sig=y201uHo50AdP0%2B5G7L%2B0x%2BJT4DiAkTX7MaM2gzZ6g0E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:00.0822064","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A00Z&sr=b&sp=r&sig=lLJzUzLV%2BSat7BJlv%2BuXaoL3nlEFOdySC1k0FSPwx8c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:00.0821105","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A00Z&sr=b&sp=r&sig=jMdaV0wW6BNRk3oA2XMH5qpKzoWTnUYyZ3AT10U38vw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:00.0822316","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A38Z&sr=b&sp=r&sig=iEwlfIytcM4%2BhTICDSF5cL%2F1bb18iImi6BC4ySB5Dbg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:38.6701957","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A38Z&sr=b&sp=r&sig=NXRvNHqammltpbR5t7tMqSG%2FPsAo40EFjJUl0lWq0GE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:38.6701052","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A38Z&sr=b&sp=r&sig=eLjzhqwQEN3K3KmE63V7AfgB%2F2Haj5HVnm9ZHi0rp7g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:38.6702262","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.348Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1470,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:03:00 GMT
+      - Tue, 24 Oct 2023 12:38:38 GMT
       mise-correlation-id:
-      - 9243a11b-e248-4daa-bde0-2fc773ab67c8
+      - 33422c7a-4051-4b77-856f-26cbfc2f2fc8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1492,10 +772,478 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A05Z&sr=b&sp=r&sig=e4XbD2OHpG30xLc5FkwJkAKyLspXFyMVhp9Sj7Xl6jA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:05.3852011","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A05Z&sr=b&sp=r&sig=11hlP06xjT4JcfGi6v%2F6rUlt5YBAKM6%2BDE98ypWIubA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:05.3851171","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A05Z&sr=b&sp=r&sig=NnfSE3u4H8qug1gz97okCysnAujttIDr44gRPAN1G54%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:05.3852148","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A44Z&sr=b&sp=r&sig=G8hu3M%2Fwd8p0QRIOWyxOq4PT4SI6%2Fqa7iWEUja40xPM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:44.9860634","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A44Z&sr=b&sp=r&sig=g%2FRn3BP3qYGTc%2Busk%2FuAvflp%2F5Tlcsk9rji3iqmooQ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:44.9859797","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A44Z&sr=b&sp=r&sig=kMwaHCCf334JM0D1fOHhWApOmeiyQOk1YRV0DugpTMo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:44.9860864","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.348Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:38:45 GMT
+      mise-correlation-id:
+      - 9714dec7-a3b1-4b36-831f-9b2f3fae8309
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A50Z&sr=b&sp=r&sig=%2BDl%2FAYsYIqj%2F6Z3IY28HRZlr23ul4OC5D6BBy3m3Ej4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:50.3298438","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A50Z&sr=b&sp=r&sig=o9rbOsHnhn6%2FU5xJ5eE8OP0xW8gQJno6TI8yrADBXmw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:50.3297298","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A50Z&sr=b&sp=r&sig=b5KwU6expbUr7NqKOi0bwsTDfQ2jKyYgc65VcM%2FBXXM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:50.329868","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.348Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:38:50 GMT
+      mise-correlation-id:
+      - 6d4c821f-812c-4f50-8ed0-2ee83cc52000
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A55Z&sr=b&sp=r&sig=tjSvhfEnq7RbMwsHuINHXjX%2FnodQTRSrEQZimj%2FLATo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:55.5830536","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A55Z&sr=b&sp=r&sig=467WNj6NYRdKPRUoP0B0JSkCR9XAGDnhwElqX%2FOXo4E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:55.582961","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A55Z&sr=b&sp=r&sig=XzC9rNNJsXnXC8nCzPyp6EW32ZC8ekmffLZDiiAxQxQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:55.5830686","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.348Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:38:55 GMT
+      mise-correlation-id:
+      - 8a2b0158-49eb-4104-86ff-690c1e034150
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A00Z&sr=b&sp=r&sig=V9Iyqb2LHLpcdr88qg4Klxdjk2DjjRKlEyTayuYAUCA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:00.9784178","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A00Z&sr=b&sp=r&sig=8mZUSG5GD4LYOfCS%2BvS5UhDjDwQ%2F33ogtGhfaNeZIAg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:00.9783292","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A00Z&sr=b&sp=r&sig=G6Sb%2BQ0vwPrVh2DGvkFNhpm0Qouh9t1zUmBf%2BSH%2ByoM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:00.9784392","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.348Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:39:00 GMT
+      mise-correlation-id:
+      - 6137ad8d-9886-4776-addc-d9cc546ed5d7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A07Z&sr=b&sp=r&sig=prCLLYD94mG6zTYav%2FA3uPNA7nyt8MbV8TNBoIObq50%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:07.0448659","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A07Z&sr=b&sp=r&sig=16ye8Bjf9VUsXlREjcBgTsObXxrrTlArjibZHZVBJ34%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:07.0447591","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A07Z&sr=b&sp=r&sig=l0VhUKTIVwcf13bMjavXrCRAMRU%2F8nvxsMlhWUdMGRw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:07.0448904","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.348Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:39:07 GMT
+      mise-correlation-id:
+      - cf955e00-0f18-4039-8d0d-c2b5ba2ad62f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A12Z&sr=b&sp=r&sig=3k2zSb0pEF0ii69d8GB8JumS0wl6orBDArYVUVka%2FOI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:12.3222718","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A12Z&sr=b&sp=r&sig=J%2BvScsxgWcKGueStgC1Ay7xuOW03Fwu%2FBm9s0ZlmGZI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:12.3221675","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A12Z&sr=b&sp=r&sig=QbcM7M%2BT33rRokV6jXQCtXS7pnopEQtiUN6EqgTfH34%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:12.3222963","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.348Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:39:12 GMT
+      mise-correlation-id:
+      - dbbe771e-3956-4c47-9199-3bbf2ba28f2e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A17Z&sr=b&sp=r&sig=tWHxQpW0krY8u5Pu5w%2B%2BE4o3rGdpls8mO2qzMvZQojw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:17.6338305","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A17Z&sr=b&sp=r&sig=BKYcLoDNwct1Hq6TUD13ZDzZ03VKkecNxgS4S4aZkzM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:17.6337544","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A17Z&sr=b&sp=r&sig=e6LAqXTbDrxeeOB1kovR4cibbj8V1Z2xXkyRB95e1No%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:17.6338465","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"CONFIGURING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:16.947Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:39:17 GMT
+      mise-correlation-id:
+      - 182edc37-3b6b-4af9-88f5-ec3af7cdfeed
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A22Z&sr=b&sp=r&sig=s8WFZSV1U5PkC48aIl%2FVXO01K1hJftjfPp2cOqL39MM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:22.9812729","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A22Z&sr=b&sp=r&sig=CQJ1piN7%2F45Dsr3r1M0viny%2Bleih%2BTpV7X1rNwvUZ9Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:22.9812151","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A22Z&sr=b&sp=r&sig=DM9mIzve05oMgCvpfZGv4cvZZjQruatKnwOGQO9VWbE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:22.9812869","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:39:22 GMT
+      mise-correlation-id:
+      - f87a9b70-90a1-4052-ba7f-a2fae29fe5a7
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A28Z&sr=b&sp=r&sig=zqYTAvz6XQgwpIPcqkehOPr7IEwX953SFAQAYWQpUps%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:28.2510287","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A28Z&sr=b&sp=r&sig=83rEdI3%2Fr1Kj%2F46xn1LM6l83858v5%2FV9OFqk6nesWYo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:28.2509229","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A28Z&sr=b&sp=r&sig=Y6P4smydWEwH51RGagbbx2u%2F1GqeDy2oRJDMkn240bA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:28.2510495","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:39:28 GMT
+      mise-correlation-id:
+      - 59ac9436-902b-4357-9f97-8e5044a76328
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A34Z&sr=b&sp=r&sig=1RFDyOVp9%2FllA%2Fmo%2FLOR%2FzwP%2FUAbdBmNd%2F6N6Pk6MHM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:34.7771794","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A34Z&sr=b&sp=r&sig=9GYMwGeAR0mwLej6KZ8CQ5usxck3Eh%2BgUZgmiTuPtcA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:34.7771137","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A34Z&sr=b&sp=r&sig=m%2FKY3hJ588YIzk8iFpCQHnbCUJvpL4Mf17JuR3kkYyk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:34.777194","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:39:34 GMT
+      mise-correlation-id:
+      - ecf64a6e-3847-4adb-b539-3d41a503a4a8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A40Z&sr=b&sp=r&sig=n95gRiYKAHUygdzCPRuP2igl9XOhPZTXwpaE%2FcyAy6I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:40.0789538","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A40Z&sr=b&sp=r&sig=niCipBenkXymWc%2BDNxRGmlG60%2FL%2FaeeCZ49DtdSA3jg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:40.0788657","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A40Z&sr=b&sp=r&sig=zRhzrKAvTVgS8gD4tjLZ5C5Jhim9agRXKsBI7u1raKc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:40.0789776","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:39:40 GMT
+      mise-correlation-id:
+      - 3f130b24-32c9-4f06-93ae-8e57dc14d4f6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A45Z&sr=b&sp=r&sig=VMf9BHDrg4QDGxFeW1UUECmGef9XvcWDhS6BM7K94Ws%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:45.4144003","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A45Z&sr=b&sp=r&sig=Oq2ve32qS4bqw%2F2CCQ%2FhWQyl4c9AUmWEyk28LsqKyn0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:45.4143128","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A45Z&sr=b&sp=r&sig=zeFOdYLXthq0eDbYWhkbw4mWfUxKfw%2FORJ8mPWXLV3U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:45.4144248","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:39:45 GMT
+      mise-correlation-id:
+      - f4792f04-2282-4a7b-b233-ca900e953106
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A50Z&sr=b&sp=r&sig=tB9GREV1XfREEmmgTTqvac9N7vRU%2BTdQSxvEAl8IFrA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:50.7224568","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A50Z&sr=b&sp=r&sig=zhyoK0sg7b%2BYXLvONJU7sxRudFHVNn6yrUq2trq8ANE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:50.7223785","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A50Z&sr=b&sp=r&sig=sfvNSfDBAVDYA7mhK%2BlBaOmuVTsrs2gaoXvX9t50m1Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:50.7224704","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:39:50 GMT
+      mise-correlation-id:
+      - c2a40db9-6044-42bd-8618-2ddabfb73b3c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A56Z&sr=b&sp=r&sig=2FY3xih86EWIbNOX8AlZb1StagWxbOVLxqXTZ8%2BItp8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:56.053256","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A56Z&sr=b&sp=r&sig=3mhVkf0%2Ba9zvg9xtgTcMQw7UdkYQLySi7RM6d3CjikU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:56.0531902","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A56Z&sr=b&sp=r&sig=ikOMZqjYkDOcVei7qD3xHduqSXvKl1s%2BMMuQNghxKQQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:56.0532705","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1506,9 +1254,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:03:05 GMT
+      - Tue, 24 Oct 2023 12:39:56 GMT
       mise-correlation-id:
-      - bcdf4cf0-a821-479c-bb5d-d98ee1ba6a7b
+      - b34bf8d2-fb93-4867-8d6c-cb390cd5e63f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1528,23 +1276,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A10Z&sr=b&sp=r&sig=N7df2OxNV1sixPo1ihI8rk5rKCDrATUNEA5O7aZCuMo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:10.6808737","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A10Z&sr=b&sp=r&sig=JDB%2Bva8kzpS88D8TGYff3GkLyIdWm7I8IjT2Ab8Wi80%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:10.6807955","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A10Z&sr=b&sp=r&sig=dCrezkeNEgy3GQ%2BfOd3ze6QSN%2BszP8yj0Yc68Q%2FXUIM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:10.6808905","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A01Z&sr=b&sp=r&sig=lW7RdBchKhM9rgmmFM%2Bgq7vyJ3UyUp46bDdC%2FrJEYJ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:01.3127621","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A01Z&sr=b&sp=r&sig=WWsV1xIb7cPIGNMRlylhgAP%2F0wCD8QGM4aYXbAK8Zsw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:01.3126839","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A01Z&sr=b&sp=r&sig=9LEtu7ptkFiKGTWr6a38Fpkl2fRnqZx8nB6M4fJrdgw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:01.3127774","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3200'
+      - '3197'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:03:10 GMT
+      - Tue, 24 Oct 2023 12:40:01 GMT
       mise-correlation-id:
-      - 5f88ec17-0d05-4d69-930f-b525f1cc812c
+      - 2f304894-841f-4bf8-bdc9-589ff94a41b4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,23 +1312,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A15Z&sr=b&sp=r&sig=oN3rppXUxknaCPq1mWi2fwTg1IJiUrlYri6wUq%2BKg7w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:15.9446476","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A15Z&sr=b&sp=r&sig=kXY8Lz%2BFXGNZwdLobBn4ERAFgFaU%2FQXYFBlRgsiiiHI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:15.9445552","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A15Z&sr=b&sp=r&sig=NoAZmqEmlivt2%2FTtI4J2iEsftc2ABJ0nwr0XjM0uPtw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:15.9446618","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A06Z&sr=b&sp=r&sig=qhkltbzDonm%2FURMn%2Foe0iVP5zXNmRrWve2JmG5iZNtA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:06.7008406","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A06Z&sr=b&sp=r&sig=DfHEhIgWF2SYJBapGPEMoxYw16lxmP6zmKcLtzJy3G8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:06.7007664","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A06Z&sr=b&sp=r&sig=CjvvbvLMcRaQel5NrlNmXhauEKOG%2Ffj9x5FHQjRh1Yk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:06.7008545","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3200'
+      - '3197'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:03:15 GMT
+      - Tue, 24 Oct 2023 12:40:06 GMT
       mise-correlation-id:
-      - 06810e2a-8dad-4f53-94d2-801933a2efe1
+      - 7523e45c-4b00-4c1c-bc1e-30a6c94bb116
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,23 +1348,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A21Z&sr=b&sp=r&sig=1m2Jif1FVFSmRGClhZj7w4znYdA1oeYk6GR8RP0zza8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:21.2618887","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A21Z&sr=b&sp=r&sig=C28%2BSlQ1wHyz3Uofp470a%2B0B8s3jr%2FrKfCkjfl4tw5s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:21.2617787","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A21Z&sr=b&sp=r&sig=hG19Sx5eHSP2%2Bj07f6wW7TFwni8xpvZALovOaRjockg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:21.2619097","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A12Z&sr=b&sp=r&sig=9bmlcFd%2B5%2BJtX6C8zgbByPIpXVAchFQK3smGi2NU5Zg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:12.007771","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A12Z&sr=b&sp=r&sig=X5r5arTYAlNaoc4LYjBFjlAO2wWrCDETaaUVp2nhR6M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:12.0076861","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A12Z&sr=b&sp=r&sig=eK%2B%2BTiFl7OIVTCRTo%2BdxXcA906G1fBMscZa1fpP56AY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:12.007793","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3200'
+      - '3199'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:03:21 GMT
+      - Tue, 24 Oct 2023 12:40:12 GMT
       mise-correlation-id:
-      - 6f4dfc67-2b25-4d46-aad0-8c9ce80829df
+      - 59e25a77-8294-4e6b-ac03-1478eb1822b2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,23 +1384,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A26Z&sr=b&sp=r&sig=Ar9hY5lw0aK%2F8D4903SktoKWULcsAf4Ji6kw6IESl30%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:26.5799042","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A26Z&sr=b&sp=r&sig=FSZpLuWy%2FeOXw3w%2FJVuz6gHDJSL2a0V7s%2B4LUFqr%2BaY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:26.57981","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A26Z&sr=b&sp=r&sig=W%2BTsua3psH%2BmVBuY2Ii2u0Qv6mcuSQYlGQKlBR0%2BYd0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:26.5799256","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A17Z&sr=b&sp=r&sig=b8BlwHsbyWGjSgiYJrZs7D%2F5hQLCp6HV5VEwrICHaZo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:17.3348206","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A17Z&sr=b&sp=r&sig=mZhTNusLHQWiop%2BIvYTfAiGBfwV0EAyycjWqMqBFbJ0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:17.3347355","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A17Z&sr=b&sp=r&sig=F1NCYVBNgrU5aAwCs%2FvE0RzxR4O8I8NFbheQ8B3J0h4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:17.3348353","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3206'
+      - '3197'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:03:26 GMT
+      - Tue, 24 Oct 2023 12:40:17 GMT
       mise-correlation-id:
-      - 29d45175-00e2-4445-b222-51ecbfc1e39f
+      - dc2707ea-c3aa-4523-8a77-49f2e5480b69
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,46 +1420,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A31Z&sr=b&sp=r&sig=7pZoWCO5Yomtjqx%2FC45dexpnw4bon4SQWP2w%2FiOeuZ0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:31.8532882","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A31Z&sr=b&sp=r&sig=%2BNSPffOt0QJ5nSR%2BIA%2FFORKi50LxwJArXHjNBLhEdrg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:31.8532018","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A31Z&sr=b&sp=r&sig=khOY0P96TERyolvFPQ4%2FG5ogxUF%2BdPf9jYJjf34haxg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:31.8533099","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 21:03:31 GMT
-      mise-correlation-id:
-      - 36a6720d-0d81-45d2-9c36-634d5179ad3e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A37Z&sr=b&sp=r&sig=eeBBt%2BP3dFjI%2FKmCBm7DLOxd64CP8D6Z1K1ZCjlnquw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:37.1259127","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A37Z&sr=b&sp=r&sig=H01xnn%2BBJRRu9XZmfeTQlsmjsLUE3kEfqQxGJiiW0N4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:37.1258219","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A37Z&sr=b&sp=r&sig=riqteZ3%2BXSQPEMHUoVIw88C8%2FxHqRlmy5VNrVaN3sKo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:37.125934","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A22Z&sr=b&sp=r&sig=P91kmHTShPbCGQk0P601lRUQ0ulPYhtCEecRSqRJDCU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:22.6830868","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A22Z&sr=b&sp=r&sig=oRuHQdZTxFyh%2Bp%2Bfk6cTdbPCCCQwttqxq3LfDFk3fGM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:22.6830014","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A22Z&sr=b&sp=r&sig=hk%2FfDgaTyQGg8madBzK2h%2FYqgPHrGpAu%2FunA4OAqhIQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:22.6831007","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1722,9 +1434,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:03:37 GMT
+      - Tue, 24 Oct 2023 12:40:22 GMT
       mise-correlation-id:
-      - 7628793d-3ce9-40c1-8966-21b656cab21b
+      - fe007427-6708-44cf-9d5c-566e6cc64328
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,23 +1456,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A42Z&sr=b&sp=r&sig=uCZbSOdvZDJx%2Be%2BLuHoof0CpNAaK6ALDwL5WC4BnDnc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:42.6539914","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A42Z&sr=b&sp=r&sig=rEUdiFpGEfKkWUTnMzSoAU3Gl4gzGmogSDrIsIh1VEs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:42.6539243","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A42Z&sr=b&sp=r&sig=q8A8SJyDkcZyqSHZoTKUl%2Fjxi4eqBs4Uou6GqzKH%2F%2FY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:42.6540069","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A27Z&sr=b&sp=r&sig=zo6mOGrZu0N2kZYcA6m29H512eshdSS5hKI72jSWSUc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:27.9594515","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A27Z&sr=b&sp=r&sig=yRPuP79d5yIMV%2BwmVE0FVlt6p79G%2BRrK7vb%2BC9bLuZg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:27.9593711","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A27Z&sr=b&sp=r&sig=UDhI%2FBnpwWe3Pxbxw8acR%2BH6PohY1C0B5JjiDX7SJv4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:27.9594696","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3202'
+      - '3201'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:03:42 GMT
+      - Tue, 24 Oct 2023 12:40:27 GMT
       mise-correlation-id:
-      - 7f79487a-873f-4372-b408-64b43291d7de
+      - cd6fd491-0151-4b24-bca2-36ebbf44a6f2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,23 +1492,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A48Z&sr=b&sp=r&sig=HRzDFK7sci3FKBuAInozeSmjTKz3Veb3ah%2Fz9N7fObU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:48.0086446","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A48Z&sr=b&sp=r&sig=WbvYC3EBruzDaMqns835zqPT%2B6qVqurDj5JWu4JHvWA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:48.0085469","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A48Z&sr=b&sp=r&sig=EHuTz%2BR3Gf3vBABm3bT6qtc1nPc9DwoeBAQakaF%2Fo%2FE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:48.0086665","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A33Z&sr=b&sp=r&sig=S586quXfKbMp6UW2d0FzOY%2BJxRbYh6whqdvJm9AuFYw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:33.2497386","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A33Z&sr=b&sp=r&sig=1mbgvSWpjZuuvWRr9q%2F3ciRxgFOrl3j6px8YiVzQHi8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:33.2496403","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A33Z&sr=b&sp=r&sig=eDThP%2FZcm7l%2F7u7XFrtfzuwLtT9A3RrpDsz5PxJtOes%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:33.2497617","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3202'
+      - '3199'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:03:48 GMT
+      - Tue, 24 Oct 2023 12:40:33 GMT
       mise-correlation-id:
-      - 5e3cbf9f-629b-406b-9b6b-f08ebc743366
+      - b94e3a09-2244-4210-8ec7-a21c37431fc4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1816,24 +1528,276 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A53Z&sr=b&sp=r&sig=w7Sd%2BTLLsPzH1yIVYEgPONJ%2FrKOrqvViU1HreFNrIIc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:53.3124689","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A53Z&sr=b&sp=r&sig=fVajLvrMW%2FoOR2xYptevM3z5yNDHi%2BtQlPAw3rvj%2FLA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:53.3123984","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A53Z&sr=b&sp=r&sig=%2B%2FjAAIvuzLaeoVakixv74AOUMvLCKeNov%2FyRa34wjCA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:53.3124858","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-18T21:01:08.118Z","endDateTime":"2023-10-18T21:03:50.247Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:03:50.347Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A38Z&sr=b&sp=r&sig=pGWC0TKNhkM2nx%2B%2B7XO6Yxkha6TS9t0QreAEgak2xOk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:38.8687714","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A38Z&sr=b&sp=r&sig=K4HSi7RHL4fjkiX3J62t6RTj6O03GXW8c5AjcRlRgkE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:38.8686865","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A38Z&sr=b&sp=r&sig=6mbLZKdX8kiNQUnVdjNfqMaphApSAJWTVXCU0RNtKr4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:38.8687882","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3343'
+      - '3195'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:03:53 GMT
+      - Tue, 24 Oct 2023 12:40:38 GMT
       mise-correlation-id:
-      - b46d6b88-ced6-44b6-a5df-3bdc1a4b7f41
+      - 3f8a84b4-32a9-448a-bbbc-17ef76fd8189
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A44Z&sr=b&sp=r&sig=0gTSHxx%2FaTGUJVDzsQUB4qDxeqETRchD%2BA3Me8gOOug%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:44.1728041","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A44Z&sr=b&sp=r&sig=TW0%2B8PrRVEbS8PaGLjCSmi7huDTc2zwmJU0g6uv0mBY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:44.1727019","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A44Z&sr=b&sp=r&sig=dnWbQXxLNpvq0CpUHyErQEdPp3VFJQrzz3q6uU7bBLM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:44.172828","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:40:44 GMT
+      mise-correlation-id:
+      - bfacf9e9-e32b-4599-9ab3-a2c09874bfc9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A49Z&sr=b&sp=r&sig=gJ3EjSWc53xR%2FpMNj7No2UvfUUuNF5CHMdOU%2FVMUk2M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:49.4939703","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A49Z&sr=b&sp=r&sig=RUg4omaXXl5lNaM7hb9ChjMo2b%2BI9jmZzo7dgSxyVVo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:49.4939016","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A49Z&sr=b&sp=r&sig=QB5LeQdMw0CL6c18MgC%2BQ9wXM0mbQ8IX7ExRQgr4%2BVE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:49.4939857","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:40:49 GMT
+      mise-correlation-id:
+      - e9fa8f72-1323-4568-8ff9-057579827c08
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A54Z&sr=b&sp=r&sig=XIHwapOez9PjJu5tp1syDfX85p7QqFT%2BOhN1bzhY%2FEM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:54.8327978","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A54Z&sr=b&sp=r&sig=r7P861g8ldGTWi5RrspmQIj5xY9mEojSDBAlCDOkSec%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:54.8327242","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A54Z&sr=b&sp=r&sig=dInzbI1HZtReNMZVtof2otZK%2BYlMQnwiQAfrD6lfFEo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:54.8328117","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:40:54 GMT
+      mise-correlation-id:
+      - 8b7e47eb-0e40-4dab-87e2-2c14d4edc20b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A00Z&sr=b&sp=r&sig=iodPFluEKSVJdYC6C4R2m0qaEDn330M93uOkW98wGFk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:00.1525604","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A00Z&sr=b&sp=r&sig=2qB3sPVysYf4L0e8ONgI6Xa3wESH8nbVroHD%2FH5H1bk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:41:00.1524894","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A00Z&sr=b&sp=r&sig=aoqTOROW93NRAA11DTtYxJ%2FbhXnnqLAMfimYkGc%2F3a4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:00.152575","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:41:00 GMT
+      mise-correlation-id:
+      - 681a93b6-6629-4844-8450-1ff9c0158b84
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A05Z&sr=b&sp=r&sig=tJMxBbVJ0bSPqD77HOUxHsyh4coIoaoNfaOumWhRuEY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:05.4869967","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A05Z&sr=b&sp=r&sig=lqsFd%2FC%2Fb5KwO6BJIBEKFSCiSPGcdmZDjCOsbtgx03U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:41:05.4869259","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A05Z&sr=b&sp=r&sig=F9Fg0bf5o%2BAPFoP%2FO1ynWwxEw4IsTQV5AaLwKWzdi0M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:05.4870107","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:41:05 GMT
+      mise-correlation-id:
+      - c59b3abb-aca0-4ab9-a1ea-91949bd28613
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A11Z&sr=b&sp=r&sig=RO5vzR%2BCSYQ6gnkwVq%2FSvHJn2y3dNoQ3svE0kGKSKRk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:11.2479289","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A11Z&sr=b&sp=r&sig=PVKkRao77tbtYN6mxzPl8lvls0%2FPplwoBg4qDhb%2BRHs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:41:11.2478623","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A11Z&sr=b&sp=r&sig=IFkMFIxHdJknn%2FBNFLMfo9fZf8ML6O8SssrPoLXBQls%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:11.2479435","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:41:11 GMT
+      mise-correlation-id:
+      - e28d4cb9-6aef-4696-ba69-10712f3805f1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A16Z&sr=b&sp=r&sig=DYLvyiDqMI%2BuK%2BUTdHcrj%2FPFEjDRmUmFUMD7YvFW4IA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:16.5968222","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A16Z&sr=b&sp=r&sig=2z2RvFdgdpWvGtimwkt2fLDVRBCymoPhxPjpCJ8wGTE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:41:16.5967557","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A16Z&sr=b&sp=r&sig=HA%2FlAziXWxghfOr4k5j%2FMzz1FBEd4PKQE5jqLVoLCMI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:16.5968364","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-24T12:38:33.174Z","endDateTime":"2023-10-24T12:41:12.772Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:41:14.269Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3336'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:41:16 GMT
+      mise-correlation-id:
+      - 9879e0ee-82d1-4583-84bf-df471aa87719
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1856,7 +1820,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:00:05.4265706Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:00:05.4265706Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:37:32.8275879Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:37:32.8275879Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1865,9 +1829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:03:55 GMT
+      - Tue, 24 Oct 2023 12:41:18 GMT
       etag:
-      - '"7500ab84-0000-0100-0000-653047570000"'
+      - '"d300a757-0000-0100-0000-6537ba8e0000"'
       expires:
       - '-1'
       pragma:
@@ -1897,24 +1861,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=update-test-case&api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=update-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A56Z&sr=b&sp=r&sig=Y2L%2FeTnyDtMI6dNJZwcQ%2B7DGA9t%2BewbnTfxwscsoJ3U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:56.9661402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A56Z&sr=b&sp=r&sig=AtupBzmw8SXZHUQ%2FLqSo3l6rdH5eS04sMQV%2FZZcd6sI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:56.9660704","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A56Z&sr=b&sp=r&sig=lYLqP2LRS5XpcUCSLfLb8ryoB9221SDB6eZN5icG2Bw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:56.9661552","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-18T21:01:08.118Z","endDateTime":"2023-10-18T21:03:50.247Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:03:50.347Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A19Z&sr=b&sp=r&sig=%2FHsO3B1MbQcFqWm3cCvE1RHH%2ByPrg1SflXUZrC2mazE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:19.4161485","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A19Z&sr=b&sp=r&sig=z7VEHDZnKANjzQDSHW0dg%2FkAeKqBXg7qUPOO2LFD7DY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:41:19.4160733","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A19Z&sr=b&sp=r&sig=n4AkjTUi285EgvH33rAkBooCu3cSOD8B5m6YPeaF%2BLI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:19.4161632","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-24T12:38:33.174Z","endDateTime":"2023-10-24T12:41:12.772Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:41:14.269Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3349'
+      - '3346'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:03:56 GMT
+      - Tue, 24 Oct 2023 12:41:19 GMT
       mise-correlation-id:
-      - 74fb3f96-3d38-47d3-b7e0-ca38a68fa765
+      - a10e9412-fffb-4687-b45a-945bb89b25b8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1937,7 +1901,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:00:05.4265706Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:00:05.4265706Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:37:32.8275879Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:37:32.8275879Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1946,9 +1910,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:04:19 GMT
+      - Tue, 24 Oct 2023 12:41:40 GMT
       etag:
-      - '"7500ab84-0000-0100-0000-653047570000"'
+      - '"d300a757-0000-0100-0000-6537ba8e0000"'
       expires:
       - '-1'
       pragma:
@@ -1978,24 +1942,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A20Z&sr=b&sp=r&sig=OxN6E6eU0%2BqcvP0cPOPJ5xPYoJsNgsQsG0657OJvJxY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:20.8634595","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A20Z&sr=b&sp=r&sig=JRtoJy4jrYgUsnbwPFLR6MLTGumafvc5t7uF6oo6nYY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:04:20.8633817","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A20Z&sr=b&sp=r&sig=WVPOmd1BJTI6p6JCzWbkytSaz2BFsoKg28SfDHTXWxY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:20.8634746","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/499faf9c-551e-45c0-a250-576b8c2ac218_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A20Z&sr=b&sp=r&sig=KvvTq%2BwUrPV%2B%2By%2B2VVhLs1O7%2F96cik624GgxkUYx%2FM8%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:20.8634879","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/499faf9c-551e-45c0-a250-576b8c2ac218_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A20Z&sr=b&sp=r&sig=Subbfqwq2yVQP4U5WCbwWVUtLueir%2BTbu1BXBbrOhzg%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:20.8635025","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-18T21:01:08.118Z","endDateTime":"2023-10-18T21:03:50.247Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:04:16.808Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A41Z&sr=b&sp=r&sig=wm5Hy0oJRcBygc8honEl9mbE%2F2LgFNwVhvK5ld3GKMU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:41.6277557","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A41Z&sr=b&sp=r&sig=fxyJMoH51PYTIaD5HWjI7gCGUxd75nZyrhYIkA7Db4s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:41:41.6276895","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A41Z&sr=b&sp=r&sig=ORhhSkvBC7M%2Fj6BErknGfXR3LazdPxCFUmvZA9K6ncU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:41.6277705","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/5889d508-9234-4e62-b777-691b556ebc88_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A41Z&sr=b&sp=r&sig=HvywYibtqgl7p3M9utr42k2rxXfMVNw5nVwjfEC6rFY%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:41.6277841","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/5889d508-9234-4e62-b777-691b556ebc88_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A41Z&sr=b&sp=r&sig=rx3VH85121yoV0j3LcvnHglYvvFV%2FxuruqBpi5inv%2Fs%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:41.627798","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-24T12:38:33.174Z","endDateTime":"2023-10-24T12:41:12.772Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:41:21.686Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4502'
+      - '4492'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:04:20 GMT
+      - Tue, 24 Oct 2023 12:41:41 GMT
       mise-correlation-id:
-      - 5689af57-6283-49a3-8819-9330f4bc37e1
+      - 31b9412b-27a2-47f4-af6e-2370569ddb96
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2019,25 +1983,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A21Z&sr=b&sp=r&sig=CKiNh8wZkbhdcGJnWDekyqnus23pqSOuPNon8SuVDOM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:21.2506113","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A21Z&sr=b&sp=r&sig=co12FPNh7S0mWDggonEGYV69gZMzovqu%2Fh8jlisSBT8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:04:21.2505375","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A21Z&sr=b&sp=r&sig=MuiKQcnKOCVxxbeprVrGm1PHGfNim8%2FjMExE2CxNY0g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:21.2506264","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/499faf9c-551e-45c0-a250-576b8c2ac218_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A21Z&sr=b&sp=r&sig=Xb0SambvcZAWQuloYb9tjRKUNCEEeQZyglaUATE07ZA%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:21.2506411","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/499faf9c-551e-45c0-a250-576b8c2ac218_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A21Z&sr=b&sp=r&sig=eG0wehuNdtTtNTkPyEumjkNxKXEbZ4CQw5A5CA2x82Y%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:21.2506549","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
-        test run description","status":"FAILED","startDateTime":"2023-10-18T21:01:08.118Z","endDateTime":"2023-10-18T21:03:50.247Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:04:21.241Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A42Z&sr=b&sp=r&sig=GSEb2bTvz9%2F%2F3qn7s11urFhV6JtTecFjZ5if02m5zfo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:42.0287404","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A42Z&sr=b&sp=r&sig=tQT2RNTADQTmMTlgFAB1C3m9gMIK2blsF2mPIr%2FMZFg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:41:42.0286825","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A42Z&sr=b&sp=r&sig=WDGOw%2F9nliltXXLKxfiFf040lg%2FzOI89vo3vqUSr2ac%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:42.0287552","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/5889d508-9234-4e62-b777-691b556ebc88_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A42Z&sr=b&sp=r&sig=hgvLUQ1TXY44rUDMx8nu9FjS3FHE7DMNf0VZDTJhw%2Fs%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:42.0287691","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/5889d508-9234-4e62-b777-691b556ebc88_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A42Z&sr=b&sp=r&sig=6672W94Fxiyifjm5Ra8fOJaR8KVBgsHrYdth%2Fe6t1Zc%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:42.0287832","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
+        test run description","status":"FAILED","startDateTime":"2023-10-24T12:38:33.174Z","endDateTime":"2023-10-24T12:41:12.772Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:41:42.019Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4535'
+      - '4544'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:04:21 GMT
+      - Tue, 24 Oct 2023 12:41:42 GMT
       mise-correlation-id:
-      - 8c0a3491-5ff2-470b-9f06-8b4fa8b49fb1
+      - f239674f-7122-4456-84c1-4d8004d77c1d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2060,7 +2024,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:00:05.4265706Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:00:05.4265706Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:37:32.8275879Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:37:32.8275879Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2069,9 +2033,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:04:22 GMT
+      - Tue, 24 Oct 2023 12:41:42 GMT
       etag:
-      - '"7500ab84-0000-0100-0000-653047570000"'
+      - '"d300a757-0000-0100-0000-6537ba8e0000"'
       expires:
       - '-1'
       pragma:
@@ -2101,25 +2065,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A23Z&sr=b&sp=r&sig=iFd2k%2FomCPpRvZ%2FnvVJNLGvR0ieSYJ4izVsAMQqddeA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:23.8956923","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A23Z&sr=b&sp=r&sig=l%2Bb41XVlZNdoChRqs%2F%2BDIwNMBroRnq15d%2FtQn7arlcM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:04:23.895622","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A23Z&sr=b&sp=r&sig=G1qIvd8EPNl4KOo5AUux6%2Fjm8A4ixbcuYA11n6DzyUQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:23.8957071","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/499faf9c-551e-45c0-a250-576b8c2ac218_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A23Z&sr=b&sp=r&sig=KuKVArffiNeoiNRxM%2FytepmF9cRwEc7VP4h8ulSx%2F7s%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:23.8957219","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/499faf9c-551e-45c0-a250-576b8c2ac218_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A23Z&sr=b&sp=r&sig=k1HsJHJA5f7EHEvFEYtJWJJ34ao6R3fICrnKqZljlJo%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:23.8957368","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
-        test run description","status":"FAILED","startDateTime":"2023-10-18T21:01:08.118Z","endDateTime":"2023-10-18T21:03:50.247Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:04:21.241Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A44Z&sr=b&sp=r&sig=I1HUZyfnbf4Do8A3Zut5fgTnMDgpDbdPfsy0CpdlW4g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:44.6010185","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A44Z&sr=b&sp=r&sig=f1RO14Rf0EH5AwvMR6nlxdUbpp6OnR3bCw92yfsXH88%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:41:44.6009472","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A44Z&sr=b&sp=r&sig=Ld8ag%2FPpql6rLSc0R1N3RAcpPSyiQ8rLIjFTxaLG5DE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:44.6010325","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/5889d508-9234-4e62-b777-691b556ebc88_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A44Z&sr=b&sp=r&sig=xPCKH8HPaQz4HxyaltiSEtAS%2FTsCx%2BbIGGMOGUgTIuQ%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:44.6010466","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/5889d508-9234-4e62-b777-691b556ebc88_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A44Z&sr=b&sp=r&sig=hDqn0vvbQQ3vDILMj3NlSGGpUBaB6nbNhj%2F67pMl9zs%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:44.6010608","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
+        test run description","status":"FAILED","startDateTime":"2023-10-24T12:38:33.174Z","endDateTime":"2023-10-24T12:41:12.772Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:41:42.019Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4548'
+      - '4538'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 21:04:23 GMT
+      - Tue, 24 Oct 2023 12:41:44 GMT
       mise-correlation-id:
-      - 6bc130f4-c4d5-4181-91ee-86ca981cde8a
+      - 4d5b0e19-9571-4d71-a1e4-e289e832a25e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_update.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_update.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:00:04.8936167Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:00:04.8936167Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:00:05.4265706Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:00:05.4265706Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:39 GMT
+      - Wed, 18 Oct 2023 21:00:39 GMT
       etag:
-      - '"d901ec7c-0000-0100-0000-65294d680000"'
+      - '"7500ab84-0000-0100-0000-653047570000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 14:00:41 GMT
+      - Wed, 18 Oct 2023 21:00:41 GMT
       mise-correlation-id:
-      - bdeb8f39-0b7d-478d-8f0b-e64c689d8d55
+      - e1710f88-c9d0-4d6a-8c93-4a653696f144
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"1e33ae22-2715-439e-bcc6-9b766cd03d65": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "11255139-f90f-426d-8aa3-dbf877da33a2":
+      {"passFailMetrics": {"d51e59fd-7da5-457d-9f97-b741816c8463": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "2c428843-c903-4c3f-9cff-097da70e820c":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc": {"aggregate": "avg", "clientMetric":
+      "50"}, "f5da1b17-25ae-4efb-bf5f-7deb5066ed10": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T14:00:42.365Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:42.365Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T21:00:41.604Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:00:41.604Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:42 GMT
+      - Wed, 18 Oct 2023 21:00:41 GMT
       location:
-      - https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+      - https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - c80b9b6d-c91f-4165-a18c-83c4d02d71d0
+      - 3f69cb7b-230c-4a32-a8ee-8b6b437a7b4e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:42 GMT
+      - Wed, 18 Oct 2023 21:00:41 GMT
       mise-correlation-id:
-      - c50b3a57-a8fb-4cf8-b3e5-9001d7c18eea
+      - 6ff0671d-a1ca-4be8-9ed9-43fce1dcc281
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,10 +275,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A10%3A43Z&sr=b&sp=r&sig=9VFT7hjtBBDCVr7UR2S9KjrTmL8Ik5pe9OGfOOnMwDQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:10:43.2759373","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A10%3A45Z&sr=b&sp=r&sig=HHXvsLlEL46jlTH4gdLLaJp0LNVQkGJxvePr8OsXjUo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:10:45.6319651","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -289,11 +289,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:43 GMT
+      - Wed, 18 Oct 2023 21:00:45 GMT
       location:
-      - https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 59161456-d403-4fdf-85ba-9989defee502
+      - 236e98fe-10c5-4fe2-b15d-abdb2a245bb1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A10%3A43Z&sr=b&sp=r&sig=aLIr99TCfKeRyfa5wsFin4L6gSq%2BfD2bZj75NZ%2FzOTA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:10:43.5415752","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A10%3A45Z&sr=b&sp=r&sig=6llYXSscv3AZt%2F7XbFwwvMEnkVWlv5DlA5PVc%2FEKmOE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:10:45.9316804","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:43 GMT
+      - Wed, 18 Oct 2023 21:00:45 GMT
       mise-correlation-id:
-      - b8845bb7-674c-4e43-872e-647517d27b4c
+      - 9db9e66a-ecab-4bca-b146-bd56070a39ca
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,46 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A10%3A49Z&sr=b&sp=r&sig=d9J3SQS6jvV4YIIrhHrF2X%2B6Wn%2F2uik7N%2FeeUtuzS3Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:10:49.3375767","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:00:49 GMT
-      mise-correlation-id:
-      - 7aec6cf3-5f80-4484-9dfc-e7f761c224a1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A10%3A54Z&sr=b&sp=r&sig=xfFlmkXb4eeu%2BY8%2Bvd89naZqBAQT4SORiCz8vpccII0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:10:54.6156257","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A10%3A51Z&sr=b&sp=r&sig=501JtCqFUCw%2By6WS9eQPOTlQazsxWzdDAs80Xkk4%2FR0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:10:51.2517241","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:54 GMT
+      - Wed, 18 Oct 2023 21:00:51 GMT
       mise-correlation-id:
-      - d2156233-8b38-4cb6-b7f7-c2378955b13e
+      - 5b8fcdde-891f-4baa-bfbf-550d81e2fa23
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A10%3A59Z&sr=b&sp=r&sig=CmZLkdi2PeUSW0ewO6E9EffXtMayydCXSPeGk75SaiI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:10:59.8720481","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A10%3A56Z&sr=b&sp=r&sig=HQ00lte%2BJULqrgE4LgA%2Fs19Pnya772AfoTGyhhFhrJg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:10:56.5440011","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:00:59 GMT
+      - Wed, 18 Oct 2023 21:00:56 GMT
       mise-correlation-id:
-      - 680b671d-2d01-4d51-8068-315ce97e452f
+      - e8125eca-cf57-4c2f-9b8c-bf459f157ed6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,11 +421,47 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A00Z&sr=b&sp=r&sig=putTES0vuXwoHE6mT2gySm8CiZ3RhbRnMNm%2FN17qqY0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:00.1536715","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T14:00:42.365Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:56.286Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A11%3A01Z&sr=b&sp=r&sig=G0HcAl39fj2Pf25394uiFUCnne1l%2Fj%2BGyNU1We3otEA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:11:01.8391517","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:01:01 GMT
+      mise-correlation-id:
+      - d76f4258-e6f2-4c87-a751-4f80d755cccf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A02Z&sr=b&sp=r&sig=j1bRQ%2F5y8%2BYCbEnM2fNC9FUUuUmkGoUFC9CrM6QnRU0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:02.15059","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T21:00:41.604Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:00:57.676Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,9 +472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:00 GMT
+      - Wed, 18 Oct 2023 21:01:02 GMT
       mise-correlation-id:
-      - 56398d78-e2f9-466e-a43b-1402f5c92911
+      - e1674189-bf21-4abe-ad4a-aa46443f1276
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:00:04.8936167Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:00:04.8936167Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:00:05.4265706Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:00:05.4265706Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:01 GMT
+      - Wed, 18 Oct 2023 21:01:03 GMT
       etag:
-      - '"d901ec7c-0000-0100-0000-65294d680000"'
+      - '"7500ab84-0000-0100-0000-653047570000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A03Z&sr=b&sp=r&sig=YqRhvN2XlZLVYC0LTavenHIIFDD191UKS%2FJw6CqNh2w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:03.2558542","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T14:00:42.365Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:56.286Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A04Z&sr=b&sp=r&sig=h%2BgXul%2BKEbo3SQ6LG3IiaZbMG0TWL31B76%2FsglemSS4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:04.4564431","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T21:00:41.604Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:00:57.676Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1591'
+      - '1595'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:03 GMT
+      - Wed, 18 Oct 2023 21:01:04 GMT
       mise-correlation-id:
-      - 62f2aa4d-6349-4bfa-8830-155a01a5562e
+      - b76eda63-ca61-4eb6-800c-8881ce3b7d2a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:00:04.8936167Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:00:04.8936167Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:00:05.4265706Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:00:05.4265706Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:03 GMT
+      - Wed, 18 Oct 2023 21:01:05 GMT
       etag:
-      - '"d901ec7c-0000-0100-0000-65294d680000"'
+      - '"7500ab84-0000-0100-0000-653047570000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 14:01:05 GMT
+      - Wed, 18 Oct 2023 21:01:06 GMT
       mise-correlation-id:
-      - 1f6fea90-b71e-4544-94e8-cf8bc7d7034b
+      - 617822c6-557b-4369-93d8-87117e32bc59
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A06Z&sr=b&sp=r&sig=2wx89lKRB2PD5H1wcC%2BlknVD5WDM9RT6ZmiUcnLWCDU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:06.1086709","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A06Z&sr=b&sp=r&sig=u0BDiHxZvaWDfSUam2fqGNxDs%2FNaiZK5Ug0E70J0Hy8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:06.1085375","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A06Z&sr=b&sp=r&sig=41olk9W8pM5VYC9vHh3GLCzr1Gv8PZ19xUJeXq64PBw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:06.1086942","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:06.026Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A07Z&sr=b&sp=r&sig=0bnJVIwuHfhlahYrRUpjVHQFCwsFI3K8p4kNdIZ0i84%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:07.7740297","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A07Z&sr=b&sp=r&sig=ujihJ1grP6OPzBvqH1Wizr66XNsEVEK3wkH29lT2JVk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:07.7738927","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A07Z&sr=b&sp=r&sig=g7%2FMn%2BAAtW3bTooXh6vCPcpb7pnCoFf%2BT5gLwG6rMmk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:07.7740612","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"ACCEPTED","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:07.656Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3152'
+      - '3154'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:06 GMT
+      - Wed, 18 Oct 2023 21:01:07 GMT
       location:
-      - https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+      - https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - e1351d96-d092-435e-b8e1-d3592409e740
+      - d69ad249-0956-49a7-99b9-ef6fb87c3ecb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,370 +700,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A06Z&sr=b&sp=r&sig=XPOTvSJWt2xg33TRWI5Uf65G5PAj6VXMNO6hAq3dVqw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:06.6958242","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A06Z&sr=b&sp=r&sig=yYYCW%2FyZRhWSIHqJ91sG7MORBAnthj%2FzJ6dyu1CgMgs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:06.6957556","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A06Z&sr=b&sp=r&sig=JpMvdodJLVYRCgWI0UvtnvuSJ9Z5H9aTa0knNyE5IRI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:06.6958376","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:06.026Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3152'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:01:06 GMT
-      mise-correlation-id:
-      - 569cb83c-e00e-4a75-89b4-21c11209fd59
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A12Z&sr=b&sp=r&sig=VxGHBTSE9IYYyGoElCgo0gy9EcXi7ZnblouNima2rWA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:12.0536344","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A12Z&sr=b&sp=r&sig=hSkPldJDdvbqOBX9TidkgnyPqEoJhZM5lip3tzspS%2F4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:12.0535425","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A12Z&sr=b&sp=r&sig=o1UCxOc41H6vcnQSoSiDhdtIdvGIscAYtB7TR8kiupA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:12.0536563","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:07.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:01:12 GMT
-      mise-correlation-id:
-      - 4c5b328d-3c34-420f-86a0-96a00821ebe3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A17Z&sr=b&sp=r&sig=gDt4Pe8dY7SEWcpi90tDtrmz7UWFp7Hk0c9HzRIx%2BJY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:17.3911509","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A17Z&sr=b&sp=r&sig=JJ6%2BfgVtnSHH74Syn9T0B5WMQdYvZuawITA32qCn2zE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:17.3910533","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A17Z&sr=b&sp=r&sig=zUj07Pd0wRMKimVYhr7iLDkbAQO0Q%2FuXY4dAq%2FmblHw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:17.391176","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:07.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:01:17 GMT
-      mise-correlation-id:
-      - 80bbab42-4b1d-483c-ae1c-f88c879b6fe0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A22Z&sr=b&sp=r&sig=YOiO%2Be1RQ8a6mEd7WtAyEmgIKUgb6Q1VREleImcrtsQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:22.7153491","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A22Z&sr=b&sp=r&sig=VyzQxiCaoeLpg5yrFB1SEV1XIl%2FY%2BGousMpbkQ4RJ9g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:22.7152776","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A22Z&sr=b&sp=r&sig=Ulwe6veURtDhFmxtW2nrIas70igjydfQlhSPjVuYyGs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:22.7153636","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:07.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:01:22 GMT
-      mise-correlation-id:
-      - db53b3ee-a50a-4713-9e40-19ea95a42322
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A28Z&sr=b&sp=r&sig=O7Cpt8g1fLkH6YkKZx7Owi%2FHJXTsgV6LAW9FrDukyYk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:28.010236","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A28Z&sr=b&sp=r&sig=q47hPqvkRlPRm216zNAJDXSlZOvDY3ZFkJonvfW2V5s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:28.0101564","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A28Z&sr=b&sp=r&sig=cXyD2mnj1g7TS1Alnv2bwhIbYJ6NWD82O8fHutC%2Ffzc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:28.0102576","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:07.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:01:28 GMT
-      mise-correlation-id:
-      - f66f24fd-36f7-47c9-921e-42421da2e889
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A33Z&sr=b&sp=r&sig=lxh3XolURUcuUcc0FTuvfzj%2BE4QpyjvTrZsuW%2FvU9lo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:33.2528021","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A33Z&sr=b&sp=r&sig=VbKDW%2FunDoGzdQYt1Ue%2FrM2T5XgyDuVrSfplOIqUdlk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:33.2527103","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A33Z&sr=b&sp=r&sig=Xd8EqEuKXUWEAeCQ7sbkjz0no%2Bkkx5MCTc78ureQU6c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:33.2528248","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:07.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:01:33 GMT
-      mise-correlation-id:
-      - c43fe15d-c396-44af-b3c9-7cc3df1dac38
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A38Z&sr=b&sp=r&sig=tuWfAN%2BsFGV58xKVSBdthAF0BQVFleU55mCwyEUDu9c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:38.5891889","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A38Z&sr=b&sp=r&sig=COqK5Nf5ZFtzwtF%2B1dU234BDurrNB5uSJJvXtOLsh20%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:38.589099","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A38Z&sr=b&sp=r&sig=hWeRIkxACVExrFkiZwJ%2FFfuo%2BaAknr6fl9sv%2F1TUfSo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:38.589206","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:07.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:01:38 GMT
-      mise-correlation-id:
-      - 6fd0c4e3-a6cf-49bc-becc-e9cd2b0b24e0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A43Z&sr=b&sp=r&sig=9Mpia%2Fjnw8y%2BStfI9JlLzlL37VTr2W8FjLW4tba70Mo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:43.9160275","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A43Z&sr=b&sp=r&sig=fIAf4LIlch2i9S%2Br66Hz74yK5iHGDLhdvUSqXy0kPsI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:43.9159453","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A43Z&sr=b&sp=r&sig=kJV3DnRt5K1x3crNLRfwf55pRDfqJSVRK%2BqTOD5t0HQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:43.9160453","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:07.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:01:43 GMT
-      mise-correlation-id:
-      - 32a0307d-e365-410e-951e-267317a81a3c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A49Z&sr=b&sp=r&sig=SjVODxOnL66bdC0%2FynV4k65mO4pitUWl1yyoKnnf%2BTY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:49.2294667","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A49Z&sr=b&sp=r&sig=%2B8HhaBMQCjL0Uqmt4gyf0eerGj55UHCKVfDF0MNLzrE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:49.229391","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A49Z&sr=b&sp=r&sig=MDXZ8SGRieMtNFjvKlKtuKB7WDi16u7YlOQDSuIEqs4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:49.2294812","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"CONFIGURING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:47.996Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:01:49 GMT
-      mise-correlation-id:
-      - 9e4e9ea2-84aa-40f8-afbc-cff515ef7302
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A54Z&sr=b&sp=r&sig=R6hCQjuq5WP4b6Wv0LKsMevtkD1jLm2rJYLY5q4Olac%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:54.4748384","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A54Z&sr=b&sp=r&sig=FzNwj2KNFfJnhWVtWxMnZ1vocAmwML3Le8BBvkbMtic%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:54.4747591","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A54Z&sr=b&sp=r&sig=A7fO8lHVwl1ZiJpZPoDtXgze60%2BPOQ2BcanNwo8BBPY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:54.4748562","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:01:54 GMT
-      mise-correlation-id:
-      - 263ddfa4-f5f8-40a9-b3c9-4a83f4fb4da6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A59Z&sr=b&sp=r&sig=LIeIpy9NrqcuilK5VDn8Pjy%2F4L69ZcxRGuR%2FkcPzHR0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:59.6985434","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A59Z&sr=b&sp=r&sig=I7ILCRFx7gHv2ajbEaEA%2F5j8HBFbvXzVL4BHlY3nS%2Fs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:59.6984512","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A59Z&sr=b&sp=r&sig=xSQ%2BoLLbp5dKnG%2F3lT3EgXgtm2UMjYqD1jq%2Byg5TjZU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:59.6985658","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A08Z&sr=b&sp=r&sig=oIy2gfU2djxp8FHVcfO0ojfoRJZq6fZOy1nnyV6fjlE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:08.239368","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A08Z&sr=b&sp=r&sig=GC83Be18XyG%2BiN9UxYpDFegVIf%2Fa%2FJIJ4ixQZ5R0%2BmQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:08.2392839","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A08Z&sr=b&sp=r&sig=T%2BfHRrf1c0%2FdrZlI4GYQKBRRjh6VKEabih%2BLcjIkhbY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:08.2393825","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"NOTSTARTED","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:08.118Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1074,9 +714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:01:59 GMT
+      - Wed, 18 Oct 2023 21:01:08 GMT
       mise-correlation-id:
-      - 49f1d9dd-b739-466e-bc81-4ccc32455b22
+      - b817a5f0-eaf8-491c-a9d5-28b27de475c9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1096,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A04Z&sr=b&sp=r&sig=PpG1Pytpz3T8Frk9ecDOlu7uogVGgEp5kxTzS%2BC6wMY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:04.9979922","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A04Z&sr=b&sp=r&sig=o0f9r1ydn1wzicQ3IzD%2FRtsxZWV6%2Be2cVZVmymzByvk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:04.9979094","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A04Z&sr=b&sp=r&sig=yOItqeLNw0hDEWinOgCQKjV1J2g68k8XHbCLSk%2B7eUg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:04.9980101","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A13Z&sr=b&sp=r&sig=9pYMkRnlqwqTuBhs4d9ik5mlDG8DsP9Zp4%2BuPR46iAE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:13.6181635","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A13Z&sr=b&sp=r&sig=Sw7Cqdv4oMba4i3RnGN2QmZq7XVl23IIUV3fznWGueA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:13.6180911","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A13Z&sr=b&sp=r&sig=5mE4HB1N%2FWn%2BEe3aGBe7ztE7lXr8T%2BUKfixiVH6LoN4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:13.6181786","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:08.335Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3200'
+      - '3203'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:02:05 GMT
+      - Wed, 18 Oct 2023 21:01:13 GMT
       mise-correlation-id:
-      - 8b501c91-16f3-4c7b-b433-34cdc74a8d61
+      - 24278a74-e6b5-4696-a11e-42def4dd8e19
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1132,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A10Z&sr=b&sp=r&sig=agtvMLAYGUC8dmj8bcH7eSZfLWNsd4qUNVrtIF1hi%2BI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:10.3460581","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A10Z&sr=b&sp=r&sig=OvFzpEXPcAWKCvGeLvAaKjPB2mE%2Fc8LS1VOjQU0DTwQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:10.3459658","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A10Z&sr=b&sp=r&sig=A%2FxmZ6lHlJcXyEtDDYuUwhylYSU8eNMQg2b5s6Qew1c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:10.3460802","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A18Z&sr=b&sp=r&sig=PPkk6wn0U6S3Ug8Ckbj8YpAy%2BtYnZYWvFt5xDUokuQI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:18.8911943","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A18Z&sr=b&sp=r&sig=zhmi0JKjG4bwdWTzVAQdBorIKx%2F4WhvMu2sx6sRUj4o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:18.8911213","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A18Z&sr=b&sp=r&sig=4pyBgHBYC%2Frcg9FyFmGv9o3d%2Bn%2B%2FPpvVY%2F5v8HZdG%2Fo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:18.8912087","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:08.335Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3198'
+      - '3211'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:02:10 GMT
+      - Wed, 18 Oct 2023 21:01:18 GMT
       mise-correlation-id:
-      - a6342cc7-eec5-4fdb-a61b-413c6791be15
+      - 8ad9da36-58fb-4a2d-a107-8a2d1d0857b6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1168,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A15Z&sr=b&sp=r&sig=eKdDMZvLzBpID33ZfceWgXzsUQHCe1vumMWHFyFrgtI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:15.6351615","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A15Z&sr=b&sp=r&sig=VgT1L3pDt0CMMsaw2spLcxwJSqPXYzcmb%2BUXq8qIoz4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:15.6350578","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A15Z&sr=b&sp=r&sig=IjnrtYd75uXHzrk4fn88DdQqteDxmgLNyHinomIs4gg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:15.635187","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A24Z&sr=b&sp=r&sig=RTkAcspkcFEdfhmbAEXG9QFHd%2BD7%2B1NAuYT8TL1a1MI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:24.20183","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A24Z&sr=b&sp=r&sig=BIjVoOFfAe6V3kwziGxjZj2qdKKRPuTX1Tpg7%2FhIOWM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:24.2017619","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A24Z&sr=b&sp=r&sig=r5p%2Flu9QRBXRnhydLzdJH%2F2l4wJFQHDXFweK%2B9fzEns%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:24.2018445","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:08.335Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3193'
+      - '3205'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:02:15 GMT
+      - Wed, 18 Oct 2023 21:01:24 GMT
       mise-correlation-id:
-      - 1ec8ef79-70f0-4d8a-8bb3-8f88ec7a8c22
+      - 5b01bffc-0ce7-49d2-aaa5-964a7acad87f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1204,118 +844,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A21Z&sr=b&sp=r&sig=74UX5uiH3VGiOWLkFM7Gn%2BlgbYEV%2B%2B8re41FVTjPIig%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:21.0073382","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A21Z&sr=b&sp=r&sig=9YqvO2eeMEewuPiQnQarC8LPodGkYeZYqAi%2BjPwM3v0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:21.0072581","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A21Z&sr=b&sp=r&sig=m86SgQWFAiwx4wIT63iq4hTE%2Fr1YdyN8CJfZ8MbdCIU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:21.0073592","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:02:21 GMT
-      mise-correlation-id:
-      - 9a338b2f-45f8-462f-b1be-379bf8420e5f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A26Z&sr=b&sp=r&sig=OThkiH9Kp3DLFgclnI%2FCIeVSpuUMJ81%2FEYA9B9RxmVY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:26.3196973","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A26Z&sr=b&sp=r&sig=h5bJ6a9F5UQYKewsWQ2jsksyGM2JFuT7V2%2FK2Gl9L%2Fs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:26.3196043","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A26Z&sr=b&sp=r&sig=DqkmspmR1zCRA9RcVBajKLsBEkAjhtoxdK426t9jync%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:26.3197122","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:02:26 GMT
-      mise-correlation-id:
-      - c5b7c502-6a96-4fa4-957a-f5f6af636fec
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A31Z&sr=b&sp=r&sig=wAzI3rml1sUlTyxnpSq7GbmFiTYYpmOWsHtMJj29eFg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:31.618941","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A31Z&sr=b&sp=r&sig=EKbLg7FlPpiy%2FnZG0lfkTcSryFCYxAGXUTZaldxMQsg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:31.6188513","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A31Z&sr=b&sp=r&sig=c%2FwUEMHf%2FT0LCBbugDkWUgTQa7PHR4gD013UqGWbX10%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:31.6189627","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:02:31 GMT
-      mise-correlation-id:
-      - 748754c6-6fc4-4f5a-a61e-6ba4fa081e34
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A36Z&sr=b&sp=r&sig=XXuFj0v%2Fz%2BM42wYnr%2FVlfiGuWQgS46OMR7dv6HIIa3c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:36.9404878","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A36Z&sr=b&sp=r&sig=0rfIgV2%2BJBh9Jg3DKAyTS3vSalZom6ax5D9DVaJgpHo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:36.9403988","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A36Z&sr=b&sp=r&sig=0OlPzUDZ5m8y9jVv5MhpHgAydH%2BGK31yOqMc%2FWjy6iA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:36.9405105","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A29Z&sr=b&sp=r&sig=dEJdFHSYrbCMYSN7iA%2BeaueVoTJ3s0X7OUG3iz0Hv%2FQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:29.4575097","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A29Z&sr=b&sp=r&sig=%2BiWHcuoPaJXofQnB6PIXi%2FnfQ2zOaHbJC6MvFOzXRAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:29.457422","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A29Z&sr=b&sp=r&sig=MCCB%2BFgq9lUdHkMdHiMbANlX9JTwnkO4WCgVnH7bdGg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:29.4575321","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:08.335Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1326,9 +858,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:02:36 GMT
+      - Wed, 18 Oct 2023 21:01:29 GMT
       mise-correlation-id:
-      - 9a3333f5-2497-4367-9d7b-2e5829af9c4e
+      - 817988e1-fb14-40e8-ac8f-f5cbfb69b34c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1348,10 +880,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A42Z&sr=b&sp=r&sig=kXZzSgzx%2FHdoyQMHC29cAeO506mHEOosSNAUo%2B%2FeJKo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:42.2743153","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A42Z&sr=b&sp=r&sig=JHDPag0s7lHVo%2BSud83veS87HA0ugJZ7qMhEL55XFcQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:42.2742522","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A42Z&sr=b&sp=r&sig=2r3Ij3Ik74GdbyhFVFH1iLYnoGUlSlyWo2FMaGmryVI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:42.2743311","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A34Z&sr=b&sp=r&sig=j5g38c03oXqJRUkzFh9voyOoJYsbw7%2FUDUsE0tGKH80%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:34.7601642","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A34Z&sr=b&sp=r&sig=BfZdaBqvdmEdmeKGSxtojHd24uhg%2F0o5PQh3mVicVKM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:34.7600691","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A34Z&sr=b&sp=r&sig=A9%2FinUdDtElNxAEN9A0ccvLF%2BrF5AniHSKJtriN40CI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:34.7601858","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:08.335Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:01:34 GMT
+      mise-correlation-id:
+      - 5b13592c-c3f8-4991-aab2-0783ce25656b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A40Z&sr=b&sp=r&sig=nwEQp03KBvSeGrctto5Tu6%2BBcGrwwtCHggFK%2BCV7bZ8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:40.0313942","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A40Z&sr=b&sp=r&sig=UhLROJVlXzycFSiEblQKJWYNaUCqvNSGBWY4S76MU48%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:40.031289","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A40Z&sr=b&sp=r&sig=KNN0hWA%2FaQFvVr5dzl%2BxcXZuIbXlR%2BmcfnVELTH1Gaw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:40.0314164","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:08.335Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:01:40 GMT
+      mise-correlation-id:
+      - a5f9c06d-8520-4b7c-9587-0e9b2e1cc4b0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A45Z&sr=b&sp=r&sig=vC5pqtegljKwSs%2FsNn%2B3CPIn6VkTCKAi2qTB0DfBZeA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:45.3760874","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A45Z&sr=b&sp=r&sig=vIWuoOhpKCCJebUUvMBVKid7v0GXfUPAO%2B0eevBM8vA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:45.3760021","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A45Z&sr=b&sp=r&sig=FlLlk5sfVxHRx8mOUsVQPwTbaNoo%2BQy30se95oWiJZ0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:45.3761093","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:08.335Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:01:45 GMT
+      mise-correlation-id:
+      - 9b421cfc-5527-4c99-bf3a-04dd855704b5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A50Z&sr=b&sp=r&sig=L7OejuNbfcrWxSR6Z8yOf6DHnya0a5WOyPRRxOjoX2M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:50.6759824","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A50Z&sr=b&sp=r&sig=x6AtzbdoQJG40fCfSzBTi6se8yVCl4d92qiT1tXzS%2Bw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:50.6758835","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A50Z&sr=b&sp=r&sig=Sgrt4ALyYQTUZlgno2X3Y%2FKTixCL4gqJq%2F6xKF7ilew%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:50.676003","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:08.335Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1362,9 +1002,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:02:42 GMT
+      - Wed, 18 Oct 2023 21:01:50 GMT
       mise-correlation-id:
-      - d0580409-f3e7-40f6-b971-f4e3c67c6180
+      - 597c707b-d9cf-4060-a32b-9a62296d5995
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1384,23 +1024,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A47Z&sr=b&sp=r&sig=pCWrwgfYHX4Dl43uB7fRyoh37GK9npywnAbSNKPN7qQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:47.6284239","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A47Z&sr=b&sp=r&sig=mWdZbepIHo%2FvWgh9k6EKVAB%2BfIOqD9qLjWDydKmUrL4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:47.6283461","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A47Z&sr=b&sp=r&sig=p8HWpZdv%2FNIqhDnYMJdAtGZrYcxl3ysUxlfbSnPykvI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:47.6284406","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A55Z&sr=b&sp=r&sig=TjIewHUwkHHI%2F3UFeA5hl9ZcMBNvrUV2CMqF2zK0qLQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:55.9662511","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A55Z&sr=b&sp=r&sig=p875GayKnp2JiLXaiPh4bSPpyVQe%2FJ6WXis5Mg%2Bp%2BBk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:01:55.9661286","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A01%3A55Z&sr=b&sp=r&sig=CHHHEOh5s9TD6YqRBTaOFakurbPvy9A7Pf%2FBl2O9A%2BA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:01:55.9662753","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"CONFIGURING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:52.047Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3198'
+      - '3206'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:02:47 GMT
+      - Wed, 18 Oct 2023 21:01:55 GMT
       mise-correlation-id:
-      - fe261867-6bed-4634-b558-338d8efdf80f
+      - 01a91bf1-44dd-4cbc-b564-2ce797cc5d85
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1420,23 +1060,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A52Z&sr=b&sp=r&sig=6fgISOJZO%2BjJbWPxdRqAT0fv6Un3blhHtRCpARrKOhc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:52.9509479","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A52Z&sr=b&sp=r&sig=41jHNtG%2FpzRvt2jEglXKhoqxkmNK0ZKjR36wIUJoXno%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:52.95085","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A52Z&sr=b&sp=r&sig=8eRd1ZF9sJ6QrV4aC1kbzeRhNha3sVyvdrJ%2BVH31qZU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:52.9509735","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A01Z&sr=b&sp=r&sig=1IRKFB1er78qFfBvsfHlMsL5YLdDMNRnnhKxigQNtHk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:01.3060451","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A01Z&sr=b&sp=r&sig=pdobFSRNdA%2B1%2Fxcd%2FX5i8e%2Bg%2Bi13zvdVSIkK%2FXDmLJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:01.3059303","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A01Z&sr=b&sp=r&sig=QP2i4FS6nXfKFQIslAQIE3iCa8RIxjlanNrV9Dc6Vgg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:01.306066","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3196'
+      - '3203'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:02:52 GMT
+      - Wed, 18 Oct 2023 21:02:01 GMT
       mise-correlation-id:
-      - 757d0452-e988-4079-b53b-74335b2ee20d
+      - 883e935b-fc9b-4dba-b970-ff7d916a6f85
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1456,154 +1096,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A58Z&sr=b&sp=r&sig=7xMnxb%2B2itVeHFzavJn0mVIza7JXwESKsHdLtLYio44%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:58.2147903","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A58Z&sr=b&sp=r&sig=bY1LHuF2dA4XRsL6UJNKj67NlUf07qPdEFSKPQzZJ3w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:58.2146912","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A58Z&sr=b&sp=r&sig=sgHDc3MJYhcjNH26rertmKC4lrqPACVs4q8OFjvfCQQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:58.2148148","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:02:58 GMT
-      mise-correlation-id:
-      - 31b351a0-2141-4868-b1f2-38c34c3981e2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A03Z&sr=b&sp=r&sig=TzHaJJ2wJct%2FZjD%2F2OPMU8zKOrc3NOpTY7YU8VUOzTs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:03.4515128","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A03Z&sr=b&sp=r&sig=bKJOFfTo5bzmDWvaNyFvCkbNcgveA4M5u585g61i3ws%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:03.4514468","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A03Z&sr=b&sp=r&sig=HZnNqtg%2BplM%2FuzyIfNfsmWLP%2Bf0h9oyRcs1eWt0yvSc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:03.4515287","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:03:03 GMT
-      mise-correlation-id:
-      - a5feb101-bc90-4191-a5d8-933de072573a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A08Z&sr=b&sp=r&sig=qXAbbNUU1v49nbijNDdfqJiguoicDKHi2ccYnLFJlqU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:08.7313039","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A08Z&sr=b&sp=r&sig=MpfJtYHt%2F3RNJ2C8xU3NzG4KhYVL%2FpI3koPyK0YBW8g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:08.7311968","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A08Z&sr=b&sp=r&sig=39AE5MpPEpdbZF7j0dYOn4qSPgReBko8qssTyIlrTmo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:08.7313319","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:03:08 GMT
-      mise-correlation-id:
-      - 55d0c464-7c5b-4630-b778-3243b5525bb1
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A14Z&sr=b&sp=r&sig=ORgd3dmq6OpH%2BhCv79KHrw3OsOVNRYs6t8zqqYxtyfs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:14.0450116","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A14Z&sr=b&sp=r&sig=xdSgmDTesRywLBfU4C%2Fd7xbPsuXdqH5rvcHs6kMHGAw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:14.0449256","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A14Z&sr=b&sp=r&sig=lwENXvzPVkC4vhKo84FuCyRIzTVK9EsA3LZaM6uGwx8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:14.0450276","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:03:14 GMT
-      mise-correlation-id:
-      - d1444ce5-758a-47ca-8429-fa3aa7bb79b2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A19Z&sr=b&sp=r&sig=WtF9Qp4l8ay7zQgdM3%2BfEPaqQe9udk5v22LDqNvfYbo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:19.3573975","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A19Z&sr=b&sp=r&sig=cG%2B1Pb%2FV2EgcRsRqBk%2BzrPkf2hfEbLUoKZdVs1m0zjs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:19.3573171","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A19Z&sr=b&sp=r&sig=ENBHzLgrNZXSJXft7EHDr8pqrNgwOmUk78e5FKzxMm0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:19.3574184","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A07Z&sr=b&sp=r&sig=h7kNd5AV2%2Ftvh34umoYVma9q%2FaX2a1Xj2Uw0WYWECBw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:07.1179456","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A07Z&sr=b&sp=r&sig=9eSxlsAZ6xmog34I%2FEj5GRilH8CnJpoyPLQyQg6HyzQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:07.1178718","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A07Z&sr=b&sp=r&sig=wfeb7SM4AljmfvTyWIFWc%2BTBfrlubaB0bxzRcu10XsQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:07.1179611","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1614,9 +1110,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:03:19 GMT
+      - Wed, 18 Oct 2023 21:02:07 GMT
       mise-correlation-id:
-      - 9de303c8-0376-4060-893e-8efcbd9ee879
+      - 8e33ff5d-aed5-4b57-ac96-ced3669451cc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,82 +1132,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A24Z&sr=b&sp=r&sig=%2Fwkj8pcabFPtLzJ2HOwKQtZZLvLgONdwbKAxRfrKRHA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:24.6955171","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A24Z&sr=b&sp=r&sig=%2Fz3iSw25UDBOSMcBl8tH8h95R9hFA0cga19gHqjARj4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:24.6954153","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A24Z&sr=b&sp=r&sig=AvlbDbuRPuvKff6JoYRS38FTdvRc9qBIiXJMcgO%2BFcI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:24.6955409","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:03:24 GMT
-      mise-correlation-id:
-      - 2e69f639-b2f3-481a-99fd-2e947b7915ea
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A29Z&sr=b&sp=r&sig=72cX3hqVkEa8xQdtONFCHocz5gZEXy3AwCRoWaEorQ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:29.9730999","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A29Z&sr=b&sp=r&sig=ACQh2L%2FsmuoMnzvKndpCK7gnN7pl8QGSQbsWksONDbA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:29.9730152","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A29Z&sr=b&sp=r&sig=4ZQaSpWoE2gxNDthGv3mxy%2FF7YIW5USe%2B24U2SzpM2o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:29.9731206","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 14:03:29 GMT
-      mise-correlation-id:
-      - 4ec0f2cc-b62f-48ef-ae21-4876de5d5834
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A35Z&sr=b&sp=r&sig=OgInEqQr1NPaWDg33Q6tUvSWuDRWZv5p8qE0ZdgWLoA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:35.2307933","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A35Z&sr=b&sp=r&sig=BpSmFfzXIv1jqQjT9ntg%2Fu9h5onOX2Fmz0llJXewD4Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:35.2307286","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A35Z&sr=b&sp=r&sig=D0tPqlhMT0lyj%2BeVYNw5PNRuXPnO7F%2FyN0kcQ42%2F3fQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:35.2308081","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A12Z&sr=b&sp=r&sig=auHLPB1I8w0ytcWKT6yJUzuJRQYYVJSzQqid2dsZdMI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:12.4041594","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A12Z&sr=b&sp=r&sig=s%2B%2BLJE7V6uQyykaH7pIb89GSJZPuy2eHQUqsUVMqMsY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:12.4040844","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A12Z&sr=b&sp=r&sig=QO%2BXROwxdhYnorbAF1y6EZkOzr35oRrNYh88ENO%2FAHE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:12.4041749","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1722,9 +1146,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:03:35 GMT
+      - Wed, 18 Oct 2023 21:02:12 GMT
       mise-correlation-id:
-      - 303fa122-0eb9-48f9-ad9e-526fe4eeeef2
+      - dc92ed33-48bc-44b9-9651-6db060596b72
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,10 +1168,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A40Z&sr=b&sp=r&sig=X2cWmLEychbTtkYYMoZ0cRdkZWOF4rEIG0XgN0JzEkE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:40.5850678","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A40Z&sr=b&sp=r&sig=bkPIDDNieS79h7KSUo7iitabgHBrqUMbtuhIR6oNi8M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:40.584932","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A40Z&sr=b&sp=r&sig=CNH4ZVa6Pspq%2FJQquz6OUB6M9MshmicewEpnPS00kHU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:40.5850942","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A17Z&sr=b&sp=r&sig=Y8Bpd9c1fpDtR06wevMXql9GBgxohCwZDdfCiMz0kA8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:17.675229","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A17Z&sr=b&sp=r&sig=vlnnXPdvGkCNmblajBzdfCZnwRfCHFQU5Oxztsrbtjc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:17.6751405","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A17Z&sr=b&sp=r&sig=PpBaD17EQUoEJlJnIOpsv8eV4ZjghlwU%2BUP9Uiws5Rg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:17.6752431","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +1182,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:03:40 GMT
+      - Wed, 18 Oct 2023 21:02:17 GMT
       mise-correlation-id:
-      - e056498e-233b-43aa-991e-2f8160b9c00b
+      - fb5afa65-0a4c-4706-a7a0-23d16f9b1863
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,24 +1204,636 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A45Z&sr=b&sp=r&sig=r9lIJZNvSvZ4gAQnaZKfPQ%2FvyFtg0eb4AjqLqRFfzhk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:45.840249","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A45Z&sr=b&sp=r&sig=Jg13ksL3Pnu1FJ448NlFk096uNjHfu2NlS4dxncLP90%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:45.8401601","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A45Z&sr=b&sp=r&sig=50U8eWD%2FP5qgfDLahTmx2Ddr%2F%2FCwMTutELgn11fIgwU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:45.8402737","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-13T14:01:06.931Z","endDateTime":"2023-10-13T14:03:44.514Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:03:44.596Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A23Z&sr=b&sp=r&sig=FKNB0IFYGtI0x1B02JKusAtwnpQt9f9V1wxA%2B%2FaBf%2Fc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:23.0019523","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A23Z&sr=b&sp=r&sig=81KMg7Kp7M1nbydGVYOdbdDVBu0bklRvoPTOvKFnpB0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:23.0018822","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A23Z&sr=b&sp=r&sig=ZKd1I1q316NoHCCkpQwKEaFrvhIFnf0kaU%2BFUukYx9o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:23.001967","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3334'
+      - '3199'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:03:45 GMT
+      - Wed, 18 Oct 2023 21:02:23 GMT
       mise-correlation-id:
-      - 1ef09cf5-f19b-4e00-b124-caef0c507c87
+      - 7ba6d1ec-5696-41c5-8435-4d23a34bca5c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A28Z&sr=b&sp=r&sig=IJfdt2b0GqRyS5y2RvT08TDxHJbZ6UHe6mrM0ZTCyBg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:28.34281","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A28Z&sr=b&sp=r&sig=C4uXiRrutGev1ss8DYtWqCunGMGWH%2F%2F3WlHmuF43HQU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:28.3427304","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A28Z&sr=b&sp=r&sig=87rOraMskimXrh5EatXeGFgoaeXyexTFhupWJGw%2BbLY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:28.3428246","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:02:28 GMT
+      mise-correlation-id:
+      - 75873ac8-18de-485b-be3d-6401fba2e9a8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A33Z&sr=b&sp=r&sig=nXfRQNjXRcF1c84taZr9xyI3dCNM1%2BV5aVR1zqSk%2BmI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:33.6680342","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A33Z&sr=b&sp=r&sig=lBUx5NX7zFZnh619vO6JmULbiwC0h7aD2IuqgDu4KuE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:33.6679663","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A33Z&sr=b&sp=r&sig=6eJgKGm6nDodeS6mjsdkKyKByX%2F8NjOhuwXUFfIsqh0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:33.6680477","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:02:33 GMT
+      mise-correlation-id:
+      - ba364eda-e230-4880-bb0d-ddc3d397562d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A38Z&sr=b&sp=r&sig=ARQPQLcHhJ9gKpd07qygGY%2BjajD%2Fdf6vrBHmAP4%2FM3E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:38.9674106","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A38Z&sr=b&sp=r&sig=ke1kMa5kQaqeS%2B8AfNfQwl8NOzw5vgfXxZ73XpO3nYU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:38.967323","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A38Z&sr=b&sp=r&sig=jCW4OZsqqfkeYhXvXNsFtPM8Gdl7BHH1S1VdHjo9Wm4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:38.9674277","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:02:38 GMT
+      mise-correlation-id:
+      - 1a523414-a840-41e6-a202-787d1264c2fa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A44Z&sr=b&sp=r&sig=8yNZT2KnhseLgdc8Tt6JBjhaYcSLbC%2FM5UWl2x17r3I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:44.2317429","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A44Z&sr=b&sp=r&sig=%2BdtiKW%2B9jGWsZHmsMZbLEVTjss1CvwtlpTbA56B8Avs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:44.2315948","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A44Z&sr=b&sp=r&sig=tc686Gxrlvdg4JB6OY1X7WgwUNtbfp3pcZ6mGCl8EoE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:44.2317676","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:02:44 GMT
+      mise-correlation-id:
+      - 9b772465-3c22-44ac-8b8d-8eb5c34ea164
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A49Z&sr=b&sp=r&sig=zs3wkMfkgf8o7l%2BSogNmm2QBn1LAwAQZXhq%2BpaenItc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:49.5251403","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A49Z&sr=b&sp=r&sig=oc2SKsOSj4KgOv3FVFltrnT4SG6JbUB%2B4hTg59pBSno%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:49.5250659","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A49Z&sr=b&sp=r&sig=nGClf7DOWeu%2BJrqRLm2q8obCnRFOltbc4KXs7xP7j1Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:49.5251548","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:02:49 GMT
+      mise-correlation-id:
+      - 09e29155-173c-425b-bba4-2e293d1b5c5e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A54Z&sr=b&sp=r&sig=nu1Jasu7Ywl%2B5CKcfUP9fvRpCjnIKyvdlK%2FaNldDH8M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:54.8132376","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A54Z&sr=b&sp=r&sig=fHYig5A2DA4IDXnSygR0dtKtJFKhZ2hNHhzU1VYN1rU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:02:54.8131465","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A02%3A54Z&sr=b&sp=r&sig=tX%2F0hI4nBG2gn4TY3duqVmjkhRlzbX39ROLJEKt%2BvpU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:02:54.8132607","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:02:54 GMT
+      mise-correlation-id:
+      - 0c7f880e-b8b5-48d3-85c5-4dff743331d6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A00Z&sr=b&sp=r&sig=y201uHo50AdP0%2B5G7L%2B0x%2BJT4DiAkTX7MaM2gzZ6g0E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:00.0822064","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A00Z&sr=b&sp=r&sig=lLJzUzLV%2BSat7BJlv%2BuXaoL3nlEFOdySC1k0FSPwx8c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:00.0821105","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A00Z&sr=b&sp=r&sig=jMdaV0wW6BNRk3oA2XMH5qpKzoWTnUYyZ3AT10U38vw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:00.0822316","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:03:00 GMT
+      mise-correlation-id:
+      - 9243a11b-e248-4daa-bde0-2fc773ab67c8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A05Z&sr=b&sp=r&sig=e4XbD2OHpG30xLc5FkwJkAKyLspXFyMVhp9Sj7Xl6jA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:05.3852011","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A05Z&sr=b&sp=r&sig=11hlP06xjT4JcfGi6v%2F6rUlt5YBAKM6%2BDE98ypWIubA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:05.3851171","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A05Z&sr=b&sp=r&sig=NnfSE3u4H8qug1gz97okCysnAujttIDr44gRPAN1G54%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:05.3852148","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:03:05 GMT
+      mise-correlation-id:
+      - bcdf4cf0-a821-479c-bb5d-d98ee1ba6a7b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A10Z&sr=b&sp=r&sig=N7df2OxNV1sixPo1ihI8rk5rKCDrATUNEA5O7aZCuMo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:10.6808737","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A10Z&sr=b&sp=r&sig=JDB%2Bva8kzpS88D8TGYff3GkLyIdWm7I8IjT2Ab8Wi80%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:10.6807955","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A10Z&sr=b&sp=r&sig=dCrezkeNEgy3GQ%2BfOd3ze6QSN%2BszP8yj0Yc68Q%2FXUIM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:10.6808905","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:03:10 GMT
+      mise-correlation-id:
+      - 5f88ec17-0d05-4d69-930f-b525f1cc812c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A15Z&sr=b&sp=r&sig=oN3rppXUxknaCPq1mWi2fwTg1IJiUrlYri6wUq%2BKg7w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:15.9446476","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A15Z&sr=b&sp=r&sig=kXY8Lz%2BFXGNZwdLobBn4ERAFgFaU%2FQXYFBlRgsiiiHI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:15.9445552","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A15Z&sr=b&sp=r&sig=NoAZmqEmlivt2%2FTtI4J2iEsftc2ABJ0nwr0XjM0uPtw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:15.9446618","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:03:15 GMT
+      mise-correlation-id:
+      - 06810e2a-8dad-4f53-94d2-801933a2efe1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A21Z&sr=b&sp=r&sig=1m2Jif1FVFSmRGClhZj7w4znYdA1oeYk6GR8RP0zza8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:21.2618887","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A21Z&sr=b&sp=r&sig=C28%2BSlQ1wHyz3Uofp470a%2B0B8s3jr%2FrKfCkjfl4tw5s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:21.2617787","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A21Z&sr=b&sp=r&sig=hG19Sx5eHSP2%2Bj07f6wW7TFwni8xpvZALovOaRjockg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:21.2619097","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:03:21 GMT
+      mise-correlation-id:
+      - 6f4dfc67-2b25-4d46-aad0-8c9ce80829df
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A26Z&sr=b&sp=r&sig=Ar9hY5lw0aK%2F8D4903SktoKWULcsAf4Ji6kw6IESl30%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:26.5799042","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A26Z&sr=b&sp=r&sig=FSZpLuWy%2FeOXw3w%2FJVuz6gHDJSL2a0V7s%2B4LUFqr%2BaY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:26.57981","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A26Z&sr=b&sp=r&sig=W%2BTsua3psH%2BmVBuY2Ii2u0Qv6mcuSQYlGQKlBR0%2BYd0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:26.5799256","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:03:26 GMT
+      mise-correlation-id:
+      - 29d45175-00e2-4445-b222-51ecbfc1e39f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A31Z&sr=b&sp=r&sig=7pZoWCO5Yomtjqx%2FC45dexpnw4bon4SQWP2w%2FiOeuZ0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:31.8532882","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A31Z&sr=b&sp=r&sig=%2BNSPffOt0QJ5nSR%2BIA%2FFORKi50LxwJArXHjNBLhEdrg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:31.8532018","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A31Z&sr=b&sp=r&sig=khOY0P96TERyolvFPQ4%2FG5ogxUF%2BdPf9jYJjf34haxg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:31.8533099","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:03:31 GMT
+      mise-correlation-id:
+      - 36a6720d-0d81-45d2-9c36-634d5179ad3e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A37Z&sr=b&sp=r&sig=eeBBt%2BP3dFjI%2FKmCBm7DLOxd64CP8D6Z1K1ZCjlnquw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:37.1259127","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A37Z&sr=b&sp=r&sig=H01xnn%2BBJRRu9XZmfeTQlsmjsLUE3kEfqQxGJiiW0N4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:37.1258219","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A37Z&sr=b&sp=r&sig=riqteZ3%2BXSQPEMHUoVIw88C8%2FxHqRlmy5VNrVaN3sKo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:37.125934","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:03:37 GMT
+      mise-correlation-id:
+      - 7628793d-3ce9-40c1-8966-21b656cab21b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A42Z&sr=b&sp=r&sig=uCZbSOdvZDJx%2Be%2BLuHoof0CpNAaK6ALDwL5WC4BnDnc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:42.6539914","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A42Z&sr=b&sp=r&sig=rEUdiFpGEfKkWUTnMzSoAU3Gl4gzGmogSDrIsIh1VEs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:42.6539243","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A42Z&sr=b&sp=r&sig=q8A8SJyDkcZyqSHZoTKUl%2Fjxi4eqBs4Uou6GqzKH%2F%2FY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:42.6540069","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:03:42 GMT
+      mise-correlation-id:
+      - 7f79487a-873f-4372-b408-64b43291d7de
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A48Z&sr=b&sp=r&sig=HRzDFK7sci3FKBuAInozeSmjTKz3Veb3ah%2Fz9N7fObU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:48.0086446","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A48Z&sr=b&sp=r&sig=WbvYC3EBruzDaMqns835zqPT%2B6qVqurDj5JWu4JHvWA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:48.0085469","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A48Z&sr=b&sp=r&sig=EHuTz%2BR3Gf3vBABm3bT6qtc1nPc9DwoeBAQakaF%2Fo%2FE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:48.0086665","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-18T21:01:08.118Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:01:58.114Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:03:48 GMT
+      mise-correlation-id:
+      - 5e3cbf9f-629b-406b-9b6b-f08ebc743366
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A53Z&sr=b&sp=r&sig=w7Sd%2BTLLsPzH1yIVYEgPONJ%2FrKOrqvViU1HreFNrIIc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:53.3124689","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A53Z&sr=b&sp=r&sig=fVajLvrMW%2FoOR2xYptevM3z5yNDHi%2BtQlPAw3rvj%2FLA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:53.3123984","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A53Z&sr=b&sp=r&sig=%2B%2FjAAIvuzLaeoVakixv74AOUMvLCKeNov%2FyRa34wjCA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:53.3124858","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-18T21:01:08.118Z","endDateTime":"2023-10-18T21:03:50.247Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:03:50.347Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3343'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 21:03:53 GMT
+      mise-correlation-id:
+      - b46d6b88-ced6-44b6-a5df-3bdc1a4b7f41
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,7 +1856,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:00:04.8936167Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:00:04.8936167Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:00:05.4265706Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:00:05.4265706Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1829,9 +1865,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:03:47 GMT
+      - Wed, 18 Oct 2023 21:03:55 GMT
       etag:
-      - '"d901ec7c-0000-0100-0000-65294d680000"'
+      - '"7500ab84-0000-0100-0000-653047570000"'
       expires:
       - '-1'
       pragma:
@@ -1861,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=update-test-case&api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=update-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A48Z&sr=b&sp=r&sig=XktsP1sExu%2BD1Q0beJDAYnbTFG4tVOd5XXJ7M1inLjY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:48.0209377","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A48Z&sr=b&sp=r&sig=FuCe58hs%2Bx0rasGoln2MSTtRcUKwKMF1h%2B5G0llNRkE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:48.0208389","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A48Z&sr=b&sp=r&sig=QXqnACd2V%2FPAqozaeedSKJsiZJ2U1j04iDIwUlxFcac%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:48.0209649","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-13T14:01:06.931Z","endDateTime":"2023-10-13T14:03:44.514Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:03:44.596Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A56Z&sr=b&sp=r&sig=Y2L%2FeTnyDtMI6dNJZwcQ%2B7DGA9t%2BewbnTfxwscsoJ3U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:56.9661402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A56Z&sr=b&sp=r&sig=AtupBzmw8SXZHUQ%2FLqSo3l6rdH5eS04sMQV%2FZZcd6sI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:03:56.9660704","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A03%3A56Z&sr=b&sp=r&sig=lYLqP2LRS5XpcUCSLfLb8ryoB9221SDB6eZN5icG2Bw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:03:56.9661552","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-18T21:01:08.118Z","endDateTime":"2023-10-18T21:03:50.247Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:03:50.347Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3347'
+      - '3349'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:03:48 GMT
+      - Wed, 18 Oct 2023 21:03:56 GMT
       mise-correlation-id:
-      - fb411ea1-8bad-41df-a42c-6d29a5a0a9b1
+      - 74fb3f96-3d38-47d3-b7e0-ca38a68fa765
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1901,7 +1937,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:00:04.8936167Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:00:04.8936167Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:00:05.4265706Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:00:05.4265706Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1910,9 +1946,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:04:08 GMT
+      - Wed, 18 Oct 2023 21:04:19 GMT
       etag:
-      - '"d901ec7c-0000-0100-0000-65294d680000"'
+      - '"7500ab84-0000-0100-0000-653047570000"'
       expires:
       - '-1'
       pragma:
@@ -1942,24 +1978,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=NsvarUZwxpv%2FhDLG0zQvSMhVcNtJF42fB5kT6nk3j9c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:10.244822","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=YvvWGQjNe7GiN5CP05j%2BqjTLtU6wbSM0NwaIrOgr2so%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:04:10.2447386","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=QDv6MnMHjlElviGcqgQprT0Qblia0a574CJdtDhVKZQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:10.2448423","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/4bc9df91-e6fd-413a-95db-3c80fba7fbd9_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=fjMaJ33BC4GowUWllecv8r1NlAbchx1sRdoEwd0bOeY%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:10.2448621","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/4bc9df91-e6fd-413a-95db-3c80fba7fbd9_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=Hec7lXI6NM8ge8%2BWtHG58xS%2B7T5WOhFJqgacUJ2a7C8%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:10.2448808","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-13T14:01:06.931Z","endDateTime":"2023-10-13T14:03:44.514Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:03:57.184Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A20Z&sr=b&sp=r&sig=OxN6E6eU0%2BqcvP0cPOPJ5xPYoJsNgsQsG0657OJvJxY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:20.8634595","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A20Z&sr=b&sp=r&sig=JRtoJy4jrYgUsnbwPFLR6MLTGumafvc5t7uF6oo6nYY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:04:20.8633817","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A20Z&sr=b&sp=r&sig=WVPOmd1BJTI6p6JCzWbkytSaz2BFsoKg28SfDHTXWxY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:20.8634746","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/499faf9c-551e-45c0-a250-576b8c2ac218_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A20Z&sr=b&sp=r&sig=KvvTq%2BwUrPV%2B%2By%2B2VVhLs1O7%2F96cik624GgxkUYx%2FM8%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:20.8634879","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/499faf9c-551e-45c0-a250-576b8c2ac218_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A20Z&sr=b&sp=r&sig=Subbfqwq2yVQP4U5WCbwWVUtLueir%2BTbu1BXBbrOhzg%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:20.8635025","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-18T21:01:08.118Z","endDateTime":"2023-10-18T21:03:50.247Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:04:16.808Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4493'
+      - '4502'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:04:10 GMT
+      - Wed, 18 Oct 2023 21:04:20 GMT
       mise-correlation-id:
-      - c2ff7399-8755-44a8-9d3d-16cdfe5e6743
+      - 5689af57-6283-49a3-8819-9330f4bc37e1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1983,25 +2019,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=AhQfpv7tAZbAMbrzerBVfJ4fUIz%2FFWz0gVLIcby8tOU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:10.6576131","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=C0%2F3Cw4EjWA1TlVRt2IwKaD2xvmXxI5%2BXUokIRbcX%2BY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:04:10.6575471","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=mIS0ggezXUpaGcaq63jnPfs56gRwDtQdYc5QohQjE%2FI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:10.657628","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/4bc9df91-e6fd-413a-95db-3c80fba7fbd9_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=uOqfcz0aTH%2FU63pSOkFUtfJmOp8L67q2GFFWPmfeKuM%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:10.6576414","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/4bc9df91-e6fd-413a-95db-3c80fba7fbd9_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=LD5fbE6RlFnbi6a0cngn6n2dncTqa%2BFA0jLuytoxvOU%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:10.6576557","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
-        test run description","status":"FAILED","startDateTime":"2023-10-13T14:01:06.931Z","endDateTime":"2023-10-13T14:03:44.514Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:04:10.649Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A21Z&sr=b&sp=r&sig=CKiNh8wZkbhdcGJnWDekyqnus23pqSOuPNon8SuVDOM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:21.2506113","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A21Z&sr=b&sp=r&sig=co12FPNh7S0mWDggonEGYV69gZMzovqu%2Fh8jlisSBT8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:04:21.2505375","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A21Z&sr=b&sp=r&sig=MuiKQcnKOCVxxbeprVrGm1PHGfNim8%2FjMExE2CxNY0g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:21.2506264","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/499faf9c-551e-45c0-a250-576b8c2ac218_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A21Z&sr=b&sp=r&sig=Xb0SambvcZAWQuloYb9tjRKUNCEEeQZyglaUATE07ZA%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:21.2506411","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/499faf9c-551e-45c0-a250-576b8c2ac218_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A21Z&sr=b&sp=r&sig=eG0wehuNdtTtNTkPyEumjkNxKXEbZ4CQw5A5CA2x82Y%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:21.2506549","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
+        test run description","status":"FAILED","startDateTime":"2023-10-18T21:01:08.118Z","endDateTime":"2023-10-18T21:03:50.247Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:04:21.241Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4544'
+      - '4535'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:04:10 GMT
+      - Wed, 18 Oct 2023 21:04:21 GMT
       mise-correlation-id:
-      - fa6571a5-4b72-4caf-9152-c24985fa9676
+      - 8c0a3491-5ff2-470b-9f06-8b4fa8b49fb1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2024,7 +2060,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:00:04.8936167Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:00:04.8936167Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T21:00:05.4265706Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T21:00:05.4265706Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2033,9 +2069,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:04:11 GMT
+      - Wed, 18 Oct 2023 21:04:22 GMT
       etag:
-      - '"d901ec7c-0000-0100-0000-65294d680000"'
+      - '"7500ab84-0000-0100-0000-653047570000"'
       expires:
       - '-1'
       pragma:
@@ -2065,25 +2101,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://b2be796a-de3c-4657-b759-c7cb52c18cf5.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A12Z&sr=b&sp=r&sig=cADMUwy%2FGHI9f%2BVNyl69ULteYKeNwpuIWAvblNwwO9M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:12.6584826","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A12Z&sr=b&sp=r&sig=y1dBHj9Dsh9RyCV%2B7MVfs6QiGJeZnj%2BYGAzsVOt7I5M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:04:12.6584023","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A12Z&sr=b&sp=r&sig=tuz1ZnAe34X%2BQiGCGmw%2FFUFhUEJDw49b9527mQyhVIs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:12.6585043","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/4bc9df91-e6fd-413a-95db-3c80fba7fbd9_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A12Z&sr=b&sp=r&sig=9ECg%2FYP4PYjz3jaDrm8SBrx2p3S715KQuKrSIDw8HiI%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:12.6585246","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/4bc9df91-e6fd-413a-95db-3c80fba7fbd9_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A12Z&sr=b&sp=r&sig=7%2FA4ZVZowF%2FhwTMgrXEX1ze7MOcr6dL60N%2FSe%2BnImEk%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:12.6585461","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
-        test run description","status":"FAILED","startDateTime":"2023-10-13T14:01:06.931Z","endDateTime":"2023-10-13T14:03:44.514Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:04:10.649Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d51e59fd-7da5-457d-9f97-b741816c8463":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"2c428843-c903-4c3f-9cff-097da70e820c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5da1b17-25ae-4efb-bf5f-7deb5066ed10":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/9db17719-408d-4ab1-b573-cc546efaf0e3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A23Z&sr=b&sp=r&sig=iFd2k%2FomCPpRvZ%2FnvVJNLGvR0ieSYJ4izVsAMQqddeA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:23.8956923","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/dc9a5884-6230-40e7-a2be-fea2ae7289cb?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A23Z&sr=b&sp=r&sig=l%2Bb41XVlZNdoChRqs%2F%2BDIwNMBroRnq15d%2FtQn7arlcM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T22:04:23.895622","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/382b068b-269d-4c0e-9cf5-3d8416a2539c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A23Z&sr=b&sp=r&sig=G1qIvd8EPNl4KOo5AUux6%2Fjm8A4ixbcuYA11n6DzyUQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:23.8957071","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/499faf9c-551e-45c0-a250-576b8c2ac218_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A23Z&sr=b&sp=r&sig=KuKVArffiNeoiNRxM%2FytepmF9cRwEc7VP4h8ulSx%2F7s%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:23.8957219","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9f91a7d3-7a17-46ce-8df6-3cf49cd43a94/499faf9c-551e-45c0-a250-576b8c2ac218_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T22%3A04%3A23Z&sr=b&sp=r&sig=k1HsJHJA5f7EHEvFEYtJWJJ34ao6R3fICrnKqZljlJo%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-18T22:04:23.8957368","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
+        test run description","status":"FAILED","startDateTime":"2023-10-18T21:01:08.118Z","endDateTime":"2023-10-18T21:03:50.247Z","executedDateTime":"2023-10-18T21:01:07.381Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-18T21:01:07.656Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T21:04:21.241Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4553'
+      - '4548'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 14:04:12 GMT
+      - Wed, 18 Oct 2023 21:04:23 GMT
       mise-correlation-id:
-      - 9c2eaa90-5276-4de8-88a2-8c74e717288a
+      - 6bc130f4-c4d5-4181-91ee-86ca981cde8a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_update.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_update.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:31:57.6921376Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:31:57.6921376Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:32:13.9583816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:32:13.9583816Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:32:31 GMT
+      - Mon, 30 Oct 2023 07:32:48 GMT
       etag:
-      - '"3c007239-0000-0100-0000-653edd5f0000"'
+      - '"3f00727e-0000-0100-0000-653f5c010000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:32:32 GMT
+      - Mon, 30 Oct 2023 07:32:49 GMT
       mise-correlation-id:
-      - 822c057b-1ef2-441e-b2aa-da9fc0e22412
+      - 30e87e9c-dc5a-43b8-ac41-f550156df59f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"f95e1e68-3aac-4fbf-a348-6e114857d051": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "079fa455-c798-4c54-840f-9f07e0088a58":
+      {"passFailMetrics": {"3db8a6d6-3f09-4732-b8e2-90283934a5ec": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "1939d566-e166-4396-911c-2b7e175572e8": {"aggregate": "avg", "clientMetric":
+      "50"}, "e4b7a6af-1f8e-4c3b-b288-6ccce0369650": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:32:33.368Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:32:33.368Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:32:49.804Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:32:49.804Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:32:33 GMT
+      - Mon, 30 Oct 2023 07:32:49 GMT
       location:
-      - https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+      - https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - b42eaf81-769b-428a-b2e4-cdab26146813
+      - cd7b4e78-c843-4205-b4b6-b87e52f79dd7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:32:33 GMT
+      - Mon, 30 Oct 2023 07:32:50 GMT
       mise-correlation-id:
-      - c0a26aab-2119-4101-8a6b-f6b7deb7b605
+      - 0fbd2abd-06ff-42e2-a672-0410727206d0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,10 +275,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A42%3A35Z&sr=b&sp=r&sig=94Gx1S9Tc3DYa2Gph22vjj5wePg2%2BVySTNNOYuMnaHY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:42:35.5527581","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A42%3A50Z&sr=b&sp=r&sig=pFLwR2Ql0QX8rWTWZwl8tVnM6I5nLkgaSW%2FNk1vy5Wk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:42:50.9992742","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -289,11 +289,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:32:35 GMT
+      - Mon, 30 Oct 2023 07:32:51 GMT
       location:
-      - https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 2069b02e-2b78-4386-8281-d930d304a0ab
+      - 2a6b5eb2-a9e1-4c74-98ba-bf4f5a00a69e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,46 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A42%3A35Z&sr=b&sp=r&sig=QuFltEYlig2Ns%2BwDm548iMJuiVuBTx%2BubyedYVTocoA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:42:35.9443274","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:32:35 GMT
-      mise-correlation-id:
-      - ca62a544-35c9-4a29-b833-748d9b130de8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A42%3A41Z&sr=b&sp=r&sig=j3jTX%2BCcXSgPEm2QfkzV5mAymiROMdXs9ew3MCaiFdw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:42:41.2383454","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A42%3A51Z&sr=b&sp=r&sig=%2BN8bixwvy8jPROvhNmw7jCIa0EQtV2qidX3mpxyaxtY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:42:51.3641224","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:32:41 GMT
+      - Mon, 30 Oct 2023 07:32:51 GMT
       mise-correlation-id:
-      - 4b6da78a-9aae-448b-a8c9-2a9db6a9f60c
+      - 04dba0c1-8304-458e-a162-8515cf3fc678
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,10 +349,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A42%3A46Z&sr=b&sp=r&sig=P50MIvKZEyyRZ4eRalaDqKS7BvrIH2hZ6RJfKWRqGn8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:42:46.5352465","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A42%3A56Z&sr=b&sp=r&sig=Y7FfjlGvnVGdL%2BHo9L7y0zIC1JHs7bObr7wrdVQQSKA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:42:56.6804593","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:32:56 GMT
+      mise-correlation-id:
+      - ebbc736a-2bcc-4e70-82d9-f36a1e946681
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A43%3A02Z&sr=b&sp=r&sig=4GPXJkri1DKv3X1TDtOGwoRmixuAXPn6vAyFfLbmaqU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:43:02.0070525","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:32:46 GMT
+      - Mon, 30 Oct 2023 07:33:02 GMT
       mise-correlation-id:
-      - 414e263f-d22a-42b4-8eb4-8a3e242cb082
+      - f373ca6c-8978-4f36-9d0b-061207b69cee
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A42%3A51Z&sr=b&sp=r&sig=tIPOG7frGbLV3RwC1THEshi0I4pXnau2y8haYYjgwYE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:42:51.8536822","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A43%3A07Z&sr=b&sp=r&sig=O4PqRszKoXLa7ozTA2%2BZytxszUr2qkbWju52FnzcxYU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:43:07.2738259","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:32:51 GMT
+      - Mon, 30 Oct 2023 07:33:07 GMT
       mise-correlation-id:
-      - 05488d58-75cd-43f4-be6b-ce9f883d01de
+      - adf0bc72-ba87-47d0-9425-758e24fb5a33
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,11 +457,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A32%3A52Z&sr=b&sp=r&sig=3O3zb8NBd74rswxJtzSHB%2BVAbUa%2FqeNBF8HohOBcDuA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:32:52.1642344","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:32:33.368Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:32:48.596Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A07Z&sr=b&sp=r&sig=LxdyJg6%2BWS%2Fa2BBK6QP0HPwz3QoKJKWk9GpdefnCnWY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:33:07.5423759","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:32:49.804Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:33:03.667Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,9 +472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:32:52 GMT
+      - Mon, 30 Oct 2023 07:33:07 GMT
       mise-correlation-id:
-      - 8a626af5-db7d-422f-a7e8-04d999ba5f4b
+      - aade2ec7-7228-43ac-ae4b-abf4d460aad2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:31:57.6921376Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:31:57.6921376Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:32:13.9583816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:32:13.9583816Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:32:53 GMT
+      - Mon, 30 Oct 2023 07:33:09 GMT
       etag:
-      - '"3c007239-0000-0100-0000-653edd5f0000"'
+      - '"3f00727e-0000-0100-0000-653f5c010000"'
       expires:
       - '-1'
       pragma:
@@ -538,11 +538,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A32%3A54Z&sr=b&sp=r&sig=YCWfR48ZvylCb%2BeXHRz%2BYltgE9hHCfJxIxns0qfH1Xw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:32:54.7135407","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:32:33.368Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:32:48.596Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A10Z&sr=b&sp=r&sig=24Wzha%2FyAz6s0FPqRIO1jp9pt2d3%2FJRq6SSgf16ywu4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:33:10.0031559","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:32:49.804Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:33:03.667Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:32:54 GMT
+      - Mon, 30 Oct 2023 07:33:10 GMT
       mise-correlation-id:
-      - b3c1e1a8-46aa-4e66-8121-70d536b77cbf
+      - cb1fc2a8-cde2-48e7-9978-8ed58735566c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:31:57.6921376Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:31:57.6921376Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:32:13.9583816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:32:13.9583816Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:32:56 GMT
+      - Mon, 30 Oct 2023 07:33:10 GMT
       etag:
-      - '"3c007239-0000-0100-0000-653edd5f0000"'
+      - '"3f00727e-0000-0100-0000-653f5c010000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:32:57 GMT
+      - Mon, 30 Oct 2023 07:33:12 GMT
       mise-correlation-id:
-      - 51274076-7a77-40bb-844d-5a804f5b0ae6
+      - ddc05cab-942d-4b0d-b53f-d867c7993b08
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A32%3A59Z&sr=b&sp=r&sig=J3sle2Bm9gAuvvYHpe9VMqF6VbW%2BLMg4zH1r1hlgthw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:32:59.6500619","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A32%3A59Z&sr=b&sp=r&sig=5m8FMgDxgowkCGRlb9pnK8SsHZS3VUk9193zthUwDSA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:32:59.6498681","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A32%3A59Z&sr=b&sp=r&sig=KBRPYbpyn0WANZVn8lDCNSOOzO3Lvbs7tiNclELysg4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:32:59.6500908","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:32:59.567Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A14Z&sr=b&sp=r&sig=3X%2BPjrH14jOKLlMdMjg89ck%2B3gQc7%2BzZHvXnWA5GKAg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:14.4150592","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A14Z&sr=b&sp=r&sig=QDQG0TihROY7k3D8OBrNrpQHhbl7iQez%2BaJb9c4Jwqg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:33:14.414935","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A14Z&sr=b&sp=r&sig=KszZd1yV5x0lwC3P5yYvt3O3GCAw6kDJs90TOjPcyrU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:14.4150834","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"ACCEPTED","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:33:14.324Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3150'
+      - '3155'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:32:59 GMT
+      - Mon, 30 Oct 2023 07:33:14 GMT
       location:
-      - https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+      - https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 313922bc-a526-4dff-a5ef-6841bf2a2bc9
+      - b5d10a86-99d0-4c0d-ae81-73052a94ae74
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A00Z&sr=b&sp=r&sig=ns74hd18EJuy21Rg9r0p07XOZew47GeknbEtP3MbWZg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:00.0861767","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A00Z&sr=b&sp=r&sig=kpCkWTJinmU8tg0VDLMiFVz1F6S%2Bm5HglvZTvO3eb4E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:00.0853529","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A00Z&sr=b&sp=r&sig=Yx0V7jhYiMmAiHL15YJjItnYuqQW6xflSW0SjPuIT60%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:00.0861999","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"NOTSTARTED","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:32:59.96Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A14Z&sr=b&sp=r&sig=%2Badj1SbQDtdtnTQEH3WY3ug6CuJoLG71Lliga2bLByo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:14.83142","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A14Z&sr=b&sp=r&sig=xV7TaLrA34DgiSaK2h535N5dV1dItG%2Fa%2FYXN%2F9kEIY4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:33:14.8313536","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A14Z&sr=b&sp=r&sig=rDJZql1PrCitzR7CCKLziRnfOfy4miTtOUQCSaUCs%2Bg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:14.8314336","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"NOTSTARTED","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:33:14.761Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3193'
+      - '3201'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:33:00 GMT
+      - Mon, 30 Oct 2023 07:33:14 GMT
       mise-correlation-id:
-      - 11c01a9a-dbfd-4ec0-adb3-511fcab7e4c7
+      - 1b3848f5-ee23-40aa-a7f3-d30a1d1f17b0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A05Z&sr=b&sp=r&sig=AUyoqkEHq%2Ft663TKtAao%2Bez8WvwCLzuGSqQurVWm09M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:05.3499436","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A05Z&sr=b&sp=r&sig=MqTw2IAXj5uT2mw8Z44I2%2F6euKZWlsqo%2Bn1lPjAtpgY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:05.3498747","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A05Z&sr=b&sp=r&sig=5JtDrv9DFB7MqgFPMPswXARhIgYLr8KoB%2F2fR%2FUfTQU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:05.3499601","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A20Z&sr=b&sp=r&sig=hCdTp7OXenFMtV%2BRXrvOC9bADgAdtwdHXk%2FT32nQfwQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:20.1318899","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A20Z&sr=b&sp=r&sig=xCd2FLXvDovmtG5XN9mnC9XD2c0ZifGpGvmY4UcOMw4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:33:20.1318178","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A20Z&sr=b&sp=r&sig=uekgxZ%2BYWTN6jKFZorRK5A6R4SHqUgH8zsy9TvQbM3M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:20.1319046","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:33:14.993Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3205'
+      - '3201'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:33:05 GMT
+      - Mon, 30 Oct 2023 07:33:20 GMT
       mise-correlation-id:
-      - 53dbac10-22a1-4b17-b46c-55254c1f0251
+      - 2ec6dbbc-a969-476e-8218-73950801737b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,118 +772,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A10Z&sr=b&sp=r&sig=heDnRAd0vRo7aYr2pAOJaTVN3ETHTbmzR%2BcJlB670zA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:10.7153402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A10Z&sr=b&sp=r&sig=%2FSwoRzitv9UeEmOqzdZ431WhUJWWmoWec5q6ORR5EUI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:10.7152728","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A10Z&sr=b&sp=r&sig=buQI85iL8OlyNNXiVnTsxR9W%2FPoyk89NHNx6W7gyOA4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:10.715354","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:33:10 GMT
-      mise-correlation-id:
-      - 47857295-7f19-4b15-86fb-defd5103747b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A16Z&sr=b&sp=r&sig=QMi8P6a7SpQZICr2a1x4vxZoyawpqSUItTWUXKbPDOU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:16.0311174","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A16Z&sr=b&sp=r&sig=Vbf9OrOlhU9TVVRjGAsEP9%2BcgCLMHss0Gu1wlPUzcTU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:16.0310437","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A16Z&sr=b&sp=r&sig=D2Po7Vq%2B5q6yqVRdvKz0jpiInXv8w624fLWqYGwDkrc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:16.0311309","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:33:16 GMT
-      mise-correlation-id:
-      - f2d0a635-e0a8-4469-8cb1-9890389134e7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A21Z&sr=b&sp=r&sig=INr6Im4nXGRuEb8ZCLPJ8cqoIbWnxCj7auTU%2Fkq%2FVtM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:21.3562943","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A21Z&sr=b&sp=r&sig=T0GgWkSE%2B0lRml9uAQoLrN4CbIeNwP5T7uM4VSTt0Ds%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:21.3562074","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A21Z&sr=b&sp=r&sig=exe9B55k47T9pQkP8HHzzZ6MFK4rjXflwKLWYe5LdTo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:21.356317","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:33:21 GMT
-      mise-correlation-id:
-      - 233965dd-6a0f-49ff-9d37-446691b2de6c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A26Z&sr=b&sp=r&sig=Ry%2BdBaGtDDO6o4Zx9cseAO%2FLWq5KnNsmQ89kFyGRqO0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:26.6374357","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A26Z&sr=b&sp=r&sig=4z2TBPRwEo3LEXnvznD%2FNZDh%2BGrni%2F13ShGJgAobW%2FU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:26.6373619","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A26Z&sr=b&sp=r&sig=hv18sxhNNZyUaRxzhE4gLvmEi43dsVfMsQiae6UYtLk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:26.6374495","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A25Z&sr=b&sp=r&sig=VM21pJW9i0GBOkEkCGqK1%2FdPYayffKCHxxjqgfi0gCw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:25.4489583","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A25Z&sr=b&sp=r&sig=UoRrsdwgO%2BAGs8FQpPOQBDavnXTl2vlCQRdGhPizt%2FY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:33:25.4488694","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A25Z&sr=b&sp=r&sig=GNwrGjtKamKoAK%2FfK5L1xvzteXK7IaMDNoktd%2BW32pM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:25.4489792","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:33:14.993Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -894,9 +786,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:33:26 GMT
+      - Mon, 30 Oct 2023 07:33:25 GMT
       mise-correlation-id:
-      - e84b1511-2bba-46f5-9665-16de28b2dad8
+      - 215afc8d-e6bc-4033-80d2-85ac9b96b70b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -916,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A31Z&sr=b&sp=r&sig=ex30uQr0zt9icHRO9409%2BreokwAeLOZBlkqGB%2FbrPXo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:31.906682","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A31Z&sr=b&sp=r&sig=SKitpb%2FU2HjwlYgFc0M4WkC%2B%2F1LNx9ILgy%2BLYs%2FmDFY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:31.9066026","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A31Z&sr=b&sp=r&sig=UOxUkQeUe5G6n5ffO%2FsHA68hYKyTNZ%2B8kUajTj3qdeA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:31.9067054","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A30Z&sr=b&sp=r&sig=BFRxlT%2FsKno0CYZYN5H%2FzPjMg8wljWkPDoISTIL9BJ0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:30.7683454","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A30Z&sr=b&sp=r&sig=4oQKJ8tGoUWSjhALJVPDUxKT4aeKlFtPEMBdi9WLBls%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:33:30.7682611","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A30Z&sr=b&sp=r&sig=Kgzvz14svYsxLbf1%2FigHQecSPiVf7bR64hU%2FBFbk40M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:30.7683675","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:33:14.993Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3210'
+      - '3203'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:33:31 GMT
+      - Mon, 30 Oct 2023 07:33:30 GMT
       mise-correlation-id:
-      - 34131c5c-8405-4a83-9c34-85d9294d6b7e
+      - 4e9dd9d5-9d52-4131-b2db-62ef56428610
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -952,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A37Z&sr=b&sp=r&sig=fPUKTtTidXHoKd4JCRBer39jXUUQXzAygRyW%2F70JRBo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:37.1684423","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A37Z&sr=b&sp=r&sig=VqCiuvEHetmxW%2BFsOPet1VxSA1vLs%2BjMMXzCpmTSXIY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:37.1683564","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A37Z&sr=b&sp=r&sig=s%2Fin7ojMY9osKsP1x2Dr7bbkfc%2Ff4ot%2F9dCQAgAxoS8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:37.1684629","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A36Z&sr=b&sp=r&sig=tyAIXSwLFemBzZtKlIdSqwZpJzFC3Fp23REs5HiOy70%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:36.1167164","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A36Z&sr=b&sp=r&sig=sAMptjX7TQJnKl11OIcf%2FyfNxYrqHuPOzQ1gAm8Vp%2FY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:33:36.1166356","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A36Z&sr=b&sp=r&sig=mLG7wgf6pwccjnWMMulSqi%2B%2FWrCjbUlUi1NpifJAuOM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:36.1167348","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:33:14.993Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3205'
+      - '3203'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:33:37 GMT
+      - Mon, 30 Oct 2023 07:33:36 GMT
       mise-correlation-id:
-      - afc0d90f-1f87-4e3b-99df-e4501fcb536b
+      - 7b32c860-8806-4430-979c-118f5c1b63fe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -988,23 +880,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A42Z&sr=b&sp=r&sig=LZB1TgpYqQlXRTrvGCiTfkLnqhiHgTLvFfCyihnEafI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:42.4438014","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A42Z&sr=b&sp=r&sig=v%2Fdpm%2FDPrkENE%2FiN%2BStcz6PjDYgjcrb9U%2B%2B4Tm2%2FQ0Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:42.4437341","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A42Z&sr=b&sp=r&sig=p56rFynwOLJb2jGb84%2BRrkhU32z7u2l%2FH48k9QLG6gE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:42.4438163","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A41Z&sr=b&sp=r&sig=E8EHUQriPqSB0U%2BsIsEuXAyickld0GsJPSK1WudUug8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:41.3752072","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A41Z&sr=b&sp=r&sig=ywTNxyW9H0alLhS%2FtJAhv4jZxEv5COIlBpKRd3vFSaA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:33:41.3751401","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A41Z&sr=b&sp=r&sig=gUhWEilDY7AyKTVWRshJ6PfNZ%2Bg12EujtsnU%2FJSMkXo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:41.3752216","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:33:14.993Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3211'
+      - '3203'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:33:42 GMT
+      - Mon, 30 Oct 2023 07:33:41 GMT
       mise-correlation-id:
-      - 20c6a991-dc36-4e1e-bdd5-8d509b9be38a
+      - 9fe6bcf0-e519-4db5-ae7c-4ab9504188f5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1024,82 +916,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A47Z&sr=b&sp=r&sig=6G3m65LvG9q5%2Fm4bM5%2BCpTPfW2TchCamEulB%2FWRoBHs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:47.7711727","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A47Z&sr=b&sp=r&sig=FxHpPj6mjBLFjNSqmsXRyu2wSi2mS4NkCStUhjiGnws%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:47.7710708","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A47Z&sr=b&sp=r&sig=XJXiIZNFhN7KgrWFJPeqwPihy76EVxflCOfM1YF8gZU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:47.771194","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:33:47 GMT
-      mise-correlation-id:
-      - 93c57821-ee78-4a65-904d-aa3307f8d16f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A53Z&sr=b&sp=r&sig=YYdb4%2BovbKx0UIBON6t7%2BZttAZ4c04m91gXOySyiaso%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:53.0348606","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A53Z&sr=b&sp=r&sig=zOP7ILRih%2FFJuSwhb6hbrpMfIEbe6qU1Krzwv%2F8hjjg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:53.0347901","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A53Z&sr=b&sp=r&sig=qIwfg4hB0x%2BqbkYJ%2FD4TZG6NgT646lsXo%2Fc%2BOgrIRaM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:53.0348752","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3209'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:33:53 GMT
-      mise-correlation-id:
-      - adf390d8-e252-463a-bf6e-2493ce8325ad
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A58Z&sr=b&sp=r&sig=lQ2JBRJO04BXqPMK3ot5F%2FdWs0bcwI%2FdVao0PwmGtGE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:58.3489541","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A58Z&sr=b&sp=r&sig=AMBLpUPofV0MkBXVnqGwLWB4mNudCLL16m69TQyUu9w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:58.3488861","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A58Z&sr=b&sp=r&sig=Vu3BK6ro%2Bm9ESh8bZdetit15xnF940x8cSyxU4SXhm4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:58.3489692","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONED","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:58.291Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A46Z&sr=b&sp=r&sig=UGw%2B0hOI5CsoFmBHe%2BCfURxAqdHkvI9NPqqSa2SUWTQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:46.7054242","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A46Z&sr=b&sp=r&sig=hiJ8cjQRp1cbCZCwCSLYHxJDgXhRvZ2k28qJwwTF2FI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:33:46.7053424","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A46Z&sr=b&sp=r&sig=gLk4diP7LJqIU0pFSFNvMM64woXkvjuh4MiRb89s4I0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:46.7054457","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:33:14.993Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1110,9 +930,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:33:58 GMT
+      - Mon, 30 Oct 2023 07:33:46 GMT
       mise-correlation-id:
-      - 26c3cf78-eff0-4b3c-8192-f107e941b951
+      - 09ec6cca-6d93-4154-ba0d-e8aceb0b66b1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1132,10 +952,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A03Z&sr=b&sp=r&sig=YZQpB0eoPgbm8obOE1%2FpwcG51EtCRosgcvAhX9Yu5wI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:03.6691795","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A03Z&sr=b&sp=r&sig=%2FtxyPVnsYYXZajDbhAK%2BdEJe6auSUkAIS1ffKgkTKzk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:03.6690935","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A03Z&sr=b&sp=r&sig=2sqR%2BlFlFpanf4BrkB2eM43zcg%2BmMVTXdP4oqCQ4p8s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:03.6692016","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A51Z&sr=b&sp=r&sig=Vr5hwAlkwYD6WROcZAl94n3Bkeoz5pWEfcSD5Q9Am0I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:51.9654666","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A51Z&sr=b&sp=r&sig=%2BjrX8EScUfzZaP1%2Bl5driYm5AYUrSXzcaYh7US6rkTY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:33:51.9654025","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A51Z&sr=b&sp=r&sig=LvYDob2IwFXeWuZsP9Fp%2FdSdE5mE5ZtK8DMPgV12stY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:51.9654814","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:33:14.993Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1146,9 +966,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:34:03 GMT
+      - Mon, 30 Oct 2023 07:33:51 GMT
       mise-correlation-id:
-      - 45d3f8dc-85ef-48f3-b3ed-7197324c303d
+      - dbdb0c33-1fac-47ff-b288-dcbcc61bb608
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1168,190 +988,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A08Z&sr=b&sp=r&sig=SN1VGv9eJOF%2BLpfCvWh17BJU8j%2B4kL1j5i2HNw7cwKo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:08.9995735","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A08Z&sr=b&sp=r&sig=5h3FopAf07OxiFbDXWvNGUuzsN9Q958ManUk099lQuk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:08.9994833","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A08Z&sr=b&sp=r&sig=E26pxzcqDkl3h97bojSWr5MoYNklVw%2F%2BJKpNdv%2BYjk4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:08.9995885","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:34:09 GMT
-      mise-correlation-id:
-      - 3ff037de-440c-4a77-ba2c-f6ff988190db
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A14Z&sr=b&sp=r&sig=Am7L5DkB360Zmw%2BzksSKZH8vEqToQHgdt5rvyE3jN7o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:14.2671947","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A14Z&sr=b&sp=r&sig=A3Fj82v0O%2BZOxzpGT%2FfSK%2Buq0n4RuTRyVy9X2k8BPlY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:14.2671083","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A14Z&sr=b&sp=r&sig=mxbYjszGPlf68HxyXpLn%2FmgllgL3mai6cx0W8cjgFss%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:14.267217","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:34:14 GMT
-      mise-correlation-id:
-      - 7027a5c9-91b4-42e6-9343-078fbb350f17
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A19Z&sr=b&sp=r&sig=WJKdMLsaxbu%2FFjDO1fmWNeTJeyIKtH%2FUBYVeAXRcTus%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:19.6347918","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A19Z&sr=b&sp=r&sig=eQk0CRmgRC5ZDuLCLNBm6CrVbkjkPCEuUirzsodTLtc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:19.6347148","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A19Z&sr=b&sp=r&sig=ieBNgcgrh4Ua4s7T6YBOjUHWsAbqdLEIW2yWSxb4RhQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:19.6348057","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3195'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:34:19 GMT
-      mise-correlation-id:
-      - 98d0bab1-ab20-4a3b-9838-2872bf0612cf
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A24Z&sr=b&sp=r&sig=WUvwy8YCPZ%2B1leIoi9yWe3LceAcIkhelS%2BVuYvk3sgc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:24.9043583","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A24Z&sr=b&sp=r&sig=%2FBk5Y9UpsyMi9nFMXvLQJJvwvR9NUyyeZgJZKpYb4A4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:24.9042839","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A24Z&sr=b&sp=r&sig=w5CTgxlvZClmE98Z%2FOsEl9Zn8eIU3XvrBFj8%2BznpG%2Bs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:24.9043727","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:34:24 GMT
-      mise-correlation-id:
-      - 18291121-80eb-4485-b96f-9989166bf884
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A30Z&sr=b&sp=r&sig=gZDsuqGgy8PeN%2FHsQvSZCfb%2FRwuwgeD4Zs4TznKqtiw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:30.1697315","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A30Z&sr=b&sp=r&sig=pDk%2FnVuqpCog%2BpK4webMdp9VgmEywbkVLDX5KcxYvNk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:30.1696535","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A30Z&sr=b&sp=r&sig=RmMTV9Kh1aAE%2FkLJPj%2ByONrJhbQHz3nruEq124MKqv8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:30.1697473","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:34:30 GMT
-      mise-correlation-id:
-      - 980403f1-94b6-45b1-8d51-959581a01b55
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A35Z&sr=b&sp=r&sig=JqeQ6frvGFSYCQoRFGeY5ovsXy%2F1Wxuk5BUVmugmVto%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:35.9381836","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A35Z&sr=b&sp=r&sig=WmOrBecha7Ptbfy%2BTuDBuCcpN0QO8119LKrtYnzTMFQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:35.9381097","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A35Z&sr=b&sp=r&sig=VKBvanyziwuwwNYJvoG7SgDPDOqCW4Fc%2BKMunO9Yqe4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:35.9381976","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A57Z&sr=b&sp=r&sig=ufbWtzen4gpiYoZ0GXtfhxja4HnpQWBLvSlTFel37OY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:57.2310751","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A57Z&sr=b&sp=r&sig=dSSQ1C54TyNcDCNDDoBCqM9fdODRHp3vQsbda9J4wfQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:33:57.2310083","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A33%3A57Z&sr=b&sp=r&sig=QlnXNLk2DeNSIkSLDYxcMC0sDRCuUqZCtoc8Y40Qj%2FE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:33:57.2310888","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:33:14.993Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1362,9 +1002,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:34:35 GMT
+      - Mon, 30 Oct 2023 07:33:57 GMT
       mise-correlation-id:
-      - 70bdca6b-8300-48bc-8d04-932b0e58f374
+      - 174be4e2-8577-4284-946b-5617efafc783
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1384,23 +1024,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A41Z&sr=b&sp=r&sig=Fr4P1fdb%2Fpjif014NTQcPbQWPubPqYnPvznY8QO8sIo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:41.6773675","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A41Z&sr=b&sp=r&sig=volQNnz5A6Ve1TaJOQWzB3xSbrBqcccJGB%2BiwPjaWUI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:41.6772767","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A41Z&sr=b&sp=r&sig=L%2B%2F%2FXLgvpAxE5iQYnJdRHHJ7fQR%2BBvxZm4qagYdqWMo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:41.6773827","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A02Z&sr=b&sp=r&sig=IsvftP7VmxZtVSa4I9K%2BzD%2FasFV1FjA%2BT0r%2FNXrNeig%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:02.5954037","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A02Z&sr=b&sp=r&sig=6V3CjBzoL0GN5rlovscy9C8NbSIReIUuEmuw%2FRKQ08s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:34:02.5953339","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A02Z&sr=b&sp=r&sig=6NFLaIjvu2wFqLOc0vClk9h0fYefxzI%2BBHSeoAuIcMs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:02.5954178","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"CONFIGURING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:33:59.913Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3203'
+      - '3206'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:34:41 GMT
+      - Mon, 30 Oct 2023 07:34:02 GMT
       mise-correlation-id:
-      - 94bd0978-88a6-492f-a193-c4c67e275b3a
+      - 82408d6c-7ea6-48d2-bcba-211a07a4d265
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1420,46 +1060,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A46Z&sr=b&sp=r&sig=n1qPZZJXvCSQag4AA99K9wRhXfQXZyK0C2Y6w%2FaUd8U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:46.9556545","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A46Z&sr=b&sp=r&sig=gc8EiK5Ekk09B74Nl3KdU8r5TdlnZt6ODe91WAt%2Bolk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:46.9555839","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A46Z&sr=b&sp=r&sig=NvkQZWSfC8nt3FTUt%2FMJL%2F8rk4%2Fr3WshH7YfgHlSjGI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:46.955669","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:34:46 GMT
-      mise-correlation-id:
-      - 8dabde97-fdfb-4f8d-8efe-340e754d1fcb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A52Z&sr=b&sp=r&sig=f%2Fm7YHT8B8Gvbc0fdurXfypo2gUBOVAU8f%2FgKIdd3ow%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:52.223554","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A52Z&sr=b&sp=r&sig=p0mCLiISbPD7y9cUv74Ih9oDBOqQlpdSpkOd1F1rTKM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:52.2234812","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A52Z&sr=b&sp=r&sig=xVa4HcIIStzxYrocDVlnKUuOV9PeF%2B8Hr6KvKPUl5DI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:52.2235692","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A07Z&sr=b&sp=r&sig=FOmZ2IHm0XWR2HXZyhUzrlY1kZYhE5JXL6R1h1faf3s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:07.8682911","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A07Z&sr=b&sp=r&sig=Qbdx23%2BqUxK2iUroT2wMaJfBa2IGq1RPyH7P51IJh3o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:34:07.8681935","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A07Z&sr=b&sp=r&sig=98pHgcHtT7F2wVmkXnWRJN49yS06uc%2FRCwci23pePoo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:07.8683135","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1470,9 +1074,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:34:52 GMT
+      - Mon, 30 Oct 2023 07:34:07 GMT
       mise-correlation-id:
-      - 3fec9449-7bba-47e0-87a1-e37424cac287
+      - dce98cf0-5f09-4174-85a0-bf640c2e377a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1492,23 +1096,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A57Z&sr=b&sp=r&sig=uz6VFoaFjAZjL1JVpTLa22WhDdo3dVnIiN28rBvhAJ0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:57.5005161","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A57Z&sr=b&sp=r&sig=QFI3BljyfxelW%2F5WjRHh%2F7GX732N3vdQXQ4G6HDIMGM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:57.5004273","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A57Z&sr=b&sp=r&sig=VHzSgwuQVspNH%2B3wmzEmLNFa3CubTv2ALlohX99739E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:57.5005337","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A13Z&sr=b&sp=r&sig=7UbnqkidZQVlxUdYpKvCmunZMraS4ZHVXAQZcO9nR2I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:13.1727101","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A13Z&sr=b&sp=r&sig=kQ9H9d0IKC107kvfC80Fj4uyBCSuKOcyXvQeDJCD8EQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:34:13.1726138","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A13Z&sr=b&sp=r&sig=AjsBv%2FxwCNl52jeRmeBaiHHudBZ6zaubhWi4XFlVfYg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:13.1727319","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3197'
+      - '3194'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:34:57 GMT
+      - Mon, 30 Oct 2023 07:34:13 GMT
       mise-correlation-id:
-      - 8cda88bb-3cb1-4c19-af97-32ec966f29f5
+      - a52ee29b-cb4b-44e4-ae90-79a3be77eff4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1528,10 +1132,226 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A02Z&sr=b&sp=r&sig=UapJFsZB%2FNtSKD3C61xAj2zRFK32K34kz1vNXdJ3Gxs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:02.838875","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A02Z&sr=b&sp=r&sig=0dyqc3OzlUnwWfsl7n7WqypxKMKQqsUoh3JWp9k%2Ftxo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:02.8388062","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A02Z&sr=b&sp=r&sig=Yyg%2FwqbvE5bsmXXXfe3EicmXdHsBGtkPT%2FY0x27KIoA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:02.8388955","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A18Z&sr=b&sp=r&sig=RcGQ08AdKEwHy8PEbRwAO5FBj%2BjR%2BIsSyYA%2FWyBUz9E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:18.4997589","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A18Z&sr=b&sp=r&sig=cYHqOgL5Do4eliDpSoNBOl4j47Ltv7GCv7DjLABGm80%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:34:18.4996362","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A18Z&sr=b&sp=r&sig=gIXVZIiVGgkN5M1q5BzML3QG%2F1sYRyMqfoxBZWE6x40%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:18.4998094","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:34:18 GMT
+      mise-correlation-id:
+      - c82e5a23-61ea-4978-96e0-eaf6eaded2bf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A23Z&sr=b&sp=r&sig=g5NSwLeou5hEUO6p4vnjcsBRlQarHvv9oxm76ye16zE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:23.8310763","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A23Z&sr=b&sp=r&sig=2ll5QORpASyUrAegmf4KdYGlA5MnAjiPMwhT3%2BKcqfo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:34:23.8310035","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A23Z&sr=b&sp=r&sig=SQ7bL29iIYXuHEyZ6PB55orhJ%2BTls8YUDn2xHP3FvuU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:23.8310907","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:34:23 GMT
+      mise-correlation-id:
+      - d4684179-e802-4095-b5b0-5f80f0876b65
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A29Z&sr=b&sp=r&sig=4Q%2BhDLNj8%2Fd8jLMgpPUeO9wj9nyF9Kt52Pm285uS99E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:29.1423915","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A29Z&sr=b&sp=r&sig=Q7E%2BhhJ98SBMqJJXQ8y0rbId7kaJaU1szhFW%2BjeSgGo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:34:29.1422954","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A29Z&sr=b&sp=r&sig=Jk6lQKB%2FG61iTLYkSwSA3Qe%2BTh9ZZgTd7n%2Bp20Pzv4Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:29.1424114","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:34:29 GMT
+      mise-correlation-id:
+      - d4d64b0e-7af4-40e7-92dc-9dded66c5eeb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A35Z&sr=b&sp=r&sig=HYPmEN5tH%2FT85uwYiZyZIe7npL%2Bc8PT6M1N7iszMAl0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:35.2435725","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A35Z&sr=b&sp=r&sig=LyjPNH8Q%2FbHPNgxqn8kW2ZtC%2B%2Fdf%2BTPqMhZNq%2BMhumg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:34:35.2435018","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A35Z&sr=b&sp=r&sig=isp4tyKzBA8Dx0IlRjOjRd86HBNjYfEMHhkPnbZYzhI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:35.2435871","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:34:35 GMT
+      mise-correlation-id:
+      - 15c9f777-953d-473f-b6a9-86edca63c19a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A41Z&sr=b&sp=r&sig=Is%2FCS%2Fsc6RDVLlS7q1hNJ0JTHhvve8M2kTrZFiy20EA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:41.5328326","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A41Z&sr=b&sp=r&sig=YlPRyU4h0erdfEBO4mhPWDb1YMA%2FtUYitnNJA1SZmNs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:34:41.5327629","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A41Z&sr=b&sp=r&sig=uJD9ecqT2XyCrVt3wOsfkFrm053Ds%2BlXOzMej7Lr2zY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:41.5328466","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:34:41 GMT
+      mise-correlation-id:
+      - 854cfe64-7118-4abe-aaa6-8a6ba0f08e4f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A46Z&sr=b&sp=r&sig=dSfbRXewtTgRwD4cv7gEp9JTYtWoi2CKCCAlMOqChMQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:46.7987879","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A46Z&sr=b&sp=r&sig=3F8NJFX%2FwqG6N9ZjBlBnoP8okncn0VfXGZmIldx%2Br34%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:34:46.7986881","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A46Z&sr=b&sp=r&sig=a2b9BhaOfCS1g5xc2wnEOXGTH0PWLiRYAF4VtkPiZyA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:46.7988079","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:34:46 GMT
+      mise-correlation-id:
+      - be731b0a-c320-4472-82b2-c46fc7f2c932
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A52Z&sr=b&sp=r&sig=jdLGogatLS2eSHk3c4mApcKB7670%2BzHCMFPLL9n0bGY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:52.0761728","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A52Z&sr=b&sp=r&sig=uB%2FcmjR8XWX7sDqgB3aQF266duRW6Lz5wYbcHtRHZuA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:34:52.0761062","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A52Z&sr=b&sp=r&sig=KxZw2C3tPaGnqv2%2FDPWUj9WhzELftCw6kLmuNjqJhEc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:52.0761879","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1542,9 +1362,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:35:02 GMT
+      - Mon, 30 Oct 2023 07:34:52 GMT
       mise-correlation-id:
-      - d875a875-2b35-4d85-a37d-2d1cc6c23396
+      - 398c8b0e-f6c4-4cd0-a5f7-e94f8dff9bf0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,23 +1384,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A08Z&sr=b&sp=r&sig=6dSpmISP9mNfNZZ4LPE2TQxLovBECLglQHCVmDKBS5o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:08.1543935","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A08Z&sr=b&sp=r&sig=0dHA0EWmkINTl9NnhFXgiAlNakybc7OaT%2F7y%2FA1Wirs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:08.1543002","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A08Z&sr=b&sp=r&sig=RpTHQzYPe0p%2F5031%2BiGQ9cc1lgKf2R2bEsVeuSlZU2M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:08.1544147","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A57Z&sr=b&sp=r&sig=c9iFOmjFnuBHA566wT61iSgFL2UUekXCc5%2Bs%2BwiV7qA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:57.3442034","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A57Z&sr=b&sp=r&sig=i%2BY105rDjoxQmBYsI1iINX26hLfq%2BVJQHDVrZM6%2B2ks%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:34:57.3441181","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A34%3A57Z&sr=b&sp=r&sig=x%2BUtXJXKHR%2BqGb8pSWzw7H0ZeoZsj92dX9qNCpOPS4Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:34:57.3442255","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3199'
+      - '3206'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:35:08 GMT
+      - Mon, 30 Oct 2023 07:34:57 GMT
       mise-correlation-id:
-      - e4cd1763-96fe-47f1-8f81-864377189666
+      - b799c23a-c951-4966-a261-d1747d232e67
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,10 +1420,334 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A13Z&sr=b&sp=r&sig=IXcD%2BlLKFC8ta8rVN%2B84yfYChH9OscafYMFf8sxY2%2FY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:13.5115794","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A13Z&sr=b&sp=r&sig=uC44OrgFktD%2BGQEX9l0moHv9CL2dbmaqPuRNsSn9VbA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:13.5115122","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A13Z&sr=b&sp=r&sig=od4Bo1a04Z%2FMvvoisqJkPbLW2GQdPlQ%2FT945iYGYT6Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:13.5115938","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A03Z&sr=b&sp=r&sig=YHVxVtPu%2BoC9L8PFX3%2BqSaRK3EoaW6R%2F7PZPGpa1xgA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:03.2570774","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A03Z&sr=b&sp=r&sig=RcyPUdaTEja%2FqWs0ZbpIeidXnavGd7f7OX2rkqlfs7c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:35:03.2570112","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A03Z&sr=b&sp=r&sig=YgB2kzgYZSl7QoTal953sOHFrG9k4JT8vYHc8LjVdXQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:03.2570915","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:35:03 GMT
+      mise-correlation-id:
+      - 1738d4c3-0891-44e5-ad4f-72e03b34bf7d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A08Z&sr=b&sp=r&sig=GaWJyzOdtEnXTFw3kiF9nBXZPnhNkvfiOBHvzxbS0ig%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:08.5743487","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A08Z&sr=b&sp=r&sig=tP5m5SVzGaxFIpdP%2F0fZPRJuAhcVlaHFZXOGttdy7ro%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:35:08.5742686","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A08Z&sr=b&sp=r&sig=noBzWcWFogfHmUgiSLoV5RYIpsO%2FQf5cBSbONdK1vF4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:08.5743624","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:35:08 GMT
+      mise-correlation-id:
+      - 6f90db98-0ab1-47e6-bd1a-358b762c9c99
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A13Z&sr=b&sp=r&sig=DY5V6B1hvI91auBUrQUBg0iGWpN7tyPOfMxkd1kz5ng%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:13.8461019","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A13Z&sr=b&sp=r&sig=CmXGnEEGrV4wodUM%2FDhXxswEJMKCtvOvShMpuHUQE3c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:35:13.8460267","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A13Z&sr=b&sp=r&sig=nWbvOKJmkTqlB%2Bj8aPxF6u6sKaBATy37E%2BVqtyxGLPQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:13.8461208","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:35:13 GMT
+      mise-correlation-id:
+      - a71ac923-3082-48ea-b528-183d9281f56c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A19Z&sr=b&sp=r&sig=LMJYao%2F0i15bFtEKgIo%2BB0na7ZDOhdJCwQpo8jMAUA8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:19.123346","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A19Z&sr=b&sp=r&sig=JGDAMXN8w4omx8pKGGkJhV6rhsMi010MAORWjBuUL08%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:35:19.1230503","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A19Z&sr=b&sp=r&sig=lHJ%2Bk2VKbCf2EzNcJrnbXqBljYiMRPe%2FYkWc7s%2Faa2U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:19.123515","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:35:19 GMT
+      mise-correlation-id:
+      - eb3021ac-acba-484f-b99a-ff73f72bca23
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A24Z&sr=b&sp=r&sig=0URo3aK2tE5l08niMv7hQZNy%2B8hlRmRlfMfM5J583c8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:24.404218","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A24Z&sr=b&sp=r&sig=RpFsZAcUl2yGhKAMrPA3HaO07pulAreYkjzSWVA1RXU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:35:24.4041398","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A24Z&sr=b&sp=r&sig=8mMaU94qivokNIpnXWb863bQfZo0PKBQhs8Wnd5NB5I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:24.404236","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:35:24 GMT
+      mise-correlation-id:
+      - 18e90e86-6f7f-40cf-9894-8ee6c7576b40
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A29Z&sr=b&sp=r&sig=r1bhgPtj1R8ijkSpDi8aEJjjX%2F5ws9F%2FtiAGH5LL4LA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:29.6747949","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A29Z&sr=b&sp=r&sig=i5II7nOfb45D14NZeghvfE4Muu7xIhJlEf9rkMkJOkc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:35:29.6747077","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A29Z&sr=b&sp=r&sig=X3YszwSGaPDGX6HYw%2FjtlNIZxaZtvr85XdTKpe%2BV%2FSg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:29.6748165","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:35:29 GMT
+      mise-correlation-id:
+      - 64a98954-a410-461e-951f-09c9306a463e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A34Z&sr=b&sp=r&sig=cv%2B6VLnxADPfbhdFgYcaBr5iAUY1lBOIMf4OsNp0rKY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:34.9452325","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A34Z&sr=b&sp=r&sig=hWCW5AhkOnPFFCF7BRyc4%2FSUTdxqT2DJTVYYikI0Rg8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:35:34.9451393","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A34Z&sr=b&sp=r&sig=rLxDrA9TQi1IO2YFzePA6P1ATvIJcarlAEnzPnmgBq8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:34.9452551","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:35:34 GMT
+      mise-correlation-id:
+      - ce00146b-18ac-4816-b5b4-f008745f9d60
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A40Z&sr=b&sp=r&sig=p4mb1IS0M%2BsxlW7%2BHBeqH0atFSwNoAN5Bz3WxavC3Sk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:40.2348115","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A40Z&sr=b&sp=r&sig=E8mfxyuFMv5xmngdpBFqhq6s3hOxGYjLHbDUrQRYeaw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:35:40.2347489","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A40Z&sr=b&sp=r&sig=JIs5JgRPcXLZ2UEnoMnxscCaQvU%2FAmTQwmrbbGFzWGo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:40.2348254","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:35:40 GMT
+      mise-correlation-id:
+      - 5259fb15-bf42-4040-9c38-1908d16d4863
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A45Z&sr=b&sp=r&sig=mMX4JQym0rzD84Q7D%2FAfuDqDKTXuEzJ%2FxY1zl%2BmqoVc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:45.5017718","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A45Z&sr=b&sp=r&sig=5e%2BzJ1KtLYCjOMUUSNaHUKyUFLM%2FJi%2BtaC7nqoysHGM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:35:45.5016885","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A45Z&sr=b&sp=r&sig=hjfZ4RggepQJYTSLiZnWTC65N8vi%2BBuwQGIgswc1Mrk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:45.5017948","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:35:45 GMT
+      mise-correlation-id:
+      - a73a07ff-661d-440d-b1bf-481b03906445
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A50Z&sr=b&sp=r&sig=tYQtyKbvMT0cYJFZP12hO5dkjl5g1YDpYeCwOSOkyqs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:50.766223","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A50Z&sr=b&sp=r&sig=qh7%2BI7C%2Fs25hVT6Ee4%2F8YtkQg2ZU44X3HTByNEmEaZs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:35:50.7661531","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A50Z&sr=b&sp=r&sig=XdSSci%2FZ90EfiUakG0b%2F8HbBh8GUZYi%2BnRBP3CeZkJw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:50.7662371","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1614,9 +1758,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:35:13 GMT
+      - Mon, 30 Oct 2023 07:35:50 GMT
       mise-correlation-id:
-      - 506efc14-852b-4ec2-ab18-2acae9712e54
+      - f7dec52f-cf50-4f65-af2c-9439d3fff322
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,23 +1780,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A18Z&sr=b&sp=r&sig=i3%2Fbow4%2ByBtyaJEbPL%2BJnjGohr92rZ4xz2wr%2BP8W1E8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:18.8742408","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A18Z&sr=b&sp=r&sig=DM5KKFsN6auSmZMKNE9trxy6%2BZkMv0%2BGCVMUBnskY2I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:18.8741638","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A18Z&sr=b&sp=r&sig=w2vWvoDaIACZ80fUh1E2rIFtbbkkXxS1AQNEu%2BkuLGM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:18.8742563","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A56Z&sr=b&sp=r&sig=q1hy%2B4PjGdJe7dtdX0Q6wMWZ3brnc%2F4WEh5BwnI01Kw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:56.0477533","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A56Z&sr=b&sp=r&sig=HXXhAiQy4dejeZFS7Uej2s2pvObmrJOsCoXR6zyNf5s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:35:56.0476872","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A35%3A56Z&sr=b&sp=r&sig=z9xS0WJjubuEA6fCNXhVZ2HIioztG54QPbnBFKdRBKk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:35:56.0477676","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-30T07:33:14.761Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:34:02.992Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3205'
+      - '3196'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:35:18 GMT
+      - Mon, 30 Oct 2023 07:35:56 GMT
       mise-correlation-id:
-      - 2cc04885-2601-45db-94ee-b889dbac56bb
+      - 3b5b55b3-fec1-41aa-9bab-a2c102845470
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,276 +1816,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A24Z&sr=b&sp=r&sig=1pWHvBpKuIKPG1ijn86uzzvvS9ZIAkc%2FTpRzUUoIgzY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:24.4501636","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A24Z&sr=b&sp=r&sig=gi09TAVokeS2qfz8mqlsIWI87VysOergoYjYbvhbHh0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:24.4501103","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A24Z&sr=b&sp=r&sig=h9jv1yo%2FBhVSW66CHt567ozBUWk2JFss80nMxc5arM0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:24.4501771","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A01Z&sr=b&sp=r&sig=HUbpKtjHZTZzlSxx4I1pwFfI1rJBJJzS8oUwkgsNpqg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:36:01.3244464","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A01Z&sr=b&sp=r&sig=nKB0wLSnofWoRXZiZWOg1PNB3ahvtg1P8nt%2FHVSv9oo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:36:01.3243817","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A01Z&sr=b&sp=r&sig=BMXTe1MmehoGinwOJJUUIflJhOqsKBpTkEBe%2B9ln5PQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:36:01.3244604","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-30T07:33:14.761Z","endDateTime":"2023-10-30T07:35:57.33Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:35:57.418Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3195'
+      - '3330'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:35:24 GMT
+      - Mon, 30 Oct 2023 07:36:01 GMT
       mise-correlation-id:
-      - 9f399ad2-c263-4e15-aafc-bdae725c1591
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A29Z&sr=b&sp=r&sig=UIOOjrxH7wpq%2FJmajSN36cY1I67h1fDnUym69xZpNLU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:29.7622278","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A29Z&sr=b&sp=r&sig=xNwFsNGihUQNQToeNfudZ1GaDLPcuLLe%2B%2Bv0deeQMNg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:29.7621305","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A29Z&sr=b&sp=r&sig=Mx5gxhBEreMmgU%2BoWqRh9ttFphuo0m%2BnPxiDPrKNcVw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:29.7622496","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:35:29 GMT
-      mise-correlation-id:
-      - 5762f053-12be-45b0-8776-4b06bb1353bd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A35Z&sr=b&sp=r&sig=Sv4bN7%2Bnn9Mxk%2BP02OPG0kMaVgmsDmGkDX98MNPLycU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:35.026934","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A35Z&sr=b&sp=r&sig=fxc0E9rYG5Zw9g9w0UIwJcAiYkyRC5jODg13mXlGw2w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:35.0268641","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A35Z&sr=b&sp=r&sig=TXuYhi5v%2BVNIOfc50c4sTuc3Vl8BpsN%2FtyJV4ZK14hU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:35.0269703","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:35:35 GMT
-      mise-correlation-id:
-      - 78cfa8f9-16f4-4b70-be98-f4c90fac78ea
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A40Z&sr=b&sp=r&sig=WWSJz2vqgb7qNWxG6IC864QFRuYLVQavEzwuM88rcm0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:40.3034738","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A40Z&sr=b&sp=r&sig=YndoxEylQjyem2yTKPPj%2Fz3ZjA0CRsj9RFDuCunRKDE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:40.3034011","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A40Z&sr=b&sp=r&sig=HnUSjBMlCeDhUazVswRGKbE2u9SaGspx2OaMYCqPb1c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:40.3034884","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:35:40 GMT
-      mise-correlation-id:
-      - 01c2e8c6-2bc8-472c-bf5b-9f035dd0699d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A45Z&sr=b&sp=r&sig=wQUqHL6Zzy3zmjUY83XjpnCRWQfjkV5QAaACop6C5v8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:45.6354327","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A45Z&sr=b&sp=r&sig=hLCaP3hXGKigATYqpaOCcIwMw7RSBnF32q4sd4Ok1JY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:45.635364","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A45Z&sr=b&sp=r&sig=4qWTazfn1OEO44HQn2smGLfjQMHVoALTlVv7XlshzE0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:45.6354475","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:35:45 GMT
-      mise-correlation-id:
-      - 6f423380-f1e4-4337-ad70-b06bc5a8968d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A50Z&sr=b&sp=r&sig=n62lG0%2FkO5uGnpwIJWlPwfmkNZ2d8UaGnnd7fQekwDQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:50.9644624","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A50Z&sr=b&sp=r&sig=MA8ps03azwDZgX4kRbE9rntvYX7HWlh5i%2B7BrHyV9sg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:50.9643918","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A50Z&sr=b&sp=r&sig=kJX%2FVLNwj6eegEz4cMWHCf%2BIQebyNmFV0zsVr9GTsus%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:50.9644763","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:35:50 GMT
-      mise-correlation-id:
-      - 3c50b35a-a6fa-4b4c-b3e2-c3a649be5ab8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A56Z&sr=b&sp=r&sig=bXtAcFpGRmuVUIPWtaCubhQv7fWnjxXmXRsL3i36lhY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:56.2501894","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A56Z&sr=b&sp=r&sig=BwyfYkc9vxLgY8SOly2KGeoUrElnOw85KZ0uO1IOuG4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:56.2501225","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A56Z&sr=b&sp=r&sig=V44jxBX0RrCPOfEBo%2FmhKx8cU9b1jFtFN40%2B7F%2FNjCk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:56.2502044","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:35:56 GMT
-      mise-correlation-id:
-      - 5d2dbc47-9fa3-44f4-82e3-a305970d815c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A01Z&sr=b&sp=r&sig=bg2FwqDYl5y%2B%2FuVmi48Y2ojgUBZN7OgkDndOaki%2F14w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:01.5339291","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A01Z&sr=b&sp=r&sig=IpFZCz33pFEaLKh3n3TNR%2FfuQmrUj4t1md9kp%2B%2BcpWY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:36:01.5338565","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A01Z&sr=b&sp=r&sig=Dx%2BiVjrAEbTpIYlpz%2BK7IgjZaL5e6p7RZnj6EBC8wPs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:01.5339442","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-29T22:32:59.96Z","endDateTime":"2023-10-29T22:35:56.551Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:35:56.693Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3342'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:36:01 GMT
-      mise-correlation-id:
-      - f7c0923c-6eca-4f7e-ae75-56c405958a72
+      - cb9c5cb3-0117-411e-8917-1a8b23a594c7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1964,7 +1856,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:31:57.6921376Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:31:57.6921376Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:32:13.9583816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:32:13.9583816Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1973,9 +1865,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:36:02 GMT
+      - Mon, 30 Oct 2023 07:36:02 GMT
       etag:
-      - '"3c007239-0000-0100-0000-653edd5f0000"'
+      - '"3f00727e-0000-0100-0000-653f5c010000"'
       expires:
       - '-1'
       pragma:
@@ -2005,24 +1897,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=update-test-case&api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=update-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A05Z&sr=b&sp=r&sig=mG2GIcBj5ecDJ3FTVhyodLna0NVyqVkLLnkZRtPKaEE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:05.1010456","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A05Z&sr=b&sp=r&sig=VNQKVN2kj7CL12L9jcB8Xb158C805Yl4jFU%2FEh6udG8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:36:05.1009486","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A05Z&sr=b&sp=r&sig=aKWqfJN2v0VyMA9syl%2BCCVCGU%2FIX0VPQ02pqY2e8wPk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:05.101068","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-29T22:32:59.96Z","endDateTime":"2023-10-29T22:35:56.551Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:36:03.74Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A03Z&sr=b&sp=r&sig=4WCR%2FrqIqz%2FE0d%2Bb1abcMKamk0wboocI%2Bf06OXpHWBo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:36:03.8465702","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A03Z&sr=b&sp=r&sig=oFKn4oZQIUpnRiMfvUm5g3PRAHQWfpOMybnSKv%2BHSWc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:36:03.8464896","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A03Z&sr=b&sp=r&sig=YQ2jxE%2B0J261nAEZoJJG%2BX0sIvp1r7EZ5bqbpb804aA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:36:03.8465854","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-30T07:33:14.761Z","endDateTime":"2023-10-30T07:35:57.33Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:35:57.418Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3342'
+      - '3352'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:36:05 GMT
+      - Mon, 30 Oct 2023 07:36:03 GMT
       mise-correlation-id:
-      - 233a5536-5fc2-4962-871f-630079cf0664
+      - bd7c650b-3f04-4129-9bc0-24a7f2a7196f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2045,7 +1937,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:31:57.6921376Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:31:57.6921376Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:32:13.9583816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:32:13.9583816Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2054,9 +1946,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:36:26 GMT
+      - Mon, 30 Oct 2023 07:36:25 GMT
       etag:
-      - '"3c007239-0000-0100-0000-653edd5f0000"'
+      - '"3f00727e-0000-0100-0000-653f5c010000"'
       expires:
       - '-1'
       pragma:
@@ -2086,24 +1978,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A27Z&sr=b&sp=r&sig=EL%2F2hAF5UOUa9G3CcWnWObo6eUx7A3m6%2FnghGEkTU5E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:27.7229288","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A27Z&sr=b&sp=r&sig=s9LPvNmhPCbYfusRfpJt%2Bb%2FWjLQZwqNN3Nj21zHxvrw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:36:27.7228413","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A27Z&sr=b&sp=r&sig=81QMtsgnQQWE%2FysSwveI2gFwSVGHMKXFtYxg3EymOKM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:27.7229513","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/59bbd2cd-fa03-40dd-955f-583928730b95_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A27Z&sr=b&sp=r&sig=Nki7QizanwFhl74pTwbqOZ0O%2BD4ukhdi8BkQEUENe2U%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:27.7229895","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/59bbd2cd-fa03-40dd-955f-583928730b95_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A27Z&sr=b&sp=r&sig=UGCCyII2D9gYvMpsmByc8CAO3kqWl4YcL8Hfgo2FEqg%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:27.7230121","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-29T22:32:59.96Z","endDateTime":"2023-10-29T22:35:56.551Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:36:12.266Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A26Z&sr=b&sp=r&sig=kcFUspLF9IaAQJY5s4pagdEnZnC4cmNUYozf5%2Bsndz0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:36:26.5052911","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A26Z&sr=b&sp=r&sig=iE8pQXmXrYoCZ9aC4U1cDyNT0VLeTf4dc0WF%2FtOxo9g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:36:26.5051874","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A26Z&sr=b&sp=r&sig=X9Cr1l%2BDO9Zo1Jc83DGo6hQ1hqELp5OMG%2Bc8UhLFCI0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:36:26.5053145","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/f20ac54b-4e6e-4454-aa44-f409a4c2464b_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A26Z&sr=b&sp=r&sig=S1%2Fbly343cbu2wXFsiEYoFSLn6tz3sZWZ4FCvbnFJ5g%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:36:26.5053286","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/f20ac54b-4e6e-4454-aa44-f409a4c2464b_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A26Z&sr=b&sp=r&sig=bf2zxE3e9exY8kocUr8V%2FNMgpxoGa3kYum%2FDVtRqQJg%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:36:26.5053428","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-30T07:33:14.761Z","endDateTime":"2023-10-30T07:35:57.33Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:36:22.792Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4497'
+      - '4499'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:36:27 GMT
+      - Mon, 30 Oct 2023 07:36:26 GMT
       mise-correlation-id:
-      - 51fd3c8e-7687-427c-8adb-157d3498553f
+      - 478409ad-ade5-46dd-a225-6eba4f31bb1f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2127,25 +2019,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A28Z&sr=b&sp=r&sig=aOrnOQKoZyaSTv%2BDZTbeV02D7LdjXvn1cYXZ50CBCFA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:28.1391703","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A28Z&sr=b&sp=r&sig=I0sGJbqQId7dbgO5cLxdse5J5T4kHuY8zVb3g382i98%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:36:28.1390999","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A28Z&sr=b&sp=r&sig=dfJGae04ygAms8XeMaF72uo3CqfpHpgK7WIAVHw7t4I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:28.1391863","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/59bbd2cd-fa03-40dd-955f-583928730b95_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A28Z&sr=b&sp=r&sig=uiABM9RpysreRscfxxbz8bDzVBiepdmoVQICZm%2Fxy30%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:28.1392021","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/59bbd2cd-fa03-40dd-955f-583928730b95_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A28Z&sr=b&sp=r&sig=kXoz7Dl5PIeTsLOO5utfchVedo8Z9p2RXgXwab2%2BXUo%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:28.1392183","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
-        test run description","status":"FAILED","startDateTime":"2023-10-29T22:32:59.96Z","endDateTime":"2023-10-29T22:35:56.551Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:36:28.13Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A26Z&sr=b&sp=r&sig=GuwKv4TrRfUsVd86N5SKKzfzRlwZGZ0gRIh1r81EZ3Q%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:36:26.9524628","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A26Z&sr=b&sp=r&sig=a7Rab5WdHE6ft%2B4U7pCQP4qma5hApOX3%2BthUrO8E7cQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:36:26.9523703","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A26Z&sr=b&sp=r&sig=ozGtaQd1AEyAfFsUX%2BYnSygTQGmbkomaGle98uz5Fjo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:36:26.9524892","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/f20ac54b-4e6e-4454-aa44-f409a4c2464b_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A26Z&sr=b&sp=r&sig=LayYc5evAYsmnYPJeHiFDjIBQ4uul4uJPEww3NiS%2FOM%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:36:26.9525139","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/f20ac54b-4e6e-4454-aa44-f409a4c2464b_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A26Z&sr=b&sp=r&sig=SueaCdtZjc0TKMo2tlfximERmPi%2B%2BQtwAMQz5AhWQfI%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:36:26.952539","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
+        test run description","status":"FAILED","startDateTime":"2023-10-30T07:33:14.761Z","endDateTime":"2023-10-30T07:35:57.33Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:36:26.943Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4535'
+      - '4541'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:36:28 GMT
+      - Mon, 30 Oct 2023 07:36:26 GMT
       mise-correlation-id:
-      - a0bc9d29-f8f2-4036-876f-c372f90a8b17
+      - 97e8b84b-fbad-46bb-9e1d-1b63b964e33d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2168,7 +2060,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:31:57.6921376Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:31:57.6921376Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:32:13.9583816Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:32:13.9583816Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2177,9 +2069,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:36:28 GMT
+      - Mon, 30 Oct 2023 07:36:28 GMT
       etag:
-      - '"3c007239-0000-0100-0000-653edd5f0000"'
+      - '"3f00727e-0000-0100-0000-653f5c010000"'
       expires:
       - '-1'
       pragma:
@@ -2209,25 +2101,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://53460ca0-85a1-4cd9-8141-102a454e34be.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A30Z&sr=b&sp=r&sig=CdW8XIv9br%2BdTJVw2Yjycaek15MeFT5Zqz2B3gLJ%2FJU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:30.5965281","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A30Z&sr=b&sp=r&sig=HJEFz%2BUa0cLtUD2tU9iHJvlRXX0Pjf2gzOy972G0OBQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:36:30.5964576","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A30Z&sr=b&sp=r&sig=L3hgF8qpBtRybqnqM9qjXO1bAspT0r%2F0cy%2BGCZX1qFs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:30.5965435","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/59bbd2cd-fa03-40dd-955f-583928730b95_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A30Z&sr=b&sp=r&sig=Z8cnmj4qGTEMwBlrQU4ux9QDi3lk5dM83RX06eOalfE%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:30.5965596","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/59bbd2cd-fa03-40dd-955f-583928730b95_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A30Z&sr=b&sp=r&sig=Wmx98WugetWqjAPyleM5xwB6rso%2BXg1a%2BXBgT2gO1gM%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:30.5965751","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
-        test run description","status":"FAILED","startDateTime":"2023-10-29T22:32:59.96Z","endDateTime":"2023-10-29T22:35:56.551Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:36:28.13Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3db8a6d6-3f09-4732-b8e2-90283934a5ec":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"58e5f6bf-8385-4a85-8af8-3a9d322ee9ea":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"e4b7a6af-1f8e-4c3b-b288-6ccce0369650":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/7a3d9a4d-fa2e-4569-90ef-0d0e6c79f1ff?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A29Z&sr=b&sp=r&sig=uw28XVgw0E6t9fIUN95ME90pUmx3jI%2BaQifNWqV8qt8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:36:29.3738085","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/e6b39386-97cf-4495-b172-dba042215733?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A29Z&sr=b&sp=r&sig=hmtWEul2M9sAcSMkYARjhxJpNRtKDxRRoxNXCJyKdgE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:36:29.3737355","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/3920af94-7490-423a-a1c2-61f7d42c0ce4?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A29Z&sr=b&sp=r&sig=%2Fsr6jQfacO03MhUt4jy1lNlnHJFqoW04pPhvgRXEgHg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:36:29.3738284","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/f20ac54b-4e6e-4454-aa44-f409a4c2464b_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A29Z&sr=b&sp=r&sig=4fnyy2Kk0kED%2BqWL3yJUjeVEgSDl8qThoy5L2qOYx30%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:36:29.3738459","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/65d6666c-6b3d-41df-a958-a2b97a4c35f9/f20ac54b-4e6e-4454-aa44-f409a4c2464b_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A36%3A29Z&sr=b&sp=r&sig=ucg8939Tsn1WM7fIF8kMAXFXx536sqPg098SRk1OI3E%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-30T08:36:29.3738733","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
+        test run description","status":"FAILED","startDateTime":"2023-10-30T07:33:14.761Z","endDateTime":"2023-10-30T07:35:57.33Z","executedDateTime":"2023-10-30T07:33:13.193Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-30T07:33:14.324Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:36:26.943Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4543'
+      - '4536'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:36:30 GMT
+      - Mon, 30 Oct 2023 07:36:29 GMT
       mise-correlation-id:
-      - 8fa98bbd-9c3e-46aa-a09a-2ae64c3432bc
+      - bd66c6ac-06ba-42f3-a52b-5423fd9eed71
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_update.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_update.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:17:30.3807701Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:17:30.3807701Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:22:48.3302759Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:22:48.3302759Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:08 GMT
+      - Mon, 09 Oct 2023 16:23:22 GMT
       etag:
-      - '"1a0aa8f3-0000-0100-0000-64af0a5c0000"'
+      - '"9301b10e-0000-0100-0000-652428da0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:18:09 GMT
+      - Mon, 09 Oct 2023 16:23:23 GMT
       mise-correlation-id:
-      - e2748635-0820-4c4b-ad10-b2b6110c29bb
+      - 55dde3b3-d5f5-448d-bb38-5091c2092bbe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -85,12 +85,12 @@ interactions:
 - request:
     body: '{"displayName": "CLI-Test", "description": "Test created from az load test
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
-      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "loadTestConfiguration":
+      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"04a98624-9217-435e-99dd-dd590aa9fd33": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "02840846-f08d-4d2b-87ca-1297fc255f32":
+      {"passFailMetrics": {"81842833-4cca-4e6e-8d31-a4e22bcd3e9a": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "faf57da5-a443-417c-981e-3507dc4437a2":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "901f2584-261e-41a5-8958-e60fba66633c": {"aggregate": "avg", "clientMetric":
+      "50"}, "aab4b375-f0c9-4251-9c3d-7b904fbc0907": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -100,32 +100,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '768'
+      - '789'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:18:11.093Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:18:11.093Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:23:24.422Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:24.422Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1062'
+      - '1008'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:11 GMT
+      - Mon, 09 Oct 2023 16:23:24 GMT
       location:
-      - https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+      - https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 71d3f004-feff-477c-82e5-04eaff9b106b
+      - be95a5d9-f296-47a3-b96d-845d1d2161aa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:14 GMT
+      - Mon, 09 Oct 2023 16:23:24 GMT
       mise-correlation-id:
-      - cbf54c99-5d32-46fa-b076-f6616497a7ea
+      - 241cfca0-6bc4-405a-bce9-2622c292ae97
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A28%3A17Z&sr=b&sp=r&sig=AbDYzkYWjXsaSqhxXDGDVEbHEg2HfAH3h0OlyTEKZBw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:28:17.5444356","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A33%3A25Z&sr=b&sp=r&sig=b2ecREO%2BEUwHuAvTVqRd4Pl36iBIisnp2aCJskhwpyk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:33:25.2159136","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:17 GMT
+      - Mon, 09 Oct 2023 16:23:25 GMT
       location:
-      - https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 24141fc7-8062-4e0b-a7dd-3ef4446f46e7
+      - 1c0ac90c-023f-4630-886d-178b55cb8a54
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A28%3A17Z&sr=b&sp=r&sig=KF57Js1pScWGOpLn3e850Gblve8GlJRrej1tkuJ%2FZMI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:28:17.8494702","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A33%3A25Z&sr=b&sp=r&sig=hgj3XXRDNlO90KY4syJjV4NciHYM2f7BZ8wBeuMKP%2Fc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:33:25.481063","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '550'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:23:25 GMT
+      mise-correlation-id:
+      - 524bb4b0-7d94-4574-8cd2-ca341c6e3fc9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A33%3A30Z&sr=b&sp=r&sig=bYTwezqU%2FMmEnXlin1YRePOQBntp9qmBFbEeEl5O4cw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:33:30.7567124","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:17 GMT
+      - Mon, 09 Oct 2023 16:23:30 GMT
       mise-correlation-id:
-      - e305d6b2-56a4-4ae0-92d8-2116e51600c1
+      - 2c91dd80-1fa3-4220-895f-01201857b295
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,46 +385,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A28%3A23Z&sr=b&sp=r&sig=nA1eEOS07IrmUeXh%2BPWb9rFpcMv522I1%2Btqb6NLgHoU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:28:23.2094363","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:18:23 GMT
-      mise-correlation-id:
-      - 3b065e6b-50fb-450a-befd-04daa82fd04e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A28%3A28Z&sr=b&sp=r&sig=CNujd1KeMCgcejthgL10i8AlnvH4Ag%2BK4iPsLiqvmjY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:28:28.5766939","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A33%3A37Z&sr=b&sp=r&sig=9vPR%2BsC8sJc2oAV4BNaruJK6K3pGtPAwNUiy68rZOxw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:33:37.9799038","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:28 GMT
+      - Mon, 09 Oct 2023 16:23:37 GMT
       mise-correlation-id:
-      - 66f3c748-5795-4e58-b2cf-d5028caeb3e3
+      - b027d331-202a-4f55-b928-60eafa71177a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A28%3A33Z&sr=b&sp=r&sig=Bc%2Bj5ZRtklQBwP5FYnNjI4%2BS%2FQTNpozqrhM0womgL2o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:28:33.9277449","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A33%3A43Z&sr=b&sp=r&sig=oeXTauJGU5%2FtpFEhKOT1fc9%2FDlFcSgNfZkUJRNLSiCM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:33:43.2552148","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:33 GMT
+      - Mon, 09 Oct 2023 16:23:43 GMT
       mise-correlation-id:
-      - 05331b9a-8b7b-44a4-92dc-c7993ea435b1
+      - 9ed2e7b7-a064-4aae-afac-655b313bb8c0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A34Z&sr=b&sp=r&sig=0QWaJAT7Vn%2BljCo6jDIHvpBbDVi6FKHYtUn211BdMj8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:34.2199969","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:18:11.093Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:18:30.385Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A43Z&sr=b&sp=r&sig=bFIKhfITu6yX7It%2B0ifBObCaEGRwRW7n1zXpTVaDQ7I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:23:43.5398048","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:23:24.422Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:39.186Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1633'
+      - '1579'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:34 GMT
+      - Mon, 09 Oct 2023 16:23:43 GMT
       mise-correlation-id:
-      - adaa872b-77f7-4301-9240-d5c4672647f3
+      - 4032e77b-251a-4159-997d-c26f35efb1fa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:17:30.3807701Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:17:30.3807701Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:22:48.3302759Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:22:48.3302759Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:35 GMT
+      - Mon, 09 Oct 2023 16:23:44 GMT
       etag:
-      - '"1a0aa8f3-0000-0100-0000-64af0a5c0000"'
+      - '"9301b10e-0000-0100-0000-652428da0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A37Z&sr=b&sp=r&sig=7fWA9tSMelRGVS5tp30gc1Cm%2F5IM5Q2cpZOr0A1LXkE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:37.1806263","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:18:11.093Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:18:30.385Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A45Z&sr=b&sp=r&sig=OKToRzR2Td3XoH0LMy3zzq5a7i0DotsyP%2FO1805VnEc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:23:45.8958362","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:23:24.422Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:39.186Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1645'
+      - '1591'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:37 GMT
+      - Mon, 09 Oct 2023 16:23:45 GMT
       mise-correlation-id:
-      - 651ec7f1-403c-4ee3-81bd-09e6488c8c39
+      - 800c20b8-4a17-47e1-953c-33973f767ff9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:17:30.3807701Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:17:30.3807701Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:22:48.3302759Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:22:48.3302759Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:39 GMT
+      - Mon, 09 Oct 2023 16:23:47 GMT
       etag:
-      - '"1a0aa8f3-0000-0100-0000-64af0a5c0000"'
+      - '"9301b10e-0000-0100-0000-652428da0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:18:42 GMT
+      - Mon, 09 Oct 2023 16:23:48 GMT
       mise-correlation-id:
-      - 7ac19bec-3154-4019-8475-57fb0b0189d5
+      - 9339b947-b656-4c3f-9a37-b06aadf8a2d5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/d05c2cf1-7108-4773-a38a-a3fed2632d68?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A43Z&sr=b&sp=r&sig=Wpgr5Vi4ufx3y6hXaVSNXjSoCtkyu868DiadeGx7HF4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:43.8974722","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A43Z&sr=b&sp=r&sig=SHRiB5KGjMVxTLldlE5625gMArDcLcr9e4LFrd3JSjg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:43.8973642","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/bf83bb63-5002-40d9-abee-1b94af4d3294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A43Z&sr=b&sp=r&sig=AU4WXvmxli%2FQNA0BBYBv3rmyJBxA2ayNMU0vKQHP3DQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:43.8975009","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","testId":"update-test-case","status":"ACCEPTED","executedDateTime":"2023-07-12T20:18:42.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-07-12T20:18:44.235Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:18:44.235Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A49Z&sr=b&sp=r&sig=%2BV6LdtiSrgPPfgi2EIU8EgzzqFvWtkSx8h5PpJAdh6M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:23:49.8294774","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A49Z&sr=b&sp=r&sig=zmyc20zsTH%2FaVzNq3z%2BKhYzt52cPrPdfNDXZ0AOfMc4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:23:49.8293919","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A49Z&sr=b&sp=r&sig=ZwB1POFAh7kC%2BDQABLApjCDImgrZY2m11pa6GmvUFPo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:23:49.8294999","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:49.746Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3185'
+      - '3156'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:44 GMT
+      - Mon, 09 Oct 2023 16:23:49 GMT
       location:
-      - https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+      - https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 74350e3d-c7e3-4ab5-817d-e6deea1a11d6
+      - 2a26b9ef-602a-4b30-b344-7c9e8ab9c8c0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,10 +700,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/d05c2cf1-7108-4773-a38a-a3fed2632d68?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A44Z&sr=b&sp=r&sig=h5nWg3K%2FajHcSk%2B1KxYbzBgP929pIHoN%2FRT11kRkNgE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:44.6007048","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A44Z&sr=b&sp=r&sig=ae3cFs4%2BDa4%2F47L8aDytGX7ZyzfxKAenigK9j2SlXjk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:44.600634","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/bf83bb63-5002-40d9-abee-1b94af4d3294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A44Z&sr=b&sp=r&sig=LStUOBwSujvQ71bcyI2k219L%2FpI9JWh504%2F%2FFIXYHy8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:44.6007186","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","testId":"update-test-case","status":"ACCEPTED","executedDateTime":"2023-07-12T20:18:42.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-07-12T20:18:44.235Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:18:44.235Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A50Z&sr=b&sp=r&sig=qwtiuQyWwvH87m3VTPqcfJA%2Bav0p49vNV%2BHlZNE%2FCyo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:23:50.2749522","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A50Z&sr=b&sp=r&sig=t6WhLn13DlQ0lId52Kdz%2F2lw%2FOeXb6e3JT23sCZ2wkE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:23:50.2748826","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A50Z&sr=b&sp=r&sig=eMtclULdf2nmmKWna5h8OT%2Fhu%2FFzLfArYSl8quQi%2FEI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:23:50.2749672","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:50.137Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3209'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:23:50 GMT
+      mise-correlation-id:
+      - 6d800a63-7279-4e0c-b84d-33ba66a7e8eb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A55Z&sr=b&sp=r&sig=Wg1YpzmpZUIbME6XSR4fzOAueL6yufAGKQRvJ6LIyiA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:23:55.5577134","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A55Z&sr=b&sp=r&sig=ZqiRK9FXRyonF7%2B8PxU3lVtYVAS0huvxrFu7RwRROyE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:23:55.5576464","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A55Z&sr=b&sp=r&sig=%2BKE8HxogDwcCOqB90ZMOihpoczzFst7ddoQaWOpGyeU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:23:55.5577282","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:50.32Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -714,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:44 GMT
+      - Mon, 09 Oct 2023 16:23:55 GMT
       mise-correlation-id:
-      - 65422b02-e3e3-4a68-b26a-584009a3291c
+      - 390daf1d-8785-4fab-809e-cbda2389d99f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +772,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/d05c2cf1-7108-4773-a38a-a3fed2632d68?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A49Z&sr=b&sp=r&sig=NBkLe%2B0JqGgrg2cq3NK6BjkPBhfJPOvvL%2BBnOoJbWJc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:49.8706201","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A49Z&sr=b&sp=r&sig=ZRUa%2BQePx4%2Bi7ILQ6r8pQIyjMdH%2FdQ0E3BY8SBohB3c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:49.8705531","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/bf83bb63-5002-40d9-abee-1b94af4d3294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A49Z&sr=b&sp=r&sig=dvNmmE0X%2F0TC70UzwaKkuNbEiNmYqp%2B0oE2e6FnIZ%2BQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:49.8706346","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:18:45.251Z","executedDateTime":"2023-07-12T20:18:42.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-07-12T20:18:44.235Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:18:45.47Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A00Z&sr=b&sp=r&sig=FJn1eHGwA9HZbgiAsd5QK2eQG8EUWZ40018s7ZC2b8Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:00.8421495","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A00Z&sr=b&sp=r&sig=JgJD263Rh1CO9JSvOuYq6GWJ46uQt3ZwcFv7IP%2BSQWA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:00.842067","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A00Z&sr=b&sp=r&sig=E%2FS3sfXePaDSPjoe6yrM1TjgoZEjQ2i%2FtpmEoTkB5Uw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:00.842164","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:50.32Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3245'
+      - '3198'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:49 GMT
+      - Mon, 09 Oct 2023 16:24:00 GMT
       mise-correlation-id:
-      - e2fb426d-f40f-4fda-8d44-fb7905b955cc
+      - b8957b6c-b50d-4308-9a87-a50bac6d4b49
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,23 +808,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/d05c2cf1-7108-4773-a38a-a3fed2632d68?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A55Z&sr=b&sp=r&sig=%2B4XiJC3H6gz95DP17iKWWM333jh9aYTKRhT86AMwHds%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:55.1684919","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A55Z&sr=b&sp=r&sig=mo9Uq3txd2oIBRHtPVYm06cIJo1ESEB1q4fvP1TMmQA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:18:55.1684243","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/bf83bb63-5002-40d9-abee-1b94af4d3294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A18%3A55Z&sr=b&sp=r&sig=Qa9rKup45JTg8f4NmB9Yu0ZjLudOPPYXEJKApqvp6Rc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:18:55.1685068","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:18:45.251Z","executedDateTime":"2023-07-12T20:18:42.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-07-12T20:18:44.235Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:18:45.47Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A06Z&sr=b&sp=r&sig=E9mLcAweACLx0aKunzl9TWS%2FoPMuoLQrFjMloOz9m00%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:06.1266109","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A06Z&sr=b&sp=r&sig=dFCp5w24winL4v2upUc%2BKW8ZjZW%2FwcUn2UA%2FzGcVJpg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:06.1265162","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A06Z&sr=b&sp=r&sig=PTnMzVOvbXT1T3esx7%2FCCkQH1o5MJNrmAYns%2FsczO9M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:06.1266344","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:50.32Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3231'
+      - '3206'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:18:55 GMT
+      - Mon, 09 Oct 2023 16:24:06 GMT
       mise-correlation-id:
-      - be21e18f-7438-44b6-bc9d-a1ff1c0ac4a1
+      - 35ff967f-6a94-43fe-a7fa-8b2cc7ddd324
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -808,23 +844,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/d05c2cf1-7108-4773-a38a-a3fed2632d68?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A00Z&sr=b&sp=r&sig=T5lDPDpainmk09rmQiZyCmyI9Wl8JEyzsZNatTp9BHQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:00.5311646","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A00Z&sr=b&sp=r&sig=KaMGgX97J%2B46nfFd4YwgQReguJkr5gKbdGz41paGIVU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:00.5310848","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/bf83bb63-5002-40d9-abee-1b94af4d3294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A00Z&sr=b&sp=r&sig=VjOTT51j1TEhZcrYxY%2FCznc02FlOSiS8Emr3MXYvOL8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:00.5311785","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:18:45.251Z","executedDateTime":"2023-07-12T20:18:42.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-07-12T20:18:44.235Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:18:45.47Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A11Z&sr=b&sp=r&sig=F16uJ2mBVt8uL5tdBWY%2BBpJ3tt6j2tXSopx%2FeAxlIt8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:11.400376","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A11Z&sr=b&sp=r&sig=IcDymZ2jsDkmyPbfNeWfFmOwsAYr0hE9jCqWfX0b0cE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:11.4002515","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A11Z&sr=b&sp=r&sig=JgNmOMHm44MXAMKSRx072HXz%2FqwFfP%2FZrBDAQFU9s3k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:11.4003973","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:50.32Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3233'
+      - '3201'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:00 GMT
+      - Mon, 09 Oct 2023 16:24:11 GMT
       mise-correlation-id:
-      - 021be94c-33fa-40f1-9d14-487924cb86b9
+      - df9c915a-0d58-4c26-8f6f-3edc8f32201a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -844,23 +880,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/d05c2cf1-7108-4773-a38a-a3fed2632d68?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A05Z&sr=b&sp=r&sig=ySHf9bmUzoLRIPHBpOAl4DZ4bjobuBZlDEe9wqd9ATQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:05.9589398","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A05Z&sr=b&sp=r&sig=fwAl1wPGh8COmRJKLuKeKWBDh6t6%2FdnYqwQLtIXyb20%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:05.9588611","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/bf83bb63-5002-40d9-abee-1b94af4d3294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A05Z&sr=b&sp=r&sig=1XcaWCPc24hV1sArWVHUrqcqeWsiWFo2UC7rwzciYB8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:05.9589606","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:18:45.251Z","executedDateTime":"2023-07-12T20:18:42.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-07-12T20:18:44.235Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:18:45.47Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A16Z&sr=b&sp=r&sig=YosoHkbSr7ZTlBTuW0OoWCUVOYCkt6m9kZ5sCSsZrzE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:16.6769566","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A16Z&sr=b&sp=r&sig=%2F2aq1dCQ5MJYGlJS0BXFDw2VLTskGVo%2F%2FUoz1eLs9fY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:16.6768822","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A16Z&sr=b&sp=r&sig=anm8qChDk%2FKoM%2F1oyvhb9kDsKhpVVZdxMjc9oywHSQw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:16.6769731","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:50.32Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3231'
+      - '3204'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:05 GMT
+      - Mon, 09 Oct 2023 16:24:16 GMT
       mise-correlation-id:
-      - 85a0b0bd-3de3-4cfd-b25b-1cdc1c7d49fb
+      - 0b9f606d-8166-4dc0-bf9f-cab7491aafd8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -880,23 +916,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/d05c2cf1-7108-4773-a38a-a3fed2632d68?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A11Z&sr=b&sp=r&sig=Ji774M%2BZ8AGKG3WQkurWfCmqOsPl3kFLouZBDYbAFjk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:11.3068907","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A11Z&sr=b&sp=r&sig=uVZToAHUHgxYhUbrcc04quM%2FokiL6SAkSq8S70PgWQQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:11.3068248","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/bf83bb63-5002-40d9-abee-1b94af4d3294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A11Z&sr=b&sp=r&sig=sZ3TizBTBsf459YnJwn1TFfIiZpP8mOmYLUp3eoufs0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:11.3069051","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:18:45.251Z","executedDateTime":"2023-07-12T20:18:42.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-07-12T20:18:44.235Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:18:45.47Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A22Z&sr=b&sp=r&sig=dDI135URXO4X5BGrBJekSIgMZJvHcRBSIYLvB8n0P0U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:22.0032675","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A22Z&sr=b&sp=r&sig=DJ7pxG2mdoQY1gilrYsl3LiutwGDw1QpZVfrLB%2BNKOM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:22.0031778","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A22Z&sr=b&sp=r&sig=gYvTyPvpz1xtefQ3ZQOcyrTm8r3tvCg8bhIjX8MixYg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:22.0032901","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:50.32Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3233'
+      - '3196'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:12 GMT
+      - Mon, 09 Oct 2023 16:24:22 GMT
       mise-correlation-id:
-      - 6722c089-5801-467a-b22b-4e4a507bae5a
+      - 88676d49-2a1c-4f55-bcb5-1f6c81efd7f8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -916,23 +952,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/d05c2cf1-7108-4773-a38a-a3fed2632d68?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A17Z&sr=b&sp=r&sig=T0a4DYQoApZP2LpS4nEoPc0ZD%2Bg5Q%2F2tv1YMnBVey%2BM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:17.6269377","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A17Z&sr=b&sp=r&sig=8IEd8C%2Bez3DVxq56qRpt7fxRyfHbdwDRQMqJ77U%2F7rM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:17.6268541","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/bf83bb63-5002-40d9-abee-1b94af4d3294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A17Z&sr=b&sp=r&sig=WO4bycXgKzlFDcNuBsuXvT2q1B%2BY0baCSfleYd97nqs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:17.6269559","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:18:45.251Z","executedDateTime":"2023-07-12T20:18:42.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-07-12T20:18:44.235Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:18:45.47Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A27Z&sr=b&sp=r&sig=N%2B2m%2FQLevGeDkMwoIl9YtLR%2FpiC3sq1kfRvhkZe4zDQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:27.2776888","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A27Z&sr=b&sp=r&sig=A0k6AYBab6kI1ciuYse%2BgOPYuQP1mmenmUHOdiu2CS4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:27.277623","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A27Z&sr=b&sp=r&sig=VMhTEMIqsbt%2F4aBzErn96XYrWtmynKOyk5cK4XWYA9I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:27.2777055","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:50.32Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3241'
+      - '3203'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:17 GMT
+      - Mon, 09 Oct 2023 16:24:27 GMT
       mise-correlation-id:
-      - 720daaaf-4198-4fab-a16f-ccd97d2f6ba4
+      - b695e009-e610-48ac-9eff-2c560f2ab6d6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -952,23 +988,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/d05c2cf1-7108-4773-a38a-a3fed2632d68?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A23Z&sr=b&sp=r&sig=KlU414Hyzu%2F50qPTsFSTkzLKFOmIv0LTg8CZjRqZgpE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:23.3147571","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A23Z&sr=b&sp=r&sig=LbNTlSO2YrOAMUH%2BBQWkRmiWKdxBgmUoRkdAF0D%2F4Ts%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:23.3146743","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/bf83bb63-5002-40d9-abee-1b94af4d3294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A23Z&sr=b&sp=r&sig=C4CJ7Gx8k9hI0t6wCLBKkszNlWGZ2QnU%2BJv6lofxUig%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:23.3147712","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:18:45.251Z","executedDateTime":"2023-07-12T20:18:42.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-07-12T20:18:44.235Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:18:45.47Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A32Z&sr=b&sp=r&sig=gkV7QBjk4sZMqx5DxbYbck6jxO2FbWIYXQOkFy5oOqk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:32.5569254","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A32Z&sr=b&sp=r&sig=iUtdlNuxYIKbTd9NT0XCzAM7JSLTGNDnllrfoctBuzY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:32.5568584","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A32Z&sr=b&sp=r&sig=v4t%2BmpVIstOpxSxVx3qqJzO4hil0FUw6S6U%2F6e3vLao%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:32.5569389","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:32.042Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3237'
+      - '3198'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:23 GMT
+      - Mon, 09 Oct 2023 16:24:32 GMT
       mise-correlation-id:
-      - 594b5824-6890-4073-a8b2-9069b1fd7fd1
+      - ea10af8b-9c68-457b-91a0-7e82dd4f74db
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -988,23 +1024,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/d05c2cf1-7108-4773-a38a-a3fed2632d68?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A28Z&sr=b&sp=r&sig=QSz%2FmNfrTF4YQSimTREkRFZguoOGuU4OXKWUNWUrpcw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:28.5813716","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A28Z&sr=b&sp=r&sig=NYqtCLsCJHBTFavFqjQKfTG6fJKio3%2B4ZIcOBcmT6W4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:28.5813008","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/bf83bb63-5002-40d9-abee-1b94af4d3294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A28Z&sr=b&sp=r&sig=niQRJo9CA6dcZcUuocYVrKdpPO7%2FcFrhXKC5LVkTGUQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:28.5813859","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-07-12T20:18:45.251Z","executedDateTime":"2023-07-12T20:18:42.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-07-12T20:18:44.235Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:18:45.47Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A37Z&sr=b&sp=r&sig=W%2FUgREcDU1SqXoNJ3IZwT7gFZgl7KOOnQdqmy78MebY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:37.8463912","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A37Z&sr=b&sp=r&sig=d4jm%2FkKmFSD74azQ8tSITN9c95g8TqQfDGFPksL20aE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:37.8462928","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A37Z&sr=b&sp=r&sig=waGkOwanlpH3C7CFgqIfBqateU7Li1hyy4LDK2i3TXE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:37.8464164","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3235'
+      - '3196'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:28 GMT
+      - Mon, 09 Oct 2023 16:24:37 GMT
       mise-correlation-id:
-      - d6bdf2f3-9c8d-4e2d-9180-e878ff8328ab
+      - 1f25f068-cbe4-4227-9d41-a821e07377f0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1024,23 +1060,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/d05c2cf1-7108-4773-a38a-a3fed2632d68?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A33Z&sr=b&sp=r&sig=1nybFi5pAZdFQNa8EdTMWwnRJ8rYj7QNPmL31pO5sW8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:33.9016107","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A33Z&sr=b&sp=r&sig=PXwC7NzkYZI6GPjUvtBwjbOV5UJIA0wtalqiSeK761M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:33.9015479","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/bf83bb63-5002-40d9-abee-1b94af4d3294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A33Z&sr=b&sp=r&sig=ljPCW6CgQTBF5Zadvw40dH4X6oHbIn7%2F1Y4EYKMadCA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:33.9016254","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","testId":"update-test-case","status":"CONFIGURING","startDateTime":"2023-07-12T20:18:45.251Z","executedDateTime":"2023-07-12T20:18:42.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-07-12T20:18:44.235Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:30.29Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A43Z&sr=b&sp=r&sig=d4wI%2FlNVJsYcYRRsFuge0MkGhXUVi2ko%2B2bl6Lf86DA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:43.1302839","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A43Z&sr=b&sp=r&sig=4zpZAgtuNY3H0MHV8KY2OQ8u%2FRMHS8pYJJk5Kq%2FekSg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:43.1302112","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A43Z&sr=b&sp=r&sig=odCc7XWUdKksJGC%2Bw%2BET%2BXmF8JO2%2FVOs3lq5eOVRsmo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:43.1303","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3230'
+      - '3205'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:33 GMT
+      - Mon, 09 Oct 2023 16:24:43 GMT
       mise-correlation-id:
-      - c31c787c-5778-4a33-83c4-c7d9bbc32d76
+      - 09b764bd-4082-4756-9665-c39f03f494ad
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,23 +1096,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/d05c2cf1-7108-4773-a38a-a3fed2632d68?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A39Z&sr=b&sp=r&sig=%2Bj0KIv2Lvx2Deqd%2BtikwpH2OAgizYuVq5t1cv1HEWIc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:39.1760487","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A39Z&sr=b&sp=r&sig=qkp59oiC15cYp8i%2BaqfWtTGw1EHQqaItcU%2FRaOsEULI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:39.1759686","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/bf83bb63-5002-40d9-abee-1b94af4d3294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A39Z&sr=b&sp=r&sig=A63GJcvKL%2FdepEhe8GUYTwUMJ5zc7Pirf2gFt1zvi1g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:39.1760672","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:18:45.251Z","executedDateTime":"2023-07-12T20:18:42.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-07-12T20:18:44.235Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:35.388Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A48Z&sr=b&sp=r&sig=uzhktT9FUyYulLB6H6iBFaK9L9ODwOsMfMpYPvzUHXU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:48.4112296","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A48Z&sr=b&sp=r&sig=frJRMjJ6LGvd5Lai1UUZVuSJ9CNlcDEhgsvnMAi0pB8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:48.411124","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A48Z&sr=b&sp=r&sig=agKjhgJwuebtsldR66qD0Xj%2BPIb1SUC%2BTQbcHtiiA8M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:48.4112542","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3237'
+      - '3195'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:39 GMT
+      - Mon, 09 Oct 2023 16:24:48 GMT
       mise-correlation-id:
-      - 82d5e38f-bd88-40f6-9348-751607c5e76b
+      - a9c5ecf1-715b-4276-b5ce-62f59940f737
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1096,23 +1132,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/d05c2cf1-7108-4773-a38a-a3fed2632d68?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A44Z&sr=b&sp=r&sig=y2fHOuiy65nxOsLydelv1x%2BBf2NQDh9zGvHQ0edhBxQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:44.4544756","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A44Z&sr=b&sp=r&sig=jgufadbS3DWnPpSXKPKO%2F0gXw9kasPkM8nvxBW53JMM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:44.4544024","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/bf83bb63-5002-40d9-abee-1b94af4d3294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A44Z&sr=b&sp=r&sig=sw5Nt5esDMj%2FsdUsZm1i29Ze5zxdkbJI9ZalZaaw6b0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:44.4544978","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-07-12T20:18:45.251Z","executedDateTime":"2023-07-12T20:18:42.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-07-12T20:18:44.235Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:35.388Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A53Z&sr=b&sp=r&sig=vwvxKqCcmErOlxZxW%2Br%2FI8K7WwbcavdZEHa3kESkS98%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:53.6939079","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A53Z&sr=b&sp=r&sig=X1fXQ7qysGI5CxZDBb0M3aBspnPFDqTw9oFRoZUnCUM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:53.6938177","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A53Z&sr=b&sp=r&sig=ju8M2%2Fck%2BzhCivIAMJQ144usPWpkOPsxrdcyfQqyV5U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:53.6939292","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3233'
+      - '3200'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:44 GMT
+      - Mon, 09 Oct 2023 16:24:53 GMT
       mise-correlation-id:
-      - 116418fa-b419-4979-bcc6-b52ac83a75c6
+      - 042f3047-0f81-48c0-8d3d-fc1e97d7ba27
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1132,24 +1168,636 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/d05c2cf1-7108-4773-a38a-a3fed2632d68?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A49Z&sr=b&sp=r&sig=whfF77OQLvZmUUROxEWdiLC8GIgvtmxFfhiPpB9JUhg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:49.7910615","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A49Z&sr=b&sp=r&sig=bZPn6wQ1pWr%2BBldFBI%2BslDr%2Bl%2B0vkFJBRDhmCMl8cHY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:49.7909965","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/bf83bb63-5002-40d9-abee-1b94af4d3294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A49Z&sr=b&sp=r&sig=bSZ5FHbBvTYqxI20ySbAYDYYM4Ia1SRO4npzmm04FzM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:49.7910748","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-07-12T20:18:45.251Z","endDateTime":"2023-07-12T20:19:44.628Z","executedDateTime":"2023-07-12T20:18:42.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-07-12T20:18:44.235Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:47.052Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A58Z&sr=b&sp=r&sig=2sGYYZkBDeY30IqJyY%2FmEfZvg6xXdZkotVbMwF4qS0w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:58.9877486","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A58Z&sr=b&sp=r&sig=DZQ8RXa8HITNPZNO28W8IL0unstCGNs8txHuvmFf9nU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:58.9876939","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A58Z&sr=b&sp=r&sig=VfKGE7iRTi9PJHdUvf7wOkiA7DZtX6gRVySh043IZgE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:58.9877634","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3370'
+      - '3194'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:49 GMT
+      - Mon, 09 Oct 2023 16:24:59 GMT
       mise-correlation-id:
-      - e16473a7-d573-4e10-9417-adedf12bada7
+      - 491301ab-be33-4620-82cf-97b586b758f8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A04Z&sr=b&sp=r&sig=dm4G2OZfV7wSzB1bcsuUWdyoLM7HJY%2FzAqVshiJ74Lw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:04.2850205","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A04Z&sr=b&sp=r&sig=f2hef42dSTVAsQ%2FUaYwhFJQQM9KXLJno1jL4VUrTA1w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:04.2849207","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A04Z&sr=b&sp=r&sig=IhbxKdmVz6U3DlVdU7WgFrcAFX2w5p7KaU2DS2VNQ8k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:04.2850402","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:25:04 GMT
+      mise-correlation-id:
+      - 1a7adfc5-2360-401c-b4d0-4120a7f73f07
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A09Z&sr=b&sp=r&sig=54ZTirkW5SGhK7tgy%2FyAiF6h6OtNAegOgO1fgnIYlGk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:09.5602897","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A09Z&sr=b&sp=r&sig=O8qFsbrI8fnrPHGdgB8sAkgbJKcXmdSeO7kH8gJkawI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:09.5602171","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A09Z&sr=b&sp=r&sig=nPGq%2BNVMYmUkURUMlet%2FdleLr1bGnP%2FomCxijMWKctw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:09.5603045","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:25:09 GMT
+      mise-correlation-id:
+      - 4f5aa54e-9920-4d9d-b885-99daee1a4ee6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A14Z&sr=b&sp=r&sig=5o1%2BIgMh7J2hGlG3pinDjUEK7X9Zh9P9Lz6nFGedehA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:14.8491187","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A14Z&sr=b&sp=r&sig=yF2DhCPO1A8ILhIN6DmT%2B3C%2BljgsRQcgK%2BG3ZbpONkM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:14.8490339","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A14Z&sr=b&sp=r&sig=j4R9a9Q4P9efLn3AUmX1XIH4ZsDLEqx7GFpo0JmEHvQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:14.8491362","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:25:14 GMT
+      mise-correlation-id:
+      - f533ff06-6fe5-4f5f-94f0-cf6ec4435ff3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A20Z&sr=b&sp=r&sig=yKY0ttlX8Y3B3y7RgB2xWP%2B8PMNKDxz1FRZTvAeWOII%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:20.139631","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A20Z&sr=b&sp=r&sig=lxTaLxfhe19Owrlk9Pbqt35deha68T9R6n2oarVL7i4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:20.1394944","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A20Z&sr=b&sp=r&sig=TIKMVw849JGDewp%2BuVs41x8ZSRVtoO0zOyGUH85Cn9Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:20.1396544","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:25:20 GMT
+      mise-correlation-id:
+      - eda2e120-b772-479d-80ca-b74029935d3e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A25Z&sr=b&sp=r&sig=YvqOrqqPNSKGIxqxD%2F1nWPhWGfjsNvjZj%2FCs6UeRNHY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:25.4277834","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A25Z&sr=b&sp=r&sig=PxAj3ZkWOoPoGhfWOMbviYnlmsDfpS6%2BXXwOQRFmoJI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:25.4276778","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A25Z&sr=b&sp=r&sig=ZhFHLBWVfzUWnj2miWQ297WBcSeYlqBduiKi7Hjp8ac%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:25.4278066","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:25:25 GMT
+      mise-correlation-id:
+      - e39d5c8f-a717-498a-860c-ecafddcf969e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A30Z&sr=b&sp=r&sig=j0jUzqv%2BqTNBJafQ7d6zvmi2zjz1npggb%2Bmuy6XBIkQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:30.7065937","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A30Z&sr=b&sp=r&sig=pXbrXE%2F6l3ubefHpFhSuwonq9y9GY4EslikNk4oALyc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:30.7065284","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A30Z&sr=b&sp=r&sig=7y3nq5i8wiQCLLOhnavWY3e9xX3qzlOGs3BQZyKuNws%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:30.706607","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:25:30 GMT
+      mise-correlation-id:
+      - 573f7e60-4cd6-4bc4-b211-45a8cfeef684
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A35Z&sr=b&sp=r&sig=0NfVxIgz6k%2B7oDtVYW3k%2FHJ%2FaDsZ9j3wfI49wxb9HdU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:35.9840084","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A35Z&sr=b&sp=r&sig=D50Md97cZ6%2BqFpafEUv6fwovjpoad3Ik9ISTgT38W%2BM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:35.9838874","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A35Z&sr=b&sp=r&sig=ReRRPDsLGHXRNMo%2F%2BzMd2Mtp9fYHbxVENo1LbozG9L0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:35.9840326","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:25:35 GMT
+      mise-correlation-id:
+      - 27c021b1-a8dc-41c4-89a5-f3b8c2bb670e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A41Z&sr=b&sp=r&sig=IRlZ1HHWpSBc%2BLPZR5A3yUEwvABVRFbgkBQdXaVGdT8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:41.2631634","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A41Z&sr=b&sp=r&sig=NqbbiqBOXk2id393PUttM9LWPMbCTc5eWII0KsTPoqU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:41.2630804","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A41Z&sr=b&sp=r&sig=3RdBk1VVAr7AYIBO167miIlof9mEs%2BtQBNe8wmRz0rA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:41.2631777","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:25:41 GMT
+      mise-correlation-id:
+      - 34129ffb-0225-4a7b-9f19-4268906cdc70
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A46Z&sr=b&sp=r&sig=frjgvXe3n%2BO8RViZnHIqZQqwByf4yMc67cXlvbEgOXg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:46.5472478","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A46Z&sr=b&sp=r&sig=U3Rrpb70z3Ou%2B1ifqQSdkad3qAhsOEyJVvpEmbGZHm8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:46.5471432","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A46Z&sr=b&sp=r&sig=yw%2FL%2Fb640so4293zk5pByhD8yw3naEnJ8Hz44sGFR4g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:46.5472712","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:25:46 GMT
+      mise-correlation-id:
+      - 9ed121a8-4d55-40a8-bf62-3824faf97cfa
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A51Z&sr=b&sp=r&sig=UbjUwFW6UrzNhW4XP8k%2FblXDgjCUOCsBuvAIwMyQ6CI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:51.8330002","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A51Z&sr=b&sp=r&sig=VTRyqc%2FGFTunkXFUT3Qxy5oIQL%2FO0yiMW7Z7ZcUhsxw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:51.8329317","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A51Z&sr=b&sp=r&sig=juNs9myfo8QEkuB6zNH1nGO3JDfY1twDTtDm8%2BMNof0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:51.8330147","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:25:51 GMT
+      mise-correlation-id:
+      - 8f8a135d-2b58-44a3-a93e-c8a84af3768d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A57Z&sr=b&sp=r&sig=WKl1aCOfdWKqHwNZqtKj5pzq3P9V7uVhKTfuNQaV86Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:57.1094612","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A57Z&sr=b&sp=r&sig=77lQK8c52aLIcw7DXeh02XdDqP05tuvtjfnPXXKnK2c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:57.1093572","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A57Z&sr=b&sp=r&sig=LXON4KLTxsRj2ee%2FwP9J4csgo7yRpd6zhwld0Rbp65g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:57.1094831","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:25:57 GMT
+      mise-correlation-id:
+      - 8f0d3d05-972a-48b8-b7dc-8f3c66f7bc44
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A02Z&sr=b&sp=r&sig=L5LOSrRfxdjKPMMZocqxvLCsosOkfSxuuKQnDvSgr7A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:02.3782682","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A02Z&sr=b&sp=r&sig=os46kkPRDs4aVIww4u1u5yimjGgnl2%2Bpy4YTRjCV36w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:02.3781694","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A02Z&sr=b&sp=r&sig=%2FcV7x3Rvws6ACjoGLeD8yxWzzUyDvW3KuVSAA4fhmbc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:02.3782834","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:26:02 GMT
+      mise-correlation-id:
+      - 9ab8e9c0-917f-4545-ba7e-7051dddf197a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A07Z&sr=b&sp=r&sig=qQVP18YqhIIk69ehDUZrlRU4AT8UebDzubZ%2FifnsKSg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:07.8066118","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A07Z&sr=b&sp=r&sig=TYJHzcqkkD0d%2BV26%2FXGAQoOszSFc2ku4ZH%2FGLVBpWmk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:07.806542","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A07Z&sr=b&sp=r&sig=r9%2F5WZUKnFeS0Pfjr13ZTuv6yO8nbgZfkOJ4WZO%2BUdc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:07.8066277","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:26:07 GMT
+      mise-correlation-id:
+      - 4636b01b-50de-45a0-95a2-48ddc8c0ef14
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A13Z&sr=b&sp=r&sig=RDSXFwtdpnTanpREhyeRm3E9%2F8auSH%2F07YvQjFSIkio%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:13.1023512","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A13Z&sr=b&sp=r&sig=zY90cdhYvxpvc0cp7MJDSEu%2F8cODXgCnAHSX2a7N7go%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:13.1022674","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A13Z&sr=b&sp=r&sig=VMBUXuDNAlXXecUsXQL%2F9piFPXhSHWYKqwn7bQVxO4E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:13.102366","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:26:13 GMT
+      mise-correlation-id:
+      - d737655c-6082-450b-9043-3bde46d0f8ce
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A18Z&sr=b&sp=r&sig=7gYFvqqFTEN2MYANBkDqKsxAxYiNsdIvUAtzZYnMMag%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:18.8099987","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A18Z&sr=b&sp=r&sig=1axcMtGkwgYIe3oFflzhc9RWhg2aWz3bbxCkpXVtkcU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:18.8099433","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A18Z&sr=b&sp=r&sig=ST5eZAAfUW5og8HqTF8HIGOFxGu8TdiglKxxytO5m8M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:18.8100125","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3192'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:26:18 GMT
+      mise-correlation-id:
+      - f3bfe8ad-7f4f-420c-b825-02e0c19ad126
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A24Z&sr=b&sp=r&sig=fchC%2Fc%2BvJZdkX0s5dcLct8FfzfikmBnk17WR7rg58cA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:24.0983158","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A24Z&sr=b&sp=r&sig=1gF9tcZP0PAoGIcZhb5Yn8DROklF7XC6dT3z%2BnIlJzw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:24.0982215","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A24Z&sr=b&sp=r&sig=JfdQP8xTZeKe3ypNv6AkrG9mcrMgqmakwPbotmQ%2BqOM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:24.0983405","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:26:24 GMT
+      mise-correlation-id:
+      - 48253391-53b4-4fe8-958f-c260cd6cba2d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A29Z&sr=b&sp=r&sig=iPuIhx0oXCBNzv3rsfshqVd6wIIkNUlgnkJYLVl6BlA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:29.3825079","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A29Z&sr=b&sp=r&sig=gN%2FHlpkUtxIkp1DIWRGWQsLvqRWRRBb94drK2%2BDeAo4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:29.3824387","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A29Z&sr=b&sp=r&sig=rbSSLk55DpGAawNxqM5iURzVay%2FaFrPgr8hsBao4Gd0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:29.382524","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-09T16:23:50.137Z","endDateTime":"2023-10-09T16:26:26.756Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:26:26.838Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3332'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:26:29 GMT
+      mise-correlation-id:
+      - 9bb7c0e6-a79c-4d70-9590-b51d3b5e6771
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1172,7 +1820,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:17:30.3807701Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:17:30.3807701Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:22:48.3302759Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:22:48.3302759Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1181,9 +1829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:50 GMT
+      - Mon, 09 Oct 2023 16:26:30 GMT
       etag:
-      - '"1a0aa8f3-0000-0100-0000-64af0a5c0000"'
+      - '"9301b10e-0000-0100-0000-652428da0000"'
       expires:
       - '-1'
       pragma:
@@ -1213,24 +1861,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=update-test-case&api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=update-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/d05c2cf1-7108-4773-a38a-a3fed2632d68?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A51Z&sr=b&sp=r&sig=KCSME7qlCOhOhc%2B%2F9lXGjpEOsezNsfu1h2cXBQ%2B9Ugs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:51.6251017","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A51Z&sr=b&sp=r&sig=0wi6p1KuCfEhOHJ08E3hFlREfBtvifv433V%2B6Qt3PSA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:19:51.6250356","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/bf83bb63-5002-40d9-abee-1b94af4d3294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A19%3A51Z&sr=b&sp=r&sig=pNBXqos23wYLz0qEaKviXlYjpdqmZuYjS2m2juSJON8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:19:51.6251165","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-07-12T20:18:45.251Z","endDateTime":"2023-07-12T20:19:44.628Z","executedDateTime":"2023-07-12T20:18:42.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-07-12T20:18:44.235Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:47.052Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A31Z&sr=b&sp=r&sig=wEOjqaX3NBWTIv9EFaV48Z0vUlvK3qTG7kO0wCL%2Fok8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:31.6165715","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A31Z&sr=b&sp=r&sig=hXtPeZ9%2BGWO%2FAXPUL0fj1RttyNNg9OyHsIdagNNS%2FK0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:31.6164737","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A31Z&sr=b&sp=r&sig=x4y38iMN2OEHvBgBqaSAnaR%2FkXnDCoj%2FQRBjqHgdmk0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:31.6165946","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-09T16:23:50.137Z","endDateTime":"2023-10-09T16:26:26.756Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:26:31.219Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3382'
+      - '3351'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:19:51 GMT
+      - Mon, 09 Oct 2023 16:26:31 GMT
       mise-correlation-id:
-      - 1a197206-6052-4f03-a31b-d04d6b5c7c20
+      - 94a4b379-7e36-4e7e-a72e-189649cbbd0e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1253,7 +1901,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:17:30.3807701Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:17:30.3807701Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:22:48.3302759Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:22:48.3302759Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1262,9 +1910,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:20:13 GMT
+      - Mon, 09 Oct 2023 16:26:52 GMT
       etag:
-      - '"1a0aa8f3-0000-0100-0000-64af0a5c0000"'
+      - '"9301b10e-0000-0100-0000-652428da0000"'
       expires:
       - '-1'
       pragma:
@@ -1294,24 +1942,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/d05c2cf1-7108-4773-a38a-a3fed2632d68?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A20%3A13Z&sr=b&sp=r&sig=8s1rOEfwDm6W%2BR8jODPz2XBhIwxk4E89EdNMvKxlrCI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:20:13.9756806","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A20%3A13Z&sr=b&sp=r&sig=ILM3i9%2BCLHlcYpFR2OznhRoOK76YEEHPbWPDoZIsEQM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:20:13.9756097","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/bf83bb63-5002-40d9-abee-1b94af4d3294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A20%3A13Z&sr=b&sp=r&sig=greTwCWr5A8NPR30QRDqwpIbeZEnLcoLSZZI%2F9037mU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:20:13.975695","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/85519d25-2d12-47d0-b84a-fc625974fc90_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A20%3A13Z&sr=b&sp=r&sig=9wIMZmoiwyI8gmFOPeu0DlYa3c%2F8NZOhM5Nky27Nh7E%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:20:13.9757084","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/85519d25-2d12-47d0-b84a-fc625974fc90_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A20%3A13Z&sr=b&sp=r&sig=X0Z%2FAnqKlljh%2Bnm8FtyrK0bm0mbZwlqSZxOvlQ5Bx%2Bg%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:20:13.9757228","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-07-12T20:18:45.251Z","endDateTime":"2023-07-12T20:19:44.628Z","executedDateTime":"2023-07-12T20:18:42.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-07-12T20:18:44.235Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:19:54.86Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A53Z&sr=b&sp=r&sig=sJuCZmAcNy8nqEAlVe9wGhe3W64wqhw2OwqH9jvzNdc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:53.9729434","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A53Z&sr=b&sp=r&sig=9aOGkW1LfQAkS2Ou0xxUHkfSHzxN1qk0V8jzI6SkcCo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:53.9728679","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A53Z&sr=b&sp=r&sig=1JBVumbpCw%2Fj33AxJvVqGgDsVOh9iRjvc0wUiz39uq4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:53.972958","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad1a1126-4eea-4dd1-bf8d-a49ee5838e00_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A53Z&sr=b&sp=r&sig=Skml0OW3NeGXOJjV1xNTrvY5ixO8Bq%2BikXZynwhYPmY%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:53.9729719","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad1a1126-4eea-4dd1-bf8d-a49ee5838e00_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A53Z&sr=b&sp=r&sig=32t%2BMGXZPoeGoZxhkLGw47Wu4QPO9MbhFZcA803RETI%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:53.9729856","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-09T16:23:50.137Z","endDateTime":"2023-10-09T16:26:26.756Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:26:40.319Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4533'
+      - '4491'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:20:13 GMT
+      - Mon, 09 Oct 2023 16:26:53 GMT
       mise-correlation-id:
-      - 606b81c3-f607-4690-bad2-cca052bab9d7
+      - 761c25bc-7aca-40e5-8814-c805f7c94ad0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1335,25 +1983,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/d05c2cf1-7108-4773-a38a-a3fed2632d68?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A20%3A14Z&sr=b&sp=r&sig=aXwU0HgdDumQRby7x%2B4HDqb4%2FWK%2FpBhDt9d%2Bflxa5Dg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:20:14.3720284","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A20%3A14Z&sr=b&sp=r&sig=e%2FF2Mz%2FV3%2F05VqZavQi3UIGWUVQz7OxAV0zDCbdYumk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:20:14.3719669","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/bf83bb63-5002-40d9-abee-1b94af4d3294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A20%3A14Z&sr=b&sp=r&sig=LpDujfek%2FXXP2o2WEn4UY947ZSbyUDo1T3uybFjMDkY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:20:14.3720429","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/85519d25-2d12-47d0-b84a-fc625974fc90_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A20%3A14Z&sr=b&sp=r&sig=VPXWJY98sZnjC%2B89T63vSmMlpVJCj0SakzwJMaNn3nQ%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:20:14.3720559","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/85519d25-2d12-47d0-b84a-fc625974fc90_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A20%3A14Z&sr=b&sp=r&sig=y08VA6S1tRKo6P3Brq2KX95pre9waqH6QHVKtFchAGM%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:20:14.3720693","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","testId":"update-test-case","description":"Updated
-        test run description","status":"FAILED","startDateTime":"2023-07-12T20:18:45.251Z","endDateTime":"2023-07-12T20:19:44.628Z","executedDateTime":"2023-07-12T20:18:42.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-07-12T20:18:44.235Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:20:14.364Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A54Z&sr=b&sp=r&sig=txM3N737EfebR76pZzOWQzyhNFyQ%2FGUtzPFlyiRX39s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:54.3417591","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A54Z&sr=b&sp=r&sig=wneBoWHvIWIxB8yPuV%2BKHE%2FaZXcHuOaNpicI7f2Lwnc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:54.3416654","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A54Z&sr=b&sp=r&sig=8fXzDO%2FZZ90Vu6CZ5f7bczefvZxSdQ2OUKKnpmpS1V0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:54.3417771","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad1a1126-4eea-4dd1-bf8d-a49ee5838e00_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A54Z&sr=b&sp=r&sig=f%2F7mEtWwDFxPVsxZcy7Hj%2FYYN91GOiOSIUW2%2Bh4bhTI%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:54.3417946","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad1a1126-4eea-4dd1-bf8d-a49ee5838e00_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A54Z&sr=b&sp=r&sig=Ngz%2BcmghNzsBHkho2EOLGZ63iusSzMWT9w3S%2BRFyguY%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:54.3418131","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
+        test run description","status":"FAILED","startDateTime":"2023-10-09T16:23:50.137Z","endDateTime":"2023-10-09T16:26:26.756Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:26:54.332Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4584'
+      - '4549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:20:14 GMT
+      - Mon, 09 Oct 2023 16:26:54 GMT
       mise-correlation-id:
-      - 8aaf024e-787b-4b40-9e0f-931f89db4790
+      - c9a30b51-e449-41d6-86e4-8a173d3ddd5c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1376,7 +2024,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:17:30.3807701Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:17:30.3807701Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:22:48.3302759Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:22:48.3302759Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1385,9 +2033,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:20:15 GMT
+      - Mon, 09 Oct 2023 16:26:55 GMT
       etag:
-      - '"1a0aa8f3-0000-0100-0000-64af0a5c0000"'
+      - '"9301b10e-0000-0100-0000-652428da0000"'
       expires:
       - '-1'
       pragma:
@@ -1417,25 +2065,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://650e77f0-8c77-4c7b-9941-ddfda274a30b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"04a98624-9217-435e-99dd-dd590aa9fd33":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"undetermined"},"02840846-f08d-4d2b-87ca-1297fc255f32":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"undetermined"},"901f2584-261e-41a5-8958-e60fba66633c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"undetermined"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/d05c2cf1-7108-4773-a38a-a3fed2632d68?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A20%3A16Z&sr=b&sp=r&sig=0BFa6Xw%2FB3z7BD9fDpitcKCG6Q9eDtTDOYhfpMHqLkM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:20:16.9085234","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/75a628bb-1d3f-4bb8-b164-0b201f5a7298?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A20%3A16Z&sr=b&sp=r&sig=ZdreuK71ymTpPMADfu%2FwiaTmn5wie4yHOKPnqGMkD%2FI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:20:16.9084326","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/bf83bb63-5002-40d9-abee-1b94af4d3294?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A20%3A16Z&sr=b&sp=r&sig=rQNbZ9m6HWlFQgY9MBJ5zRIaU4e4SMuhCJNbvA1%2FqkY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:20:16.9085479","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/85519d25-2d12-47d0-b84a-fc625974fc90_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A20%3A16Z&sr=b&sp=r&sig=OrKtDQR%2BPvCHbnud0TLKL32%2BdG2J%2FJTrkZu6Vb9D0ng%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:20:16.908572","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ebaab81-bc9d-4797-a417-76ae8ea5f618/85519d25-2d12-47d0-b84a-fc625974fc90_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A20%3A16Z&sr=b&sp=r&sig=XKXfZdZbT64ZFVBggTqTwQWt3xxvyduqK1CybulF49U%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-07-12T21:20:16.9085952","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","testId":"update-test-case","description":"Updated
-        test run description","status":"FAILED","startDateTime":"2023-07-12T20:18:45.251Z","endDateTime":"2023-07-12T20:19:44.628Z","executedDateTime":"2023-07-12T20:18:42.992Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-07-12T20:18:44.235Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:20:14.364Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A56Z&sr=b&sp=r&sig=rhJMRz3y%2Fs8cb6Twol2P0GTnt1oiyY4%2Bep9AhHTkNhI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:56.6745488","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A56Z&sr=b&sp=r&sig=BS8r2Q36NDdGMkczqszDAJqHM8cf353QIFXrgAsXoeM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:56.674451","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A56Z&sr=b&sp=r&sig=U4KE54h46zh800mk2Bvx5T2z5TRERg%2B2sKgizwmH3go%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:56.6745655","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad1a1126-4eea-4dd1-bf8d-a49ee5838e00_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A56Z&sr=b&sp=r&sig=AZyyiKqlbQgM05Iyr8m5Es%2BLnGsJYEyvZanJE0RHCv0%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:56.6745823","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad1a1126-4eea-4dd1-bf8d-a49ee5838e00_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A56Z&sr=b&sp=r&sig=65QcjAUDyVHzgPhbh0j2g4FkVCZ61%2BB767pNp2lPUXU%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:56.6745994","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
+        test run description","status":"FAILED","startDateTime":"2023-10-09T16:23:50.137Z","endDateTime":"2023-10-09T16:26:26.756Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:26:54.332Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4579'
+      - '4540'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:20:16 GMT
+      - Mon, 09 Oct 2023 16:26:56 GMT
       mise-correlation-id:
-      - dbc94264-175e-4288-bf49-b1e2a28912ae
+      - 66573033-9ab7-4db0-8713-636c30e30b80
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_update.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_update.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:37:32.8275879Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:37:32.8275879Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:31:57.6921376Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:31:57.6921376Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:07 GMT
+      - Sun, 29 Oct 2023 22:32:31 GMT
       etag:
-      - '"d300a757-0000-0100-0000-6537ba8e0000"'
+      - '"3c007239-0000-0100-0000-653edd5f0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:38:08 GMT
+      - Sun, 29 Oct 2023 22:32:32 GMT
       mise-correlation-id:
-      - e17b5d56-7bf7-4689-b48a-85fe6a7c4c24
+      - 822c057b-1ef2-441e-b2aa-da9fc0e22412
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"43111ca2-0af0-47af-b425-5c4c79d0bd98": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "658dd14a-02d6-42b2-b43f-5b87e77480d6":
+      {"passFailMetrics": {"f95e1e68-3aac-4fbf-a348-6e114857d051": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "079fa455-c798-4c54-840f-9f07e0088a58":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "0810b81b-3082-4e5b-95fe-9a40c26cd6d8": {"aggregate": "avg", "clientMetric":
+      "50"}, "1939d566-e166-4396-911c-2b7e175572e8": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:38:08.745Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:08.745Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:32:33.368Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:32:33.368Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:08 GMT
+      - Sun, 29 Oct 2023 22:32:33 GMT
       location:
-      - https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+      - https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 5717ebe4-87bc-4d02-8b3a-015831c80258
+      - b42eaf81-769b-428a-b2e4-cdab26146813
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:09 GMT
+      - Sun, 29 Oct 2023 22:32:33 GMT
       mise-correlation-id:
-      - 35a2b741-e787-4861-b4ec-1e2892cb1cbf
+      - c0a26aab-2119-4101-8a6b-f6b7deb7b605
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,10 +275,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A48%3A09Z&sr=b&sp=r&sig=Jz9TW4nYShkp2I20QQOrbpgrfKtf4bk0RTpTunhji%2Fs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:48:09.6325184","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A42%3A35Z&sr=b&sp=r&sig=94Gx1S9Tc3DYa2Gph22vjj5wePg2%2BVySTNNOYuMnaHY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:42:35.5527581","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -289,11 +289,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:09 GMT
+      - Sun, 29 Oct 2023 22:32:35 GMT
       location:
-      - https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - e74c893b-b99d-49fd-b76f-efc591387de6
+      - 2069b02e-2b78-4386-8281-d930d304a0ab
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A48%3A09Z&sr=b&sp=r&sig=fG59pRyqLawfVo5HCtHD%2Bq9sXgrI4bxQmko3ijNlIXM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:48:09.9506007","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:38:09 GMT
-      mise-correlation-id:
-      - 018d572e-8212-4de1-ab16-f157a9bfa471
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A48%3A15Z&sr=b&sp=r&sig=J7NunEoN%2FWtq0scx7a2ZkaMWDV1IvUudBdGqLTMVWVI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:48:15.6520237","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:38:15 GMT
-      mise-correlation-id:
-      - cfa499c5-e5c7-4ead-b78a-47ae6bbd3ea2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A48%3A21Z&sr=b&sp=r&sig=koZ75bpbAmqqBFiBGZ32GlI8w%2Bg%2Fn4HlQOigUxtOSvI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:48:21.0314396","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A42%3A35Z&sr=b&sp=r&sig=QuFltEYlig2Ns%2BwDm548iMJuiVuBTx%2BubyedYVTocoA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:42:35.9443274","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:21 GMT
+      - Sun, 29 Oct 2023 22:32:35 GMT
       mise-correlation-id:
-      - 3b41ec80-7bfb-4aca-9de3-a982ae350d7e
+      - ca62a544-35c9-4a29-b833-748d9b130de8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,10 +349,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A48%3A26Z&sr=b&sp=r&sig=v1baoTa1WfhlzaWUfNoTzs1ztuNIM%2FnDglQrFeY1IJE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:48:26.3478811","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A42%3A41Z&sr=b&sp=r&sig=j3jTX%2BCcXSgPEm2QfkzV5mAymiROMdXs9ew3MCaiFdw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:42:41.2383454","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:32:41 GMT
+      mise-correlation-id:
+      - 4b6da78a-9aae-448b-a8c9-2a9db6a9f60c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A42%3A46Z&sr=b&sp=r&sig=P50MIvKZEyyRZ4eRalaDqKS7BvrIH2hZ6RJfKWRqGn8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:42:46.5352465","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:26 GMT
+      - Sun, 29 Oct 2023 22:32:46 GMT
       mise-correlation-id:
-      - 06ebcf3b-f51a-41ef-a8c6-8423b0472a9e
+      - 414e263f-d22a-42b4-8eb4-8a3e242cb082
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +421,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A26Z&sr=b&sp=r&sig=tQ%2F%2BfcCWNI8iCuv1ma4oooB0ZtTHYVvK3O%2Fo7ocvo3o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:26.6636093","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:38:08.745Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:23.625Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A42%3A51Z&sr=b&sp=r&sig=tIPOG7frGbLV3RwC1THEshi0I4pXnau2y8haYYjgwYE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:42:51.8536822","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1583'
+      - '547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:26 GMT
+      - Sun, 29 Oct 2023 22:32:51 GMT
       mise-correlation-id:
-      - e905a9b0-959f-41a2-aa6b-f184f42f7d17
+      - 05488d58-75cd-43f4-be6b-ce9f883d01de
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A32%3A52Z&sr=b&sp=r&sig=3O3zb8NBd74rswxJtzSHB%2BVAbUa%2FqeNBF8HohOBcDuA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:32:52.1642344","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:32:33.368Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:32:48.596Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1581'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:32:52 GMT
+      mise-correlation-id:
+      - 8a626af5-db7d-422f-a7e8-04d999ba5f4b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:37:32.8275879Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:37:32.8275879Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:31:57.6921376Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:31:57.6921376Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:28 GMT
+      - Sun, 29 Oct 2023 22:32:53 GMT
       etag:
-      - '"d300a757-0000-0100-0000-6537ba8e0000"'
+      - '"3c007239-0000-0100-0000-653edd5f0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A29Z&sr=b&sp=r&sig=8L2lQ0IdVvCRvgIYZqN8p90SNEibRJSh06KfXZ4kN%2BM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:29.221557","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:38:08.745Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:23.625Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A32%3A54Z&sr=b&sp=r&sig=YCWfR48ZvylCb%2BeXHRz%2BYltgE9hHCfJxIxns0qfH1Xw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:32:54.7135407","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:32:33.368Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:32:48.596Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1590'
+      - '1593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:29 GMT
+      - Sun, 29 Oct 2023 22:32:54 GMT
       mise-correlation-id:
-      - 96b4ab91-ecab-477b-883e-c6bfdd8f236d
+      - b3c1e1a8-46aa-4e66-8121-70d536b77cbf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:37:32.8275879Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:37:32.8275879Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:31:57.6921376Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:31:57.6921376Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:30 GMT
+      - Sun, 29 Oct 2023 22:32:56 GMT
       etag:
-      - '"d300a757-0000-0100-0000-6537ba8e0000"'
+      - '"3c007239-0000-0100-0000-653edd5f0000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:38:31 GMT
+      - Sun, 29 Oct 2023 22:32:57 GMT
       mise-correlation-id:
-      - 7d549d94-bda5-4554-98b4-c7a3fdb8d940
+      - 51274076-7a77-40bb-844d-5a804f5b0ae6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A32Z&sr=b&sp=r&sig=TIodo0hViUeqbZcnEi68RQSLB4J8R5RTQJKvtprSCjs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:32.76729","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A32Z&sr=b&sp=r&sig=irT2FZKig%2FKDbG4bzUo9ItaRXxYQCiEbVheYe0B%2FMwk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:32.7671914","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A32Z&sr=b&sp=r&sig=GqWdoDprI%2BHsVgNyevtMzdFEJ2gI%2FpJ9u78j5QTsXBw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:32.767315","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"ACCEPTED","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:32.69Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A32%3A59Z&sr=b&sp=r&sig=J3sle2Bm9gAuvvYHpe9VMqF6VbW%2BLMg4zH1r1hlgthw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:32:59.6500619","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A32%3A59Z&sr=b&sp=r&sig=5m8FMgDxgowkCGRlb9pnK8SsHZS3VUk9193zthUwDSA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:32:59.6498681","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A32%3A59Z&sr=b&sp=r&sig=KBRPYbpyn0WANZVn8lDCNSOOzO3Lvbs7tiNclELysg4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:32:59.6500908","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"ACCEPTED","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:32:59.567Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3151'
+      - '3150'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:32 GMT
+      - Sun, 29 Oct 2023 22:32:59 GMT
       location:
-      - https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+      - https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 00fa1173-de27-4d87-8a34-78a4888f6d69
+      - 313922bc-a526-4dff-a5ef-6841bf2a2bc9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A33Z&sr=b&sp=r&sig=P6J7Papes8EvqPrhs87KO4sDr0FUhjAFAdkniZIhOeg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:33.3158056","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A33Z&sr=b&sp=r&sig=iVpcckNlsL2ezVg2RtKlNLjafWvJ7xzKPdsU9805JFk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:33.3157285","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A33Z&sr=b&sp=r&sig=BpyPEE9RL8DxntVzEoivWtokbKMmc%2BcI3nOWTOu73x8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:33.3158207","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"NOTSTARTED","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.174Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A00Z&sr=b&sp=r&sig=ns74hd18EJuy21Rg9r0p07XOZew47GeknbEtP3MbWZg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:00.0861767","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A00Z&sr=b&sp=r&sig=kpCkWTJinmU8tg0VDLMiFVz1F6S%2Bm5HglvZTvO3eb4E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:00.0853529","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A00Z&sr=b&sp=r&sig=Yx0V7jhYiMmAiHL15YJjItnYuqQW6xflSW0SjPuIT60%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:00.0861999","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"NOTSTARTED","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:32:59.96Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3194'
+      - '3193'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:33 GMT
+      - Sun, 29 Oct 2023 22:33:00 GMT
       mise-correlation-id:
-      - f4cda962-0894-496b-85d1-9eeaae039fe3
+      - 11c01a9a-dbfd-4ec0-adb3-511fcab7e4c7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,23 +736,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A38Z&sr=b&sp=r&sig=iEwlfIytcM4%2BhTICDSF5cL%2F1bb18iImi6BC4ySB5Dbg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:38.6701957","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A38Z&sr=b&sp=r&sig=NXRvNHqammltpbR5t7tMqSG%2FPsAo40EFjJUl0lWq0GE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:38.6701052","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A38Z&sr=b&sp=r&sig=eLjzhqwQEN3K3KmE63V7AfgB%2F2Haj5HVnm9ZHi0rp7g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:38.6702262","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.348Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A05Z&sr=b&sp=r&sig=AUyoqkEHq%2Ft663TKtAao%2Bez8WvwCLzuGSqQurVWm09M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:05.3499436","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A05Z&sr=b&sp=r&sig=MqTw2IAXj5uT2mw8Z44I2%2F6euKZWlsqo%2Bn1lPjAtpgY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:05.3498747","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A05Z&sr=b&sp=r&sig=5JtDrv9DFB7MqgFPMPswXARhIgYLr8KoB%2F2fR%2FUfTQU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:05.3499601","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3202'
+      - '3205'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:38:38 GMT
+      - Sun, 29 Oct 2023 22:33:05 GMT
       mise-correlation-id:
-      - 33422c7a-4051-4b77-856f-26cbfc2f2fc8
+      - 53dbac10-22a1-4b17-b46c-55254c1f0251
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -772,154 +772,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A44Z&sr=b&sp=r&sig=G8hu3M%2Fwd8p0QRIOWyxOq4PT4SI6%2Fqa7iWEUja40xPM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:44.9860634","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A44Z&sr=b&sp=r&sig=g%2FRn3BP3qYGTc%2Busk%2FuAvflp%2F5Tlcsk9rji3iqmooQ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:44.9859797","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A44Z&sr=b&sp=r&sig=kMwaHCCf334JM0D1fOHhWApOmeiyQOk1YRV0DugpTMo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:44.9860864","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.348Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:38:45 GMT
-      mise-correlation-id:
-      - 9714dec7-a3b1-4b36-831f-9b2f3fae8309
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A50Z&sr=b&sp=r&sig=%2BDl%2FAYsYIqj%2F6Z3IY28HRZlr23ul4OC5D6BBy3m3Ej4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:50.3298438","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A50Z&sr=b&sp=r&sig=o9rbOsHnhn6%2FU5xJ5eE8OP0xW8gQJno6TI8yrADBXmw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:50.3297298","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A50Z&sr=b&sp=r&sig=b5KwU6expbUr7NqKOi0bwsTDfQ2jKyYgc65VcM%2FBXXM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:50.329868","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.348Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:38:50 GMT
-      mise-correlation-id:
-      - 6d4c821f-812c-4f50-8ed0-2ee83cc52000
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A55Z&sr=b&sp=r&sig=tjSvhfEnq7RbMwsHuINHXjX%2FnodQTRSrEQZimj%2FLATo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:55.5830536","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A55Z&sr=b&sp=r&sig=467WNj6NYRdKPRUoP0B0JSkCR9XAGDnhwElqX%2FOXo4E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:38:55.582961","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A38%3A55Z&sr=b&sp=r&sig=XzC9rNNJsXnXC8nCzPyp6EW32ZC8ekmffLZDiiAxQxQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:38:55.5830686","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.348Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:38:55 GMT
-      mise-correlation-id:
-      - 8a2b0158-49eb-4104-86ff-690c1e034150
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A00Z&sr=b&sp=r&sig=V9Iyqb2LHLpcdr88qg4Klxdjk2DjjRKlEyTayuYAUCA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:00.9784178","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A00Z&sr=b&sp=r&sig=8mZUSG5GD4LYOfCS%2BvS5UhDjDwQ%2F33ogtGhfaNeZIAg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:00.9783292","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A00Z&sr=b&sp=r&sig=G6Sb%2BQ0vwPrVh2DGvkFNhpm0Qouh9t1zUmBf%2BSH%2ByoM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:00.9784392","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.348Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:39:00 GMT
-      mise-correlation-id:
-      - 6137ad8d-9886-4776-addc-d9cc546ed5d7
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A07Z&sr=b&sp=r&sig=prCLLYD94mG6zTYav%2FA3uPNA7nyt8MbV8TNBoIObq50%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:07.0448659","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A07Z&sr=b&sp=r&sig=16ye8Bjf9VUsXlREjcBgTsObXxrrTlArjibZHZVBJ34%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:07.0447591","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A07Z&sr=b&sp=r&sig=l0VhUKTIVwcf13bMjavXrCRAMRU%2F8nvxsMlhWUdMGRw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:07.0448904","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.348Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A10Z&sr=b&sp=r&sig=heDnRAd0vRo7aYr2pAOJaTVN3ETHTbmzR%2BcJlB670zA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:10.7153402","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A10Z&sr=b&sp=r&sig=%2FSwoRzitv9UeEmOqzdZ431WhUJWWmoWec5q6ORR5EUI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:10.7152728","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A10Z&sr=b&sp=r&sig=buQI85iL8OlyNNXiVnTsxR9W%2FPoyk89NHNx6W7gyOA4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:10.715354","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -930,9 +786,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:39:07 GMT
+      - Sun, 29 Oct 2023 22:33:10 GMT
       mise-correlation-id:
-      - cf955e00-0f18-4039-8d0d-c2b5ba2ad62f
+      - 47857295-7f19-4b15-86fb-defd5103747b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -952,46 +808,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A12Z&sr=b&sp=r&sig=3k2zSb0pEF0ii69d8GB8JumS0wl6orBDArYVUVka%2FOI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:12.3222718","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A12Z&sr=b&sp=r&sig=J%2BvScsxgWcKGueStgC1Ay7xuOW03Fwu%2FBm9s0ZlmGZI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:12.3221675","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A12Z&sr=b&sp=r&sig=QbcM7M%2BT33rRokV6jXQCtXS7pnopEQtiUN6EqgTfH34%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:12.3222963","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:38:33.348Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:39:12 GMT
-      mise-correlation-id:
-      - dbbe771e-3956-4c47-9199-3bbf2ba28f2e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A17Z&sr=b&sp=r&sig=tWHxQpW0krY8u5Pu5w%2B%2BE4o3rGdpls8mO2qzMvZQojw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:17.6338305","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A17Z&sr=b&sp=r&sig=BKYcLoDNwct1Hq6TUD13ZDzZ03VKkecNxgS4S4aZkzM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:17.6337544","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A17Z&sr=b&sp=r&sig=e6LAqXTbDrxeeOB1kovR4cibbj8V1Z2xXkyRB95e1No%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:17.6338465","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"CONFIGURING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:16.947Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A16Z&sr=b&sp=r&sig=QMi8P6a7SpQZICr2a1x4vxZoyawpqSUItTWUXKbPDOU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:16.0311174","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A16Z&sr=b&sp=r&sig=Vbf9OrOlhU9TVVRjGAsEP9%2BcgCLMHss0Gu1wlPUzcTU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:16.0310437","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A16Z&sr=b&sp=r&sig=D2Po7Vq%2B5q6yqVRdvKz0jpiInXv8w624fLWqYGwDkrc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:16.0311309","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1002,9 +822,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:39:17 GMT
+      - Sun, 29 Oct 2023 22:33:16 GMT
       mise-correlation-id:
-      - 182edc37-3b6b-4af9-88f5-ec3af7cdfeed
+      - f2d0a635-e0a8-4469-8cb1-9890389134e7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1024,10 +844,262 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A22Z&sr=b&sp=r&sig=s8WFZSV1U5PkC48aIl%2FVXO01K1hJftjfPp2cOqL39MM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:22.9812729","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A22Z&sr=b&sp=r&sig=CQJ1piN7%2F45Dsr3r1M0viny%2Bleih%2BTpV7X1rNwvUZ9Q%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:22.9812151","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A22Z&sr=b&sp=r&sig=DM9mIzve05oMgCvpfZGv4cvZZjQruatKnwOGQO9VWbE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:22.9812869","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A21Z&sr=b&sp=r&sig=INr6Im4nXGRuEb8ZCLPJ8cqoIbWnxCj7auTU%2Fkq%2FVtM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:21.3562943","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A21Z&sr=b&sp=r&sig=T0GgWkSE%2B0lRml9uAQoLrN4CbIeNwP5T7uM4VSTt0Ds%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:21.3562074","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A21Z&sr=b&sp=r&sig=exe9B55k47T9pQkP8HHzzZ6MFK4rjXflwKLWYe5LdTo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:21.356317","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:33:21 GMT
+      mise-correlation-id:
+      - 233965dd-6a0f-49ff-9d37-446691b2de6c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A26Z&sr=b&sp=r&sig=Ry%2BdBaGtDDO6o4Zx9cseAO%2FLWq5KnNsmQ89kFyGRqO0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:26.6374357","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A26Z&sr=b&sp=r&sig=4z2TBPRwEo3LEXnvznD%2FNZDh%2BGrni%2F13ShGJgAobW%2FU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:26.6373619","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A26Z&sr=b&sp=r&sig=hv18sxhNNZyUaRxzhE4gLvmEi43dsVfMsQiae6UYtLk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:26.6374495","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:33:26 GMT
+      mise-correlation-id:
+      - e84b1511-2bba-46f5-9665-16de28b2dad8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A31Z&sr=b&sp=r&sig=ex30uQr0zt9icHRO9409%2BreokwAeLOZBlkqGB%2FbrPXo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:31.906682","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A31Z&sr=b&sp=r&sig=SKitpb%2FU2HjwlYgFc0M4WkC%2B%2F1LNx9ILgy%2BLYs%2FmDFY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:31.9066026","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A31Z&sr=b&sp=r&sig=UOxUkQeUe5G6n5ffO%2FsHA68hYKyTNZ%2B8kUajTj3qdeA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:31.9067054","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:33:31 GMT
+      mise-correlation-id:
+      - 34131c5c-8405-4a83-9c34-85d9294d6b7e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A37Z&sr=b&sp=r&sig=fPUKTtTidXHoKd4JCRBer39jXUUQXzAygRyW%2F70JRBo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:37.1684423","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A37Z&sr=b&sp=r&sig=VqCiuvEHetmxW%2BFsOPet1VxSA1vLs%2BjMMXzCpmTSXIY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:37.1683564","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A37Z&sr=b&sp=r&sig=s%2Fin7ojMY9osKsP1x2Dr7bbkfc%2Ff4ot%2F9dCQAgAxoS8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:37.1684629","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:33:37 GMT
+      mise-correlation-id:
+      - afc0d90f-1f87-4e3b-99df-e4501fcb536b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A42Z&sr=b&sp=r&sig=LZB1TgpYqQlXRTrvGCiTfkLnqhiHgTLvFfCyihnEafI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:42.4438014","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A42Z&sr=b&sp=r&sig=v%2Fdpm%2FDPrkENE%2FiN%2BStcz6PjDYgjcrb9U%2B%2B4Tm2%2FQ0Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:42.4437341","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A42Z&sr=b&sp=r&sig=p56rFynwOLJb2jGb84%2BRrkhU32z7u2l%2FH48k9QLG6gE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:42.4438163","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3211'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:33:42 GMT
+      mise-correlation-id:
+      - 20c6a991-dc36-4e1e-bdd5-8d509b9be38a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A47Z&sr=b&sp=r&sig=6G3m65LvG9q5%2Fm4bM5%2BCpTPfW2TchCamEulB%2FWRoBHs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:47.7711727","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A47Z&sr=b&sp=r&sig=FxHpPj6mjBLFjNSqmsXRyu2wSi2mS4NkCStUhjiGnws%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:47.7710708","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A47Z&sr=b&sp=r&sig=XJXiIZNFhN7KgrWFJPeqwPihy76EVxflCOfM1YF8gZU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:47.771194","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:33:47 GMT
+      mise-correlation-id:
+      - 93c57821-ee78-4a65-904d-aa3307f8d16f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A53Z&sr=b&sp=r&sig=YYdb4%2BovbKx0UIBON6t7%2BZttAZ4c04m91gXOySyiaso%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:53.0348606","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A53Z&sr=b&sp=r&sig=zOP7ILRih%2FFJuSwhb6hbrpMfIEbe6qU1Krzwv%2F8hjjg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:53.0347901","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A53Z&sr=b&sp=r&sig=qIwfg4hB0x%2BqbkYJ%2FD4TZG6NgT646lsXo%2Fc%2BOgrIRaM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:53.0348752","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:00.18Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3209'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:33:53 GMT
+      mise-correlation-id:
+      - adf390d8-e252-463a-bf6e-2493ce8325ad
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A58Z&sr=b&sp=r&sig=lQ2JBRJO04BXqPMK3ot5F%2FdWs0bcwI%2FdVao0PwmGtGE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:58.3489541","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A58Z&sr=b&sp=r&sig=AMBLpUPofV0MkBXVnqGwLWB4mNudCLL16m69TQyUu9w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:33:58.3488861","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A33%3A58Z&sr=b&sp=r&sig=Vu3BK6ro%2Bm9ESh8bZdetit15xnF940x8cSyxU4SXhm4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:33:58.3489692","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONED","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:33:58.291Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1038,9 +1110,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:39:22 GMT
+      - Sun, 29 Oct 2023 22:33:58 GMT
       mise-correlation-id:
-      - f87a9b70-90a1-4052-ba7f-a2fae29fe5a7
+      - 26c3cf78-eff0-4b3c-8192-f107e941b951
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1060,370 +1132,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A28Z&sr=b&sp=r&sig=zqYTAvz6XQgwpIPcqkehOPr7IEwX953SFAQAYWQpUps%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:28.2510287","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A28Z&sr=b&sp=r&sig=83rEdI3%2Fr1Kj%2F46xn1LM6l83858v5%2FV9OFqk6nesWYo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:28.2509229","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A28Z&sr=b&sp=r&sig=Y6P4smydWEwH51RGagbbx2u%2F1GqeDy2oRJDMkn240bA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:28.2510495","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:39:28 GMT
-      mise-correlation-id:
-      - 59ac9436-902b-4357-9f97-8e5044a76328
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A34Z&sr=b&sp=r&sig=1RFDyOVp9%2FllA%2Fmo%2FLOR%2FzwP%2FUAbdBmNd%2F6N6Pk6MHM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:34.7771794","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A34Z&sr=b&sp=r&sig=9GYMwGeAR0mwLej6KZ8CQ5usxck3Eh%2BgUZgmiTuPtcA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:34.7771137","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A34Z&sr=b&sp=r&sig=m%2FKY3hJ588YIzk8iFpCQHnbCUJvpL4Mf17JuR3kkYyk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:34.777194","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:39:34 GMT
-      mise-correlation-id:
-      - ecf64a6e-3847-4adb-b539-3d41a503a4a8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A40Z&sr=b&sp=r&sig=n95gRiYKAHUygdzCPRuP2igl9XOhPZTXwpaE%2FcyAy6I%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:40.0789538","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A40Z&sr=b&sp=r&sig=niCipBenkXymWc%2BDNxRGmlG60%2FL%2FaeeCZ49DtdSA3jg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:40.0788657","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A40Z&sr=b&sp=r&sig=zRhzrKAvTVgS8gD4tjLZ5C5Jhim9agRXKsBI7u1raKc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:40.0789776","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:39:40 GMT
-      mise-correlation-id:
-      - 3f130b24-32c9-4f06-93ae-8e57dc14d4f6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A45Z&sr=b&sp=r&sig=VMf9BHDrg4QDGxFeW1UUECmGef9XvcWDhS6BM7K94Ws%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:45.4144003","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A45Z&sr=b&sp=r&sig=Oq2ve32qS4bqw%2F2CCQ%2FhWQyl4c9AUmWEyk28LsqKyn0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:45.4143128","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A45Z&sr=b&sp=r&sig=zeFOdYLXthq0eDbYWhkbw4mWfUxKfw%2FORJ8mPWXLV3U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:45.4144248","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:39:45 GMT
-      mise-correlation-id:
-      - f4792f04-2282-4a7b-b233-ca900e953106
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A50Z&sr=b&sp=r&sig=tB9GREV1XfREEmmgTTqvac9N7vRU%2BTdQSxvEAl8IFrA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:50.7224568","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A50Z&sr=b&sp=r&sig=zhyoK0sg7b%2BYXLvONJU7sxRudFHVNn6yrUq2trq8ANE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:50.7223785","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A50Z&sr=b&sp=r&sig=sfvNSfDBAVDYA7mhK%2BlBaOmuVTsrs2gaoXvX9t50m1Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:50.7224704","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:39:50 GMT
-      mise-correlation-id:
-      - c2a40db9-6044-42bd-8618-2ddabfb73b3c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A56Z&sr=b&sp=r&sig=2FY3xih86EWIbNOX8AlZb1StagWxbOVLxqXTZ8%2BItp8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:56.053256","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A56Z&sr=b&sp=r&sig=3mhVkf0%2Ba9zvg9xtgTcMQw7UdkYQLySi7RM6d3CjikU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:39:56.0531902","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A39%3A56Z&sr=b&sp=r&sig=ikOMZqjYkDOcVei7qD3xHduqSXvKl1s%2BMMuQNghxKQQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:39:56.0532705","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:39:56 GMT
-      mise-correlation-id:
-      - b34bf8d2-fb93-4867-8d6c-cb390cd5e63f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A01Z&sr=b&sp=r&sig=lW7RdBchKhM9rgmmFM%2Bgq7vyJ3UyUp46bDdC%2FrJEYJ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:01.3127621","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A01Z&sr=b&sp=r&sig=WWsV1xIb7cPIGNMRlylhgAP%2F0wCD8QGM4aYXbAK8Zsw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:01.3126839","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A01Z&sr=b&sp=r&sig=9LEtu7ptkFiKGTWr6a38Fpkl2fRnqZx8nB6M4fJrdgw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:01.3127774","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:40:01 GMT
-      mise-correlation-id:
-      - 2f304894-841f-4bf8-bdc9-589ff94a41b4
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A06Z&sr=b&sp=r&sig=qhkltbzDonm%2FURMn%2Foe0iVP5zXNmRrWve2JmG5iZNtA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:06.7008406","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A06Z&sr=b&sp=r&sig=DfHEhIgWF2SYJBapGPEMoxYw16lxmP6zmKcLtzJy3G8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:06.7007664","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A06Z&sr=b&sp=r&sig=CjvvbvLMcRaQel5NrlNmXhauEKOG%2Ffj9x5FHQjRh1Yk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:06.7008545","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:40:06 GMT
-      mise-correlation-id:
-      - 7523e45c-4b00-4c1c-bc1e-30a6c94bb116
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A12Z&sr=b&sp=r&sig=9bmlcFd%2B5%2BJtX6C8zgbByPIpXVAchFQK3smGi2NU5Zg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:12.007771","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A12Z&sr=b&sp=r&sig=X5r5arTYAlNaoc4LYjBFjlAO2wWrCDETaaUVp2nhR6M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:12.0076861","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A12Z&sr=b&sp=r&sig=eK%2B%2BTiFl7OIVTCRTo%2BdxXcA906G1fBMscZa1fpP56AY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:12.007793","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:40:12 GMT
-      mise-correlation-id:
-      - 59e25a77-8294-4e6b-ac03-1478eb1822b2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A17Z&sr=b&sp=r&sig=b8BlwHsbyWGjSgiYJrZs7D%2F5hQLCp6HV5VEwrICHaZo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:17.3348206","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A17Z&sr=b&sp=r&sig=mZhTNusLHQWiop%2BIvYTfAiGBfwV0EAyycjWqMqBFbJ0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:17.3347355","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A17Z&sr=b&sp=r&sig=F1NCYVBNgrU5aAwCs%2FvE0RzxR4O8I8NFbheQ8B3J0h4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:17.3348353","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:40:17 GMT
-      mise-correlation-id:
-      - dc2707ea-c3aa-4523-8a77-49f2e5480b69
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A22Z&sr=b&sp=r&sig=P91kmHTShPbCGQk0P601lRUQ0ulPYhtCEecRSqRJDCU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:22.6830868","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A22Z&sr=b&sp=r&sig=oRuHQdZTxFyh%2Bp%2Bfk6cTdbPCCCQwttqxq3LfDFk3fGM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:22.6830014","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A22Z&sr=b&sp=r&sig=hk%2FfDgaTyQGg8madBzK2h%2FYqgPHrGpAu%2FunA4OAqhIQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:22.6831007","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A03Z&sr=b&sp=r&sig=YZQpB0eoPgbm8obOE1%2FpwcG51EtCRosgcvAhX9Yu5wI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:03.6691795","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A03Z&sr=b&sp=r&sig=%2FtxyPVnsYYXZajDbhAK%2BdEJe6auSUkAIS1ffKgkTKzk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:03.6690935","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A03Z&sr=b&sp=r&sig=2sqR%2BlFlFpanf4BrkB2eM43zcg%2BmMVTXdP4oqCQ4p8s%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:03.6692016","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1434,9 +1146,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:40:22 GMT
+      - Sun, 29 Oct 2023 22:34:03 GMT
       mise-correlation-id:
-      - fe007427-6708-44cf-9d5c-566e6cc64328
+      - 45d3f8dc-85ef-48f3-b3ed-7197324c303d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1456,10 +1168,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A27Z&sr=b&sp=r&sig=zo6mOGrZu0N2kZYcA6m29H512eshdSS5hKI72jSWSUc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:27.9594515","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A27Z&sr=b&sp=r&sig=yRPuP79d5yIMV%2BwmVE0FVlt6p79G%2BRrK7vb%2BC9bLuZg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:27.9593711","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A27Z&sr=b&sp=r&sig=UDhI%2FBnpwWe3Pxbxw8acR%2BH6PohY1C0B5JjiDX7SJv4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:27.9594696","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A08Z&sr=b&sp=r&sig=SN1VGv9eJOF%2BLpfCvWh17BJU8j%2B4kL1j5i2HNw7cwKo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:08.9995735","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A08Z&sr=b&sp=r&sig=5h3FopAf07OxiFbDXWvNGUuzsN9Q958ManUk099lQuk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:08.9994833","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A08Z&sr=b&sp=r&sig=E26pxzcqDkl3h97bojSWr5MoYNklVw%2F%2BJKpNdv%2BYjk4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:08.9995885","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1470,9 +1182,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:40:27 GMT
+      - Sun, 29 Oct 2023 22:34:09 GMT
       mise-correlation-id:
-      - cd6fd491-0151-4b24-bca2-36ebbf44a6f2
+      - 3ff037de-440c-4a77-ba2c-f6ff988190db
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1492,23 +1204,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A33Z&sr=b&sp=r&sig=S586quXfKbMp6UW2d0FzOY%2BJxRbYh6whqdvJm9AuFYw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:33.2497386","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A33Z&sr=b&sp=r&sig=1mbgvSWpjZuuvWRr9q%2F3ciRxgFOrl3j6px8YiVzQHi8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:33.2496403","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A33Z&sr=b&sp=r&sig=eDThP%2FZcm7l%2F7u7XFrtfzuwLtT9A3RrpDsz5PxJtOes%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:33.2497617","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A14Z&sr=b&sp=r&sig=Am7L5DkB360Zmw%2BzksSKZH8vEqToQHgdt5rvyE3jN7o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:14.2671947","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A14Z&sr=b&sp=r&sig=A3Fj82v0O%2BZOxzpGT%2FfSK%2Buq0n4RuTRyVy9X2k8BPlY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:14.2671083","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A14Z&sr=b&sp=r&sig=mxbYjszGPlf68HxyXpLn%2FmgllgL3mai6cx0W8cjgFss%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:14.267217","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3199'
+      - '3200'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:40:33 GMT
+      - Sun, 29 Oct 2023 22:34:14 GMT
       mise-correlation-id:
-      - b94e3a09-2244-4210-8ec7-a21c37431fc4
+      - 7027a5c9-91b4-42e6-9343-078fbb350f17
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1528,10 +1240,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A38Z&sr=b&sp=r&sig=pGWC0TKNhkM2nx%2B%2B7XO6Yxkha6TS9t0QreAEgak2xOk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:38.8687714","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A38Z&sr=b&sp=r&sig=K4HSi7RHL4fjkiX3J62t6RTj6O03GXW8c5AjcRlRgkE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:38.8686865","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A38Z&sr=b&sp=r&sig=6mbLZKdX8kiNQUnVdjNfqMaphApSAJWTVXCU0RNtKr4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:38.8687882","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A19Z&sr=b&sp=r&sig=WJKdMLsaxbu%2FFjDO1fmWNeTJeyIKtH%2FUBYVeAXRcTus%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:19.6347918","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A19Z&sr=b&sp=r&sig=eQk0CRmgRC5ZDuLCLNBm6CrVbkjkPCEuUirzsodTLtc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:19.6347148","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A19Z&sr=b&sp=r&sig=ieBNgcgrh4Ua4s7T6YBOjUHWsAbqdLEIW2yWSxb4RhQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:19.6348057","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1542,9 +1254,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:40:38 GMT
+      - Sun, 29 Oct 2023 22:34:19 GMT
       mise-correlation-id:
-      - 3f8a84b4-32a9-448a-bbbc-17ef76fd8189
+      - 98d0bab1-ab20-4a3b-9838-2872bf0612cf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1564,23 +1276,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A44Z&sr=b&sp=r&sig=0gTSHxx%2FaTGUJVDzsQUB4qDxeqETRchD%2BA3Me8gOOug%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:44.1728041","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A44Z&sr=b&sp=r&sig=TW0%2B8PrRVEbS8PaGLjCSmi7huDTc2zwmJU0g6uv0mBY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:44.1727019","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A44Z&sr=b&sp=r&sig=dnWbQXxLNpvq0CpUHyErQEdPp3VFJQrzz3q6uU7bBLM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:44.172828","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A24Z&sr=b&sp=r&sig=WUvwy8YCPZ%2B1leIoi9yWe3LceAcIkhelS%2BVuYvk3sgc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:24.9043583","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A24Z&sr=b&sp=r&sig=%2FBk5Y9UpsyMi9nFMXvLQJJvwvR9NUyyeZgJZKpYb4A4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:24.9042839","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A24Z&sr=b&sp=r&sig=w5CTgxlvZClmE98Z%2FOsEl9Zn8eIU3XvrBFj8%2BznpG%2Bs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:24.9043727","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3196'
+      - '3203'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:40:44 GMT
+      - Sun, 29 Oct 2023 22:34:24 GMT
       mise-correlation-id:
-      - bfacf9e9-e32b-4599-9ab3-a2c09874bfc9
+      - 18291121-80eb-4485-b96f-9989166bf884
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1600,23 +1312,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A49Z&sr=b&sp=r&sig=gJ3EjSWc53xR%2FpMNj7No2UvfUUuNF5CHMdOU%2FVMUk2M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:49.4939703","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A49Z&sr=b&sp=r&sig=RUg4omaXXl5lNaM7hb9ChjMo2b%2BI9jmZzo7dgSxyVVo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:49.4939016","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A49Z&sr=b&sp=r&sig=QB5LeQdMw0CL6c18MgC%2BQ9wXM0mbQ8IX7ExRQgr4%2BVE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:49.4939857","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A30Z&sr=b&sp=r&sig=gZDsuqGgy8PeN%2FHsQvSZCfb%2FRwuwgeD4Zs4TznKqtiw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:30.1697315","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A30Z&sr=b&sp=r&sig=pDk%2FnVuqpCog%2BpK4webMdp9VgmEywbkVLDX5KcxYvNk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:30.1696535","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A30Z&sr=b&sp=r&sig=RmMTV9Kh1aAE%2FkLJPj%2ByONrJhbQHz3nruEq124MKqv8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:30.1697473","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3201'
+      - '3203'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:40:49 GMT
+      - Sun, 29 Oct 2023 22:34:30 GMT
       mise-correlation-id:
-      - e9fa8f72-1323-4568-8ff9-057579827c08
+      - 980403f1-94b6-45b1-8d51-959581a01b55
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1636,10 +1348,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A54Z&sr=b&sp=r&sig=XIHwapOez9PjJu5tp1syDfX85p7QqFT%2BOhN1bzhY%2FEM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:54.8327978","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A54Z&sr=b&sp=r&sig=r7P861g8ldGTWi5RrspmQIj5xY9mEojSDBAlCDOkSec%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:40:54.8327242","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A40%3A54Z&sr=b&sp=r&sig=dInzbI1HZtReNMZVtof2otZK%2BYlMQnwiQAfrD6lfFEo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:40:54.8328117","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A35Z&sr=b&sp=r&sig=JqeQ6frvGFSYCQoRFGeY5ovsXy%2F1Wxuk5BUVmugmVto%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:35.9381836","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A35Z&sr=b&sp=r&sig=WmOrBecha7Ptbfy%2BTuDBuCcpN0QO8119LKrtYnzTMFQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:35.9381097","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A35Z&sr=b&sp=r&sig=VKBvanyziwuwwNYJvoG7SgDPDOqCW4Fc%2BKMunO9Yqe4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:35.9381976","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1650,9 +1362,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:40:54 GMT
+      - Sun, 29 Oct 2023 22:34:35 GMT
       mise-correlation-id:
-      - 8b7e47eb-0e40-4dab-87e2-2c14d4edc20b
+      - 70bdca6b-8300-48bc-8d04-932b0e58f374
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1672,10 +1384,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A00Z&sr=b&sp=r&sig=iodPFluEKSVJdYC6C4R2m0qaEDn330M93uOkW98wGFk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:00.1525604","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A00Z&sr=b&sp=r&sig=2qB3sPVysYf4L0e8ONgI6Xa3wESH8nbVroHD%2FH5H1bk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:41:00.1524894","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A00Z&sr=b&sp=r&sig=aoqTOROW93NRAA11DTtYxJ%2FbhXnnqLAMfimYkGc%2F3a4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:00.152575","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A41Z&sr=b&sp=r&sig=Fr4P1fdb%2Fpjif014NTQcPbQWPubPqYnPvznY8QO8sIo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:41.6773675","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A41Z&sr=b&sp=r&sig=volQNnz5A6Ve1TaJOQWzB3xSbrBqcccJGB%2BiwPjaWUI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:41.6772767","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A41Z&sr=b&sp=r&sig=L%2B%2F%2FXLgvpAxE5iQYnJdRHHJ7fQR%2BBvxZm4qagYdqWMo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:41.6773827","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:34:41 GMT
+      mise-correlation-id:
+      - 94bd0978-88a6-492f-a193-c4c67e275b3a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A46Z&sr=b&sp=r&sig=n1qPZZJXvCSQag4AA99K9wRhXfQXZyK0C2Y6w%2FaUd8U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:46.9556545","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A46Z&sr=b&sp=r&sig=gc8EiK5Ekk09B74Nl3KdU8r5TdlnZt6ODe91WAt%2Bolk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:46.9555839","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A46Z&sr=b&sp=r&sig=NvkQZWSfC8nt3FTUt%2FMJL%2F8rk4%2Fr3WshH7YfgHlSjGI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:46.955669","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:34:46 GMT
+      mise-correlation-id:
+      - 8dabde97-fdfb-4f8d-8efe-340e754d1fcb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A52Z&sr=b&sp=r&sig=f%2Fm7YHT8B8Gvbc0fdurXfypo2gUBOVAU8f%2FgKIdd3ow%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:52.223554","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A52Z&sr=b&sp=r&sig=p0mCLiISbPD7y9cUv74Ih9oDBOqQlpdSpkOd1F1rTKM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:52.2234812","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A52Z&sr=b&sp=r&sig=xVa4HcIIStzxYrocDVlnKUuOV9PeF%2B8Hr6KvKPUl5DI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:52.2235692","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1686,9 +1470,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:41:00 GMT
+      - Sun, 29 Oct 2023 22:34:52 GMT
       mise-correlation-id:
-      - 681a93b6-6629-4844-8450-1ff9c0158b84
+      - 3fec9449-7bba-47e0-87a1-e37424cac287
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,10 +1492,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A05Z&sr=b&sp=r&sig=tJMxBbVJ0bSPqD77HOUxHsyh4coIoaoNfaOumWhRuEY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:05.4869967","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A05Z&sr=b&sp=r&sig=lqsFd%2FC%2Fb5KwO6BJIBEKFSCiSPGcdmZDjCOsbtgx03U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:41:05.4869259","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A05Z&sr=b&sp=r&sig=F9Fg0bf5o%2BAPFoP%2FO1ynWwxEw4IsTQV5AaLwKWzdi0M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:05.4870107","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A57Z&sr=b&sp=r&sig=uz6VFoaFjAZjL1JVpTLa22WhDdo3dVnIiN28rBvhAJ0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:57.5005161","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A57Z&sr=b&sp=r&sig=QFI3BljyfxelW%2F5WjRHh%2F7GX732N3vdQXQ4G6HDIMGM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:34:57.5004273","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A34%3A57Z&sr=b&sp=r&sig=VHzSgwuQVspNH%2B3wmzEmLNFa3CubTv2ALlohX99739E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:34:57.5005337","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:34:57 GMT
+      mise-correlation-id:
+      - 8cda88bb-3cb1-4c19-af97-32ec966f29f5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A02Z&sr=b&sp=r&sig=UapJFsZB%2FNtSKD3C61xAj2zRFK32K34kz1vNXdJ3Gxs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:02.838875","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A02Z&sr=b&sp=r&sig=0dyqc3OzlUnwWfsl7n7WqypxKMKQqsUoh3JWp9k%2Ftxo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:02.8388062","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A02Z&sr=b&sp=r&sig=Yyg%2FwqbvE5bsmXXXfe3EicmXdHsBGtkPT%2FY0x27KIoA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:02.8388955","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:35:02 GMT
+      mise-correlation-id:
+      - d875a875-2b35-4d85-a37d-2d1cc6c23396
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A08Z&sr=b&sp=r&sig=6dSpmISP9mNfNZZ4LPE2TQxLovBECLglQHCVmDKBS5o%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:08.1543935","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A08Z&sr=b&sp=r&sig=0dHA0EWmkINTl9NnhFXgiAlNakybc7OaT%2F7y%2FA1Wirs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:08.1543002","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A08Z&sr=b&sp=r&sig=RpTHQzYPe0p%2F5031%2BiGQ9cc1lgKf2R2bEsVeuSlZU2M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:08.1544147","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1722,9 +1578,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:41:05 GMT
+      - Sun, 29 Oct 2023 22:35:08 GMT
       mise-correlation-id:
-      - c59b3abb-aca0-4ab9-a1ea-91949bd28613
+      - e4cd1763-96fe-47f1-8f81-864377189666
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,10 +1600,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A11Z&sr=b&sp=r&sig=RO5vzR%2BCSYQ6gnkwVq%2FSvHJn2y3dNoQ3svE0kGKSKRk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:11.2479289","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A11Z&sr=b&sp=r&sig=PVKkRao77tbtYN6mxzPl8lvls0%2FPplwoBg4qDhb%2BRHs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:41:11.2478623","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A11Z&sr=b&sp=r&sig=IFkMFIxHdJknn%2FBNFLMfo9fZf8ML6O8SssrPoLXBQls%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:11.2479435","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-24T12:38:33.174Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:39:21.833Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A13Z&sr=b&sp=r&sig=IXcD%2BlLKFC8ta8rVN%2B84yfYChH9OscafYMFf8sxY2%2FY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:13.5115794","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A13Z&sr=b&sp=r&sig=uC44OrgFktD%2BGQEX9l0moHv9CL2dbmaqPuRNsSn9VbA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:13.5115122","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A13Z&sr=b&sp=r&sig=od4Bo1a04Z%2FMvvoisqJkPbLW2GQdPlQ%2FT945iYGYT6Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:13.5115938","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:35:13 GMT
+      mise-correlation-id:
+      - 506efc14-852b-4ec2-ab18-2acae9712e54
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A18Z&sr=b&sp=r&sig=i3%2Fbow4%2ByBtyaJEbPL%2BJnjGohr92rZ4xz2wr%2BP8W1E8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:18.8742408","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A18Z&sr=b&sp=r&sig=DM5KKFsN6auSmZMKNE9trxy6%2BZkMv0%2BGCVMUBnskY2I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:18.8741638","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A18Z&sr=b&sp=r&sig=w2vWvoDaIACZ80fUh1E2rIFtbbkkXxS1AQNEu%2BkuLGM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:18.8742563","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:35:18 GMT
+      mise-correlation-id:
+      - 2cc04885-2601-45db-94ee-b889dbac56bb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A24Z&sr=b&sp=r&sig=1pWHvBpKuIKPG1ijn86uzzvvS9ZIAkc%2FTpRzUUoIgzY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:24.4501636","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A24Z&sr=b&sp=r&sig=gi09TAVokeS2qfz8mqlsIWI87VysOergoYjYbvhbHh0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:24.4501103","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A24Z&sr=b&sp=r&sig=h9jv1yo%2FBhVSW66CHt567ozBUWk2JFss80nMxc5arM0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:24.4501771","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3195'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:35:24 GMT
+      mise-correlation-id:
+      - 9f399ad2-c263-4e15-aafc-bdae725c1591
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A29Z&sr=b&sp=r&sig=UIOOjrxH7wpq%2FJmajSN36cY1I67h1fDnUym69xZpNLU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:29.7622278","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A29Z&sr=b&sp=r&sig=xNwFsNGihUQNQToeNfudZ1GaDLPcuLLe%2B%2Bv0deeQMNg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:29.7621305","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A22%3A23Z&ske=2023-10-31T05%3A52%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A29Z&sr=b&sp=r&sig=Mx5gxhBEreMmgU%2BoWqRh9ttFphuo0m%2BnPxiDPrKNcVw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:29.7622496","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +1722,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:41:11 GMT
+      - Sun, 29 Oct 2023 22:35:29 GMT
       mise-correlation-id:
-      - e28d4cb9-6aef-4696-ba69-10712f3805f1
+      - 5762f053-12be-45b0-8776-4b06bb1353bd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,24 +1744,204 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A16Z&sr=b&sp=r&sig=DYLvyiDqMI%2BuK%2BUTdHcrj%2FPFEjDRmUmFUMD7YvFW4IA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:16.5968222","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A16Z&sr=b&sp=r&sig=2z2RvFdgdpWvGtimwkt2fLDVRBCymoPhxPjpCJ8wGTE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:41:16.5967557","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A16Z&sr=b&sp=r&sig=HA%2FlAziXWxghfOr4k5j%2FMzz1FBEd4PKQE5jqLVoLCMI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:16.5968364","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-24T12:38:33.174Z","endDateTime":"2023-10-24T12:41:12.772Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:41:14.269Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A35Z&sr=b&sp=r&sig=Sv4bN7%2Bnn9Mxk%2BP02OPG0kMaVgmsDmGkDX98MNPLycU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:35.026934","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A35Z&sr=b&sp=r&sig=fxc0E9rYG5Zw9g9w0UIwJcAiYkyRC5jODg13mXlGw2w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:35.0268641","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A35Z&sr=b&sp=r&sig=TXuYhi5v%2BVNIOfc50c4sTuc3Vl8BpsN%2FtyJV4ZK14hU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:35.0269703","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3336'
+      - '3198'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:41:16 GMT
+      - Sun, 29 Oct 2023 22:35:35 GMT
       mise-correlation-id:
-      - 9879e0ee-82d1-4583-84bf-df471aa87719
+      - 78cfa8f9-16f4-4b70-be98-f4c90fac78ea
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A40Z&sr=b&sp=r&sig=WWSJz2vqgb7qNWxG6IC864QFRuYLVQavEzwuM88rcm0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:40.3034738","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A40Z&sr=b&sp=r&sig=YndoxEylQjyem2yTKPPj%2Fz3ZjA0CRsj9RFDuCunRKDE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:40.3034011","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A40Z&sr=b&sp=r&sig=HnUSjBMlCeDhUazVswRGKbE2u9SaGspx2OaMYCqPb1c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:40.3034884","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:35:40 GMT
+      mise-correlation-id:
+      - 01c2e8c6-2bc8-472c-bf5b-9f035dd0699d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A45Z&sr=b&sp=r&sig=wQUqHL6Zzy3zmjUY83XjpnCRWQfjkV5QAaACop6C5v8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:45.6354327","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A45Z&sr=b&sp=r&sig=hLCaP3hXGKigATYqpaOCcIwMw7RSBnF32q4sd4Ok1JY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:45.635364","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A45Z&sr=b&sp=r&sig=4qWTazfn1OEO44HQn2smGLfjQMHVoALTlVv7XlshzE0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:45.6354475","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:35:45 GMT
+      mise-correlation-id:
+      - 6f423380-f1e4-4337-ad70-b06bc5a8968d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A50Z&sr=b&sp=r&sig=n62lG0%2FkO5uGnpwIJWlPwfmkNZ2d8UaGnnd7fQekwDQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:50.9644624","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A50Z&sr=b&sp=r&sig=MA8ps03azwDZgX4kRbE9rntvYX7HWlh5i%2B7BrHyV9sg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:50.9643918","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A50Z&sr=b&sp=r&sig=kJX%2FVLNwj6eegEz4cMWHCf%2BIQebyNmFV0zsVr9GTsus%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:50.9644763","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:35:50 GMT
+      mise-correlation-id:
+      - 3c50b35a-a6fa-4b4c-b3e2-c3a649be5ab8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A56Z&sr=b&sp=r&sig=bXtAcFpGRmuVUIPWtaCubhQv7fWnjxXmXRsL3i36lhY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:56.2501894","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A56Z&sr=b&sp=r&sig=BwyfYkc9vxLgY8SOly2KGeoUrElnOw85KZ0uO1IOuG4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:35:56.2501225","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A35%3A56Z&sr=b&sp=r&sig=V44jxBX0RrCPOfEBo%2FmhKx8cU9b1jFtFN40%2B7F%2FNjCk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:35:56.2502044","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-29T22:32:59.96Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:34:03.352Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:35:56 GMT
+      mise-correlation-id:
+      - 5d2dbc47-9fa3-44f4-82e3-a305970d815c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A01Z&sr=b&sp=r&sig=bg2FwqDYl5y%2B%2FuVmi48Y2ojgUBZN7OgkDndOaki%2F14w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:01.5339291","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A01Z&sr=b&sp=r&sig=IpFZCz33pFEaLKh3n3TNR%2FfuQmrUj4t1md9kp%2B%2BcpWY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:36:01.5338565","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A01Z&sr=b&sp=r&sig=Dx%2BiVjrAEbTpIYlpz%2BK7IgjZaL5e6p7RZnj6EBC8wPs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:01.5339442","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-29T22:32:59.96Z","endDateTime":"2023-10-29T22:35:56.551Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:35:56.693Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3342'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:36:01 GMT
+      mise-correlation-id:
+      - f7c0923c-6eca-4f7e-ae75-56c405958a72
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,18 +1964,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:37:32.8275879Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:37:32.8275879Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:31:57.6921376Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:31:57.6921376Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:41:18 GMT
+      - Sun, 29 Oct 2023 22:36:02 GMT
       etag:
-      - '"d300a757-0000-0100-0000-6537ba8e0000"'
+      - '"3c007239-0000-0100-0000-653edd5f0000"'
       expires:
       - '-1'
       pragma:
@@ -1861,24 +2005,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=update-test-case&api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=update-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A19Z&sr=b&sp=r&sig=%2FHsO3B1MbQcFqWm3cCvE1RHH%2ByPrg1SflXUZrC2mazE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:19.4161485","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A19Z&sr=b&sp=r&sig=z7VEHDZnKANjzQDSHW0dg%2FkAeKqBXg7qUPOO2LFD7DY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:41:19.4160733","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A19Z&sr=b&sp=r&sig=n4AkjTUi285EgvH33rAkBooCu3cSOD8B5m6YPeaF%2BLI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:19.4161632","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-24T12:38:33.174Z","endDateTime":"2023-10-24T12:41:12.772Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:41:14.269Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A05Z&sr=b&sp=r&sig=mG2GIcBj5ecDJ3FTVhyodLna0NVyqVkLLnkZRtPKaEE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:05.1010456","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A05Z&sr=b&sp=r&sig=VNQKVN2kj7CL12L9jcB8Xb158C805Yl4jFU%2FEh6udG8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:36:05.1009486","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A25%3A35Z&ske=2023-10-31T05%3A55%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A05Z&sr=b&sp=r&sig=aKWqfJN2v0VyMA9syl%2BCCVCGU%2FIX0VPQ02pqY2e8wPk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:05.101068","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-29T22:32:59.96Z","endDateTime":"2023-10-29T22:35:56.551Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:36:03.74Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3346'
+      - '3342'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:41:19 GMT
+      - Sun, 29 Oct 2023 22:36:05 GMT
       mise-correlation-id:
-      - a10e9412-fffb-4687-b45a-945bb89b25b8
+      - 233a5536-5fc2-4962-871f-630079cf0664
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1901,18 +2045,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:37:32.8275879Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:37:32.8275879Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:31:57.6921376Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:31:57.6921376Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:41:40 GMT
+      - Sun, 29 Oct 2023 22:36:26 GMT
       etag:
-      - '"d300a757-0000-0100-0000-6537ba8e0000"'
+      - '"3c007239-0000-0100-0000-653edd5f0000"'
       expires:
       - '-1'
       pragma:
@@ -1942,24 +2086,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A41Z&sr=b&sp=r&sig=wm5Hy0oJRcBygc8honEl9mbE%2F2LgFNwVhvK5ld3GKMU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:41.6277557","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A41Z&sr=b&sp=r&sig=fxyJMoH51PYTIaD5HWjI7gCGUxd75nZyrhYIkA7Db4s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:41:41.6276895","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A41Z&sr=b&sp=r&sig=ORhhSkvBC7M%2Fj6BErknGfXR3LazdPxCFUmvZA9K6ncU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:41.6277705","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/5889d508-9234-4e62-b777-691b556ebc88_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A41Z&sr=b&sp=r&sig=HvywYibtqgl7p3M9utr42k2rxXfMVNw5nVwjfEC6rFY%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:41.6277841","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/5889d508-9234-4e62-b777-691b556ebc88_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A41Z&sr=b&sp=r&sig=rx3VH85121yoV0j3LcvnHglYvvFV%2FxuruqBpi5inv%2Fs%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:41.627798","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-24T12:38:33.174Z","endDateTime":"2023-10-24T12:41:12.772Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:41:21.686Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A27Z&sr=b&sp=r&sig=EL%2F2hAF5UOUa9G3CcWnWObo6eUx7A3m6%2FnghGEkTU5E%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:27.7229288","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A27Z&sr=b&sp=r&sig=s9LPvNmhPCbYfusRfpJt%2Bb%2FWjLQZwqNN3Nj21zHxvrw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:36:27.7228413","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A27Z&sr=b&sp=r&sig=81QMtsgnQQWE%2FysSwveI2gFwSVGHMKXFtYxg3EymOKM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:27.7229513","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/59bbd2cd-fa03-40dd-955f-583928730b95_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A27Z&sr=b&sp=r&sig=Nki7QizanwFhl74pTwbqOZ0O%2BD4ukhdi8BkQEUENe2U%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:27.7229895","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/59bbd2cd-fa03-40dd-955f-583928730b95_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A27Z&sr=b&sp=r&sig=UGCCyII2D9gYvMpsmByc8CAO3kqWl4YcL8Hfgo2FEqg%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:27.7230121","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-29T22:32:59.96Z","endDateTime":"2023-10-29T22:35:56.551Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:36:12.266Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4492'
+      - '4497'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:41:41 GMT
+      - Sun, 29 Oct 2023 22:36:27 GMT
       mise-correlation-id:
-      - 31b9412b-27a2-47f4-af6e-2370569ddb96
+      - 51fd3c8e-7687-427c-8adb-157d3498553f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1983,25 +2127,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A42Z&sr=b&sp=r&sig=GSEb2bTvz9%2F%2F3qn7s11urFhV6JtTecFjZ5if02m5zfo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:42.0287404","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A42Z&sr=b&sp=r&sig=tQT2RNTADQTmMTlgFAB1C3m9gMIK2blsF2mPIr%2FMZFg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:41:42.0286825","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A42Z&sr=b&sp=r&sig=WDGOw%2F9nliltXXLKxfiFf040lg%2FzOI89vo3vqUSr2ac%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:42.0287552","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/5889d508-9234-4e62-b777-691b556ebc88_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A42Z&sr=b&sp=r&sig=hgvLUQ1TXY44rUDMx8nu9FjS3FHE7DMNf0VZDTJhw%2Fs%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:42.0287691","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/5889d508-9234-4e62-b777-691b556ebc88_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T12%3A33%3A16Z&ske=2023-10-25T20%3A03%3A16Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A42Z&sr=b&sp=r&sig=6672W94Fxiyifjm5Ra8fOJaR8KVBgsHrYdth%2Fe6t1Zc%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:42.0287832","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
-        test run description","status":"FAILED","startDateTime":"2023-10-24T12:38:33.174Z","endDateTime":"2023-10-24T12:41:12.772Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:41:42.019Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A28Z&sr=b&sp=r&sig=aOrnOQKoZyaSTv%2BDZTbeV02D7LdjXvn1cYXZ50CBCFA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:28.1391703","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A28Z&sr=b&sp=r&sig=I0sGJbqQId7dbgO5cLxdse5J5T4kHuY8zVb3g382i98%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:36:28.1390999","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A28Z&sr=b&sp=r&sig=dfJGae04ygAms8XeMaF72uo3CqfpHpgK7WIAVHw7t4I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:28.1391863","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/59bbd2cd-fa03-40dd-955f-583928730b95_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A28Z&sr=b&sp=r&sig=uiABM9RpysreRscfxxbz8bDzVBiepdmoVQICZm%2Fxy30%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:28.1392021","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/59bbd2cd-fa03-40dd-955f-583928730b95_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A28Z&sr=b&sp=r&sig=kXoz7Dl5PIeTsLOO5utfchVedo8Z9p2RXgXwab2%2BXUo%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:28.1392183","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
+        test run description","status":"FAILED","startDateTime":"2023-10-29T22:32:59.96Z","endDateTime":"2023-10-29T22:35:56.551Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:36:28.13Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4544'
+      - '4535'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:41:42 GMT
+      - Sun, 29 Oct 2023 22:36:28 GMT
       mise-correlation-id:
-      - f239674f-7122-4456-84c1-4d8004d77c1d
+      - a0bc9d29-f8f2-4036-876f-c372f90a8b17
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2024,18 +2168,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:37:32.8275879Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:37:32.8275879Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:31:57.6921376Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:31:57.6921376Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:41:42 GMT
+      - Sun, 29 Oct 2023 22:36:28 GMT
       etag:
-      - '"d300a757-0000-0100-0000-6537ba8e0000"'
+      - '"3c007239-0000-0100-0000-653edd5f0000"'
       expires:
       - '-1'
       pragma:
@@ -2065,25 +2209,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60546151-1071-493a-802e-3f7bab7e1716.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://6e00a06f-c6cb-42c8-90ca-6fa242214b13.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"43111ca2-0af0-47af-b425-5c4c79d0bd98":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"658dd14a-02d6-42b2-b43f-5b87e77480d6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"0810b81b-3082-4e5b-95fe-9a40c26cd6d8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/6f80b913-8223-418c-b910-2783b5c29eb1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A44Z&sr=b&sp=r&sig=I1HUZyfnbf4Do8A3Zut5fgTnMDgpDbdPfsy0CpdlW4g%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:44.6010185","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/32db2f45-1575-4561-99fd-a23ac59558a9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A44Z&sr=b&sp=r&sig=f1RO14Rf0EH5AwvMR6nlxdUbpp6OnR3bCw92yfsXH88%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:41:44.6009472","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/823a6d77-000d-408a-a02a-f7355c02df37?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A44Z&sr=b&sp=r&sig=Ld8ag%2FPpql6rLSc0R1N3RAcpPSyiQ8rLIjFTxaLG5DE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:44.6010325","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/5889d508-9234-4e62-b777-691b556ebc88_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A44Z&sr=b&sp=r&sig=xPCKH8HPaQz4HxyaltiSEtAS%2FTsCx%2BbIGGMOGUgTIuQ%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:44.6010466","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/80a5d40b-3b75-43f3-b6c6-e30a500ee7e5/5889d508-9234-4e62-b777-691b556ebc88_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A41%3A44Z&sr=b&sp=r&sig=hDqn0vvbQQ3vDILMj3NlSGGpUBaB6nbNhj%2F67pMl9zs%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-24T13:41:44.6010608","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
-        test run description","status":"FAILED","startDateTime":"2023-10-24T12:38:33.174Z","endDateTime":"2023-10-24T12:41:12.772Z","executedDateTime":"2023-10-24T12:38:32.421Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-24T12:38:32.69Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:41:42.019Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f95e1e68-3aac-4fbf-a348-6e114857d051":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"079fa455-c798-4c54-840f-9f07e0088a58":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1939d566-e166-4396-911c-2b7e175572e8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/d40dc629-c02b-4c05-b0b1-d91da055a274?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A30Z&sr=b&sp=r&sig=CdW8XIv9br%2BdTJVw2Yjycaek15MeFT5Zqz2B3gLJ%2FJU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:30.5965281","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/3a3a5705-61d9-41be-a9db-0cd9fe719fd3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A30Z&sr=b&sp=r&sig=HJEFz%2BUa0cLtUD2tU9iHJvlRXX0Pjf2gzOy972G0OBQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:36:30.5964576","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/9670d7a0-eff4-4b4d-a633-b14e625b18cd?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A30Z&sr=b&sp=r&sig=L3hgF8qpBtRybqnqM9qjXO1bAspT0r%2F0cy%2BGCZX1qFs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:30.5965435","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/59bbd2cd-fa03-40dd-955f-583928730b95_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A30Z&sr=b&sp=r&sig=Z8cnmj4qGTEMwBlrQU4ux9QDi3lk5dM83RX06eOalfE%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:30.5965596","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a4fd53ca-be80-4d1e-9167-e7604c008237/59bbd2cd-fa03-40dd-955f-583928730b95_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A36%3A30Z&sr=b&sp=r&sig=Wmx98WugetWqjAPyleM5xwB6rso%2BXg1a%2BXBgT2gO1gM%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-29T23:36:30.5965751","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
+        test run description","status":"FAILED","startDateTime":"2023-10-29T22:32:59.96Z","endDateTime":"2023-10-29T22:35:56.551Z","executedDateTime":"2023-10-29T22:32:58.278Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-29T22:32:59.567Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:36:28.13Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4538'
+      - '4543'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:41:44 GMT
+      - Sun, 29 Oct 2023 22:36:30 GMT
       mise-correlation-id:
-      - 4d5b0e19-9571-4d71-a1e4-e289e832a25e
+      - 8fa98bbd-9c3e-46aa-a09a-2ae64c3432bc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_update.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_update.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:27:13.4267962Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:27:13.4267962Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:00:04.8936167Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:00:04.8936167Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:47 GMT
+      - Fri, 13 Oct 2023 14:00:39 GMT
       etag:
-      - '"57008419-0000-0100-0000-652454130000"'
+      - '"d901ec7c-0000-0100-0000-65294d680000"'
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:27:49 GMT
+      - Fri, 13 Oct 2023 14:00:41 GMT
       mise-correlation-id:
-      - 3ec3ab34-e45b-4704-a857-41ca60b243e9
+      - bdeb8f39-0b7d-478d-8f0b-e64c689d8d55
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"221ac857-5bee-45f0-8cb4-2ebffcccff79": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "ff2fb94a-507c-4ad1-89e5-8f5528a903bf":
+      {"passFailMetrics": {"1e33ae22-2715-439e-bcc6-9b766cd03d65": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "11255139-f90f-426d-8aa3-dbf877da33a2":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "96e99621-3d0b-47a2-8839-bcf040f609fb": {"aggregate": "avg", "clientMetric":
+      "50"}, "af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -104,13 +104,13 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:27:49.636Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:49.636Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T14:00:42.365Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:42.365Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:49 GMT
+      - Fri, 13 Oct 2023 14:00:42 GMT
       location:
-      - https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+      - https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 26e56b3e-3501-49f5-b888-4732c55e28c5
+      - c80b9b6d-c91f-4165-a18c-83c4d02d71d0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -143,9 +143,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:49 GMT
+      - Fri, 13 Oct 2023 14:00:42 GMT
       mise-correlation-id:
-      - 0a050af2-b53c-49a1-b435-e1da10931583
+      - c50b3a57-a8fb-4cf8-b3e5-9001d7c18eea
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -273,27 +273,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A37%3A50Z&sr=b&sp=r&sig=1%2FzXPxqv328EbNVgn2vRIjPCBksB27hEEI8G4kUt%2FuA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:37:50.5137933","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A10%3A43Z&sr=b&sp=r&sig=9VFT7hjtBBDCVr7UR2S9KjrTmL8Ik5pe9OGfOOnMwDQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:10:43.2759373","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:50 GMT
+      - Fri, 13 Oct 2023 14:00:43 GMT
       location:
-      - https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 8ca2d520-9e1f-4d4b-976f-809dad4427d5
+      - 59161456-d403-4fdf-85ba-9989defee502
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -311,25 +311,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A37%3A50Z&sr=b&sp=r&sig=obGIrt4bJ36ecFNJVwtFQ0TS0GlmoeoQPx6I0vptEN0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:37:50.786426","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A10%3A43Z&sr=b&sp=r&sig=aLIr99TCfKeRyfa5wsFin4L6gSq%2BfD2bZj75NZ%2FzOTA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:10:43.5415752","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '548'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:50 GMT
+      - Fri, 13 Oct 2023 14:00:43 GMT
       mise-correlation-id:
-      - 4f5feced-b53b-433a-a736-085025291067
+      - b8845bb7-674c-4e43-872e-647517d27b4c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -347,25 +347,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A37%3A56Z&sr=b&sp=r&sig=HAodjV44fsj0yk93C23Nlslw8vX1JHSbkIF9OBHTTEs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:37:56.0970508","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A10%3A49Z&sr=b&sp=r&sig=d9J3SQS6jvV4YIIrhHrF2X%2B6Wn%2F2uik7N%2FeeUtuzS3Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:10:49.3375767","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:27:56 GMT
+      - Fri, 13 Oct 2023 14:00:49 GMT
       mise-correlation-id:
-      - af7eddce-a36c-4e82-9d7b-2905ef88430d
+      - 7aec6cf3-5f80-4484-9dfc-e7f761c224a1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -383,25 +383,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A38%3A01Z&sr=b&sp=r&sig=M6dNUVnWHorSQOOEPPntHIAPQ0k%2FzOTzoQsaxiy46T8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:38:01.4107016","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A10%3A54Z&sr=b&sp=r&sig=xfFlmkXb4eeu%2BY8%2Bvd89naZqBAQT4SORiCz8vpccII0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:10:54.6156257","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:01 GMT
+      - Fri, 13 Oct 2023 14:00:54 GMT
       mise-correlation-id:
-      - 77663aae-5ade-429c-b479-e3b32b920158
+      - d2156233-8b38-4cb6-b7f7-c2378955b13e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -419,25 +419,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A38%3A06Z&sr=b&sp=r&sig=lvJSeNATfxZzqJ4Eg15uIPtqwploFZvXyHgP%2FMoP0qg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:38:06.732419","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A10%3A59Z&sr=b&sp=r&sig=CmZLkdi2PeUSW0ewO6E9EffXtMayydCXSPeGk75SaiI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:10:59.8720481","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '548'
+      - '547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:06 GMT
+      - Fri, 13 Oct 2023 14:00:59 GMT
       mise-correlation-id:
-      - 2783bdd6-ca22-452d-90c8-40ca1be602bb
+      - 680b671d-2d01-4d51-8068-315ce97e452f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -455,26 +455,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A07Z&sr=b&sp=r&sig=GgnekROnxrvbm4deLgOcAadebZTTmWtcsFbLvKI5Zww%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:07.0496521","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:27:49.636Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:03.213Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A00Z&sr=b&sp=r&sig=putTES0vuXwoHE6mT2gySm8CiZ3RhbRnMNm%2FN17qqY0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:00.1536715","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T14:00:42.365Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:56.286Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1577'
+      - '1579'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:07 GMT
+      - Fri, 13 Oct 2023 14:01:00 GMT
       mise-correlation-id:
-      - ea7e40ec-9556-407b-afe9-2a72585e26b2
+      - 56398d78-e2f9-466e-a43b-1402f5c92911
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:27:13.4267962Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:27:13.4267962Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:00:04.8936167Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:00:04.8936167Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:08 GMT
+      - Fri, 13 Oct 2023 14:01:01 GMT
       etag:
-      - '"57008419-0000-0100-0000-652454130000"'
+      - '"d901ec7c-0000-0100-0000-65294d680000"'
       expires:
       - '-1'
       pragma:
@@ -536,26 +536,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A09Z&sr=b&sp=r&sig=O0aL3Gg6T8JoEe3QLx80cjwICqFqFoi2gwn1q5Qs0Qw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:09.3745381","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:27:49.636Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:03.213Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A03Z&sr=b&sp=r&sig=YqRhvN2XlZLVYC0LTavenHIIFDD191UKS%2FJw6CqNh2w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:03.2558542","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T14:00:42.365Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:00:56.286Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1589'
+      - '1591'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:09 GMT
+      - Fri, 13 Oct 2023 14:01:03 GMT
       mise-correlation-id:
-      - 058d8c9f-c101-4baa-b885-e9973b645f33
+      - 62f2aa4d-6349-4bfa-8830-155a01a5562e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:27:13.4267962Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:27:13.4267962Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:00:04.8936167Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:00:04.8936167Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:10 GMT
+      - Fri, 13 Oct 2023 14:01:03 GMT
       etag:
-      - '"57008419-0000-0100-0000-652454130000"'
+      - '"d901ec7c-0000-0100-0000-65294d680000"'
       expires:
       - '-1'
       pragma:
@@ -617,9 +617,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:28:11 GMT
+      - Fri, 13 Oct 2023 14:01:05 GMT
       mise-correlation-id:
-      - 8d5628cf-2629-427e-9ecb-f30a90c9ab9a
+      - 1f6fea90-b71e-4544-94e8-cf8bc7d7034b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -660,27 +660,27 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A12Z&sr=b&sp=r&sig=L4SChe921S9eG0lPPSe3mq72Cc1SrVsvSzLFmIOXKRA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:12.3669788","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A12Z&sr=b&sp=r&sig=vGo5uBTavwMIvv7Hyt5MVf0zeVmBCTduICCPtwLe2cM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:12.3668152","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A12Z&sr=b&sp=r&sig=uNqnDUpEWvKJar9ycfV4FdtdHf5i5MqHNq9rDE2UFPQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:12.3670046","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:12.297Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A06Z&sr=b&sp=r&sig=2wx89lKRB2PD5H1wcC%2BlknVD5WDM9RT6ZmiUcnLWCDU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:06.1086709","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A06Z&sr=b&sp=r&sig=u0BDiHxZvaWDfSUam2fqGNxDs%2FNaiZK5Ug0E70J0Hy8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:06.1085375","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A06Z&sr=b&sp=r&sig=41olk9W8pM5VYC9vHh3GLCzr1Gv8PZ19xUJeXq64PBw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:06.1086942","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:06.026Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3148'
+      - '3152'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:12 GMT
+      - Fri, 13 Oct 2023 14:01:06 GMT
       location:
-      - https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+      - https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 469465d5-c8c7-4e4e-bbd4-85eb28b970d3
+      - e1351d96-d092-435e-b8e1-d3592409e740
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -698,25 +698,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A12Z&sr=b&sp=r&sig=93yw8x62XB%2BbY9NvXbIxY%2BD4BgFKD0uoSNU%2FcUUAdOE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:12.8925912","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A12Z&sr=b&sp=r&sig=%2FVShzY6CyrGjwocG3RPcQzvm3QvMA%2BQRsNssDNziLAg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:12.8925218","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A12Z&sr=b&sp=r&sig=rL733XD3FTdi%2BbH20mOqL1Mz62GJy1a%2FhhywFHAFZZI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:12.8926051","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:12.736Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A06Z&sr=b&sp=r&sig=XPOTvSJWt2xg33TRWI5Uf65G5PAj6VXMNO6hAq3dVqw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:06.6958242","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A06Z&sr=b&sp=r&sig=yYYCW%2FyZRhWSIHqJ91sG7MORBAnthj%2FzJ6dyu1CgMgs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:06.6957556","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A06Z&sr=b&sp=r&sig=JpMvdodJLVYRCgWI0UvtnvuSJ9Z5H9aTa0knNyE5IRI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:06.6958376","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"ACCEPTED","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:06.026Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3207'
+      - '3152'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:12 GMT
+      - Fri, 13 Oct 2023 14:01:06 GMT
       mise-correlation-id:
-      - 1f5c5a26-4dbb-4bf8-bb3f-d3336aa6d70e
+      - 569cb83c-e00e-4a75-89b4-21c11209fd59
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -734,25 +734,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A18Z&sr=b&sp=r&sig=iGmHO0j3gMxSbUoqObQlhoWnEW6%2Fx1gAMDv5eHi4YYs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:18.168805","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A18Z&sr=b&sp=r&sig=CVFLn6sDvfBmBZfcOc5JdOvS6jkQEEjetYdUPlFmLd4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:18.168712","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A18Z&sr=b&sp=r&sig=DaM7T3isguY%2Fkurq5wuHTU0SEU%2BYeiAnav5v5gAuMM4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:18.1688286","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:12.981Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A12Z&sr=b&sp=r&sig=VxGHBTSE9IYYyGoElCgo0gy9EcXi7ZnblouNima2rWA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:12.0536344","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A12Z&sr=b&sp=r&sig=hSkPldJDdvbqOBX9TidkgnyPqEoJhZM5lip3tzspS%2F4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:12.0535425","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A12Z&sr=b&sp=r&sig=o1UCxOc41H6vcnQSoSiDhdtIdvGIscAYtB7TR8kiupA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:12.0536563","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:07.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3199'
+      - '3197'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:18 GMT
+      - Fri, 13 Oct 2023 14:01:12 GMT
       mise-correlation-id:
-      - 6b899ddf-110c-4bd6-b1d9-6dbf8a6f1d70
+      - 4c5b328d-3c34-420f-86a0-96a00821ebe3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -770,12 +770,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A23Z&sr=b&sp=r&sig=SECKh4vSFuUaoP%2Bn%2Bcp92jmzQczGKhxKlJ9chchAxMo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:23.4540057","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A23Z&sr=b&sp=r&sig=kR%2B3CF%2FPJyhy0UGKlQSBvsyWxB8D5JVTpUueAW5ccvk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:23.453923","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A23Z&sr=b&sp=r&sig=erwoXBFRw0RNgmPBRUyYj6tBXXnWLnSaacgquGdrfmA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:23.4540267","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:12.981Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A17Z&sr=b&sp=r&sig=gDt4Pe8dY7SEWcpi90tDtrmz7UWFp7Hk0c9HzRIx%2BJY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:17.3911509","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A17Z&sr=b&sp=r&sig=JJ6%2BfgVtnSHH74Syn9T0B5WMQdYvZuawITA32qCn2zE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:17.3910533","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A17Z&sr=b&sp=r&sig=zUj07Pd0wRMKimVYhr7iLDkbAQO0Q%2FuXY4dAq%2FmblHw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:17.391176","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:07.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -786,9 +786,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:23 GMT
+      - Fri, 13 Oct 2023 14:01:17 GMT
       mise-correlation-id:
-      - 6fffffc0-dc8c-45ae-a229-9f0e77c6a2f5
+      - 80bbab42-4b1d-483c-ae1c-f88c879b6fe0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -806,48 +806,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A28Z&sr=b&sp=r&sig=AO9SdgLEbyzrDO2nU8DZ0vCLEtcWV9EkgUyTU0fh2y8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:28.7657039","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A28Z&sr=b&sp=r&sig=vnbfgyMIyHK0fM4IBXCWHt39nWdw9bDZByKraWCRrxk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:28.7656056","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A28Z&sr=b&sp=r&sig=pm3dazl1xALWXKfjTXl%2FpzBP%2Fs3MYcTpXGdRilEefeQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:28.7657253","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:12.981Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3199'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:28:28 GMT
-      mise-correlation-id:
-      - d1d2c4f6-08f3-4618-8d41-ffe4b07fa091
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A34Z&sr=b&sp=r&sig=hSh3U0NWhGIRg79W7LlqJZsEVloandAPV66mcfwvTS8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:34.0856791","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A34Z&sr=b&sp=r&sig=PbjIJGFy2Y5WCdBtKze8W5q4nLQ67VW631ILW3bjf88%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:34.0855833","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A34Z&sr=b&sp=r&sig=uk9suJ%2Blfi%2FUm3JrlyVJsZehllhP%2BLD1AmCOfjUtdgQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:34.0857073","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:12.981Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A22Z&sr=b&sp=r&sig=YOiO%2Be1RQ8a6mEd7WtAyEmgIKUgb6Q1VREleImcrtsQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:22.7153491","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A22Z&sr=b&sp=r&sig=VyzQxiCaoeLpg5yrFB1SEV1XIl%2FY%2BGousMpbkQ4RJ9g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:22.7152776","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A22Z&sr=b&sp=r&sig=Ulwe6veURtDhFmxtW2nrIas70igjydfQlhSPjVuYyGs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:22.7153636","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:07.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -858,9 +822,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:34 GMT
+      - Fri, 13 Oct 2023 14:01:22 GMT
       mise-correlation-id:
-      - 311170da-e709-47cd-af82-a40f51c23ab0
+      - db53b3ee-a50a-4713-9e40-19ea95a42322
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -878,25 +842,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A39Z&sr=b&sp=r&sig=rtJx%2B%2FmYTL7QMr2AyzwKZYlMb9f4zHjNBKmiNKK4c%2B0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:39.4216622","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A39Z&sr=b&sp=r&sig=ZcDVyeytpCKx2P8iN%2ByhpLLjOEhN%2BwBhUAHmDjDlygs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:39.4215753","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A39Z&sr=b&sp=r&sig=%2BzylHX%2B1O0mFz%2B6QiLHGWYfTIXVkIlPhGf6f%2Fn%2FKSkg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:39.421683","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:12.981Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A28Z&sr=b&sp=r&sig=O7Cpt8g1fLkH6YkKZx7Owi%2FHJXTsgV6LAW9FrDukyYk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:28.010236","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A28Z&sr=b&sp=r&sig=q47hPqvkRlPRm216zNAJDXSlZOvDY3ZFkJonvfW2V5s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:28.0101564","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A28Z&sr=b&sp=r&sig=cXyD2mnj1g7TS1Alnv2bwhIbYJ6NWD82O8fHutC%2Ffzc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:28.0102576","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:07.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3214'
+      - '3198'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:39 GMT
+      - Fri, 13 Oct 2023 14:01:28 GMT
       mise-correlation-id:
-      - 67525711-4ac2-43f7-808e-a122f751172f
+      - f66f24fd-36f7-47c9-921e-42421da2e889
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -914,12 +878,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A44Z&sr=b&sp=r&sig=njFvEnrthR6vIZOQOj0%2F4clLucPCM1SDJIuXIg2IY8k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:44.7038419","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A44Z&sr=b&sp=r&sig=SR%2BaP3vxW22wwiecmFCphKEEpI0%2B9wc%2BgjEhLjjUUZI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:44.7037483","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A44Z&sr=b&sp=r&sig=K64ZwGLOZwrR5ZL1PruKxASEkPcv3hTKh6EKn%2FHgC9Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:44.7038688","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:12.981Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A33Z&sr=b&sp=r&sig=lxh3XolURUcuUcc0FTuvfzj%2BE4QpyjvTrZsuW%2FvU9lo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:33.2528021","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A33Z&sr=b&sp=r&sig=VbKDW%2FunDoGzdQYt1Ue%2FrM2T5XgyDuVrSfplOIqUdlk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:33.2527103","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A33Z&sr=b&sp=r&sig=Xd8EqEuKXUWEAeCQ7sbkjz0no%2Bkkx5MCTc78ureQU6c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:33.2528248","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:07.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -930,9 +894,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:44 GMT
+      - Fri, 13 Oct 2023 14:01:33 GMT
       mise-correlation-id:
-      - b6795a38-8d38-4026-90c7-a34f782e5422
+      - c43fe15d-c396-44af-b3c9-7cc3df1dac38
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -950,48 +914,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A50Z&sr=b&sp=r&sig=MY903Kqdhxk4mNe5SsKeBD%2FAhOfTj574dZ8Kgu97ya4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:50.0292024","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A50Z&sr=b&sp=r&sig=sLJGBpRFM%2BSqGram7R6l6iBimV2Vx8L%2FQNNJ7FvUu5Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:50.0291108","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A50Z&sr=b&sp=r&sig=laEy3pwMId8BiUIYdd3OFtWQGt78XGmElb7LrQpLQ50%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:50.0292211","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:12.981Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:28:50 GMT
-      mise-correlation-id:
-      - b5db658b-a3bf-41e0-b4d3-a54502b8278f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A55Z&sr=b&sp=r&sig=W3kg9EY4NVWF%2FjDB1oRmkcGkRfxtjMh6HUqSe2gnYFM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:55.3184371","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A55Z&sr=b&sp=r&sig=Ba9oQerrXfBABDyrOod%2Fig65X%2F2%2BK236ryZ8T6A0YEo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:55.3183523","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A55Z&sr=b&sp=r&sig=f1hXkJ2UEC1tvHBNIvhSlDrsFetCnLfqE2bVjgYc%2FiI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:55.318451","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:54.629Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A38Z&sr=b&sp=r&sig=tuWfAN%2BsFGV58xKVSBdthAF0BQVFleU55mCwyEUDu9c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:38.5891889","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A38Z&sr=b&sp=r&sig=COqK5Nf5ZFtzwtF%2B1dU234BDurrNB5uSJJvXtOLsh20%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:38.589099","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A38Z&sr=b&sp=r&sig=hWeRIkxACVExrFkiZwJ%2FFfuo%2BaAknr6fl9sv%2F1TUfSo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:38.589206","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:07.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1002,9 +930,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:28:55 GMT
+      - Fri, 13 Oct 2023 14:01:38 GMT
       mise-correlation-id:
-      - 560d84ca-d989-4210-9ac8-0fcdd9b41ddf
+      - 6fd0c4e3-a6cf-49bc-becc-e9cd2b0b24e0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1022,12 +950,48 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A00Z&sr=b&sp=r&sig=nsNBRNH97jspvfDTB9yeal0%2Fn1773OC6vjIArAkbZoI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:00.6255949","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A00Z&sr=b&sp=r&sig=P%2Fyl3QB3hNpNpK5KJiZTIbWKbbn2Wrxqw%2BL8b0KVOx0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:00.6255106","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A00Z&sr=b&sp=r&sig=9fXvVWp7JiffVTT%2BDpMkZ2qqYKmMfolbSf2DIoSS9sU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:00.625609","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A43Z&sr=b&sp=r&sig=9Mpia%2Fjnw8y%2BStfI9JlLzlL37VTr2W8FjLW4tba70Mo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:43.9160275","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A43Z&sr=b&sp=r&sig=fIAf4LIlch2i9S%2Br66Hz74yK5iHGDLhdvUSqXy0kPsI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:43.9159453","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A43Z&sr=b&sp=r&sig=kJV3DnRt5K1x3crNLRfwf55pRDfqJSVRK%2BqTOD5t0HQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:43.9160453","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:07.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:01:43 GMT
+      mise-correlation-id:
+      - 32a0307d-e365-410e-951e-267317a81a3c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A49Z&sr=b&sp=r&sig=SjVODxOnL66bdC0%2FynV4k65mO4pitUWl1yyoKnnf%2BTY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:49.2294667","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A49Z&sr=b&sp=r&sig=%2B8HhaBMQCjL0Uqmt4gyf0eerGj55UHCKVfDF0MNLzrE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:49.229391","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A49Z&sr=b&sp=r&sig=MDXZ8SGRieMtNFjvKlKtuKB7WDi16u7YlOQDSuIEqs4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:49.2294812","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"CONFIGURING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:47.996Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1038,9 +1002,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:00 GMT
+      - Fri, 13 Oct 2023 14:01:49 GMT
       mise-correlation-id:
-      - 83e5fd83-a5d6-4ca6-b776-e94828aa8b48
+      - 9e4e9ea2-84aa-40f8-afbc-cff515ef7302
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1058,25 +1022,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A05Z&sr=b&sp=r&sig=Wqv37Sb3BDvfoRNjpS%2B8kE8QG4DkqwB265fmxQnx6Tw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:05.9081946","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A05Z&sr=b&sp=r&sig=rZVGCL%2FBMe55EJ6QI0Qd%2BasEnv580lTE8WGB%2Fo3ljVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:05.9081065","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A05Z&sr=b&sp=r&sig=e73z1DzUkH3fUkyMRv%2B4kzUQ6WMazT%2Fn45611CzQyGY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:05.9082171","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A54Z&sr=b&sp=r&sig=R6hCQjuq5WP4b6Wv0LKsMevtkD1jLm2rJYLY5q4Olac%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:54.4748384","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A54Z&sr=b&sp=r&sig=FzNwj2KNFfJnhWVtWxMnZ1vocAmwML3Le8BBvkbMtic%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:54.4747591","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A54Z&sr=b&sp=r&sig=A7fO8lHVwl1ZiJpZPoDtXgze60%2BPOQ2BcanNwo8BBPY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:54.4748562","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3204'
+      - '3194'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:29:05 GMT
+      - Fri, 13 Oct 2023 14:01:54 GMT
       mise-correlation-id:
-      - 21a68a58-369e-4910-a805-2369b5f008b6
+      - 263ddfa4-f5f8-40a9-b3c9-4a83f4fb4da6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1094,480 +1058,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A11Z&sr=b&sp=r&sig=4UZCcT0l%2FW%2BgKA8AFIRU9AZEfdya7jsmlnoZ%2BDJTqRs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:11.2683604","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A11Z&sr=b&sp=r&sig=IAhR1A5PscZIeDk65YhtDMmoCdaA5kb4xhqmI%2Fzu5l0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:11.2682604","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A11Z&sr=b&sp=r&sig=3941zikaVMex%2Be7Yc7f5jSy6OeaV07700Uggykl%2B7XE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:11.2683836","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:29:11 GMT
-      mise-correlation-id:
-      - ad90417d-e924-4fa7-89cb-9427d1dcdb12
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A16Z&sr=b&sp=r&sig=Wmbje8Tb4N33eeCN2DGhqIPaoVbaLTKgm6P9zsiFVTc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:16.557065","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A16Z&sr=b&sp=r&sig=d6XM0S5fqoK7u3%2BROLWrS%2FRAX6WCJ%2F4BLqbuLMFTKao%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:16.5569835","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A16Z&sr=b&sp=r&sig=OLj1CzIcx7%2ByJjOYJPhxGKnoHW%2BBbX%2FSJBJOq4tpUlw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:16.5570866","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:29:16 GMT
-      mise-correlation-id:
-      - f3fe99cc-b18e-4089-9c9e-f7d17aec54f3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A21Z&sr=b&sp=r&sig=MZ7UPwzwsEzGwU5MQ2rKCFaYZ9xsJnKPEc7e0kt7R3c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:21.852666","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A21Z&sr=b&sp=r&sig=xTrBH0LeDcVeJooiQvxZjLEjUolarmakL5IUXvvyAhs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:21.8525845","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A21Z&sr=b&sp=r&sig=435xs330Rj%2BfHM2iTcDG6GRgonKP5AagOzw3EpBfZgs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:21.8526831","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3193'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:29:21 GMT
-      mise-correlation-id:
-      - e0e5f969-f090-4876-907c-e96beee1a213
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A27Z&sr=b&sp=r&sig=b4dIP6Z1qsp4XcD5hj3ga%2FmEYgK1ok8th2wlGYrI3aM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:27.1537771","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A27Z&sr=b&sp=r&sig=zpJOY%2BoViYw7YrMkjtJOqRPLesgBOjci98ENLSXncrw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:27.1536817","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A27Z&sr=b&sp=r&sig=VmlO0swORTB04ioElmGKROGtBvEFwrv4PLVH8YoKi4I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:27.1537934","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:29:27 GMT
-      mise-correlation-id:
-      - 1f41904b-7579-4aae-845a-022f19e27849
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A32Z&sr=b&sp=r&sig=FhwGnZroVUi7dknjcxgXvdl7DNwTN5QTYU37FcLgnmY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:32.4506644","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A32Z&sr=b&sp=r&sig=38GoGcwsAy6fXfiPSNpSWyqix9%2FGAOwcrMwzBq4dly0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:32.4505814","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A32Z&sr=b&sp=r&sig=Q46aKSsB4KCZOSdCZSu6o3%2B2TMux9Qs%2B5QFYby3SqLQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:32.4506852","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:29:32 GMT
-      mise-correlation-id:
-      - 5caa7e8c-8f79-430d-af9e-9b0a38883d77
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A37Z&sr=b&sp=r&sig=BOtL4LyHhR0J%2BEk9NkMpRNY3%2BfVSSMsLR78X1p%2BF91c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:37.7379422","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A37Z&sr=b&sp=r&sig=NzjUhFDhVzd%2F6UZOM7k5d%2Bk2TE5zGpMl3qWG3cBZbm0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:37.7378566","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A37Z&sr=b&sp=r&sig=h3EaBmaBHvCZDUAIZgUU5gbcNApJIM0r9JDe4xKmUCc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:37.7379568","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:29:37 GMT
-      mise-correlation-id:
-      - 646169a9-0deb-4fbb-9f3f-d83eb3d548d6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A43Z&sr=b&sp=r&sig=JNbR8EEaG31zrA8D71PuUprWsM7IemlYoJ0AvvooZ8s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:43.0159426","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A43Z&sr=b&sp=r&sig=zrXcNYvlFAibW7FbzwTDH3mM7ENg8jlSfNEp62Lfwmc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:43.0158559","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A43Z&sr=b&sp=r&sig=BFYFxYDNu14JcClYgUlwL2aVMUFA18crz5EgDwfXtuE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:43.0159649","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:29:43 GMT
-      mise-correlation-id:
-      - 7e6aa3d1-ccd3-436c-b507-fd95af69eb21
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A48Z&sr=b&sp=r&sig=y09GSSLExi9soKFXi7BBvcGNxVBaOcnPt0hAoKSkmrw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:48.4519785","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A48Z&sr=b&sp=r&sig=MZEmmKqkJqS8VLhlXtbOuO37VOeZ56Y%2B4nxXMWVoAAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:48.4519129","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A48Z&sr=b&sp=r&sig=eMSoEe3tJKe9qGZwXbE6dZw1X1%2B%2FBSGFducpGsXnlkk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:48.4519933","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:29:48 GMT
-      mise-correlation-id:
-      - 5b1aba4f-7b28-4cb4-9b53-d10cc284ac7f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A53Z&sr=b&sp=r&sig=326ukxWJfgmsdFfZAD94%2Bz0FSmWgIol997jFik8WtdM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:53.7499197","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A53Z&sr=b&sp=r&sig=1GgdyQ5xLf97ZUA%2FOMSn5ZXiczPzoebPpMHAdHm6%2Fh4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:53.7498288","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A53Z&sr=b&sp=r&sig=IoHd9Nvu9cW9JGvQCO2JC4NNxzUCqfdNFJnr5ZLbRw8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:53.7499416","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:29:53 GMT
-      mise-correlation-id:
-      - e42c56ba-cee7-45c9-8d73-8562eb4514ee
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A59Z&sr=b&sp=r&sig=no0O68gj3LPDP0Oq7TjXPU4yu4pBkPGPkGwnSx2GNTg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:59.0304938","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A59Z&sr=b&sp=r&sig=J8W8Sh2w1Z4N2qtaqA8dI3oT%2FbJ%2BrKBrXOGRa27Thtw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:59.0304197","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A59Z&sr=b&sp=r&sig=u4fH8OwYIrx4TfbVK2%2BtCExeKJl6c5Q54JrqpedzbcU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:59.0305081","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:29:59 GMT
-      mise-correlation-id:
-      - b41e9fc7-4250-4c2c-8f34-775f12eaa24e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A04Z&sr=b&sp=r&sig=mVuEE0xz3NpTe5fSu%2FiSKST2unLrbJAPbCcHWKPlUJY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:04.3155742","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A04Z&sr=b&sp=r&sig=hHGpzQt%2F%2FUAMAv56jFwTx1UEipvEmPYT2eTB7pk%2BP7o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:04.315504","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A04Z&sr=b&sp=r&sig=A57jAVRy3s7PKNF0ATNuX3KcvlkB8LvrTIdKw89%2FFPw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:04.3155895","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:30:04 GMT
-      mise-correlation-id:
-      - b1307a0d-a264-4f1b-b11f-164f1ec2aa1f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A09Z&sr=b&sp=r&sig=vpRE1nOtdAqIXqZcbi6ujooWjpeKNVMcnr%2BuSzwmvJ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:09.6414412","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A09Z&sr=b&sp=r&sig=emu%2FuTgDJlWBvxAxAgQ9cuJL8sjbHK2fpbWHPEZrvF0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:09.6413656","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A09Z&sr=b&sp=r&sig=sCVouBjIEcj2dkmZRXxx5%2BfGnjo86SWXscg4j8V5Fj8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:09.6414557","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:30:09 GMT
-      mise-correlation-id:
-      - 60e89e0d-8ffe-4996-9e5d-89377ae697bf
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A14Z&sr=b&sp=r&sig=d7nmxeznnuWLKsuzJT9x%2FQTAfVfzf8vSmySlmPlTtkk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:14.9694115","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A14Z&sr=b&sp=r&sig=tFF6h%2F0KxOipJftm%2Bpw5TVV1%2BWkNsdOMLqr8NApQ7ig%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:14.9692865","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A14Z&sr=b&sp=r&sig=4%2BoaEMAWJgUMvng4rglsR0BuaTzU1WBG5NBEYvzNXPQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:14.9694253","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3202'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:30:14 GMT
-      mise-correlation-id:
-      - 5e2152b7-597d-4121-80ce-a75c0dcbf095
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A20Z&sr=b&sp=r&sig=yvBpWw7KO%2BDNPQyZoHSUpXu5225%2BjSd6jfnwBS3LotQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:20.2818777","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A20Z&sr=b&sp=r&sig=BFcjYgv%2B%2BciSSrb2qfa8WrRzg6v8TimoX78Mw2Kwwv0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:20.2818064","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A20Z&sr=b&sp=r&sig=WecudHWix%2FZchq%2Br%2F0zmIusXyMRvTiluf5AvG5VjzC0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:20.2818919","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A59Z&sr=b&sp=r&sig=LIeIpy9NrqcuilK5VDn8Pjy%2F4L69ZcxRGuR%2FkcPzHR0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:59.6985434","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A59Z&sr=b&sp=r&sig=I7ILCRFx7gHv2ajbEaEA%2F5j8HBFbvXzVL4BHlY3nS%2Fs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:01:59.6984512","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A01%3A59Z&sr=b&sp=r&sig=xSQ%2BoLLbp5dKnG%2F3lT3EgXgtm2UMjYqD1jq%2Byg5TjZU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:01:59.6985658","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1578,9 +1074,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:30:20 GMT
+      - Fri, 13 Oct 2023 14:01:59 GMT
       mise-correlation-id:
-      - 916bd156-de60-4c62-9d6d-9d44a151c0ae
+      - 49f1d9dd-b739-466e-bc81-4ccc32455b22
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1598,48 +1094,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A25Z&sr=b&sp=r&sig=3LMOh7oJx8%2FOYpE3ikuWqhq3fj6pnz4SRlDVmLHKJPQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:25.6173502","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A25Z&sr=b&sp=r&sig=dUxpNDKo6tmkZ0PS2WtLGVLpu6La1rFO9GmAyYO6YTQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:25.6172635","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A25Z&sr=b&sp=r&sig=d7Ot6uS4L7LB%2FkRv5LbJndtskXFYHRzCluuaijIzcqI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:25.6173685","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:30:25 GMT
-      mise-correlation-id:
-      - 955669f7-bb22-473e-901b-cee3fb9f282c
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A30Z&sr=b&sp=r&sig=guB%2FVy9C4eV4blYA6ENLory3%2BSJIUGhjGctMYpgaB68%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:30.90158","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A30Z&sr=b&sp=r&sig=X3lbPpTptHJO696IERNvXe%2BS8dZvdeLFSVe2wG5nz8E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:30.9015084","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A30Z&sr=b&sp=r&sig=dXGqzbhEBRKD%2BBwrWRtILrpam74xTVwIF%2BPQkMGyc0E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:30.9015947","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A04Z&sr=b&sp=r&sig=PpG1Pytpz3T8Frk9ecDOlu7uogVGgEp5kxTzS%2BC6wMY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:04.9979922","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A04Z&sr=b&sp=r&sig=o0f9r1ydn1wzicQ3IzD%2FRtsxZWV6%2Be2cVZVmymzByvk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:04.9979094","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A04Z&sr=b&sp=r&sig=yOItqeLNw0hDEWinOgCQKjV1J2g68k8XHbCLSk%2B7eUg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:04.9980101","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1650,9 +1110,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:30:30 GMT
+      - Fri, 13 Oct 2023 14:02:05 GMT
       mise-correlation-id:
-      - c3dd3512-2a6a-45c9-aae1-2c4db8453ad1
+      - 8b501c91-16f3-4c7b-b433-34cdc74a8d61
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1670,12 +1130,300 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A36Z&sr=b&sp=r&sig=3rx7paqOSIWyu6PpDsKxbgIVcNjoSKSCSIlVfwxFHcA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:36.2380598","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A36Z&sr=b&sp=r&sig=F03mjnjOVYHa%2F3G7CnGpHyQa7ktGJgG8FENsD5yBoLo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:36.2379814","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A36Z&sr=b&sp=r&sig=RhLLa7vuK83fGFhq%2FYjPspZWmpqu9vTck2TFSjA1NGU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:36.2380846","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A10Z&sr=b&sp=r&sig=agtvMLAYGUC8dmj8bcH7eSZfLWNsd4qUNVrtIF1hi%2BI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:10.3460581","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A10Z&sr=b&sp=r&sig=OvFzpEXPcAWKCvGeLvAaKjPB2mE%2Fc8LS1VOjQU0DTwQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:10.3459658","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A10Z&sr=b&sp=r&sig=A%2FxmZ6lHlJcXyEtDDYuUwhylYSU8eNMQg2b5s6Qew1c%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:10.3460802","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:02:10 GMT
+      mise-correlation-id:
+      - a6342cc7-eec5-4fdb-a61b-413c6791be15
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A15Z&sr=b&sp=r&sig=eKdDMZvLzBpID33ZfceWgXzsUQHCe1vumMWHFyFrgtI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:15.6351615","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A15Z&sr=b&sp=r&sig=VgT1L3pDt0CMMsaw2spLcxwJSqPXYzcmb%2BUXq8qIoz4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:15.6350578","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A15Z&sr=b&sp=r&sig=IjnrtYd75uXHzrk4fn88DdQqteDxmgLNyHinomIs4gg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:15.635187","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:02:15 GMT
+      mise-correlation-id:
+      - 1ec8ef79-70f0-4d8a-8bb3-8f88ec7a8c22
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A21Z&sr=b&sp=r&sig=74UX5uiH3VGiOWLkFM7Gn%2BlgbYEV%2B%2B8re41FVTjPIig%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:21.0073382","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A21Z&sr=b&sp=r&sig=9YqvO2eeMEewuPiQnQarC8LPodGkYeZYqAi%2BjPwM3v0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:21.0072581","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A21Z&sr=b&sp=r&sig=m86SgQWFAiwx4wIT63iq4hTE%2Fr1YdyN8CJfZ8MbdCIU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:21.0073592","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:02:21 GMT
+      mise-correlation-id:
+      - 9a338b2f-45f8-462f-b1be-379bf8420e5f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A26Z&sr=b&sp=r&sig=OThkiH9Kp3DLFgclnI%2FCIeVSpuUMJ81%2FEYA9B9RxmVY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:26.3196973","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A26Z&sr=b&sp=r&sig=h5bJ6a9F5UQYKewsWQ2jsksyGM2JFuT7V2%2FK2Gl9L%2Fs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:26.3196043","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A26Z&sr=b&sp=r&sig=DqkmspmR1zCRA9RcVBajKLsBEkAjhtoxdK426t9jync%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:26.3197122","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:02:26 GMT
+      mise-correlation-id:
+      - c5b7c502-6a96-4fa4-957a-f5f6af636fec
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A31Z&sr=b&sp=r&sig=wAzI3rml1sUlTyxnpSq7GbmFiTYYpmOWsHtMJj29eFg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:31.618941","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A31Z&sr=b&sp=r&sig=EKbLg7FlPpiy%2FnZG0lfkTcSryFCYxAGXUTZaldxMQsg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:31.6188513","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A31Z&sr=b&sp=r&sig=c%2FwUEMHf%2FT0LCBbugDkWUgTQa7PHR4gD013UqGWbX10%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:31.6189627","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3197'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:02:31 GMT
+      mise-correlation-id:
+      - 748754c6-6fc4-4f5a-a61e-6ba4fa081e34
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A36Z&sr=b&sp=r&sig=XXuFj0v%2Fz%2BM42wYnr%2FVlfiGuWQgS46OMR7dv6HIIa3c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:36.9404878","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A36Z&sr=b&sp=r&sig=0rfIgV2%2BJBh9Jg3DKAyTS3vSalZom6ax5D9DVaJgpHo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:36.9403988","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A36Z&sr=b&sp=r&sig=0OlPzUDZ5m8y9jVv5MhpHgAydH%2BGK31yOqMc%2FWjy6iA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:36.9405105","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:02:36 GMT
+      mise-correlation-id:
+      - 9a3333f5-2497-4367-9d7b-2e5829af9c4e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A42Z&sr=b&sp=r&sig=kXZzSgzx%2FHdoyQMHC29cAeO506mHEOosSNAUo%2B%2FeJKo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:42.2743153","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A42Z&sr=b&sp=r&sig=JHDPag0s7lHVo%2BSud83veS87HA0ugJZ7qMhEL55XFcQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:42.2742522","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A42Z&sr=b&sp=r&sig=2r3Ij3Ik74GdbyhFVFH1iLYnoGUlSlyWo2FMaGmryVI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:42.2743311","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:02:42 GMT
+      mise-correlation-id:
+      - d0580409-f3e7-40f6-b971-f4e3c67c6180
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A47Z&sr=b&sp=r&sig=pCWrwgfYHX4Dl43uB7fRyoh37GK9npywnAbSNKPN7qQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:47.6284239","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A47Z&sr=b&sp=r&sig=mWdZbepIHo%2FvWgh9k6EKVAB%2BfIOqD9qLjWDydKmUrL4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:47.6283461","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A47Z&sr=b&sp=r&sig=p8HWpZdv%2FNIqhDnYMJdAtGZrYcxl3ysUxlfbSnPykvI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:47.6284406","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:02:47 GMT
+      mise-correlation-id:
+      - fe261867-6bed-4634-b558-338d8efdf80f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A52Z&sr=b&sp=r&sig=6fgISOJZO%2BjJbWPxdRqAT0fv6Un3blhHtRCpARrKOhc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:52.9509479","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A52Z&sr=b&sp=r&sig=41jHNtG%2FpzRvt2jEglXKhoqxkmNK0ZKjR36wIUJoXno%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:52.95085","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A52Z&sr=b&sp=r&sig=8eRd1ZF9sJ6QrV4aC1kbzeRhNha3sVyvdrJ%2BVH31qZU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:52.9509735","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1686,9 +1434,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:30:36 GMT
+      - Fri, 13 Oct 2023 14:02:52 GMT
       mise-correlation-id:
-      - 9dc356e9-efee-4d6f-855f-890690a29487
+      - 757d0452-e988-4079-b53b-74335b2ee20d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1706,12 +1454,84 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A41Z&sr=b&sp=r&sig=lsaIs01s6P9ZvysOFzrFBbiBYItRzWGv98criqwezc0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:41.5202376","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A41Z&sr=b&sp=r&sig=B8Mqr%2FJOTuTNN5BhzcGWXUl8vLEtiRghVf8auZTMZJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:41.5201421","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A41Z&sr=b&sp=r&sig=EgXk1AKgQu5cSnuipNLBaTYukYKAB9ZT5AaTn%2FW3raQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:41.5202595","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A58Z&sr=b&sp=r&sig=7xMnxb%2B2itVeHFzavJn0mVIza7JXwESKsHdLtLYio44%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:58.2147903","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A58Z&sr=b&sp=r&sig=bY1LHuF2dA4XRsL6UJNKj67NlUf07qPdEFSKPQzZJ3w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:02:58.2146912","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A02%3A58Z&sr=b&sp=r&sig=sgHDc3MJYhcjNH26rertmKC4lrqPACVs4q8OFjvfCQQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:02:58.2148148","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3194'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:02:58 GMT
+      mise-correlation-id:
+      - 31b351a0-2141-4868-b1f2-38c34c3981e2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A03Z&sr=b&sp=r&sig=TzHaJJ2wJct%2FZjD%2F2OPMU8zKOrc3NOpTY7YU8VUOzTs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:03.4515128","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A03Z&sr=b&sp=r&sig=bKJOFfTo5bzmDWvaNyFvCkbNcgveA4M5u585g61i3ws%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:03.4514468","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A03Z&sr=b&sp=r&sig=HZnNqtg%2BplM%2FuzyIfNfsmWLP%2Bf0h9oyRcs1eWt0yvSc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:03.4515287","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:03:03 GMT
+      mise-correlation-id:
+      - a5feb101-bc90-4191-a5d8-933de072573a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A08Z&sr=b&sp=r&sig=qXAbbNUU1v49nbijNDdfqJiguoicDKHi2ccYnLFJlqU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:08.7313039","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A08Z&sr=b&sp=r&sig=MpfJtYHt%2F3RNJ2C8xU3NzG4KhYVL%2FpI3koPyK0YBW8g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:08.7311968","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A08Z&sr=b&sp=r&sig=39AE5MpPEpdbZF7j0dYOn4qSPgReBko8qssTyIlrTmo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:08.7313319","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1722,9 +1542,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:30:41 GMT
+      - Fri, 13 Oct 2023 14:03:08 GMT
       mise-correlation-id:
-      - c9ef15ef-82d2-40e2-860d-0caa59d6487c
+      - 55d0c464-7c5b-4630-b778-3243b5525bb1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1742,25 +1562,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A46Z&sr=b&sp=r&sig=twjBp%2Bo9B%2BuAyFL7%2F3039%2BHlTrNtI9tsc71nvgif6xQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:46.7902922","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A46Z&sr=b&sp=r&sig=e1Dl6zOgBEqDORDpcq64zKZyF%2Bf0P49zKO1sILLmrWI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:46.7902021","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A46Z&sr=b&sp=r&sig=7an%2FtpvARA9a%2BBWMqJczxfN0lEgsROtsY359ZsUYao0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:46.7903145","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A14Z&sr=b&sp=r&sig=ORgd3dmq6OpH%2BhCv79KHrw3OsOVNRYs6t8zqqYxtyfs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:14.0450116","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A14Z&sr=b&sp=r&sig=xdSgmDTesRywLBfU4C%2Fd7xbPsuXdqH5rvcHs6kMHGAw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:14.0449256","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A14Z&sr=b&sp=r&sig=lwENXvzPVkC4vhKo84FuCyRIzTVK9EsA3LZaM6uGwx8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:14.0450276","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3206'
+      - '3196'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:30:46 GMT
+      - Fri, 13 Oct 2023 14:03:14 GMT
       mise-correlation-id:
-      - 3e8a0711-3175-4c9f-9725-cde42b2408ab
+      - d1444ce5-758a-47ca-8429-fa3aa7bb79b2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1778,26 +1598,206 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A52Z&sr=b&sp=r&sig=vTXdCR6B%2FMxgi%2BOOSVXfQbC%2BshcvqOPMTxy5iD8pIyI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:52.1355587","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A52Z&sr=b&sp=r&sig=emx%2B1Ar7xO8KIbCR7IE0ZAEhdsGrYrywykXpP4RGHV4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:52.1354735","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A52Z&sr=b&sp=r&sig=kVtay59HC9BiI8V2f2U1%2BcoOZikTBL3DDC03Xs36MGk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:52.13558","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-09T19:28:12.736Z","endDateTime":"2023-10-09T19:30:51.916Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:30:52.004Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A19Z&sr=b&sp=r&sig=WtF9Qp4l8ay7zQgdM3%2BfEPaqQe9udk5v22LDqNvfYbo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:19.3573975","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A19Z&sr=b&sp=r&sig=cG%2B1Pb%2FV2EgcRsRqBk%2BzrPkf2hfEbLUoKZdVs1m0zjs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:19.3573171","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A19Z&sr=b&sp=r&sig=ENBHzLgrNZXSJXft7EHDr8pqrNgwOmUk78e5FKzxMm0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:19.3574184","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3335'
+      - '3200'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:30:52 GMT
+      - Fri, 13 Oct 2023 14:03:19 GMT
       mise-correlation-id:
-      - 0badaab4-d79d-4ffb-9baf-d559ab61e6a9
+      - 9de303c8-0376-4060-893e-8efcbd9ee879
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A24Z&sr=b&sp=r&sig=%2Fwkj8pcabFPtLzJ2HOwKQtZZLvLgONdwbKAxRfrKRHA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:24.6955171","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A24Z&sr=b&sp=r&sig=%2Fz3iSw25UDBOSMcBl8tH8h95R9hFA0cga19gHqjARj4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:24.6954153","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A24Z&sr=b&sp=r&sig=AvlbDbuRPuvKff6JoYRS38FTdvRc9qBIiXJMcgO%2BFcI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:24.6955409","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:03:24 GMT
+      mise-correlation-id:
+      - 2e69f639-b2f3-481a-99fd-2e947b7915ea
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A29Z&sr=b&sp=r&sig=72cX3hqVkEa8xQdtONFCHocz5gZEXy3AwCRoWaEorQ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:29.9730999","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A29Z&sr=b&sp=r&sig=ACQh2L%2FsmuoMnzvKndpCK7gnN7pl8QGSQbsWksONDbA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:29.9730152","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A29Z&sr=b&sp=r&sig=4ZQaSpWoE2gxNDthGv3mxy%2FF7YIW5USe%2B24U2SzpM2o%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:29.9731206","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:03:29 GMT
+      mise-correlation-id:
+      - 4ec0f2cc-b62f-48ef-ae21-4876de5d5834
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A35Z&sr=b&sp=r&sig=OgInEqQr1NPaWDg33Q6tUvSWuDRWZv5p8qE0ZdgWLoA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:35.2307933","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A35Z&sr=b&sp=r&sig=BpSmFfzXIv1jqQjT9ntg%2Fu9h5onOX2Fmz0llJXewD4Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:35.2307286","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A35Z&sr=b&sp=r&sig=D0tPqlhMT0lyj%2BeVYNw5PNRuXPnO7F%2FyN0kcQ42%2F3fQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:35.2308081","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3200'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:03:35 GMT
+      mise-correlation-id:
+      - 303fa122-0eb9-48f9-ad9e-526fe4eeeef2
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A40Z&sr=b&sp=r&sig=X2cWmLEychbTtkYYMoZ0cRdkZWOF4rEIG0XgN0JzEkE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:40.5850678","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A40Z&sr=b&sp=r&sig=bkPIDDNieS79h7KSUo7iitabgHBrqUMbtuhIR6oNi8M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:40.584932","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A40Z&sr=b&sp=r&sig=CNH4ZVa6Pspq%2FJQquz6OUB6M9MshmicewEpnPS00kHU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:40.5850942","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-13T14:01:06.931Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:01:52.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:03:40 GMT
+      mise-correlation-id:
+      - e056498e-233b-43aa-991e-2f8160b9c00b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A45Z&sr=b&sp=r&sig=r9lIJZNvSvZ4gAQnaZKfPQ%2FvyFtg0eb4AjqLqRFfzhk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:45.840249","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A45Z&sr=b&sp=r&sig=Jg13ksL3Pnu1FJ448NlFk096uNjHfu2NlS4dxncLP90%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:45.8401601","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T13%3A53%3A09Z&ske=2023-10-14T21%3A23%3A09Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A45Z&sr=b&sp=r&sig=50U8eWD%2FP5qgfDLahTmx2Ddr%2F%2FCwMTutELgn11fIgwU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:45.8402737","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-13T14:01:06.931Z","endDateTime":"2023-10-13T14:03:44.514Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:03:44.596Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3334'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 14:03:45 GMT
+      mise-correlation-id:
+      - 1ef09cf5-f19b-4e00-b124-caef0c507c87
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,7 +1820,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:27:13.4267962Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:27:13.4267962Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:00:04.8936167Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:00:04.8936167Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1829,9 +1829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:30:53 GMT
+      - Fri, 13 Oct 2023 14:03:47 GMT
       etag:
-      - '"57008419-0000-0100-0000-652454130000"'
+      - '"d901ec7c-0000-0100-0000-65294d680000"'
       expires:
       - '-1'
       pragma:
@@ -1859,26 +1859,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=update-test-case&api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=update-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A54Z&sr=b&sp=r&sig=AH6Gg%2Fq%2B1QCm78AOVTTyC4cGP85jS8dPhuro4cljFRk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:54.4819149","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A54Z&sr=b&sp=r&sig=zZAQe9HV2Guydn0VkmOIp46N5tat24zJfT6p8Nk8hWg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:54.481828","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A54Z&sr=b&sp=r&sig=sqU5tgpDn%2BXkodj2SfLqk8bpnv6xSU32TjnuwlNNEe4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:54.4819365","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-09T19:28:12.736Z","endDateTime":"2023-10-09T19:30:51.916Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:30:53.535Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A48Z&sr=b&sp=r&sig=XktsP1sExu%2BD1Q0beJDAYnbTFG4tVOd5XXJ7M1inLjY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:48.0209377","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A48Z&sr=b&sp=r&sig=FuCe58hs%2Bx0rasGoln2MSTtRcUKwKMF1h%2B5G0llNRkE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:03:48.0208389","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A03%3A48Z&sr=b&sp=r&sig=QXqnACd2V%2FPAqozaeedSKJsiZJ2U1j04iDIwUlxFcac%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:03:48.0209649","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-13T14:01:06.931Z","endDateTime":"2023-10-13T14:03:44.514Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:03:44.596Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3344'
+      - '3347'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:30:54 GMT
+      - Fri, 13 Oct 2023 14:03:48 GMT
       mise-correlation-id:
-      - 6c6c4ff1-4d12-4753-b235-669ac1833a9b
+      - fb411ea1-8bad-41df-a42c-6d29a5a0a9b1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1901,7 +1901,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:27:13.4267962Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:27:13.4267962Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:00:04.8936167Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:00:04.8936167Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1910,9 +1910,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:31:15 GMT
+      - Fri, 13 Oct 2023 14:04:08 GMT
       etag:
-      - '"57008419-0000-0100-0000-652454130000"'
+      - '"d901ec7c-0000-0100-0000-65294d680000"'
       expires:
       - '-1'
       pragma:
@@ -1940,26 +1940,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=kl4ScxWAHrW6M1eQhoc4QN4PnZ8HiVVtb5P7maymau4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:17.0179876","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=iK3maKEQW22fcsxUb%2BXdFWXpujlmHFRWtBtwE8xgNKQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:31:17.0179203","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=wG9aiJlYKj6Lc6HJdQGDGomhd0w3h5m8WSLzm2K4leE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:17.0180037","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/3ee3ba5e-37d3-4452-83cf-f393a6743f15_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=Y4wtIeEyI3FoDUI22Ays9lM1AiZlRtyvjTVN03msiXY%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:17.0180193","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/3ee3ba5e-37d3-4452-83cf-f393a6743f15_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=1X%2BxtgdW1u%2Ft81%2FWdjOSIDg0tTxLYwStaWR9rHSbET0%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:17.0180371","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-09T19:28:12.736Z","endDateTime":"2023-10-09T19:30:51.916Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:31:01.464Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=NsvarUZwxpv%2FhDLG0zQvSMhVcNtJF42fB5kT6nk3j9c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:10.244822","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=YvvWGQjNe7GiN5CP05j%2BqjTLtU6wbSM0NwaIrOgr2so%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:04:10.2447386","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=QDv6MnMHjlElviGcqgQprT0Qblia0a574CJdtDhVKZQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:10.2448423","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/4bc9df91-e6fd-413a-95db-3c80fba7fbd9_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=fjMaJ33BC4GowUWllecv8r1NlAbchx1sRdoEwd0bOeY%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:10.2448621","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/4bc9df91-e6fd-413a-95db-3c80fba7fbd9_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=Hec7lXI6NM8ge8%2BWtHG58xS%2B7T5WOhFJqgacUJ2a7C8%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:10.2448808","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-13T14:01:06.931Z","endDateTime":"2023-10-13T14:03:44.514Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:03:57.184Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4494'
+      - '4493'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:31:17 GMT
+      - Fri, 13 Oct 2023 14:04:10 GMT
       mise-correlation-id:
-      - e83463c1-9042-4c77-9a66-969a823d63d1
+      - c2ff7399-8755-44a8-9d3d-16cdfe5e6743
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1981,27 +1981,27 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=WZ1z5ja6wo5VnCey9v4B0%2FWg%2FC7c84Ik4TxtS0MAwvk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:17.4467381","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=Avu4ez0pYHfIN55ieGbUAoeVIEmHNU6NGU%2F4aNX1GDw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:31:17.4466525","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=2bdMyqB%2FFaaSTUwF7OCf71QTdVOE%2F5uiBCEIdM1abuA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:17.4467565","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/3ee3ba5e-37d3-4452-83cf-f393a6743f15_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=KnXMbFHo1UzE7gX7tVErsqV1W1eAINUuWHvuaSM7KSg%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:17.4467749","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/3ee3ba5e-37d3-4452-83cf-f393a6743f15_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=Xuu89Et5YE4luJIjlO505xGUOKc%2Bt00oYmT8rcS6CGQ%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:17.4467935","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
-        test run description","status":"FAILED","startDateTime":"2023-10-09T19:28:12.736Z","endDateTime":"2023-10-09T19:30:51.916Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:31:17.437Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=AhQfpv7tAZbAMbrzerBVfJ4fUIz%2FFWz0gVLIcby8tOU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:10.6576131","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=C0%2F3Cw4EjWA1TlVRt2IwKaD2xvmXxI5%2BXUokIRbcX%2BY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:04:10.6575471","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=mIS0ggezXUpaGcaq63jnPfs56gRwDtQdYc5QohQjE%2FI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:10.657628","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/4bc9df91-e6fd-413a-95db-3c80fba7fbd9_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=uOqfcz0aTH%2FU63pSOkFUtfJmOp8L67q2GFFWPmfeKuM%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:10.6576414","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/4bc9df91-e6fd-413a-95db-3c80fba7fbd9_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A10Z&sr=b&sp=r&sig=LD5fbE6RlFnbi6a0cngn6n2dncTqa%2BFA0jLuytoxvOU%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:10.6576557","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
+        test run description","status":"FAILED","startDateTime":"2023-10-13T14:01:06.931Z","endDateTime":"2023-10-13T14:03:44.514Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:04:10.649Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4543'
+      - '4544'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:31:17 GMT
+      - Fri, 13 Oct 2023 14:04:10 GMT
       mise-correlation-id:
-      - 83b8e066-0e90-42f9-ad5a-1c40e496b7d3
+      - fa6571a5-4b72-4caf-9152-c24985fa9676
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2024,7 +2024,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:27:13.4267962Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:27:13.4267962Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T14:00:04.8936167Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T14:00:04.8936167Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2033,9 +2033,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:31:18 GMT
+      - Fri, 13 Oct 2023 14:04:11 GMT
       etag:
-      - '"57008419-0000-0100-0000-652454130000"'
+      - '"d901ec7c-0000-0100-0000-65294d680000"'
       expires:
       - '-1'
       pragma:
@@ -2063,27 +2063,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://a80e6468-0f65-4c74-ac8d-73b5e8c68632.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A20Z&sr=b&sp=r&sig=G%2BPosyqtXwQeye96YyEJVsbsW%2B4h0NtJmFl6n2C2xv8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:20.0987793","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A20Z&sr=b&sp=r&sig=dqoKGLmf9HEdyhy3d%2BfyAQ%2BrisgnoBweBThtzNKhgks%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:31:20.0987013","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A20Z&sr=b&sp=r&sig=gsRsZurAW67bEPJzON5mfduPxqhxlRCOzswmqCRZGas%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:20.0987939","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/3ee3ba5e-37d3-4452-83cf-f393a6743f15_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A20Z&sr=b&sp=r&sig=oeQJbF09cJUqeuQC3b0s1hG9wJOp8Njc1B%2B9NF1UqoY%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:20.0988075","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/3ee3ba5e-37d3-4452-83cf-f393a6743f15_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A20Z&sr=b&sp=r&sig=XUy7Cp2nsZXqasRASrocogli6TEb3q2C9H%2BeRHAHu38%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:20.0988217","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
-        test run description","status":"FAILED","startDateTime":"2023-10-09T19:28:12.736Z","endDateTime":"2023-10-09T19:30:51.916Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:31:17.437Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1e33ae22-2715-439e-bcc6-9b766cd03d65":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"11255139-f90f-426d-8aa3-dbf877da33a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"af2ea94f-b6b7-4e48-a6f3-e6a5d0c91abc":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/120d3f54-6337-48d6-9a56-13ab6b8a73c0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A12Z&sr=b&sp=r&sig=cADMUwy%2FGHI9f%2BVNyl69ULteYKeNwpuIWAvblNwwO9M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:12.6584826","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/f3560d3c-9ef6-4ebc-88a1-f6752de9ee4d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A12Z&sr=b&sp=r&sig=y1dBHj9Dsh9RyCV%2B7MVfs6QiGJeZnj%2BYGAzsVOt7I5M%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T15:04:12.6584023","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/bf56850e-51b4-4448-a031-99424adea8f6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A12Z&sr=b&sp=r&sig=tuz1ZnAe34X%2BQiGCGmw%2FFUFhUEJDw49b9527mQyhVIs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:12.6585043","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/4bc9df91-e6fd-413a-95db-3c80fba7fbd9_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A12Z&sr=b&sp=r&sig=9ECg%2FYP4PYjz3jaDrm8SBrx2p3S715KQuKrSIDw8HiI%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:12.6585246","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8b244ee8-cc9e-4fc9-8e1d-1a59f5801768/4bc9df91-e6fd-413a-95db-3c80fba7fbd9_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T15%3A04%3A12Z&sr=b&sp=r&sig=7%2FA4ZVZowF%2FhwTMgrXEX1ze7MOcr6dL60N%2FSe%2BnImEk%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-13T15:04:12.6585461","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
+        test run description","status":"FAILED","startDateTime":"2023-10-13T14:01:06.931Z","endDateTime":"2023-10-13T14:03:44.514Z","executedDateTime":"2023-10-13T14:01:05.733Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-13T14:01:06.026Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T14:04:10.649Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4543'
+      - '4553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:31:20 GMT
+      - Fri, 13 Oct 2023 14:04:12 GMT
       mise-correlation-id:
-      - d7807ccf-3415-4759-9ec6-edcc07186be6
+      - 9c2eaa90-5276-4de8-88a2-8c74e717288a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_run_update.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_run_update.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:22:48.3302759Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:22:48.3302759Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:27:13.4267962Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:27:13.4267962Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:23:22 GMT
+      - Mon, 09 Oct 2023 19:27:47 GMT
       etag:
-      - '"9301b10e-0000-0100-0000-652428da0000"'
+      - '"57008419-0000-0100-0000-652454130000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:23:23 GMT
+      - Mon, 09 Oct 2023 19:27:49 GMT
       mise-correlation-id:
-      - 55dde3b3-d5f5-448d-bb38-5091c2092bbe
+      - 3ec3ab34-e45b-4704-a857-41ca60b243e9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"81842833-4cca-4e6e-8d31-a4e22bcd3e9a": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "faf57da5-a443-417c-981e-3507dc4437a2":
+      {"passFailMetrics": {"221ac857-5bee-45f0-8cb4-2ebffcccff79": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "ff2fb94a-507c-4ad1-89e5-8f5528a903bf":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "aab4b375-f0c9-4251-9c3d-7b904fbc0907": {"aggregate": "avg", "clientMetric":
+      "50"}, "96e99621-3d0b-47a2-8839-bcf040f609fb": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:23:24.422Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:24.422Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:27:49.636Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:27:49.636Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:23:24 GMT
+      - Mon, 09 Oct 2023 19:27:49 GMT
       location:
-      - https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+      - https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - be95a5d9-f296-47a3-b96d-845d1d2161aa
+      - 26e56b3e-3501-49f5-b888-4732c55e28c5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:23:24 GMT
+      - Mon, 09 Oct 2023 19:27:49 GMT
       mise-correlation-id:
-      - 241cfca0-6bc4-405a-bce9-2622c292ae97
+      - 0a050af2-b53c-49a1-b435-e1da10931583
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A33%3A25Z&sr=b&sp=r&sig=b2ecREO%2BEUwHuAvTVqRd4Pl36iBIisnp2aCJskhwpyk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:33:25.2159136","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A37%3A50Z&sr=b&sp=r&sig=1%2FzXPxqv328EbNVgn2vRIjPCBksB27hEEI8G4kUt%2FuA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:37:50.5137933","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:23:25 GMT
+      - Mon, 09 Oct 2023 19:27:50 GMT
       location:
-      - https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 1c0ac90c-023f-4630-886d-178b55cb8a54
+      - 8ca2d520-9e1f-4d4b-976f-809dad4427d5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A33%3A25Z&sr=b&sp=r&sig=hgj3XXRDNlO90KY4syJjV4NciHYM2f7BZ8wBeuMKP%2Fc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:33:25.481063","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A37%3A50Z&sr=b&sp=r&sig=obGIrt4bJ36ecFNJVwtFQ0TS0GlmoeoQPx6I0vptEN0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:37:50.786426","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '548'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:23:25 GMT
+      - Mon, 09 Oct 2023 19:27:50 GMT
       mise-correlation-id:
-      - 524bb4b0-7d94-4574-8cd2-ca341c6e3fc9
+      - 4f5feced-b53b-433a-a736-085025291067
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,10 +349,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A33%3A30Z&sr=b&sp=r&sig=bYTwezqU%2FMmEnXlin1YRePOQBntp9qmBFbEeEl5O4cw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:33:30.7567124","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A37%3A56Z&sr=b&sp=r&sig=HAodjV44fsj0yk93C23Nlslw8vX1JHSbkIF9OBHTTEs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:37:56.0970508","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:27:56 GMT
+      mise-correlation-id:
+      - af7eddce-a36c-4e82-9d7b-2905ef88430d
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A38%3A01Z&sr=b&sp=r&sig=M6dNUVnWHorSQOOEPPntHIAPQ0k%2FzOTzoQsaxiy46T8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:38:01.4107016","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:23:30 GMT
+      - Mon, 09 Oct 2023 19:28:01 GMT
       mise-correlation-id:
-      - 2c91dd80-1fa3-4220-895f-01201857b295
+      - 77663aae-5ade-429c-b479-e3b32b920158
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A33%3A37Z&sr=b&sp=r&sig=9vPR%2BsC8sJc2oAV4BNaruJK6K3pGtPAwNUiy68rZOxw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:33:37.9799038","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A38%3A06Z&sr=b&sp=r&sig=lvJSeNATfxZzqJ4Eg15uIPtqwploFZvXyHgP%2FMoP0qg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:38:06.732419","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '548'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:23:37 GMT
+      - Mon, 09 Oct 2023 19:28:06 GMT
       mise-correlation-id:
-      - b027d331-202a-4f55-b928-60eafa71177a
+      - 2783bdd6-ca22-452d-90c8-40ca1be602bb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,60 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A33%3A43Z&sr=b&sp=r&sig=oeXTauJGU5%2FtpFEhKOT1fc9%2FDlFcSgNfZkUJRNLSiCM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:33:43.2552148","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A07Z&sr=b&sp=r&sig=GgnekROnxrvbm4deLgOcAadebZTTmWtcsFbLvKI5Zww%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:07.0496521","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:27:49.636Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:03.213Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '1577'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:23:43 GMT
+      - Mon, 09 Oct 2023 19:28:07 GMT
       mise-correlation-id:
-      - 9ed2e7b7-a064-4aae-afac-655b313bb8c0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A43Z&sr=b&sp=r&sig=bFIKhfITu6yX7It%2B0ifBObCaEGRwRW7n1zXpTVaDQ7I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:23:43.5398048","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:23:24.422Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:39.186Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1579'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:23:43 GMT
-      mise-correlation-id:
-      - 4032e77b-251a-4159-997d-c26f35efb1fa
+      - ea7e40ec-9556-407b-afe9-2a72585e26b2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:22:48.3302759Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:22:48.3302759Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:27:13.4267962Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:27:13.4267962Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:23:44 GMT
+      - Mon, 09 Oct 2023 19:28:08 GMT
       etag:
-      - '"9301b10e-0000-0100-0000-652428da0000"'
+      - '"57008419-0000-0100-0000-652454130000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A45Z&sr=b&sp=r&sig=OKToRzR2Td3XoH0LMy3zzq5a7i0DotsyP%2FO1805VnEc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:23:45.8958362","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:23:24.422Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:39.186Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A09Z&sr=b&sp=r&sig=O0aL3Gg6T8JoEe3QLx80cjwICqFqFoi2gwn1q5Qs0Qw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:09.3745381","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:27:49.636Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:03.213Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1591'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:23:45 GMT
+      - Mon, 09 Oct 2023 19:28:09 GMT
       mise-correlation-id:
-      - 800c20b8-4a17-47e1-953c-33973f767ff9
+      - 058d8c9f-c101-4baa-b885-e9973b645f33
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:22:48.3302759Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:22:48.3302759Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:27:13.4267962Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:27:13.4267962Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:23:47 GMT
+      - Mon, 09 Oct 2023 19:28:10 GMT
       etag:
-      - '"9301b10e-0000-0100-0000-652428da0000"'
+      - '"57008419-0000-0100-0000-652454130000"'
       expires:
       - '-1'
       pragma:
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestRunNotFound","message":"Test run not found with
@@ -632,9 +632,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:23:48 GMT
+      - Mon, 09 Oct 2023 19:28:11 GMT
       mise-correlation-id:
-      - 9339b947-b656-4c3f-9a37-b06aadf8a2d5
+      - 8d5628cf-2629-427e-9ecb-f30a90c9ab9a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -662,25 +662,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A49Z&sr=b&sp=r&sig=%2BV6LdtiSrgPPfgi2EIU8EgzzqFvWtkSx8h5PpJAdh6M%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:23:49.8294774","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A49Z&sr=b&sp=r&sig=zmyc20zsTH%2FaVzNq3z%2BKhYzt52cPrPdfNDXZ0AOfMc4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:23:49.8293919","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A49Z&sr=b&sp=r&sig=ZwB1POFAh7kC%2BDQABLApjCDImgrZY2m11pa6GmvUFPo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:23:49.8294999","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:49.746Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A12Z&sr=b&sp=r&sig=L4SChe921S9eG0lPPSe3mq72Cc1SrVsvSzLFmIOXKRA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:12.3669788","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A12Z&sr=b&sp=r&sig=vGo5uBTavwMIvv7Hyt5MVf0zeVmBCTduICCPtwLe2cM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:12.3668152","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A12Z&sr=b&sp=r&sig=uNqnDUpEWvKJar9ycfV4FdtdHf5i5MqHNq9rDE2UFPQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:12.3670046","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"ACCEPTED","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:12.297Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3156'
+      - '3148'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:23:49 GMT
+      - Mon, 09 Oct 2023 19:28:12 GMT
       location:
-      - https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+      - https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
       mise-correlation-id:
-      - 2a26b9ef-602a-4b30-b344-7c9e8ab9c8c0
+      - 469465d5-c8c7-4e4e-bbd4-85eb28b970d3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,23 +700,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A50Z&sr=b&sp=r&sig=qwtiuQyWwvH87m3VTPqcfJA%2Bav0p49vNV%2BHlZNE%2FCyo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:23:50.2749522","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A50Z&sr=b&sp=r&sig=t6WhLn13DlQ0lId52Kdz%2F2lw%2FOeXb6e3JT23sCZ2wkE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:23:50.2748826","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A50Z&sr=b&sp=r&sig=eMtclULdf2nmmKWna5h8OT%2Fhu%2FFzLfArYSl8quQi%2FEI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:23:50.2749672","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:50.137Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A12Z&sr=b&sp=r&sig=93yw8x62XB%2BbY9NvXbIxY%2BD4BgFKD0uoSNU%2FcUUAdOE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:12.8925912","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A12Z&sr=b&sp=r&sig=%2FVShzY6CyrGjwocG3RPcQzvm3QvMA%2BQRsNssDNziLAg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:12.8925218","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A12Z&sr=b&sp=r&sig=rL733XD3FTdi%2BbH20mOqL1Mz62GJy1a%2FhhywFHAFZZI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:12.8926051","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"NOTSTARTED","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:12.736Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3209'
+      - '3207'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:23:50 GMT
+      - Mon, 09 Oct 2023 19:28:12 GMT
       mise-correlation-id:
-      - 6d800a63-7279-4e0c-b84d-33ba66a7e8eb
+      - 1f5c5a26-4dbb-4bf8-bb3f-d3336aa6d70e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -736,946 +736,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A55Z&sr=b&sp=r&sig=Wg1YpzmpZUIbME6XSR4fzOAueL6yufAGKQRvJ6LIyiA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:23:55.5577134","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A55Z&sr=b&sp=r&sig=ZqiRK9FXRyonF7%2B8PxU3lVtYVAS0huvxrFu7RwRROyE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:23:55.5576464","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A23%3A55Z&sr=b&sp=r&sig=%2BKE8HxogDwcCOqB90ZMOihpoczzFst7ddoQaWOpGyeU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:23:55.5577282","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:50.32Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:23:55 GMT
-      mise-correlation-id:
-      - 390daf1d-8785-4fab-809e-cbda2389d99f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A00Z&sr=b&sp=r&sig=FJn1eHGwA9HZbgiAsd5QK2eQG8EUWZ40018s7ZC2b8Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:00.8421495","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A00Z&sr=b&sp=r&sig=JgJD263Rh1CO9JSvOuYq6GWJ46uQt3ZwcFv7IP%2BSQWA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:00.842067","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A00Z&sr=b&sp=r&sig=E%2FS3sfXePaDSPjoe6yrM1TjgoZEjQ2i%2FtpmEoTkB5Uw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:00.842164","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:50.32Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:24:00 GMT
-      mise-correlation-id:
-      - b8957b6c-b50d-4308-9a87-a50bac6d4b49
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A06Z&sr=b&sp=r&sig=E9mLcAweACLx0aKunzl9TWS%2FoPMuoLQrFjMloOz9m00%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:06.1266109","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A06Z&sr=b&sp=r&sig=dFCp5w24winL4v2upUc%2BKW8ZjZW%2FwcUn2UA%2FzGcVJpg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:06.1265162","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A06Z&sr=b&sp=r&sig=PTnMzVOvbXT1T3esx7%2FCCkQH1o5MJNrmAYns%2FsczO9M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:06.1266344","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:50.32Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:24:06 GMT
-      mise-correlation-id:
-      - 35ff967f-6a94-43fe-a7fa-8b2cc7ddd324
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A11Z&sr=b&sp=r&sig=F16uJ2mBVt8uL5tdBWY%2BBpJ3tt6j2tXSopx%2FeAxlIt8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:11.400376","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A11Z&sr=b&sp=r&sig=IcDymZ2jsDkmyPbfNeWfFmOwsAYr0hE9jCqWfX0b0cE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:11.4002515","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A11Z&sr=b&sp=r&sig=JgNmOMHm44MXAMKSRx072HXz%2FqwFfP%2FZrBDAQFU9s3k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:11.4003973","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:50.32Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3201'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:24:11 GMT
-      mise-correlation-id:
-      - df9c915a-0d58-4c26-8f6f-3edc8f32201a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A16Z&sr=b&sp=r&sig=YosoHkbSr7ZTlBTuW0OoWCUVOYCkt6m9kZ5sCSsZrzE%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:16.6769566","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A16Z&sr=b&sp=r&sig=%2F2aq1dCQ5MJYGlJS0BXFDw2VLTskGVo%2F%2FUoz1eLs9fY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:16.6768822","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A16Z&sr=b&sp=r&sig=anm8qChDk%2FKoM%2F1oyvhb9kDsKhpVVZdxMjc9oywHSQw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:16.6769731","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:50.32Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3204'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:24:16 GMT
-      mise-correlation-id:
-      - 0b9f606d-8166-4dc0-bf9f-cab7491aafd8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A22Z&sr=b&sp=r&sig=dDI135URXO4X5BGrBJekSIgMZJvHcRBSIYLvB8n0P0U%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:22.0032675","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A22Z&sr=b&sp=r&sig=DJ7pxG2mdoQY1gilrYsl3LiutwGDw1QpZVfrLB%2BNKOM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:22.0031778","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A22Z&sr=b&sp=r&sig=gYvTyPvpz1xtefQ3ZQOcyrTm8r3tvCg8bhIjX8MixYg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:22.0032901","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:50.32Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:24:22 GMT
-      mise-correlation-id:
-      - 88676d49-2a1c-4f55-bcb5-1f6c81efd7f8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A27Z&sr=b&sp=r&sig=N%2B2m%2FQLevGeDkMwoIl9YtLR%2FpiC3sq1kfRvhkZe4zDQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:27.2776888","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A27Z&sr=b&sp=r&sig=A0k6AYBab6kI1ciuYse%2BgOPYuQP1mmenmUHOdiu2CS4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:27.277623","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A27Z&sr=b&sp=r&sig=VMhTEMIqsbt%2F4aBzErn96XYrWtmynKOyk5cK4XWYA9I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:27.2777055","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:23:50.32Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:24:27 GMT
-      mise-correlation-id:
-      - b695e009-e610-48ac-9eff-2c560f2ab6d6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A32Z&sr=b&sp=r&sig=gkV7QBjk4sZMqx5DxbYbck6jxO2FbWIYXQOkFy5oOqk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:32.5569254","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A32Z&sr=b&sp=r&sig=iUtdlNuxYIKbTd9NT0XCzAM7JSLTGNDnllrfoctBuzY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:32.5568584","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A32Z&sr=b&sp=r&sig=v4t%2BmpVIstOpxSxVx3qqJzO4hil0FUw6S6U%2F6e3vLao%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:32.5569389","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:32.042Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:24:32 GMT
-      mise-correlation-id:
-      - ea10af8b-9c68-457b-91a0-7e82dd4f74db
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A37Z&sr=b&sp=r&sig=W%2FUgREcDU1SqXoNJ3IZwT7gFZgl7KOOnQdqmy78MebY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:37.8463912","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A37Z&sr=b&sp=r&sig=d4jm%2FkKmFSD74azQ8tSITN9c95g8TqQfDGFPksL20aE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:37.8462928","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A37Z&sr=b&sp=r&sig=waGkOwanlpH3C7CFgqIfBqateU7Li1hyy4LDK2i3TXE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:37.8464164","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:24:37 GMT
-      mise-correlation-id:
-      - 1f25f068-cbe4-4227-9d41-a821e07377f0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A43Z&sr=b&sp=r&sig=d4wI%2FlNVJsYcYRRsFuge0MkGhXUVi2ko%2B2bl6Lf86DA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:43.1302839","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A43Z&sr=b&sp=r&sig=4zpZAgtuNY3H0MHV8KY2OQ8u%2FRMHS8pYJJk5Kq%2FekSg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:43.1302112","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A43Z&sr=b&sp=r&sig=odCc7XWUdKksJGC%2Bw%2BET%2BXmF8JO2%2FVOs3lq5eOVRsmo%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:43.1303","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3205'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:24:43 GMT
-      mise-correlation-id:
-      - 09b764bd-4082-4756-9665-c39f03f494ad
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A48Z&sr=b&sp=r&sig=uzhktT9FUyYulLB6H6iBFaK9L9ODwOsMfMpYPvzUHXU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:48.4112296","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A48Z&sr=b&sp=r&sig=frJRMjJ6LGvd5Lai1UUZVuSJ9CNlcDEhgsvnMAi0pB8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:48.411124","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A48Z&sr=b&sp=r&sig=agKjhgJwuebtsldR66qD0Xj%2BPIb1SUC%2BTQbcHtiiA8M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:48.4112542","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3195'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:24:48 GMT
-      mise-correlation-id:
-      - a9c5ecf1-715b-4276-b5ce-62f59940f737
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A53Z&sr=b&sp=r&sig=vwvxKqCcmErOlxZxW%2Br%2FI8K7WwbcavdZEHa3kESkS98%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:53.6939079","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A53Z&sr=b&sp=r&sig=X1fXQ7qysGI5CxZDBb0M3aBspnPFDqTw9oFRoZUnCUM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:53.6938177","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A53Z&sr=b&sp=r&sig=ju8M2%2Fck%2BzhCivIAMJQ144usPWpkOPsxrdcyfQqyV5U%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:53.6939292","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:24:53 GMT
-      mise-correlation-id:
-      - 042f3047-0f81-48c0-8d3d-fc1e97d7ba27
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A58Z&sr=b&sp=r&sig=2sGYYZkBDeY30IqJyY%2FmEfZvg6xXdZkotVbMwF4qS0w%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:58.9877486","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A58Z&sr=b&sp=r&sig=DZQ8RXa8HITNPZNO28W8IL0unstCGNs8txHuvmFf9nU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:24:58.9876939","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A24%3A58Z&sr=b&sp=r&sig=VfKGE7iRTi9PJHdUvf7wOkiA7DZtX6gRVySh043IZgE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:24:58.9877634","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:24:59 GMT
-      mise-correlation-id:
-      - 491301ab-be33-4620-82cf-97b586b758f8
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A04Z&sr=b&sp=r&sig=dm4G2OZfV7wSzB1bcsuUWdyoLM7HJY%2FzAqVshiJ74Lw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:04.2850205","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A04Z&sr=b&sp=r&sig=f2hef42dSTVAsQ%2FUaYwhFJQQM9KXLJno1jL4VUrTA1w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:04.2849207","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A04Z&sr=b&sp=r&sig=IhbxKdmVz6U3DlVdU7WgFrcAFX2w5p7KaU2DS2VNQ8k%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:04.2850402","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:25:04 GMT
-      mise-correlation-id:
-      - 1a7adfc5-2360-401c-b4d0-4120a7f73f07
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A09Z&sr=b&sp=r&sig=54ZTirkW5SGhK7tgy%2FyAiF6h6OtNAegOgO1fgnIYlGk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:09.5602897","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A09Z&sr=b&sp=r&sig=O8qFsbrI8fnrPHGdgB8sAkgbJKcXmdSeO7kH8gJkawI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:09.5602171","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A09Z&sr=b&sp=r&sig=nPGq%2BNVMYmUkURUMlet%2FdleLr1bGnP%2FomCxijMWKctw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:09.5603045","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:25:09 GMT
-      mise-correlation-id:
-      - 4f5aa54e-9920-4d9d-b885-99daee1a4ee6
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A14Z&sr=b&sp=r&sig=5o1%2BIgMh7J2hGlG3pinDjUEK7X9Zh9P9Lz6nFGedehA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:14.8491187","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A14Z&sr=b&sp=r&sig=yF2DhCPO1A8ILhIN6DmT%2B3C%2BljgsRQcgK%2BG3ZbpONkM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:14.8490339","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A14Z&sr=b&sp=r&sig=j4R9a9Q4P9efLn3AUmX1XIH4ZsDLEqx7GFpo0JmEHvQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:14.8491362","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:25:14 GMT
-      mise-correlation-id:
-      - f533ff06-6fe5-4f5f-94f0-cf6ec4435ff3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A20Z&sr=b&sp=r&sig=yKY0ttlX8Y3B3y7RgB2xWP%2B8PMNKDxz1FRZTvAeWOII%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:20.139631","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A20Z&sr=b&sp=r&sig=lxTaLxfhe19Owrlk9Pbqt35deha68T9R6n2oarVL7i4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:20.1394944","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A20Z&sr=b&sp=r&sig=TIKMVw849JGDewp%2BuVs41x8ZSRVtoO0zOyGUH85Cn9Y%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:20.1396544","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3195'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:25:20 GMT
-      mise-correlation-id:
-      - eda2e120-b772-479d-80ca-b74029935d3e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A25Z&sr=b&sp=r&sig=YvqOrqqPNSKGIxqxD%2F1nWPhWGfjsNvjZj%2FCs6UeRNHY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:25.4277834","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A25Z&sr=b&sp=r&sig=PxAj3ZkWOoPoGhfWOMbviYnlmsDfpS6%2BXXwOQRFmoJI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:25.4276778","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A25Z&sr=b&sp=r&sig=ZhFHLBWVfzUWnj2miWQ297WBcSeYlqBduiKi7Hjp8ac%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:25.4278066","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3198'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:25:25 GMT
-      mise-correlation-id:
-      - e39d5c8f-a717-498a-860c-ecafddcf969e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A30Z&sr=b&sp=r&sig=j0jUzqv%2BqTNBJafQ7d6zvmi2zjz1npggb%2Bmuy6XBIkQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:30.7065937","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A30Z&sr=b&sp=r&sig=pXbrXE%2F6l3ubefHpFhSuwonq9y9GY4EslikNk4oALyc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:30.7065284","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A30Z&sr=b&sp=r&sig=7y3nq5i8wiQCLLOhnavWY3e9xX3qzlOGs3BQZyKuNws%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:30.706607","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3197'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:25:30 GMT
-      mise-correlation-id:
-      - 573f7e60-4cd6-4bc4-b211-45a8cfeef684
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A35Z&sr=b&sp=r&sig=0NfVxIgz6k%2B7oDtVYW3k%2FHJ%2FaDsZ9j3wfI49wxb9HdU%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:35.9840084","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A35Z&sr=b&sp=r&sig=D50Md97cZ6%2BqFpafEUv6fwovjpoad3Ik9ISTgT38W%2BM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:35.9838874","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A35Z&sr=b&sp=r&sig=ReRRPDsLGHXRNMo%2F%2BzMd2Mtp9fYHbxVENo1LbozG9L0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:35.9840326","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3206'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:25:35 GMT
-      mise-correlation-id:
-      - 27c021b1-a8dc-41c4-89a5-f3b8c2bb670e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A41Z&sr=b&sp=r&sig=IRlZ1HHWpSBc%2BLPZR5A3yUEwvABVRFbgkBQdXaVGdT8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:41.2631634","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A41Z&sr=b&sp=r&sig=NqbbiqBOXk2id393PUttM9LWPMbCTc5eWII0KsTPoqU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:41.2630804","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A41Z&sr=b&sp=r&sig=3RdBk1VVAr7AYIBO167miIlof9mEs%2BtQBNe8wmRz0rA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:41.2631777","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:25:41 GMT
-      mise-correlation-id:
-      - 34129ffb-0225-4a7b-9f19-4268906cdc70
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A46Z&sr=b&sp=r&sig=frjgvXe3n%2BO8RViZnHIqZQqwByf4yMc67cXlvbEgOXg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:46.5472478","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A46Z&sr=b&sp=r&sig=U3Rrpb70z3Ou%2B1ifqQSdkad3qAhsOEyJVvpEmbGZHm8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:46.5471432","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A46Z&sr=b&sp=r&sig=yw%2FL%2Fb640so4293zk5pByhD8yw3naEnJ8Hz44sGFR4g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:46.5472712","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:25:46 GMT
-      mise-correlation-id:
-      - 9ed121a8-4d55-40a8-bf62-3824faf97cfa
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A51Z&sr=b&sp=r&sig=UbjUwFW6UrzNhW4XP8k%2FblXDgjCUOCsBuvAIwMyQ6CI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:51.8330002","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A51Z&sr=b&sp=r&sig=VTRyqc%2FGFTunkXFUT3Qxy5oIQL%2FO0yiMW7Z7ZcUhsxw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:51.8329317","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A51Z&sr=b&sp=r&sig=juNs9myfo8QEkuB6zNH1nGO3JDfY1twDTtDm8%2BMNof0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:51.8330147","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3200'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:25:51 GMT
-      mise-correlation-id:
-      - 8f8a135d-2b58-44a3-a93e-c8a84af3768d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A57Z&sr=b&sp=r&sig=WKl1aCOfdWKqHwNZqtKj5pzq3P9V7uVhKTfuNQaV86Y%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:57.1094612","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A57Z&sr=b&sp=r&sig=77lQK8c52aLIcw7DXeh02XdDqP05tuvtjfnPXXKnK2c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:25:57.1093572","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A25%3A57Z&sr=b&sp=r&sig=LXON4KLTxsRj2ee%2FwP9J4csgo7yRpd6zhwld0Rbp65g%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:25:57.1094831","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3194'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:25:57 GMT
-      mise-correlation-id:
-      - 8f0d3d05-972a-48b8-b7dc-8f3c66f7bc44
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A02Z&sr=b&sp=r&sig=L5LOSrRfxdjKPMMZocqxvLCsosOkfSxuuKQnDvSgr7A%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:02.3782682","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A02Z&sr=b&sp=r&sig=os46kkPRDs4aVIww4u1u5yimjGgnl2%2Bpy4YTRjCV36w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:02.3781694","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A02Z&sr=b&sp=r&sig=%2FcV7x3Rvws6ACjoGLeD8yxWzzUyDvW3KuVSAA4fhmbc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:02.3782834","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3196'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:26:02 GMT
-      mise-correlation-id:
-      - 9ab8e9c0-917f-4545-ba7e-7051dddf197a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A07Z&sr=b&sp=r&sig=qQVP18YqhIIk69ehDUZrlRU4AT8UebDzubZ%2FifnsKSg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:07.8066118","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A07Z&sr=b&sp=r&sig=TYJHzcqkkD0d%2BV26%2FXGAQoOszSFc2ku4ZH%2FGLVBpWmk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:07.806542","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A07Z&sr=b&sp=r&sig=r9%2F5WZUKnFeS0Pfjr13ZTuv6yO8nbgZfkOJ4WZO%2BUdc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:07.8066277","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '3203'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:26:07 GMT
-      mise-correlation-id:
-      - 4636b01b-50de-45a0-95a2-48ddc8c0ef14
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A13Z&sr=b&sp=r&sig=RDSXFwtdpnTanpREhyeRm3E9%2F8auSH%2F07YvQjFSIkio%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:13.1023512","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A13Z&sr=b&sp=r&sig=zY90cdhYvxpvc0cp7MJDSEu%2F8cODXgCnAHSX2a7N7go%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:13.1022674","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A13Z&sr=b&sp=r&sig=VMBUXuDNAlXXecUsXQL%2F9piFPXhSHWYKqwn7bQVxO4E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:13.102366","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A18Z&sr=b&sp=r&sig=iGmHO0j3gMxSbUoqObQlhoWnEW6%2Fx1gAMDv5eHi4YYs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:18.168805","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A18Z&sr=b&sp=r&sig=CVFLn6sDvfBmBZfcOc5JdOvS6jkQEEjetYdUPlFmLd4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:18.168712","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A18Z&sr=b&sp=r&sig=DaM7T3isguY%2Fkurq5wuHTU0SEU%2BYeiAnav5v5gAuMM4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:18.1688286","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:12.981Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1686,9 +750,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:26:13 GMT
+      - Mon, 09 Oct 2023 19:28:18 GMT
       mise-correlation-id:
-      - d737655c-6082-450b-9043-3bde46d0f8ce
+      - 6b899ddf-110c-4bd6-b1d9-6dbf8a6f1d70
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1708,10 +772,550 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A18Z&sr=b&sp=r&sig=7gYFvqqFTEN2MYANBkDqKsxAxYiNsdIvUAtzZYnMMag%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:18.8099987","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A18Z&sr=b&sp=r&sig=1axcMtGkwgYIe3oFflzhc9RWhg2aWz3bbxCkpXVtkcU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:18.8099433","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A18Z&sr=b&sp=r&sig=ST5eZAAfUW5og8HqTF8HIGOFxGu8TdiglKxxytO5m8M%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:18.8100125","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A23Z&sr=b&sp=r&sig=SECKh4vSFuUaoP%2Bn%2Bcp92jmzQczGKhxKlJ9chchAxMo%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:23.4540057","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A23Z&sr=b&sp=r&sig=kR%2B3CF%2FPJyhy0UGKlQSBvsyWxB8D5JVTpUueAW5ccvk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:23.453923","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A23Z&sr=b&sp=r&sig=erwoXBFRw0RNgmPBRUyYj6tBXXnWLnSaacgquGdrfmA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:23.4540267","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:12.981Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:28:23 GMT
+      mise-correlation-id:
+      - 6fffffc0-dc8c-45ae-a229-9f0e77c6a2f5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A28Z&sr=b&sp=r&sig=AO9SdgLEbyzrDO2nU8DZ0vCLEtcWV9EkgUyTU0fh2y8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:28.7657039","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A28Z&sr=b&sp=r&sig=vnbfgyMIyHK0fM4IBXCWHt39nWdw9bDZByKraWCRrxk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:28.7656056","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A28Z&sr=b&sp=r&sig=pm3dazl1xALWXKfjTXl%2FpzBP%2Fs3MYcTpXGdRilEefeQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:28.7657253","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:12.981Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:28:28 GMT
+      mise-correlation-id:
+      - d1d2c4f6-08f3-4618-8d41-ffe4b07fa091
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A34Z&sr=b&sp=r&sig=hSh3U0NWhGIRg79W7LlqJZsEVloandAPV66mcfwvTS8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:34.0856791","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A34Z&sr=b&sp=r&sig=PbjIJGFy2Y5WCdBtKze8W5q4nLQ67VW631ILW3bjf88%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:34.0855833","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A34Z&sr=b&sp=r&sig=uk9suJ%2Blfi%2FUm3JrlyVJsZehllhP%2BLD1AmCOfjUtdgQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:34.0857073","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:12.981Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:28:34 GMT
+      mise-correlation-id:
+      - 311170da-e709-47cd-af82-a40f51c23ab0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A39Z&sr=b&sp=r&sig=rtJx%2B%2FmYTL7QMr2AyzwKZYlMb9f4zHjNBKmiNKK4c%2B0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:39.4216622","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A39Z&sr=b&sp=r&sig=ZcDVyeytpCKx2P8iN%2ByhpLLjOEhN%2BwBhUAHmDjDlygs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:39.4215753","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A39Z&sr=b&sp=r&sig=%2BzylHX%2B1O0mFz%2B6QiLHGWYfTIXVkIlPhGf6f%2Fn%2FKSkg%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:39.421683","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:12.981Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3214'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:28:39 GMT
+      mise-correlation-id:
+      - 67525711-4ac2-43f7-808e-a122f751172f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A44Z&sr=b&sp=r&sig=njFvEnrthR6vIZOQOj0%2F4clLucPCM1SDJIuXIg2IY8k%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:44.7038419","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A44Z&sr=b&sp=r&sig=SR%2BaP3vxW22wwiecmFCphKEEpI0%2B9wc%2BgjEhLjjUUZI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:44.7037483","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A44Z&sr=b&sp=r&sig=K64ZwGLOZwrR5ZL1PruKxASEkPcv3hTKh6EKn%2FHgC9Q%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:44.7038688","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:12.981Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:28:44 GMT
+      mise-correlation-id:
+      - b6795a38-8d38-4026-90c7-a34f782e5422
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A50Z&sr=b&sp=r&sig=MY903Kqdhxk4mNe5SsKeBD%2FAhOfTj574dZ8Kgu97ya4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:50.0292024","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A50Z&sr=b&sp=r&sig=sLJGBpRFM%2BSqGram7R6l6iBimV2Vx8L%2FQNNJ7FvUu5Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:50.0291108","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A50Z&sr=b&sp=r&sig=laEy3pwMId8BiUIYdd3OFtWQGt78XGmElb7LrQpLQ50%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:50.0292211","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"PROVISIONING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:12.981Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:28:50 GMT
+      mise-correlation-id:
+      - b5db658b-a3bf-41e0-b4d3-a54502b8278f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A55Z&sr=b&sp=r&sig=W3kg9EY4NVWF%2FjDB1oRmkcGkRfxtjMh6HUqSe2gnYFM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:55.3184371","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A55Z&sr=b&sp=r&sig=Ba9oQerrXfBABDyrOod%2Fig65X%2F2%2BK236ryZ8T6A0YEo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:28:55.3183523","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A28%3A55Z&sr=b&sp=r&sig=f1hXkJ2UEC1tvHBNIvhSlDrsFetCnLfqE2bVjgYc%2FiI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:28:55.318451","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"CONFIGURING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:54.629Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:28:55 GMT
+      mise-correlation-id:
+      - 560d84ca-d989-4210-9ac8-0fcdd9b41ddf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A00Z&sr=b&sp=r&sig=nsNBRNH97jspvfDTB9yeal0%2Fn1773OC6vjIArAkbZoI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:00.6255949","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A00Z&sr=b&sp=r&sig=P%2Fyl3QB3hNpNpK5KJiZTIbWKbbn2Wrxqw%2BL8b0KVOx0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:00.6255106","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A00Z&sr=b&sp=r&sig=9fXvVWp7JiffVTT%2BDpMkZ2qqYKmMfolbSf2DIoSS9sU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:00.625609","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:00 GMT
+      mise-correlation-id:
+      - 83e5fd83-a5d6-4ca6-b776-e94828aa8b48
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A05Z&sr=b&sp=r&sig=Wqv37Sb3BDvfoRNjpS%2B8kE8QG4DkqwB265fmxQnx6Tw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:05.9081946","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A05Z&sr=b&sp=r&sig=rZVGCL%2FBMe55EJ6QI0Qd%2BasEnv580lTE8WGB%2Fo3ljVc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:05.9081065","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A05Z&sr=b&sp=r&sig=e73z1DzUkH3fUkyMRv%2B4kzUQ6WMazT%2Fn45611CzQyGY%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:05.9082171","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:05 GMT
+      mise-correlation-id:
+      - 21a68a58-369e-4910-a805-2369b5f008b6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A11Z&sr=b&sp=r&sig=4UZCcT0l%2FW%2BgKA8AFIRU9AZEfdya7jsmlnoZ%2BDJTqRs%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:11.2683604","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A11Z&sr=b&sp=r&sig=IAhR1A5PscZIeDk65YhtDMmoCdaA5kb4xhqmI%2Fzu5l0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:11.2682604","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A11Z&sr=b&sp=r&sig=3941zikaVMex%2Be7Yc7f5jSy6OeaV07700Uggykl%2B7XE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:11.2683836","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3204'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:11 GMT
+      mise-correlation-id:
+      - ad90417d-e924-4fa7-89cb-9427d1dcdb12
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A16Z&sr=b&sp=r&sig=Wmbje8Tb4N33eeCN2DGhqIPaoVbaLTKgm6P9zsiFVTc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:16.557065","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A16Z&sr=b&sp=r&sig=d6XM0S5fqoK7u3%2BROLWrS%2FRAX6WCJ%2F4BLqbuLMFTKao%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:16.5569835","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A16Z&sr=b&sp=r&sig=OLj1CzIcx7%2ByJjOYJPhxGKnoHW%2BBbX%2FSJBJOq4tpUlw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:16.5570866","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:16 GMT
+      mise-correlation-id:
+      - f3fe99cc-b18e-4089-9c9e-f7d17aec54f3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A21Z&sr=b&sp=r&sig=MZ7UPwzwsEzGwU5MQ2rKCFaYZ9xsJnKPEc7e0kt7R3c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:21.852666","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A21Z&sr=b&sp=r&sig=xTrBH0LeDcVeJooiQvxZjLEjUolarmakL5IUXvvyAhs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:21.8525845","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A21Z&sr=b&sp=r&sig=435xs330Rj%2BfHM2iTcDG6GRgonKP5AagOzw3EpBfZgs%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:21.8526831","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3193'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:21 GMT
+      mise-correlation-id:
+      - e0e5f969-f090-4876-907c-e96beee1a213
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A27Z&sr=b&sp=r&sig=b4dIP6Z1qsp4XcD5hj3ga%2FmEYgK1ok8th2wlGYrI3aM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:27.1537771","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A27Z&sr=b&sp=r&sig=zpJOY%2BoViYw7YrMkjtJOqRPLesgBOjci98ENLSXncrw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:27.1536817","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A27Z&sr=b&sp=r&sig=VmlO0swORTB04ioElmGKROGtBvEFwrv4PLVH8YoKi4I%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:27.1537934","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:27 GMT
+      mise-correlation-id:
+      - 1f41904b-7579-4aae-845a-022f19e27849
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A32Z&sr=b&sp=r&sig=FhwGnZroVUi7dknjcxgXvdl7DNwTN5QTYU37FcLgnmY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:32.4506644","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A32Z&sr=b&sp=r&sig=38GoGcwsAy6fXfiPSNpSWyqix9%2FGAOwcrMwzBq4dly0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:32.4505814","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A32Z&sr=b&sp=r&sig=Q46aKSsB4KCZOSdCZSu6o3%2B2TMux9Qs%2B5QFYby3SqLQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:32.4506852","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:32 GMT
+      mise-correlation-id:
+      - 5caa7e8c-8f79-430d-af9e-9b0a38883d77
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A37Z&sr=b&sp=r&sig=BOtL4LyHhR0J%2BEk9NkMpRNY3%2BfVSSMsLR78X1p%2BF91c%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:37.7379422","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A37Z&sr=b&sp=r&sig=NzjUhFDhVzd%2F6UZOM7k5d%2Bk2TE5zGpMl3qWG3cBZbm0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:37.7378566","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A37Z&sr=b&sp=r&sig=h3EaBmaBHvCZDUAIZgUU5gbcNApJIM0r9JDe4xKmUCc%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:37.7379568","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:37 GMT
+      mise-correlation-id:
+      - 646169a9-0deb-4fbb-9f3f-d83eb3d548d6
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A43Z&sr=b&sp=r&sig=JNbR8EEaG31zrA8D71PuUprWsM7IemlYoJ0AvvooZ8s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:43.0159426","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A43Z&sr=b&sp=r&sig=zrXcNYvlFAibW7FbzwTDH3mM7ENg8jlSfNEp62Lfwmc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:43.0158559","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A43Z&sr=b&sp=r&sig=BFYFxYDNu14JcClYgUlwL2aVMUFA18crz5EgDwfXtuE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:43.0159649","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1722,9 +1326,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:26:18 GMT
+      - Mon, 09 Oct 2023 19:29:43 GMT
       mise-correlation-id:
-      - f3bfe8ad-7f4f-420c-b825-02e0c19ad126
+      - 7e6aa3d1-ccd3-436c-b507-fd95af69eb21
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1744,10 +1348,298 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A24Z&sr=b&sp=r&sig=fchC%2Fc%2BvJZdkX0s5dcLct8FfzfikmBnk17WR7rg58cA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:24.0983158","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A24Z&sr=b&sp=r&sig=1gF9tcZP0PAoGIcZhb5Yn8DROklF7XC6dT3z%2BnIlJzw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:24.0982215","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A24Z&sr=b&sp=r&sig=JfdQP8xTZeKe3ypNv6AkrG9mcrMgqmakwPbotmQ%2BqOM%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:24.0983405","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T16:23:50.137Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:24:37.383Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A48Z&sr=b&sp=r&sig=y09GSSLExi9soKFXi7BBvcGNxVBaOcnPt0hAoKSkmrw%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:48.4519785","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A48Z&sr=b&sp=r&sig=MZEmmKqkJqS8VLhlXtbOuO37VOeZ56Y%2B4nxXMWVoAAM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:48.4519129","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A48Z&sr=b&sp=r&sig=eMSoEe3tJKe9qGZwXbE6dZw1X1%2B%2FBSGFducpGsXnlkk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:48.4519933","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:48 GMT
+      mise-correlation-id:
+      - 5b1aba4f-7b28-4cb4-9b53-d10cc284ac7f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A53Z&sr=b&sp=r&sig=326ukxWJfgmsdFfZAD94%2Bz0FSmWgIol997jFik8WtdM%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:53.7499197","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A53Z&sr=b&sp=r&sig=1GgdyQ5xLf97ZUA%2FOMSn5ZXiczPzoebPpMHAdHm6%2Fh4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:53.7498288","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A53Z&sr=b&sp=r&sig=IoHd9Nvu9cW9JGvQCO2JC4NNxzUCqfdNFJnr5ZLbRw8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:53.7499416","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:53 GMT
+      mise-correlation-id:
+      - e42c56ba-cee7-45c9-8d73-8562eb4514ee
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A59Z&sr=b&sp=r&sig=no0O68gj3LPDP0Oq7TjXPU4yu4pBkPGPkGwnSx2GNTg%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:59.0304938","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A59Z&sr=b&sp=r&sig=J8W8Sh2w1Z4N2qtaqA8dI3oT%2FbJ%2BrKBrXOGRa27Thtw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:29:59.0304197","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A29%3A59Z&sr=b&sp=r&sig=u4fH8OwYIrx4TfbVK2%2BtCExeKJl6c5Q54JrqpedzbcU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:29:59.0305081","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:29:59 GMT
+      mise-correlation-id:
+      - b41e9fc7-4250-4c2c-8f34-775f12eaa24e
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A04Z&sr=b&sp=r&sig=mVuEE0xz3NpTe5fSu%2FiSKST2unLrbJAPbCcHWKPlUJY%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:04.3155742","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A04Z&sr=b&sp=r&sig=hHGpzQt%2F%2FUAMAv56jFwTx1UEipvEmPYT2eTB7pk%2BP7o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:04.315504","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A04Z&sr=b&sp=r&sig=A57jAVRy3s7PKNF0ATNuX3KcvlkB8LvrTIdKw89%2FFPw%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:04.3155895","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3201'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:30:04 GMT
+      mise-correlation-id:
+      - b1307a0d-a264-4f1b-b11f-164f1ec2aa1f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A09Z&sr=b&sp=r&sig=vpRE1nOtdAqIXqZcbi6ujooWjpeKNVMcnr%2BuSzwmvJ4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:09.6414412","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A09Z&sr=b&sp=r&sig=emu%2FuTgDJlWBvxAxAgQ9cuJL8sjbHK2fpbWHPEZrvF0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:09.6413656","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A09Z&sr=b&sp=r&sig=sCVouBjIEcj2dkmZRXxx5%2BfGnjo86SWXscg4j8V5Fj8%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:09.6414557","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:30:09 GMT
+      mise-correlation-id:
+      - 60e89e0d-8ffe-4996-9e5d-89377ae697bf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A14Z&sr=b&sp=r&sig=d7nmxeznnuWLKsuzJT9x%2FQTAfVfzf8vSmySlmPlTtkk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:14.9694115","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A14Z&sr=b&sp=r&sig=tFF6h%2F0KxOipJftm%2Bpw5TVV1%2BWkNsdOMLqr8NApQ7ig%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:14.9692865","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A14Z&sr=b&sp=r&sig=4%2BoaEMAWJgUMvng4rglsR0BuaTzU1WBG5NBEYvzNXPQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:14.9694253","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:30:14 GMT
+      mise-correlation-id:
+      - 5e2152b7-597d-4121-80ce-a75c0dcbf095
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A20Z&sr=b&sp=r&sig=yvBpWw7KO%2BDNPQyZoHSUpXu5225%2BjSd6jfnwBS3LotQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:20.2818777","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A20Z&sr=b&sp=r&sig=BFcjYgv%2B%2BciSSrb2qfa8WrRzg6v8TimoX78Mw2Kwwv0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:20.2818064","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A20Z&sr=b&sp=r&sig=WecudHWix%2FZchq%2Br%2F0zmIusXyMRvTiluf5AvG5VjzC0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:20.2818919","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:30:20 GMT
+      mise-correlation-id:
+      - 916bd156-de60-4c62-9d6d-9d44a151c0ae
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A25Z&sr=b&sp=r&sig=3LMOh7oJx8%2FOYpE3ikuWqhq3fj6pnz4SRlDVmLHKJPQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:25.6173502","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A25Z&sr=b&sp=r&sig=dUxpNDKo6tmkZ0PS2WtLGVLpu6La1rFO9GmAyYO6YTQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:25.6172635","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A25Z&sr=b&sp=r&sig=d7Ot6uS4L7LB%2FkRv5LbJndtskXFYHRzCluuaijIzcqI%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:25.6173685","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:30:25 GMT
+      mise-correlation-id:
+      - 955669f7-bb22-473e-901b-cee3fb9f282c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A30Z&sr=b&sp=r&sig=guB%2FVy9C4eV4blYA6ENLory3%2BSJIUGhjGctMYpgaB68%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:30.90158","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A30Z&sr=b&sp=r&sig=X3lbPpTptHJO696IERNvXe%2BS8dZvdeLFSVe2wG5nz8E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:30.9015084","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A30Z&sr=b&sp=r&sig=dXGqzbhEBRKD%2BBwrWRtILrpam74xTVwIF%2BPQkMGyc0E%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:30.9015947","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1758,9 +1650,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:26:24 GMT
+      - Mon, 09 Oct 2023 19:30:30 GMT
       mise-correlation-id:
-      - 48253391-53b4-4fe8-958f-c260cd6cba2d
+      - c3dd3512-2a6a-45c9-aae1-2c4db8453ad1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1780,24 +1672,132 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A29Z&sr=b&sp=r&sig=iPuIhx0oXCBNzv3rsfshqVd6wIIkNUlgnkJYLVl6BlA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:29.3825079","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A29Z&sr=b&sp=r&sig=gN%2FHlpkUtxIkp1DIWRGWQsLvqRWRRBb94drK2%2BDeAo4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:29.3824387","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A29Z&sr=b&sp=r&sig=rbSSLk55DpGAawNxqM5iURzVay%2FaFrPgr8hsBao4Gd0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:29.382524","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-09T16:23:50.137Z","endDateTime":"2023-10-09T16:26:26.756Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:26:26.838Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A36Z&sr=b&sp=r&sig=3rx7paqOSIWyu6PpDsKxbgIVcNjoSKSCSIlVfwxFHcA%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:36.2380598","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A36Z&sr=b&sp=r&sig=F03mjnjOVYHa%2F3G7CnGpHyQa7ktGJgG8FENsD5yBoLo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:36.2379814","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A36Z&sr=b&sp=r&sig=RhLLa7vuK83fGFhq%2FYjPspZWmpqu9vTck2TFSjA1NGU%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:36.2380846","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3332'
+      - '3196'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:26:29 GMT
+      - Mon, 09 Oct 2023 19:30:36 GMT
       mise-correlation-id:
-      - 9bb7c0e6-a79c-4d70-9590-b51d3b5e6771
+      - 9dc356e9-efee-4d6f-855f-890690a29487
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A41Z&sr=b&sp=r&sig=lsaIs01s6P9ZvysOFzrFBbiBYItRzWGv98criqwezc0%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:41.5202376","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A41Z&sr=b&sp=r&sig=B8Mqr%2FJOTuTNN5BhzcGWXUl8vLEtiRghVf8auZTMZJY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:41.5201421","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A41Z&sr=b&sp=r&sig=EgXk1AKgQu5cSnuipNLBaTYukYKAB9ZT5AaTn%2FW3raQ%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:41.5202595","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3196'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:30:41 GMT
+      mise-correlation-id:
+      - c9ef15ef-82d2-40e2-860d-0caa59d6487c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A46Z&sr=b&sp=r&sig=twjBp%2Bo9B%2BuAyFL7%2F3039%2BHlTrNtI9tsc71nvgif6xQ%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:46.7902922","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A46Z&sr=b&sp=r&sig=e1Dl6zOgBEqDORDpcq64zKZyF%2Bf0P49zKO1sILLmrWI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:46.7902021","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A46Z&sr=b&sp=r&sig=7an%2FtpvARA9a%2BBWMqJczxfN0lEgsROtsY359ZsUYao0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:46.7903145","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"EXECUTING","startDateTime":"2023-10-09T19:28:12.736Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:28:58.976Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3206'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:30:46 GMT
+      mise-correlation-id:
+      - 3e8a0711-3175-4c9f-9725-cde42b2408ab
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A52Z&sr=b&sp=r&sig=vTXdCR6B%2FMxgi%2BOOSVXfQbC%2BshcvqOPMTxy5iD8pIyI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:52.1355587","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A52Z&sr=b&sp=r&sig=emx%2B1Ar7xO8KIbCR7IE0ZAEhdsGrYrywykXpP4RGHV4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:52.1354735","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A52Z&sr=b&sp=r&sig=kVtay59HC9BiI8V2f2U1%2BcoOZikTBL3DDC03Xs36MGk%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:52.13558","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-09T19:28:12.736Z","endDateTime":"2023-10-09T19:30:51.916Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:30:52.004Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '3335'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:30:52 GMT
+      mise-correlation-id:
+      - 0badaab4-d79d-4ffb-9baf-d559ab61e6a9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1820,7 +1820,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:22:48.3302759Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:22:48.3302759Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:27:13.4267962Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:27:13.4267962Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1829,9 +1829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:26:30 GMT
+      - Mon, 09 Oct 2023 19:30:53 GMT
       etag:
-      - '"9301b10e-0000-0100-0000-652428da0000"'
+      - '"57008419-0000-0100-0000-652454130000"'
       expires:
       - '-1'
       pragma:
@@ -1861,24 +1861,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=update-test-case&api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs?testId=update-test-case&api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A31Z&sr=b&sp=r&sig=wEOjqaX3NBWTIv9EFaV48Z0vUlvK3qTG7kO0wCL%2Fok8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:31.6165715","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A31Z&sr=b&sp=r&sig=hXtPeZ9%2BGWO%2FAXPUL0fj1RttyNNg9OyHsIdagNNS%2FK0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:31.6164737","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A31Z&sr=b&sp=r&sig=x4y38iMN2OEHvBgBqaSAnaR%2FkXnDCoj%2FQRBjqHgdmk0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:31.6165946","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-09T16:23:50.137Z","endDateTime":"2023-10-09T16:26:26.756Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:26:31.219Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A54Z&sr=b&sp=r&sig=AH6Gg%2Fq%2B1QCm78AOVTTyC4cGP85jS8dPhuro4cljFRk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:54.4819149","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A54Z&sr=b&sp=r&sig=zZAQe9HV2Guydn0VkmOIp46N5tat24zJfT6p8Nk8hWg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:30:54.481828","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A30%3A54Z&sr=b&sp=r&sig=sqU5tgpDn%2BXkodj2SfLqk8bpnv6xSU32TjnuwlNNEe4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:30:54.4819365","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-09T19:28:12.736Z","endDateTime":"2023-10-09T19:30:51.916Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:30:53.535Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3351'
+      - '3344'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:26:31 GMT
+      - Mon, 09 Oct 2023 19:30:54 GMT
       mise-correlation-id:
-      - 94a4b379-7e36-4e7e-a72e-189649cbbd0e
+      - 6c6c4ff1-4d12-4753-b235-669ac1833a9b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1901,7 +1901,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:22:48.3302759Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:22:48.3302759Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:27:13.4267962Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:27:13.4267962Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1910,9 +1910,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:26:52 GMT
+      - Mon, 09 Oct 2023 19:31:15 GMT
       etag:
-      - '"9301b10e-0000-0100-0000-652428da0000"'
+      - '"57008419-0000-0100-0000-652454130000"'
       expires:
       - '-1'
       pragma:
@@ -1942,24 +1942,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A53Z&sr=b&sp=r&sig=sJuCZmAcNy8nqEAlVe9wGhe3W64wqhw2OwqH9jvzNdc%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:53.9729434","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A53Z&sr=b&sp=r&sig=9aOGkW1LfQAkS2Ou0xxUHkfSHzxN1qk0V8jzI6SkcCo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:53.9728679","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A53Z&sr=b&sp=r&sig=1JBVumbpCw%2Fj33AxJvVqGgDsVOh9iRjvc0wUiz39uq4%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:53.972958","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad1a1126-4eea-4dd1-bf8d-a49ee5838e00_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A53Z&sr=b&sp=r&sig=Skml0OW3NeGXOJjV1xNTrvY5ixO8Bq%2BikXZynwhYPmY%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:53.9729719","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad1a1126-4eea-4dd1-bf8d-a49ee5838e00_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A53Z&sr=b&sp=r&sig=32t%2BMGXZPoeGoZxhkLGw47Wu4QPO9MbhFZcA803RETI%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:53.9729856","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-09T16:23:50.137Z","endDateTime":"2023-10-09T16:26:26.756Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:26:40.319Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=kl4ScxWAHrW6M1eQhoc4QN4PnZ8HiVVtb5P7maymau4%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:17.0179876","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=iK3maKEQW22fcsxUb%2BXdFWXpujlmHFRWtBtwE8xgNKQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:31:17.0179203","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=wG9aiJlYKj6Lc6HJdQGDGomhd0w3h5m8WSLzm2K4leE%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:17.0180037","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/3ee3ba5e-37d3-4452-83cf-f393a6743f15_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=Y4wtIeEyI3FoDUI22Ays9lM1AiZlRtyvjTVN03msiXY%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:17.0180193","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/3ee3ba5e-37d3-4452-83cf-f393a6743f15_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=1X%2BxtgdW1u%2Ft81%2FWdjOSIDg0tTxLYwStaWR9rHSbET0%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:17.0180371","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","status":"FAILED","startDateTime":"2023-10-09T19:28:12.736Z","endDateTime":"2023-10-09T19:30:51.916Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:31:01.464Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4491'
+      - '4494'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:26:53 GMT
+      - Mon, 09 Oct 2023 19:31:17 GMT
       mise-correlation-id:
-      - 761c25bc-7aca-40e5-8814-c805f7c94ad0
+      - e83463c1-9042-4c77-9a66-969a823d63d1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1983,25 +1983,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A54Z&sr=b&sp=r&sig=txM3N737EfebR76pZzOWQzyhNFyQ%2FGUtzPFlyiRX39s%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:54.3417591","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A54Z&sr=b&sp=r&sig=wneBoWHvIWIxB8yPuV%2BKHE%2FaZXcHuOaNpicI7f2Lwnc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:54.3416654","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A54Z&sr=b&sp=r&sig=8fXzDO%2FZZ90Vu6CZ5f7bczefvZxSdQ2OUKKnpmpS1V0%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:54.3417771","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad1a1126-4eea-4dd1-bf8d-a49ee5838e00_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A54Z&sr=b&sp=r&sig=f%2F7mEtWwDFxPVsxZcy7Hj%2FYYN91GOiOSIUW2%2Bh4bhTI%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:54.3417946","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad1a1126-4eea-4dd1-bf8d-a49ee5838e00_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A54Z&sr=b&sp=r&sig=Ngz%2BcmghNzsBHkho2EOLGZ63iusSzMWT9w3S%2BRFyguY%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:54.3418131","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
-        test run description","status":"FAILED","startDateTime":"2023-10-09T16:23:50.137Z","endDateTime":"2023-10-09T16:26:26.756Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:26:54.332Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=WZ1z5ja6wo5VnCey9v4B0%2FWg%2FC7c84Ik4TxtS0MAwvk%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:17.4467381","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=Avu4ez0pYHfIN55ieGbUAoeVIEmHNU6NGU%2F4aNX1GDw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:31:17.4466525","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=2bdMyqB%2FFaaSTUwF7OCf71QTdVOE%2F5uiBCEIdM1abuA%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:17.4467565","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/3ee3ba5e-37d3-4452-83cf-f393a6743f15_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=KnXMbFHo1UzE7gX7tVErsqV1W1eAINUuWHvuaSM7KSg%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:17.4467749","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/3ee3ba5e-37d3-4452-83cf-f393a6743f15_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A17Z&sr=b&sp=r&sig=Xuu89Et5YE4luJIjlO505xGUOKc%2Bt00oYmT8rcS6CGQ%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:17.4467935","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
+        test run description","status":"FAILED","startDateTime":"2023-10-09T19:28:12.736Z","endDateTime":"2023-10-09T19:30:51.916Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:31:17.437Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4549'
+      - '4543'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:26:54 GMT
+      - Mon, 09 Oct 2023 19:31:17 GMT
       mise-correlation-id:
-      - c9a30b51-e449-41d6-86e4-8a173d3ddd5c
+      - 83b8e066-0e90-42f9-ad5a-1c40e496b7d3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -2024,7 +2024,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:22:48.3302759Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:22:48.3302759Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:27:13.4267962Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:27:13.4267962Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -2033,9 +2033,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:26:55 GMT
+      - Mon, 09 Oct 2023 19:31:18 GMT
       etag:
-      - '"9301b10e-0000-0100-0000-652428da0000"'
+      - '"57008419-0000-0100-0000-652454130000"'
       expires:
       - '-1'
       pragma:
@@ -2065,25 +2065,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://3d870e82-a44b-4eec-9a23-040570f50c5b.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
+    uri: https://51b7e544-d81a-40c9-b511-29d9e50bc997.eastus.cnt-prod.loadtesting.azure.com/test-runs/update-test-run-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"81842833-4cca-4e6e-8d31-a4e22bcd3e9a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"faf57da5-a443-417c-981e-3507dc4437a2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"aab4b375-f0c9-4251-9c3d-7b904fbc0907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
-        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad378d65-3fc8-4701-8160-f1285b52d3e0?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A56Z&sr=b&sp=r&sig=rhJMRz3y%2Fs8cb6Twol2P0GTnt1oiyY4%2Bep9AhHTkNhI%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:56.6745488","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/82dc3ca2-3335-4d8c-b1be-bc4c87052f63?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A56Z&sr=b&sp=r&sig=BS8r2Q36NDdGMkczqszDAJqHM8cf353QIFXrgAsXoeM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:26:56.674451","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/3b5d399f-e0a0-4b93-811e-85d86ceb184b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A56Z&sr=b&sp=r&sig=U4KE54h46zh800mk2Bvx5T2z5TRERg%2B2sKgizwmH3go%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:56.6745655","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad1a1126-4eea-4dd1-bf8d-a49ee5838e00_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A56Z&sr=b&sp=r&sig=AZyyiKqlbQgM05Iyr8m5Es%2BLnGsJYEyvZanJE0RHCv0%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:56.6745823","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/27eed4f9-721c-4dac-b098-2f44c86050a1/ad1a1126-4eea-4dd1-bf8d-a49ee5838e00_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A26%3A56Z&sr=b&sp=r&sig=65QcjAUDyVHzgPhbh0j2g4FkVCZ61%2BB767pNp2lPUXU%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T17:26:56.6745994","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
-        test run description","status":"FAILED","startDateTime":"2023-10-09T16:23:50.137Z","endDateTime":"2023-10-09T16:26:26.756Z","executedDateTime":"2023-10-09T16:23:48.756Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T16:23:49.746Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:26:54.332Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"221ac857-5bee-45f0-8cb4-2ebffcccff79":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ff2fb94a-507c-4ad1-89e5-8f5528a903bf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"96e99621-3d0b-47a2-8839-bcf040f609fb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"errorDetails":[{"message":"Processing
+        error logs, please refresh to check actionable errors."}],"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"testArtifacts":{"inputArtifacts":{"configFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/76946833-0849-4b7b-89cd-62d2e60daf57?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A20Z&sr=b&sp=r&sig=G%2BPosyqtXwQeye96YyEJVsbsW%2B4h0NtJmFl6n2C2xv8%3D","fileName":"config.yaml","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:20.0987793","validationStatus":"VALIDATION_NOT_REQUIRED"},"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/6c73db6e-f7ac-4ba6-9ad0-c9a078fa988f?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A20Z&sr=b&sp=r&sig=dqoKGLmf9HEdyhy3d%2BfyAQ%2BrisgnoBweBThtzNKhgks%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:31:20.0987013","validationStatus":"VALIDATION_SUCCESS"},"inputArtifactsZipFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/849fd833-accf-432e-8736-4770c62dc0a3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A20Z&sr=b&sp=r&sig=gsRsZurAW67bEPJzON5mfduPxqhxlRCOzswmqCRZGas%3D","fileName":"inputartifacts.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:20.0987939","validationStatus":"VALIDATION_NOT_REQUIRED"},"additionalFileInfo":[]},"outputArtifacts":{"resultFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/3ee3ba5e-37d3-4452-83cf-f393a6743f15_results.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A20Z&sr=b&sp=r&sig=oeQJbF09cJUqeuQC3b0s1hG9wJOp8Njc1B%2B9NF1UqoY%3D","fileName":"csv.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:20.0988075","validationStatus":"VALIDATION_NOT_REQUIRED"},"logsFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6c5683d1-51dd-492e-abc1-14cc470e814d/3ee3ba5e-37d3-4452-83cf-f393a6743f15_logs.zip?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A31%3A20Z&sr=b&sp=r&sig=XUy7Cp2nsZXqasRASrocogli6TEb3q2C9H%2BeRHAHu38%3D","fileName":"logs.zip","fileType":"ADDITIONAL_ARTIFACTS","expireDateTime":"2023-10-09T20:31:20.0988217","validationStatus":"VALIDATION_NOT_REQUIRED"}}},"testResult":"NOT_APPLICABLE","testRunId":"update-test-run-case","displayName":"update-test-run-case","testId":"update-test-case","description":"Updated
+        test run description","status":"FAILED","startDateTime":"2023-10-09T19:28:12.736Z","endDateTime":"2023-10-09T19:30:51.916Z","executedDateTime":"2023-10-09T19:28:12.072Z","portalUrl":"https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport//resourceId/%2fsubscriptions%2f7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a%2fresourcegroups%2fclitest-load-000001%2fproviders%2fmicrosoft.loadtestservice%2floadtests%2fclitest-load-000002/testId/update-test-case/testRunId/update-test-run-case","createdDateTime":"2023-10-09T19:28:12.297Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:31:17.437Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '4540'
+      - '4543'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:26:56 GMT
+      - Mon, 09 Oct 2023 19:31:20 GMT
       mise-correlation-id:
-      - 66573033-9ab7-4db0-8713-636c30e30b80
+      - d7807ccf-3415-4759-9ec6-edcc07186be6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_server_metric.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_server_metric.yaml
@@ -18,7 +18,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-24T12:26:32.8244469Z","key2":"2023-10-24T12:26:32.8244469Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-24T12:26:32.8401041Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-24T12:26:32.8401041Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-24T12:26:32.6369492Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-29T22:19:23.3183570Z","key2":"2023-10-29T22:19:23.3183570Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-29T22:19:23.3183570Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-29T22:19:23.3183570Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-29T22:19:23.1308694Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:26:56 GMT
+      - Sun, 29 Oct 2023 22:19:45 GMT
       expires:
       - '-1'
       pragma:
@@ -60,18 +60,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:56.206785Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:56.206785Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:47.7529164Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:47.7529164Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:56 GMT
+      - Sun, 29 Oct 2023 22:19:46 GMT
       etag:
-      - '"d300e334-0000-0100-0000-6537b7d60000"'
+      - '"3c000024-0000-0100-0000-653eda490000"'
       expires:
       - '-1'
       pragma:
@@ -101,7 +101,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -114,9 +114,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:26:58 GMT
+      - Sun, 29 Oct 2023 22:19:47 GMT
       mise-correlation-id:
-      - ce0f9f1c-f71e-4c0d-9e20-ce42b93a9157
+      - 041a1b97-1f24-431a-9666-0f08603abc3f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -133,10 +133,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"5dd62580-c48d-45ba-bce1-00b1083b1464": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "9e316a14-c780-4e1e-a4ed-3e359b66bf81":
+      {"passFailMetrics": {"c6c2b638-fc20-494b-b09b-7e05a50694be": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "9698ab38-18cb-47ff-9677-243cea8858f6":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "2f8921d6-48a7-4421-b629-b9befca2c99d": {"aggregate": "avg", "clientMetric":
+      "50"}, "6f383e93-7197-45be-ab27-5ec15fac67a9": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -152,11 +152,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5dd62580-c48d-45ba-bce1-00b1083b1464":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9e316a14-c780-4e1e-a4ed-3e359b66bf81":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2f8921d6-48a7-4421-b629-b9befca2c99d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:26:58.883Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:58.883Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c6c2b638-fc20-494b-b09b-7e05a50694be":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9698ab38-18cb-47ff-9677-243cea8858f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6f383e93-7197-45be-ab27-5ec15fac67a9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:19:48.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:19:48.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -167,11 +167,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:58 GMT
+      - Sun, 29 Oct 2023 22:19:48 GMT
       location:
-      - https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+      - https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 69b0f0f8-e396-4d1c-9986-e01fd1f9bbc6
+      - 19071939-e3f9-433c-887e-2d89a172dba4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -191,7 +191,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
+    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -205,9 +205,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:59 GMT
+      - Sun, 29 Oct 2023 22:19:48 GMT
       mise-correlation-id:
-      - 56edca10-a17f-4297-9978-7234b6f04b6f
+      - b845f36c-81b7-4daf-a1b6-ee96b7bb175a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -321,25 +321,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/529f058f-3198-404f-8582-fc4fe6d3b00a/b17fbc46-72c2-4140-aeba-0a1b56767408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A59Z&sr=b&sp=r&sig=dwUQU2xRezkLQryDPehHkXR%2FLi9u%2BPU62%2BHttqH58Mw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:59.6470678","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af307327-21e9-4241-a638-e798490ba0a8/fc3ad9eb-be65-459f-a519-0f8a15c622c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A49Z&sr=b&sp=r&sig=afpuagoBgcVFVo6OpJyas7fLdaFv8vlI5PJ7jMCmgzo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:49.9124807","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:59 GMT
+      - Sun, 29 Oct 2023 22:19:49 GMT
       location:
-      - https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 21e56721-3842-4c80-918e-53df77e76e62
+      - 5ab5befc-b3d2-40cf-a54d-6cfe432d9987
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -359,10 +359,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/529f058f-3198-404f-8582-fc4fe6d3b00a/b17fbc46-72c2-4140-aeba-0a1b56767408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A59Z&sr=b&sp=r&sig=%2BiB7EdxP1uDWGjtWKgORIAIki672GEaUDdoW7Osy9NA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:59.9359393","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af307327-21e9-4241-a638-e798490ba0a8/fc3ad9eb-be65-459f-a519-0f8a15c622c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A50Z&sr=b&sp=r&sig=pG%2FZwJw8sWTTzvnGj2IcvW6Abd%2ByTFJGM1x%2Fgi6Bc7s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:50.1463152","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '555'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:19:50 GMT
+      mise-correlation-id:
+      - 9a031458-7123-4b4b-9de7-23a7b2e23660
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af307327-21e9-4241-a638-e798490ba0a8/fc3ad9eb-be65-459f-a519-0f8a15c622c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A55Z&sr=b&sp=r&sig=yNJp9%2F0YFJ8N7xPqrY0XYSczpMwQU72KzF1dsx6hFuM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:55.4482526","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -373,9 +409,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:26:59 GMT
+      - Sun, 29 Oct 2023 22:19:55 GMT
       mise-correlation-id:
-      - 8bfc3a33-92c8-4ec9-84cf-282c67c11494
+      - ed5744fc-3556-4a8d-83f4-ab9719f06199
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -395,10 +431,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/529f058f-3198-404f-8582-fc4fe6d3b00a/b17fbc46-72c2-4140-aeba-0a1b56767408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A05Z&sr=b&sp=r&sig=0R%2FrynlcaJy%2FtXR43WGfTonJxb1TI5lzSFUc0htAKA4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:05.2557909","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af307327-21e9-4241-a638-e798490ba0a8/fc3ad9eb-be65-459f-a519-0f8a15c622c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A00Z&sr=b&sp=r&sig=zO7XeIzOmIXIqdG4UOf%2F38kDhbJZrhcjE8y7flZ1KUI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:00.7616632","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:20:00 GMT
+      mise-correlation-id:
+      - 7d8d49aa-5631-40d4-b595-914a67a211c0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af307327-21e9-4241-a638-e798490ba0a8/fc3ad9eb-be65-459f-a519-0f8a15c622c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A06Z&sr=b&sp=r&sig=NtbDikEP%2F1WLf0nETBb1U%2Fsj%2Fg9nQdtZrz2VQGAgPFY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:06.0616051","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -409,9 +481,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:05 GMT
+      - Sun, 29 Oct 2023 22:20:06 GMT
       mise-correlation-id:
-      - ca795ae0-0342-4145-b2e3-306b0af06f7f
+      - e4708fea-5b6d-4503-856c-cfb64dd88665
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -431,83 +503,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/529f058f-3198-404f-8582-fc4fe6d3b00a/b17fbc46-72c2-4140-aeba-0a1b56767408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A10Z&sr=b&sp=r&sig=oYJjSjNdtASJimpeUiFz61idExUQQZ1n2J3ISEThR3g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:10.5606776","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:27:10 GMT
-      mise-correlation-id:
-      - b7c7f9b3-482c-434d-959d-af93feecff86
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/529f058f-3198-404f-8582-fc4fe6d3b00a/b17fbc46-72c2-4140-aeba-0a1b56767408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A15Z&sr=b&sp=r&sig=%2Fv07J8BA%2BtjLMOCtj97qf0Fx8Jz%2F87Ro2fJg%2FvBqYvE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:15.83834","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:27:15 GMT
-      mise-correlation-id:
-      - f2c949e1-6cef-4039-b737-c3688de61fe3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"5dd62580-c48d-45ba-bce1-00b1083b1464":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9e316a14-c780-4e1e-a4ed-3e359b66bf81":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2f8921d6-48a7-4421-b629-b9befca2c99d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/529f058f-3198-404f-8582-fc4fe6d3b00a/b17fbc46-72c2-4140-aeba-0a1b56767408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A27%3A16Z&sr=b&sp=r&sig=1z7LOIs6Eeko12%2FNj4XyAeOD9xvjyYhvFdpR3VvPeTk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:27:16.0833247","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:26:58.883Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:12.359Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c6c2b638-fc20-494b-b09b-7e05a50694be":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9698ab38-18cb-47ff-9677-243cea8858f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6f383e93-7197-45be-ab27-5ec15fac67a9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af307327-21e9-4241-a638-e798490ba0a8/fc3ad9eb-be65-459f-a519-0f8a15c622c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A20%3A06Z&sr=b&sp=r&sig=tiOFYEjxKx4145jHpRRmLzrZXKaGiVG3Z9BLDWx%2BiaA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:20:06.2881387","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:19:48.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:03.878Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -518,9 +518,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:16 GMT
+      - Sun, 29 Oct 2023 22:20:06 GMT
       mise-correlation-id:
-      - a42c9e93-5f77-4c6f-b622-83f5d99319d5
+      - c1f92455-53ab-467e-aa3c-980098ca2e3d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -543,18 +543,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:56.206785Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:56.206785Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:47.7529164Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:47.7529164Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:16 GMT
+      - Sun, 29 Oct 2023 22:20:06 GMT
       etag:
-      - '"d300e334-0000-0100-0000-6537b7d60000"'
+      - '"3c000024-0000-0100-0000-653eda490000"'
       expires:
       - '-1'
       pragma:
@@ -584,24 +584,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"5dd62580-c48d-45ba-bce1-00b1083b1464":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9e316a14-c780-4e1e-a4ed-3e359b66bf81":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2f8921d6-48a7-4421-b629-b9befca2c99d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/529f058f-3198-404f-8582-fc4fe6d3b00a/b17fbc46-72c2-4140-aeba-0a1b56767408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A27%3A18Z&sr=b&sp=r&sig=ls4jF0ypq96gYKR7ZHJtmtQF8NREkC03X7C%2F8ZnpfYQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:27:18.2042364","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:26:58.883Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:12.359Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"c6c2b638-fc20-494b-b09b-7e05a50694be":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9698ab38-18cb-47ff-9677-243cea8858f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6f383e93-7197-45be-ab27-5ec15fac67a9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af307327-21e9-4241-a638-e798490ba0a8/fc3ad9eb-be65-459f-a519-0f8a15c622c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A20%3A07Z&sr=b&sp=r&sig=oF9QiCug2pYLa1cAVH7SJm9KP8wkkb3k4JHLKGzJtO4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:20:07.7429559","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:19:48.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:03.878Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1598'
+      - '1596'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:18 GMT
+      - Sun, 29 Oct 2023 22:20:07 GMT
       mise-correlation-id:
-      - 5cd9129d-ff07-451d-a544-cee345308b2e
+      - bc96bb7b-2747-4767-9e1c-0f7b3c39bded
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -624,18 +624,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:56.206785Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:56.206785Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:47.7529164Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:47.7529164Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:18 GMT
+      - Sun, 29 Oct 2023 22:20:08 GMT
       etag:
-      - '"d300e334-0000-0100-0000-6537b7d60000"'
+      - '"3c000024-0000-0100-0000-653eda490000"'
       expires:
       - '-1'
       pragma:
@@ -654,9 +654,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-mjtieyonooy3xpjks/providers/Microsoft.Storage/storageAccounts/clitestloadpwy3mvml3":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-mjtieyonooy3xpjks/providers/Microsoft.Storage/storageAccounts/clitestloadpwy3mvml3",
-      "resourceName": "clitestloadpwy3mvml3", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testId": "server-metric-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-4n7xydiao4wylowfx/providers/Microsoft.Storage/storageAccounts/clitestloadv65xpnbee":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-4n7xydiao4wylowfx/providers/Microsoft.Storage/storageAccounts/clitestloadv65xpnbee",
+      "resourceName": "clitestloadv65xpnbee", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -672,10 +672,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-24T12:27:19.805Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:19.805Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-29T22:20:09.983Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:09.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -686,11 +686,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:19 GMT
+      - Sun, 29 Oct 2023 22:20:10 GMT
       location:
-      - https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+      - https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - 80442249-dcc9-491c-bd55-aac21d17c658
+      - 4b7be999-b5be-483d-ad54-4a9fa70709bb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -713,18 +713,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:56.206785Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:56.206785Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:47.7529164Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:47.7529164Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:21 GMT
+      - Sun, 29 Oct 2023 22:20:11 GMT
       etag:
-      - '"d300e334-0000-0100-0000-6537b7d60000"'
+      - '"3c000024-0000-0100-0000-653eda490000"'
       expires:
       - '-1'
       pragma:
@@ -754,10 +754,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-24T12:27:19.805Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:19.805Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-29T22:20:09.983Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:09.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -768,9 +768,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:22 GMT
+      - Sun, 29 Oct 2023 22:20:12 GMT
       mise-correlation-id:
-      - 9d8b6e02-d313-43b9-b4e1-72d6798d1a0f
+      - 5779c894-99b5-4e26-954c-6108678e0077
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -793,18 +793,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:56.206785Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:56.206785Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:47.7529164Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:47.7529164Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:22 GMT
+      - Sun, 29 Oct 2023 22:20:12 GMT
       etag:
-      - '"d300e334-0000-0100-0000-6537b7d60000"'
+      - '"3c000024-0000-0100-0000-653eda490000"'
       expires:
       - '-1'
       pragma:
@@ -823,9 +823,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-mjtieyonooy3xpjks/providers/Microsoft.Storage/storageAccounts/clitestloadpwy3mvml3/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-4n7xydiao4wylowfx/providers/Microsoft.Storage/storageAccounts/clitestloadv65xpnbee/providers/microsoft.insights/metricdefinitions/Availability":
       {"name": " Availability", "metricNamespace": "microsoft.storage/storageaccounts",
-      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-mjtieyonooy3xpjks/providers/Microsoft.Storage/storageAccounts/clitestloadpwy3mvml3",
+      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-4n7xydiao4wylowfx/providers/Microsoft.Storage/storageAccounts/clitestloadv65xpnbee",
       "resourceType": "Microsoft.Storage/storageAccounts"}}}'
     headers:
       Accept:
@@ -841,25 +841,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-24T12:27:19.835Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:23.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-29T22:20:10.022Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:14.59Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3235'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:23 GMT
+      - Sun, 29 Oct 2023 22:20:14 GMT
       mise-correlation-id:
-      - e6f1a824-0618-47e0-968d-213588d4c11b
+      - 03d38646-2ecd-4870-9a20-609a2f6c5b89
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -882,18 +882,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:56.206785Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:56.206785Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:47.7529164Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:47.7529164Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:25 GMT
+      - Sun, 29 Oct 2023 22:20:15 GMT
       etag:
-      - '"d300e334-0000-0100-0000-6537b7d60000"'
+      - '"3c000024-0000-0100-0000-653eda490000"'
       expires:
       - '-1'
       pragma:
@@ -923,25 +923,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-24T12:27:19.835Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:23.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-29T22:20:10.022Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:14.59Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3235'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:26 GMT
+      - Sun, 29 Oct 2023 22:20:16 GMT
       mise-correlation-id:
-      - be160bb3-07a0-4299-b087-c00bcab6010d
+      - 0de84a9b-23c2-4932-bd23-dc4f34f30d03
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -964,18 +964,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:56.206785Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:56.206785Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:47.7529164Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:47.7529164Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:26 GMT
+      - Sun, 29 Oct 2023 22:20:17 GMT
       etag:
-      - '"d300e334-0000-0100-0000-6537b7d60000"'
+      - '"3c000024-0000-0100-0000-653eda490000"'
       expires:
       - '-1'
       pragma:
@@ -994,7 +994,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-mjtieyonooy3xpjks/providers/Microsoft.Storage/storageAccounts/clitestloadpwy3mvml3/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-4n7xydiao4wylowfx/providers/Microsoft.Storage/storageAccounts/clitestloadv65xpnbee/providers/microsoft.insights/metricdefinitions/Availability":
       null}}'
     headers:
       Accept:
@@ -1010,23 +1010,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-24T12:27:19.835Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:27.826Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-29T22:20:10.022Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:19.43Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2489'
+      - '2488'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:27 GMT
+      - Sun, 29 Oct 2023 22:20:19 GMT
       mise-correlation-id:
-      - 8c2e80fc-c27e-4af2-935e-0b4e64b69fa6
+      - 9c7a1a3a-01ba-4b6e-9c2c-ae0294f10033
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1049,18 +1049,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:56.206785Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:56.206785Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:47.7529164Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:47.7529164Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:28 GMT
+      - Sun, 29 Oct 2023 22:20:21 GMT
       etag:
-      - '"d300e334-0000-0100-0000-6537b7d60000"'
+      - '"3c000024-0000-0100-0000-653eda490000"'
       expires:
       - '-1'
       pragma:
@@ -1090,23 +1090,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-24T12:27:19.835Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:27.826Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-29T22:20:10.022Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:19.43Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2489'
+      - '2488'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:29 GMT
+      - Sun, 29 Oct 2023 22:20:22 GMT
       mise-correlation-id:
-      - 02fb31e1-dd39-42f3-8288-29945ff2b3fd
+      - 0554c60d-b7d2-467d-870b-773987384354
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_server_metric.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_server_metric.yaml
@@ -13,12 +13,12 @@ interactions:
       ParameterSetName:
       - --name --resource-group
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-09T19:16:40.6491179Z","key2":"2023-10-09T19:16:40.6491179Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T19:16:40.6647645Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T19:16:40.6647645Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-09T19:16:40.4616170Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-13T13:49:46.2136108Z","key2":"2023-10-13T13:49:46.2136108Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-13T13:49:46.2292092Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-13T13:49:46.2292092Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-13T13:49:46.0417062Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:17:02 GMT
+      - Fri, 13 Oct 2023 13:50:07 GMT
       expires:
       - '-1'
       pragma:
@@ -60,7 +60,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:03.8559563Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:03.8559563Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:07.4361601Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:07.4361601Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -69,9 +69,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:04 GMT
+      - Fri, 13 Oct 2023 13:50:09 GMT
       etag:
-      - '"550015c7-0000-0100-0000-652451750000"'
+      - '"d80186ba-0000-0100-0000-65294ad70000"'
       expires:
       - '-1'
       pragma:
@@ -99,9 +99,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -114,9 +114,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:17:05 GMT
+      - Fri, 13 Oct 2023 13:50:10 GMT
       mise-correlation-id:
-      - 92b883e9-2304-4cad-862a-a62ce8d96a18
+      - 2f1f4940-4432-449a-ae72-8e4371633533
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -133,10 +133,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"230b3d9b-03f7-4242-8820-9036003f09e1": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "542cecdf-9a03-4008-8bf3-fc166fa76d17":
+      {"passFailMetrics": {"6d5afa4d-3a62-459f-a5bb-2829dcc806c1": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "c980f503-1948-49f6-b6b5-ee12f32f08c1":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "2434475b-6162-472e-b2c4-0bb94171f981": {"aggregate": "avg", "clientMetric":
+      "50"}, "f5889ca3-5ca7-4764-9d56-3387be193907": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -150,13 +150,13 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"230b3d9b-03f7-4242-8820-9036003f09e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"542cecdf-9a03-4008-8bf3-fc166fa76d17":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2434475b-6162-472e-b2c4-0bb94171f981":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:17:06.257Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:06.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6d5afa4d-3a62-459f-a5bb-2829dcc806c1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c980f503-1948-49f6-b6b5-ee12f32f08c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5889ca3-5ca7-4764-9d56-3387be193907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:50:11.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:11.108Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -167,11 +167,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:06 GMT
+      - Fri, 13 Oct 2023 13:50:11 GMT
       location:
-      - https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+      - https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 62ec8db8-94ca-4a96-afc6-ef1464019619
+      - a6e4c99c-8206-49b6-a6a0-d0f77ca5316a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -189,9 +189,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
+    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -205,9 +205,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:06 GMT
+      - Fri, 13 Oct 2023 13:50:11 GMT
       mise-correlation-id:
-      - ee29531e-9210-4f7e-9469-a3f2bf5ec408
+      - 508fa0e8-36f6-4fc7-987c-5ec9fb9522e4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -319,27 +319,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/89f816c6-7d99-40de-9c3d-dc658f4c4f3e/a5d0bd19-4814-411e-8960-b272c4f82cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A07Z&sr=b&sp=r&sig=8MSMh9DzKMVDNGRfFpB7NDZTP%2BuW4Ne1nISHEZ4wKgo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:07.8115413","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0556f433-e59a-4717-9251-def8a251f77a/214cd7e1-8950-4701-89f4-a16a1707ab21?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A12Z&sr=b&sp=r&sig=g4eMTu2oTQj3KgMvc2eCpWgUCsWuPp3A8nIQgX3tPEw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:12.7014138","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:07 GMT
+      - Fri, 13 Oct 2023 13:50:12 GMT
       location:
-      - https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 611d909d-92ac-45f8-8bcf-670f13abd68d
+      - eebdd1b1-2a13-4b82-8ca9-cf6750b2d76a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -357,12 +357,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/89f816c6-7d99-40de-9c3d-dc658f4c4f3e/a5d0bd19-4814-411e-8960-b272c4f82cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A08Z&sr=b&sp=r&sig=LVDasA06E3dOt3lqN7oh8%2BCKSpBulqRb3EYwcshczZ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:08.1011765","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0556f433-e59a-4717-9251-def8a251f77a/214cd7e1-8950-4701-89f4-a16a1707ab21?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A12Z&sr=b&sp=r&sig=kXmg02EEIQUAsYWIiKELdGdn89g9oFTROhKe%2BOvtrys%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:12.9934915","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -373,9 +373,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:08 GMT
+      - Fri, 13 Oct 2023 13:50:12 GMT
       mise-correlation-id:
-      - bef921a8-cfd6-4684-867b-3267db3ccccd
+      - 544ecde5-04aa-4064-82a9-e6e0e15bbddf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -393,25 +393,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/89f816c6-7d99-40de-9c3d-dc658f4c4f3e/a5d0bd19-4814-411e-8960-b272c4f82cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A13Z&sr=b&sp=r&sig=mfTXw31y5O%2Bb9IjSv43eEGmZT%2Bmro87pdF4UZn4AQNI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:13.950551","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0556f433-e59a-4717-9251-def8a251f77a/214cd7e1-8950-4701-89f4-a16a1707ab21?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A18Z&sr=b&sp=r&sig=LDuEtQbRkWCFRvfLKa0O9m%2BFFNblUsBocI7u4W2Y%2BtY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:18.2481207","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '552'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:13 GMT
+      - Fri, 13 Oct 2023 13:50:18 GMT
       mise-correlation-id:
-      - 5ed3e8c9-556b-4919-9b14-aa37767f0c75
+      - e09d5a60-6be2-401d-a57d-f3e430115bf0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -429,12 +429,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/89f816c6-7d99-40de-9c3d-dc658f4c4f3e/a5d0bd19-4814-411e-8960-b272c4f82cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A19Z&sr=b&sp=r&sig=AJ1%2BBWM6MgWyxvPItVt0CaESaS8xfHeSkc8DrTvQKMA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:19.2508913","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0556f433-e59a-4717-9251-def8a251f77a/214cd7e1-8950-4701-89f4-a16a1707ab21?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A23Z&sr=b&sp=r&sig=9T5GytMoRAJuPHuL4fo52eI%2BX5uC7q4z507oKFf2BHA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:23.5078428","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -445,9 +445,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:19 GMT
+      - Fri, 13 Oct 2023 13:50:23 GMT
       mise-correlation-id:
-      - ab402c5a-3f32-4c48-b01a-e72c75b45038
+      - 04f87121-fd72-4d40-944b-1eced49258da
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -465,25 +465,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/89f816c6-7d99-40de-9c3d-dc658f4c4f3e/a5d0bd19-4814-411e-8960-b272c4f82cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A24Z&sr=b&sp=r&sig=61tD5F6ZATPiS%2FpaG%2FEtKtQ0LsA8gzPt3WczGLK7P5g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:24.576677","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0556f433-e59a-4717-9251-def8a251f77a/214cd7e1-8950-4701-89f4-a16a1707ab21?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A28Z&sr=b&sp=r&sig=pLfYnY86iMIvCx0nC9iuojEK%2BqevN4931KGB4u33EC8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:28.7639201","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:24 GMT
+      - Fri, 13 Oct 2023 13:50:28 GMT
       mise-correlation-id:
-      - d87c44fe-ed01-4da9-ba95-5083d1da52fd
+      - 0028bd48-9a15-42fd-aada-1d1f30bc831f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -501,26 +501,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"230b3d9b-03f7-4242-8820-9036003f09e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"542cecdf-9a03-4008-8bf3-fc166fa76d17":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2434475b-6162-472e-b2c4-0bb94171f981":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/89f816c6-7d99-40de-9c3d-dc658f4c4f3e/a5d0bd19-4814-411e-8960-b272c4f82cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A17%3A24Z&sr=b&sp=r&sig=MMVnZSL%2FV5ptAyLRM7x8oQIZoFnxYJbAcI4r%2FoFl4LE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:17:24.8291934","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:17:06.257Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:19.836Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6d5afa4d-3a62-459f-a5bb-2829dcc806c1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c980f503-1948-49f6-b6b5-ee12f32f08c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5889ca3-5ca7-4764-9d56-3387be193907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0556f433-e59a-4717-9251-def8a251f77a/214cd7e1-8950-4701-89f4-a16a1707ab21?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A50%3A29Z&sr=b&sp=r&sig=hZUxvzh1VTFo2jhdSO6nkaU7KihlIb%2BPqKM9hixkyOI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:50:29.0713954","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:50:11.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:25.795Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1588'
+      - '1586'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:24 GMT
+      - Fri, 13 Oct 2023 13:50:29 GMT
       mise-correlation-id:
-      - cd96e8bc-2eda-4ac3-848d-fd786f6f66e5
+      - b6bda32d-c5ac-4de2-9e5a-9b56909252d9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -543,7 +543,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:03.8559563Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:03.8559563Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:07.4361601Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:07.4361601Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -552,9 +552,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:25 GMT
+      - Fri, 13 Oct 2023 13:50:30 GMT
       etag:
-      - '"550015c7-0000-0100-0000-652451750000"'
+      - '"d80186ba-0000-0100-0000-65294ad70000"'
       expires:
       - '-1'
       pragma:
@@ -582,13 +582,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"230b3d9b-03f7-4242-8820-9036003f09e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"542cecdf-9a03-4008-8bf3-fc166fa76d17":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2434475b-6162-472e-b2c4-0bb94171f981":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/89f816c6-7d99-40de-9c3d-dc658f4c4f3e/a5d0bd19-4814-411e-8960-b272c4f82cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A17%3A26Z&sr=b&sp=r&sig=yHp%2FA4iECeRgCdOKzI%2BGpC2hZ6Cww767Btckbc6nizg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:17:26.6334413","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:17:06.257Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:19.836Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"6d5afa4d-3a62-459f-a5bb-2829dcc806c1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c980f503-1948-49f6-b6b5-ee12f32f08c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5889ca3-5ca7-4764-9d56-3387be193907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0556f433-e59a-4717-9251-def8a251f77a/214cd7e1-8950-4701-89f4-a16a1707ab21?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A50%3A31Z&sr=b&sp=r&sig=W2l4OAso27zus%2BHdI5Hs%2B2x8JW1zNn9Va37QfHqpuqw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:50:31.6775357","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:50:11.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:25.795Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -599,9 +599,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:26 GMT
+      - Fri, 13 Oct 2023 13:50:31 GMT
       mise-correlation-id:
-      - b9bf4a0a-e75c-4d4b-b212-8e7a4da8f302
+      - f277be4b-1970-4013-bfb9-1cef9c743071
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -624,7 +624,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:03.8559563Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:03.8559563Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:07.4361601Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:07.4361601Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -633,9 +633,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:27 GMT
+      - Fri, 13 Oct 2023 13:50:32 GMT
       etag:
-      - '"550015c7-0000-0100-0000-652451750000"'
+      - '"d80186ba-0000-0100-0000-65294ad70000"'
       expires:
       - '-1'
       pragma:
@@ -654,9 +654,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-bqulgotcoeopvcxgz/providers/Microsoft.Storage/storageAccounts/clitestloadmtphbbmgg":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-bqulgotcoeopvcxgz/providers/Microsoft.Storage/storageAccounts/clitestloadmtphbbmgg",
-      "resourceName": "clitestloadmtphbbmgg", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testId": "server-metric-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-wx2jlwejr6cjmyjo7/providers/Microsoft.Storage/storageAccounts/clitestloadmzatmovx2":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-wx2jlwejr6cjmyjo7/providers/Microsoft.Storage/storageAccounts/clitestloadmzatmovx2",
+      "resourceName": "clitestloadmzatmovx2", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -670,12 +670,12 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-09T19:17:29.196Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:29.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-13T13:50:34.526Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:34.526Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -686,11 +686,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:29 GMT
+      - Fri, 13 Oct 2023 13:50:34 GMT
       location:
-      - https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+      - https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - 37e10461-66c5-4907-9779-77fddea23534
+      - 2be23363-cebe-4aa7-8ab4-c7a37b7d9b8e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -713,7 +713,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:03.8559563Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:03.8559563Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:07.4361601Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:07.4361601Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -722,9 +722,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:30 GMT
+      - Fri, 13 Oct 2023 13:50:34 GMT
       etag:
-      - '"550015c7-0000-0100-0000-652451750000"'
+      - '"d80186ba-0000-0100-0000-65294ad70000"'
       expires:
       - '-1'
       pragma:
@@ -752,12 +752,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-09T19:17:29.196Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:29.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-13T13:50:34.526Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:34.526Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -768,9 +768,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:30 GMT
+      - Fri, 13 Oct 2023 13:50:36 GMT
       mise-correlation-id:
-      - 600dfb34-2057-418b-8b92-f072b49842bb
+      - 0fcc83d5-4a0d-4cfc-a178-0a3227e8874f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -793,7 +793,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:03.8559563Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:03.8559563Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:07.4361601Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:07.4361601Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -802,9 +802,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:31 GMT
+      - Fri, 13 Oct 2023 13:50:37 GMT
       etag:
-      - '"550015c7-0000-0100-0000-652451750000"'
+      - '"d80186ba-0000-0100-0000-65294ad70000"'
       expires:
       - '-1'
       pragma:
@@ -823,9 +823,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-bqulgotcoeopvcxgz/providers/Microsoft.Storage/storageAccounts/clitestloadmtphbbmgg/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-wx2jlwejr6cjmyjo7/providers/Microsoft.Storage/storageAccounts/clitestloadmzatmovx2/providers/microsoft.insights/metricdefinitions/Availability":
       {"name": " Availability", "metricNamespace": "microsoft.storage/storageaccounts",
-      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-bqulgotcoeopvcxgz/providers/Microsoft.Storage/storageAccounts/clitestloadmtphbbmgg",
+      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-wx2jlwejr6cjmyjo7/providers/Microsoft.Storage/storageAccounts/clitestloadmzatmovx2",
       "resourceType": "Microsoft.Storage/storageAccounts"}}}'
     headers:
       Accept:
@@ -839,27 +839,27 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T19:17:29.277Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:32.787Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-13T13:50:34.608Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:39.22Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3235'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:32 GMT
+      - Fri, 13 Oct 2023 13:50:39 GMT
       mise-correlation-id:
-      - 6abba85b-673b-4439-bba2-adba083ddc97
+      - 4ba3c1e4-082f-49c1-ac86-3d3ce23edbac
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -882,7 +882,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:03.8559563Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:03.8559563Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:07.4361601Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:07.4361601Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -891,9 +891,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:34 GMT
+      - Fri, 13 Oct 2023 13:50:39 GMT
       etag:
-      - '"550015c7-0000-0100-0000-652451750000"'
+      - '"d80186ba-0000-0100-0000-65294ad70000"'
       expires:
       - '-1'
       pragma:
@@ -921,27 +921,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T19:17:29.277Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:32.787Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-13T13:50:34.608Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:39.22Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3235'
+      - '3234'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:35 GMT
+      - Fri, 13 Oct 2023 13:50:41 GMT
       mise-correlation-id:
-      - 1eb1497d-2c74-40b8-98f1-4d2cd3fa5fc3
+      - 89385ac7-1fa6-47e9-b988-a4ab6b0b0fa0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -964,7 +964,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:03.8559563Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:03.8559563Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:07.4361601Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:07.4361601Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -973,9 +973,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:36 GMT
+      - Fri, 13 Oct 2023 13:50:41 GMT
       etag:
-      - '"550015c7-0000-0100-0000-652451750000"'
+      - '"d80186ba-0000-0100-0000-65294ad70000"'
       expires:
       - '-1'
       pragma:
@@ -994,7 +994,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-bqulgotcoeopvcxgz/providers/Microsoft.Storage/storageAccounts/clitestloadmtphbbmgg/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-wx2jlwejr6cjmyjo7/providers/Microsoft.Storage/storageAccounts/clitestloadmzatmovx2/providers/microsoft.insights/metricdefinitions/Availability":
       null}}'
     headers:
       Accept:
@@ -1008,12 +1008,12 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T19:17:29.277Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:37.603Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-13T13:50:34.608Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:43.291Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1024,9 +1024,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:37 GMT
+      - Fri, 13 Oct 2023 13:50:43 GMT
       mise-correlation-id:
-      - 3d58a151-00a0-4383-a8de-d8b6a2570543
+      - fb306dcd-c06c-4665-8770-ac8e4c5b9788
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1049,7 +1049,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:03.8559563Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:03.8559563Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:07.4361601Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:07.4361601Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1058,9 +1058,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:38 GMT
+      - Fri, 13 Oct 2023 13:50:44 GMT
       etag:
-      - '"550015c7-0000-0100-0000-652451750000"'
+      - '"d80186ba-0000-0100-0000-65294ad70000"'
       expires:
       - '-1'
       pragma:
@@ -1088,12 +1088,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T19:17:29.277Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:37.603Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-13T13:50:34.608Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:43.291Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1104,9 +1104,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:39 GMT
+      - Fri, 13 Oct 2023 13:50:45 GMT
       mise-correlation-id:
-      - ccc0be01-b48e-4479-9b1b-7371e1036ce3
+      - 28d58dde-d357-4238-be18-ced1cd901a84
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_server_metric.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_server_metric.yaml
@@ -13,21 +13,21 @@ interactions:
       ParameterSetName:
       - --name --resource-group
       User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-azure-mgmt-storage/21.1.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2023-01-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-29T22:19:23.3183570Z","key2":"2023-10-29T22:19:23.3183570Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-29T22:19:23.3183570Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-29T22:19:23.3183570Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-29T22:19:23.1308694Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-30T07:19:10.8445155Z","key2":"2023-10-30T07:19:10.8445155Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-30T07:19:10.8601407Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-30T07:19:10.8601407Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-30T07:19:10.6257676Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1297'
+      - '1312'
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:19:45 GMT
+      - Mon, 30 Oct 2023 07:19:34 GMT
       expires:
       - '-1'
       pragma:
@@ -60,7 +60,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:47.7529164Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:47.7529164Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:34.9417917Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:34.9417917Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -69,9 +69,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:46 GMT
+      - Mon, 30 Oct 2023 07:19:36 GMT
       etag:
-      - '"3c000024-0000-0100-0000-653eda490000"'
+      - '"3f001d67-0000-0100-0000-653f58cc0000"'
       expires:
       - '-1'
       pragma:
@@ -101,7 +101,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -114,9 +114,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:19:47 GMT
+      - Mon, 30 Oct 2023 07:19:37 GMT
       mise-correlation-id:
-      - 041a1b97-1f24-431a-9666-0f08603abc3f
+      - fe87885c-3932-4026-815c-e998f3f6d4b7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -133,10 +133,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"c6c2b638-fc20-494b-b09b-7e05a50694be": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "9698ab38-18cb-47ff-9677-243cea8858f6":
+      {"passFailMetrics": {"9a51a1c3-a09b-4e02-95c6-c4212879bfc3": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "926d7eac-4682-4820-aa9e-5b4eabb8c686":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "6f383e93-7197-45be-ab27-5ec15fac67a9": {"aggregate": "avg", "clientMetric":
+      "50"}, "8a24358e-a267-40d0-b37a-83e2ca2ec3f9": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -152,11 +152,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c6c2b638-fc20-494b-b09b-7e05a50694be":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9698ab38-18cb-47ff-9677-243cea8858f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6f383e93-7197-45be-ab27-5ec15fac67a9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:19:48.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:19:48.071Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9a51a1c3-a09b-4e02-95c6-c4212879bfc3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"926d7eac-4682-4820-aa9e-5b4eabb8c686":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8a24358e-a267-40d0-b37a-83e2ca2ec3f9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:19:38.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:19:38.037Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -167,11 +167,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:48 GMT
+      - Mon, 30 Oct 2023 07:19:38 GMT
       location:
-      - https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+      - https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 19071939-e3f9-433c-887e-2d89a172dba4
+      - b06d6790-c523-4ce6-a08c-c5001622c21a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -191,7 +191,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
+    uri: https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -205,9 +205,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:48 GMT
+      - Mon, 30 Oct 2023 07:19:38 GMT
       mise-correlation-id:
-      - b845f36c-81b7-4daf-a1b6-ee96b7bb175a
+      - 3d579410-9121-464e-81b8-98b50d6eb2af
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -321,10 +321,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af307327-21e9-4241-a638-e798490ba0a8/fc3ad9eb-be65-459f-a519-0f8a15c622c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A49Z&sr=b&sp=r&sig=afpuagoBgcVFVo6OpJyas7fLdaFv8vlI5PJ7jMCmgzo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:49.9124807","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d5ee1c02-b90f-4c84-a82d-a2f97daea3c9/3cad2672-031c-4afe-9ae1-7148d72d5f75?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A29%3A39Z&sr=b&sp=r&sig=NkSYzSUV2wVIfG1YvRnh5AyObBS7%2BBkaccFHINjWKtM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:29:39.94211","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -335,11 +335,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:49 GMT
+      - Mon, 30 Oct 2023 07:19:39 GMT
       location:
-      - https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 5ab5befc-b3d2-40cf-a54d-6cfe432d9987
+      - 258630af-dcef-4e5c-aad1-f6ccfc990cfe
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -359,23 +359,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af307327-21e9-4241-a638-e798490ba0a8/fc3ad9eb-be65-459f-a519-0f8a15c622c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A50Z&sr=b&sp=r&sig=pG%2FZwJw8sWTTzvnGj2IcvW6Abd%2ByTFJGM1x%2Fgi6Bc7s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:50.1463152","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d5ee1c02-b90f-4c84-a82d-a2f97daea3c9/3cad2672-031c-4afe-9ae1-7148d72d5f75?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A29%3A40Z&sr=b&sp=r&sig=D8XaCOuhUbTp2qmJFPmH09nHUe1gw1CH2ZXk0b2N6HA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:29:40.4681587","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:19:50 GMT
+      - Mon, 30 Oct 2023 07:19:40 GMT
       mise-correlation-id:
-      - 9a031458-7123-4b4b-9de7-23a7b2e23660
+      - 958c5c2c-f006-49e4-ad18-b4c320c01735
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -395,46 +395,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af307327-21e9-4241-a638-e798490ba0a8/fc3ad9eb-be65-459f-a519-0f8a15c622c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A29%3A55Z&sr=b&sp=r&sig=yNJp9%2F0YFJ8N7xPqrY0XYSczpMwQU72KzF1dsx6hFuM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:29:55.4482526","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:19:55 GMT
-      mise-correlation-id:
-      - ed5744fc-3556-4a8d-83f4-ab9719f06199
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af307327-21e9-4241-a638-e798490ba0a8/fc3ad9eb-be65-459f-a519-0f8a15c622c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A00Z&sr=b&sp=r&sig=zO7XeIzOmIXIqdG4UOf%2F38kDhbJZrhcjE8y7flZ1KUI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:00.7616632","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d5ee1c02-b90f-4c84-a82d-a2f97daea3c9/3cad2672-031c-4afe-9ae1-7148d72d5f75?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A29%3A45Z&sr=b&sp=r&sig=3cZg6%2Fu4Va8L6fu7ikD69RfJsjyQawD1o3c68qFAEVk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:29:45.7312802","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -445,9 +409,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:00 GMT
+      - Mon, 30 Oct 2023 07:19:45 GMT
       mise-correlation-id:
-      - 7d8d49aa-5631-40d4-b595-914a67a211c0
+      - e9a06e8e-826e-4081-a91c-71f760e4b0c1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -467,10 +431,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af307327-21e9-4241-a638-e798490ba0a8/fc3ad9eb-be65-459f-a519-0f8a15c622c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A06Z&sr=b&sp=r&sig=NtbDikEP%2F1WLf0nETBb1U%2Fsj%2Fg9nQdtZrz2VQGAgPFY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:06.0616051","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d5ee1c02-b90f-4c84-a82d-a2f97daea3c9/3cad2672-031c-4afe-9ae1-7148d72d5f75?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A29%3A51Z&sr=b&sp=r&sig=h%2BQVIeWuB9spIQYt0vrK4C%2Ba6pEbKaViAkHuu1DJjw8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:29:51.0581869","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -481,9 +445,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:06 GMT
+      - Mon, 30 Oct 2023 07:19:51 GMT
       mise-correlation-id:
-      - e4708fea-5b6d-4503-856c-cfb64dd88665
+      - 4f864eab-6939-4b88-97b6-74a5ad799a47
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -503,24 +467,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c6c2b638-fc20-494b-b09b-7e05a50694be":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9698ab38-18cb-47ff-9677-243cea8858f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6f383e93-7197-45be-ab27-5ec15fac67a9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af307327-21e9-4241-a638-e798490ba0a8/fc3ad9eb-be65-459f-a519-0f8a15c622c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A20%3A06Z&sr=b&sp=r&sig=tiOFYEjxKx4145jHpRRmLzrZXKaGiVG3Z9BLDWx%2BiaA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:20:06.2881387","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:19:48.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:03.878Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d5ee1c02-b90f-4c84-a82d-a2f97daea3c9/3cad2672-031c-4afe-9ae1-7148d72d5f75?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A29%3A56Z&sr=b&sp=r&sig=%2FFST9E3GLaY0gOBNWdF%2BVp1OGwKzySJr9QB4j9JOE%2Bg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:29:56.3117769","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1586'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:06 GMT
+      - Mon, 30 Oct 2023 07:19:56 GMT
       mise-correlation-id:
-      - c1f92455-53ab-467e-aa3c-980098ca2e3d
+      - d3e01999-3ba7-48c2-bf38-8355cebc4b55
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9a51a1c3-a09b-4e02-95c6-c4212879bfc3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"926d7eac-4682-4820-aa9e-5b4eabb8c686":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8a24358e-a267-40d0-b37a-83e2ca2ec3f9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d5ee1c02-b90f-4c84-a82d-a2f97daea3c9/3cad2672-031c-4afe-9ae1-7148d72d5f75?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A19%3A56Z&sr=b&sp=r&sig=as%2BzkRojRG1ldbKbYVu8ZiyUbnEcIIic97h41uc%2FVH0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:19:56.5871858","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:19:38.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:19:55.634Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1588'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:19:56 GMT
+      mise-correlation-id:
+      - a043bba1-a26c-497a-98ea-0e35733a327f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -543,7 +543,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:47.7529164Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:47.7529164Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:34.9417917Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:34.9417917Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -552,9 +552,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:06 GMT
+      - Mon, 30 Oct 2023 07:19:57 GMT
       etag:
-      - '"3c000024-0000-0100-0000-653eda490000"'
+      - '"3f001d67-0000-0100-0000-653f58cc0000"'
       expires:
       - '-1'
       pragma:
@@ -584,11 +584,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"c6c2b638-fc20-494b-b09b-7e05a50694be":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9698ab38-18cb-47ff-9677-243cea8858f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6f383e93-7197-45be-ab27-5ec15fac67a9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/af307327-21e9-4241-a638-e798490ba0a8/fc3ad9eb-be65-459f-a519-0f8a15c622c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A20%3A07Z&sr=b&sp=r&sig=oF9QiCug2pYLa1cAVH7SJm9KP8wkkb3k4JHLKGzJtO4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:20:07.7429559","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:19:48.071Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:03.878Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"9a51a1c3-a09b-4e02-95c6-c4212879bfc3":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"926d7eac-4682-4820-aa9e-5b4eabb8c686":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"8a24358e-a267-40d0-b37a-83e2ca2ec3f9":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d5ee1c02-b90f-4c84-a82d-a2f97daea3c9/3cad2672-031c-4afe-9ae1-7148d72d5f75?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A19%3A59Z&sr=b&sp=r&sig=wO0TNQKst6YqyWpjomJmh07SS6TDzFnCtbPChYz6Ho4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:19:59.2537936","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:19:38.037Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:19:55.634Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -599,9 +599,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:07 GMT
+      - Mon, 30 Oct 2023 07:19:59 GMT
       mise-correlation-id:
-      - bc96bb7b-2747-4767-9e1c-0f7b3c39bded
+      - 73e4f4af-6b67-46bf-93d6-647309f6d3f8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -624,7 +624,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:47.7529164Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:47.7529164Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:34.9417917Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:34.9417917Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -633,9 +633,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:08 GMT
+      - Mon, 30 Oct 2023 07:20:00 GMT
       etag:
-      - '"3c000024-0000-0100-0000-653eda490000"'
+      - '"3f001d67-0000-0100-0000-653f58cc0000"'
       expires:
       - '-1'
       pragma:
@@ -654,9 +654,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-4n7xydiao4wylowfx/providers/Microsoft.Storage/storageAccounts/clitestloadv65xpnbee":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-4n7xydiao4wylowfx/providers/Microsoft.Storage/storageAccounts/clitestloadv65xpnbee",
-      "resourceName": "clitestloadv65xpnbee", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testId": "server-metric-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ifyhlc6m4jydpmrrc/providers/Microsoft.Storage/storageAccounts/clitestloadmfosrzikm":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ifyhlc6m4jydpmrrc/providers/Microsoft.Storage/storageAccounts/clitestloadmfosrzikm",
+      "resourceName": "clitestloadmfosrzikm", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -672,10 +672,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+    uri: https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-29T22:20:09.983Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:09.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-30T07:20:01.913Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:20:01.913Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -686,11 +686,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:10 GMT
+      - Mon, 30 Oct 2023 07:20:01 GMT
       location:
-      - https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+      - https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - 4b7be999-b5be-483d-ad54-4a9fa70709bb
+      - 3ca63d54-0497-4322-81b8-96ae203f84ba
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -713,7 +713,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:47.7529164Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:47.7529164Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:34.9417917Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:34.9417917Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -722,9 +722,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:11 GMT
+      - Mon, 30 Oct 2023 07:20:02 GMT
       etag:
-      - '"3c000024-0000-0100-0000-653eda490000"'
+      - '"3f001d67-0000-0100-0000-653f58cc0000"'
       expires:
       - '-1'
       pragma:
@@ -754,10 +754,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+    uri: https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-29T22:20:09.983Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:09.983Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-30T07:20:01.913Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:20:01.913Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -768,9 +768,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:12 GMT
+      - Mon, 30 Oct 2023 07:20:04 GMT
       mise-correlation-id:
-      - 5779c894-99b5-4e26-954c-6108678e0077
+      - a164ac4b-439a-49bb-a40c-5aa13d5f06b3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -793,7 +793,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:47.7529164Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:47.7529164Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:34.9417917Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:34.9417917Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -802,9 +802,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:12 GMT
+      - Mon, 30 Oct 2023 07:20:05 GMT
       etag:
-      - '"3c000024-0000-0100-0000-653eda490000"'
+      - '"3f001d67-0000-0100-0000-653f58cc0000"'
       expires:
       - '-1'
       pragma:
@@ -823,9 +823,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-4n7xydiao4wylowfx/providers/Microsoft.Storage/storageAccounts/clitestloadv65xpnbee/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ifyhlc6m4jydpmrrc/providers/Microsoft.Storage/storageAccounts/clitestloadmfosrzikm/providers/microsoft.insights/metricdefinitions/Availability":
       {"name": " Availability", "metricNamespace": "microsoft.storage/storageaccounts",
-      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-4n7xydiao4wylowfx/providers/Microsoft.Storage/storageAccounts/clitestloadv65xpnbee",
+      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ifyhlc6m4jydpmrrc/providers/Microsoft.Storage/storageAccounts/clitestloadmfosrzikm",
       "resourceType": "Microsoft.Storage/storageAccounts"}}}'
     headers:
       Accept:
@@ -841,25 +841,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-29T22:20:10.022Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:14.59Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-30T07:20:01.944Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:20:06.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3234'
+      - '3235'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:14 GMT
+      - Mon, 30 Oct 2023 07:20:06 GMT
       mise-correlation-id:
-      - 03d38646-2ecd-4870-9a20-609a2f6c5b89
+      - c71732a1-885b-4cb0-a3cf-64cd2f0f2f46
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -882,7 +882,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:47.7529164Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:47.7529164Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:34.9417917Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:34.9417917Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -891,9 +891,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:15 GMT
+      - Mon, 30 Oct 2023 07:20:07 GMT
       etag:
-      - '"3c000024-0000-0100-0000-653eda490000"'
+      - '"3f001d67-0000-0100-0000-653f58cc0000"'
       expires:
       - '-1'
       pragma:
@@ -923,25 +923,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-29T22:20:10.022Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:14.59Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-30T07:20:01.944Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:20:06.536Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3234'
+      - '3235'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:16 GMT
+      - Mon, 30 Oct 2023 07:20:08 GMT
       mise-correlation-id:
-      - 0de84a9b-23c2-4932-bd23-dc4f34f30d03
+      - b35277fb-942c-4a86-bf3a-d7846cba5778
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -964,7 +964,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:47.7529164Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:47.7529164Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:34.9417917Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:34.9417917Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -973,9 +973,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:17 GMT
+      - Mon, 30 Oct 2023 07:20:09 GMT
       etag:
-      - '"3c000024-0000-0100-0000-653eda490000"'
+      - '"3f001d67-0000-0100-0000-653f58cc0000"'
       expires:
       - '-1'
       pragma:
@@ -994,7 +994,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-4n7xydiao4wylowfx/providers/Microsoft.Storage/storageAccounts/clitestloadv65xpnbee/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ifyhlc6m4jydpmrrc/providers/Microsoft.Storage/storageAccounts/clitestloadmfosrzikm/providers/microsoft.insights/metricdefinitions/Availability":
       null}}'
     headers:
       Accept:
@@ -1010,23 +1010,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-29T22:20:10.022Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:19.43Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-30T07:20:01.944Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:20:10.108Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2488'
+      - '2489'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:19 GMT
+      - Mon, 30 Oct 2023 07:20:10 GMT
       mise-correlation-id:
-      - 9c7a1a3a-01ba-4b6e-9c2c-ae0294f10033
+      - 19f376e9-cf80-43e9-a47f-504856fdf5f7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1049,7 +1049,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:18:47.7529164Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:18:47.7529164Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:18:34.9417917Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:18:34.9417917Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1058,9 +1058,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:21 GMT
+      - Mon, 30 Oct 2023 07:20:11 GMT
       etag:
-      - '"3c000024-0000-0100-0000-653eda490000"'
+      - '"3f001d67-0000-0100-0000-653f58cc0000"'
       expires:
       - '-1'
       pragma:
@@ -1090,23 +1090,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60cfcf6c-9429-403b-b4de-707126a0e1e3.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://0b0293eb-a818-4415-8486-f10fd0d48fb1.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-29T22:20:10.022Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:19.43Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-30T07:20:01.944Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:20:10.108Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '2488'
+      - '2489'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:22 GMT
+      - Mon, 30 Oct 2023 07:20:11 GMT
       mise-correlation-id:
-      - 0554c60d-b7d2-467d-870b-773987384354
+      - 9ca05597-fc15-4dfa-a269-9271d74df72d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_server_metric.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_server_metric.yaml
@@ -18,7 +18,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-07-12T20:10:15.0865198Z","key2":"2023-07-12T20:10:15.0865198Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-07-12T20:10:15.1021673Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-07-12T20:10:15.1021673Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-07-12T20:10:14.8990356Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-09T16:10:20.1224602Z","key2":"2023-10-09T16:10:20.1224602Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T16:10:20.1380859Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T16:10:20.1380859Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-09T16:10:19.9349608Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:10:36 GMT
+      - Mon, 09 Oct 2023 16:10:41 GMT
       expires:
       - '-1'
       pragma:
@@ -60,7 +60,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:09:36.8297556Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:09:36.8297556Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:44.6045964Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:44.6045964Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -69,9 +69,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:38 GMT
+      - Mon, 09 Oct 2023 16:10:43 GMT
       etag:
-      - '"1a0a13a4-0000-0100-0000-64af08820000"'
+      - '"92011094-0000-0100-0000-652425ca0000"'
       expires:
       - '-1'
       pragma:
@@ -101,7 +101,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -114,9 +114,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:10:39 GMT
+      - Mon, 09 Oct 2023 16:10:44 GMT
       mise-correlation-id:
-      - 45dc0a00-3e7f-4e24-9853-e1c01f3a5702
+      - efc852d4-6622-4502-82f8-f3e67031cc00
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -131,12 +131,12 @@ interactions:
 - request:
     body: '{"displayName": "CLI-Test", "description": "Test created from az load test
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
-      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "loadTestConfiguration":
+      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"ef6bd7b5-2d0f-4779-a800-23bb3daf6903": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "07ef0599-99cb-4787-b7c3-acbbcc72e357":
+      {"passFailMetrics": {"66e1d36e-a95d-4108-9f45-5fa163dc6c8e": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "18a1b316-19f3-4f4e-8063-11ad0fcdaffb":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "4e54e959-ebac-461e-9e2e-40f89cd50462": {"aggregate": "avg", "clientMetric":
+      "50"}, "229029b8-34d2-49e3-9e59-1d45f5317cc3": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -146,32 +146,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '768'
+      - '789'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ef6bd7b5-2d0f-4779-a800-23bb3daf6903":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"07ef0599-99cb-4787-b7c3-acbbcc72e357":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"4e54e959-ebac-461e-9e2e-40f89cd50462":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:10:40.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:10:40.432Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"66e1d36e-a95d-4108-9f45-5fa163dc6c8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"18a1b316-19f3-4f4e-8063-11ad0fcdaffb":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229029b8-34d2-49e3-9e59-1d45f5317cc3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:10:45.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:45.019Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1069'
+      - '1015'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:40 GMT
+      - Mon, 09 Oct 2023 16:10:45 GMT
       location:
-      - https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+      - https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - b7ea2e15-fde3-4477-b906-99415706ce38
+      - eea6b4dd-8abf-4a89-8cc8-f91e8bab845b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -191,7 +191,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
+    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -205,9 +205,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:40 GMT
+      - Mon, 09 Oct 2023 16:10:45 GMT
       mise-correlation-id:
-      - 7485129d-a0f4-47d9-9f0b-abb543b2fd5e
+      - 2ccefa9a-a8c1-4fba-be97-b5b1bb25be8a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -321,25 +321,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e3c75da6-a482-4ad7-9ab0-e2cc70ffcf54/c725b402-4ca6-4c90-bcf1-73dc382d08e6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A20%3A41Z&sr=b&sp=r&sig=NJd9%2BHnOkBLXdBi7TY9iVqduj8vsTR8VbnUvQ2wYAws%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:20:41.3802844","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/895e78a5-56a8-443f-bb2b-dd873a98b133/3e1214f6-6160-4b7f-9e96-d2b0e0fef41c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A45Z&sr=b&sp=r&sig=eHouxaWDYMXvsjbTvXusIJNDEAQN%2FrkyBg02aiSB%2F78%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:45.835813","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '552'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:41 GMT
+      - Mon, 09 Oct 2023 16:10:45 GMT
       location:
-      - https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 65b2d146-3f52-43a6-89d8-b8e6c3253f61
+      - 388a9e30-5fe3-4ccd-9261-1c5b533aa452
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -359,10 +359,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e3c75da6-a482-4ad7-9ab0-e2cc70ffcf54/c725b402-4ca6-4c90-bcf1-73dc382d08e6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A20%3A41Z&sr=b&sp=r&sig=zj4V8bFABXi8B2t4l9BXxgOEtXOZS1Jtstic6zA%2Bac0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:20:41.7416543","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/895e78a5-56a8-443f-bb2b-dd873a98b133/3e1214f6-6160-4b7f-9e96-d2b0e0fef41c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A46Z&sr=b&sp=r&sig=LuAnEof3pdE7%2FhvtmvC1K3HwFQl7OEzD4w86vCQiD3w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:46.1017717","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -373,9 +373,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:41 GMT
+      - Mon, 09 Oct 2023 16:10:46 GMT
       mise-correlation-id:
-      - e0a94d25-4fb1-43e5-a9dd-6fe0aa4fcefc
+      - a3d809b4-c146-444f-ad8e-2a8dc9482402
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -395,10 +395,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e3c75da6-a482-4ad7-9ab0-e2cc70ffcf54/c725b402-4ca6-4c90-bcf1-73dc382d08e6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A20%3A47Z&sr=b&sp=r&sig=G8yORO1nYMixaRzfe1%2FlkNCrf78jQ7diUFQGkR%2Fod4c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:20:47.0485745","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/895e78a5-56a8-443f-bb2b-dd873a98b133/3e1214f6-6160-4b7f-9e96-d2b0e0fef41c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A51Z&sr=b&sp=r&sig=7UG06G9SCFj%2BpFto%2BcaHAzso2zvhsXxlp6R7EyDauqg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:51.3773953","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -409,9 +409,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:47 GMT
+      - Mon, 09 Oct 2023 16:10:51 GMT
       mise-correlation-id:
-      - 77dc41c3-b33a-499d-9e13-ef6596fb160f
+      - 3afa4181-2023-42d7-80fd-dfb5dfd1c5bd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -431,10 +431,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e3c75da6-a482-4ad7-9ab0-e2cc70ffcf54/c725b402-4ca6-4c90-bcf1-73dc382d08e6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A20%3A52Z&sr=b&sp=r&sig=MznE0GQClTM3jLVw1otNbLagssoKzDqbuY%2FjRM%2Bylc4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:20:52.3753311","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/895e78a5-56a8-443f-bb2b-dd873a98b133/3e1214f6-6160-4b7f-9e96-d2b0e0fef41c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A56Z&sr=b&sp=r&sig=hMbrBFGoUDcRWn30%2ByM1d6s%2BVD5o59R1fr54q8vX778%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:56.6446696","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -445,9 +445,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:52 GMT
+      - Mon, 09 Oct 2023 16:10:56 GMT
       mise-correlation-id:
-      - b48ea2d2-a7b0-412d-be3e-cae45a5f98af
+      - 2aefa28c-1fc9-4f5f-995c-03f078c36994
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -467,10 +467,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e3c75da6-a482-4ad7-9ab0-e2cc70ffcf54/c725b402-4ca6-4c90-bcf1-73dc382d08e6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A20%3A57Z&sr=b&sp=r&sig=7trDxznSHTLAwO41CY7ZIeLQuNaERBF%2BXKa3MRTUQ6w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:20:57.6675564","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/895e78a5-56a8-443f-bb2b-dd873a98b133/3e1214f6-6160-4b7f-9e96-d2b0e0fef41c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A01Z&sr=b&sp=r&sig=T8FiOjuLgtJ78piG%2FzOFmynFO1rfP7SzxWVE2VN1Y3I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:01.9121696","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -481,9 +481,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:57 GMT
+      - Mon, 09 Oct 2023 16:11:01 GMT
       mise-correlation-id:
-      - 2ecd860e-7672-4f48-ac37-2f514e86bbcf
+      - 2e4eb5d6-fa0c-4b95-8566-1d85babcee3c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -503,24 +503,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ef6bd7b5-2d0f-4779-a800-23bb3daf6903":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"07ef0599-99cb-4787-b7c3-acbbcc72e357":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"4e54e959-ebac-461e-9e2e-40f89cd50462":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e3c75da6-a482-4ad7-9ab0-e2cc70ffcf54/c725b402-4ca6-4c90-bcf1-73dc382d08e6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A10%3A58Z&sr=b&sp=r&sig=KoHPEuXYYTi767K4QLrASJiBPNPeOGfjkZa1uPWN1NA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:10:58.0117833","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:10:40.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:10:52.893Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"66e1d36e-a95d-4108-9f45-5fa163dc6c8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"18a1b316-19f3-4f4e-8063-11ad0fcdaffb":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229029b8-34d2-49e3-9e59-1d45f5317cc3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/895e78a5-56a8-443f-bb2b-dd873a98b133/3e1214f6-6160-4b7f-9e96-d2b0e0fef41c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A11%3A02Z&sr=b&sp=r&sig=LQOFLRNkKMX5U3WMWAE0fXbFsGNdRYBLmMdy4a5IYaA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:11:02.2111483","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:10:45.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:58.864Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1638'
+      - '1584'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:58 GMT
+      - Mon, 09 Oct 2023 16:11:02 GMT
       mise-correlation-id:
-      - 7d87bb7b-7e4a-41d1-83af-a9e2f3f8e0b1
+      - 106bdb0b-456c-4528-9eb2-d21248f3ff1b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -543,7 +543,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:09:36.8297556Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:09:36.8297556Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:44.6045964Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:44.6045964Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -552,9 +552,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:10:58 GMT
+      - Mon, 09 Oct 2023 16:11:03 GMT
       etag:
-      - '"1a0a13a4-0000-0100-0000-64af08820000"'
+      - '"92011094-0000-0100-0000-652425ca0000"'
       expires:
       - '-1'
       pragma:
@@ -584,24 +584,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ef6bd7b5-2d0f-4779-a800-23bb3daf6903":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"07ef0599-99cb-4787-b7c3-acbbcc72e357":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"4e54e959-ebac-461e-9e2e-40f89cd50462":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e3c75da6-a482-4ad7-9ab0-e2cc70ffcf54/c725b402-4ca6-4c90-bcf1-73dc382d08e6?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A11%3A01Z&sr=b&sp=r&sig=pluFWa0XVvQugNi5Kqp9ti8NvOQbJSaZyvocUEXIdfQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:11:01.2546166","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:10:40.432Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:10:52.893Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"66e1d36e-a95d-4108-9f45-5fa163dc6c8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"18a1b316-19f3-4f4e-8063-11ad0fcdaffb":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229029b8-34d2-49e3-9e59-1d45f5317cc3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/895e78a5-56a8-443f-bb2b-dd873a98b133/3e1214f6-6160-4b7f-9e96-d2b0e0fef41c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A11%3A04Z&sr=b&sp=r&sig=JMxqKwlvjUhgtW3TPIuZTvWDNj5Xdyj7kCq4h2pGkEo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:11:04.6324779","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:10:45.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:58.864Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1650'
+      - '1596'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:01 GMT
+      - Mon, 09 Oct 2023 16:11:04 GMT
       mise-correlation-id:
-      - 6f49abfc-404d-409a-ab4e-af2f575a1eb9
+      - e5e8d9a7-0954-49bb-9011-f6ca884eb85c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -624,7 +624,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:09:36.8297556Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:09:36.8297556Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:44.6045964Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:44.6045964Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -633,9 +633,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:02 GMT
+      - Mon, 09 Oct 2023 16:11:05 GMT
       etag:
-      - '"1a0a13a4-0000-0100-0000-64af08820000"'
+      - '"92011094-0000-0100-0000-652425ca0000"'
       expires:
       - '-1'
       pragma:
@@ -654,9 +654,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ki5ohuyztdnpdqj7a/providers/Microsoft.Storage/storageAccounts/clitestload3bce6hbeu":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ki5ohuyztdnpdqj7a/providers/Microsoft.Storage/storageAccounts/clitestload3bce6hbeu",
-      "resourceName": "clitestload3bce6hbeu", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testId": "server-metric-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-hesv3uzf75hlibpqo/providers/Microsoft.Storage/storageAccounts/clitestloadkx4bmx665":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-hesv3uzf75hlibpqo/providers/Microsoft.Storage/storageAccounts/clitestloadkx4bmx665",
+      "resourceName": "clitestloadkx4bmx665", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -672,10 +672,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-07-12T20:11:03.335Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:11:03.335Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-09T16:11:07.018Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:07.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -686,11 +686,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:03 GMT
+      - Mon, 09 Oct 2023 16:11:07 GMT
       location:
-      - https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+      - https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - dbe0101c-8648-4615-848e-db47d3ce4582
+      - c20cf211-a20a-458d-8b5f-03332016e0a8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -713,7 +713,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:09:36.8297556Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:09:36.8297556Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:44.6045964Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:44.6045964Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -722,9 +722,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:04 GMT
+      - Mon, 09 Oct 2023 16:11:08 GMT
       etag:
-      - '"1a0a13a4-0000-0100-0000-64af08820000"'
+      - '"92011094-0000-0100-0000-652425ca0000"'
       expires:
       - '-1'
       pragma:
@@ -754,10 +754,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-07-12T20:11:03.335Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:11:03.335Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-09T16:11:07.018Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:07.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -768,9 +768,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:06 GMT
+      - Mon, 09 Oct 2023 16:11:09 GMT
       mise-correlation-id:
-      - 74f7bae1-90b2-473c-b65a-296c4918fc07
+      - 8eb08dab-a5c9-4d8f-9835-fa6e33a1b06e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -793,7 +793,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:09:36.8297556Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:09:36.8297556Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:44.6045964Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:44.6045964Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -802,9 +802,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:06 GMT
+      - Mon, 09 Oct 2023 16:11:10 GMT
       etag:
-      - '"1a0a13a4-0000-0100-0000-64af08820000"'
+      - '"92011094-0000-0100-0000-652425ca0000"'
       expires:
       - '-1'
       pragma:
@@ -823,9 +823,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ki5ohuyztdnpdqj7a/providers/Microsoft.Storage/storageAccounts/clitestload3bce6hbeu/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-hesv3uzf75hlibpqo/providers/Microsoft.Storage/storageAccounts/clitestloadkx4bmx665/providers/microsoft.insights/metricdefinitions/Availability":
       {"name": " Availability", "metricNamespace": "microsoft.storage/storageaccounts",
-      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ki5ohuyztdnpdqj7a/providers/Microsoft.Storage/storageAccounts/clitestload3bce6hbeu",
+      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-hesv3uzf75hlibpqo/providers/Microsoft.Storage/storageAccounts/clitestloadkx4bmx665",
       "resourceType": "Microsoft.Storage/storageAccounts"}}}'
     headers:
       Accept:
@@ -841,12 +841,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-07-12T20:11:03.354Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:11:08.691Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T16:11:07.045Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:11.745Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -857,9 +857,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:08 GMT
+      - Mon, 09 Oct 2023 16:11:11 GMT
       mise-correlation-id:
-      - 8f670dcb-26fc-441b-8de2-2ae7b3654c77
+      - 610bcaee-ce25-48f3-92f4-a2cffd3b9dd4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -882,7 +882,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:09:36.8297556Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:09:36.8297556Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:44.6045964Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:44.6045964Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -891,9 +891,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:09 GMT
+      - Mon, 09 Oct 2023 16:11:11 GMT
       etag:
-      - '"1a0a13a4-0000-0100-0000-64af08820000"'
+      - '"92011094-0000-0100-0000-652425ca0000"'
       expires:
       - '-1'
       pragma:
@@ -923,12 +923,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-07-12T20:11:03.354Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:11:08.691Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T16:11:07.045Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:11.745Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -939,9 +939,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:11 GMT
+      - Mon, 09 Oct 2023 16:11:13 GMT
       mise-correlation-id:
-      - 39a23907-6419-4677-a133-c25a9884f10d
+      - 450b3061-3ad7-41ae-b026-a01894f8f82f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -964,7 +964,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:09:36.8297556Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:09:36.8297556Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:44.6045964Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:44.6045964Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -973,9 +973,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:12 GMT
+      - Mon, 09 Oct 2023 16:11:14 GMT
       etag:
-      - '"1a0a13a4-0000-0100-0000-64af08820000"'
+      - '"92011094-0000-0100-0000-652425ca0000"'
       expires:
       - '-1'
       pragma:
@@ -994,7 +994,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-ki5ohuyztdnpdqj7a/providers/Microsoft.Storage/storageAccounts/clitestload3bce6hbeu/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-hesv3uzf75hlibpqo/providers/Microsoft.Storage/storageAccounts/clitestloadkx4bmx665/providers/microsoft.insights/metricdefinitions/Availability":
       null}}'
     headers:
       Accept:
@@ -1010,10 +1010,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-07-12T20:11:03.354Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:11:13.924Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T16:11:07.045Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:16.226Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1024,9 +1024,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:13 GMT
+      - Mon, 09 Oct 2023 16:11:16 GMT
       mise-correlation-id:
-      - 6e54d1c4-ffb5-4718-a063-caa8fcddf8cc
+      - 3b5cd48f-b1f2-492a-bf99-dff557f71552
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1049,7 +1049,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:09:36.8297556Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:09:36.8297556Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:44.6045964Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:44.6045964Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1058,9 +1058,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:15 GMT
+      - Mon, 09 Oct 2023 16:11:17 GMT
       etag:
-      - '"1a0a13a4-0000-0100-0000-64af08820000"'
+      - '"92011094-0000-0100-0000-652425ca0000"'
       expires:
       - '-1'
       pragma:
@@ -1090,10 +1090,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c49ed61e-a0ac-4906-94ac-64eb8a88b658.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-07-12T20:11:03.354Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:11:13.924Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T16:11:07.045Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:16.226Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1104,9 +1104,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:16 GMT
+      - Mon, 09 Oct 2023 16:11:18 GMT
       mise-correlation-id:
-      - 20b832e2-a633-4c7b-a2fa-3590ec675c88
+      - cebe37b1-6e33-4373-ad50-bdc90ee4bd15
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_server_metric.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_server_metric.yaml
@@ -18,7 +18,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-13T13:49:46.2136108Z","key2":"2023-10-13T13:49:46.2136108Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-13T13:49:46.2292092Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-13T13:49:46.2292092Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-13T13:49:46.0417062Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-18T20:49:49.1193781Z","key2":"2023-10-18T20:49:49.1193781Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-18T20:49:49.1349786Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-18T20:49:49.1349786Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-18T20:49:48.9162257Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:50:07 GMT
+      - Wed, 18 Oct 2023 20:50:10 GMT
       expires:
       - '-1'
       pragma:
@@ -60,18 +60,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:07.4361601Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:07.4361601Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.502241Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.502241Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:09 GMT
+      - Wed, 18 Oct 2023 20:50:10 GMT
       etag:
-      - '"d80186ba-0000-0100-0000-65294ad70000"'
+      - '"75003140-0000-0100-0000-653044cb0000"'
       expires:
       - '-1'
       pragma:
@@ -101,7 +101,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -114,9 +114,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:50:10 GMT
+      - Wed, 18 Oct 2023 20:50:12 GMT
       mise-correlation-id:
-      - 2f1f4940-4432-449a-ae72-8e4371633533
+      - f7ef9209-c10a-4945-ab86-f535def3c5b2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -133,10 +133,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"6d5afa4d-3a62-459f-a5bb-2829dcc806c1": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "c980f503-1948-49f6-b6b5-ee12f32f08c1":
+      {"passFailMetrics": {"aff13ba4-f177-4bec-bdcd-5833da9bd4b1": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "3ea92c26-7335-42be-b2fc-1e0c9a754084":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "f5889ca3-5ca7-4764-9d56-3387be193907": {"aggregate": "avg", "clientMetric":
+      "50"}, "01c646b4-6dd3-4247-80a5-c3e6210d1b92": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -152,11 +152,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6d5afa4d-3a62-459f-a5bb-2829dcc806c1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c980f503-1948-49f6-b6b5-ee12f32f08c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5889ca3-5ca7-4764-9d56-3387be193907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:50:11.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:11.108Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"aff13ba4-f177-4bec-bdcd-5833da9bd4b1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3ea92c26-7335-42be-b2fc-1e0c9a754084":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01c646b4-6dd3-4247-80a5-c3e6210d1b92":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:50:12.961Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:12.961Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -167,11 +167,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:11 GMT
+      - Wed, 18 Oct 2023 20:50:12 GMT
       location:
-      - https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+      - https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - a6e4c99c-8206-49b6-a6a0-d0f77ca5316a
+      - 42c2e7c3-2454-4ddb-8041-a5f24cef28a6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -191,7 +191,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
+    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -205,9 +205,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:11 GMT
+      - Wed, 18 Oct 2023 20:50:13 GMT
       mise-correlation-id:
-      - 508fa0e8-36f6-4fc7-987c-5ec9fb9522e4
+      - 2e2cfb0a-71b3-44ba-b8f5-30219006f7d8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -321,25 +321,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0556f433-e59a-4717-9251-def8a251f77a/214cd7e1-8950-4701-89f4-a16a1707ab21?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A12Z&sr=b&sp=r&sig=g4eMTu2oTQj3KgMvc2eCpWgUCsWuPp3A8nIQgX3tPEw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:12.7014138","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3c99e00d-5338-4fb2-a627-5e4ed3700ba8/e61089e1-2669-4836-8726-7cfa345de953?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A13Z&sr=b&sp=r&sig=Il2yeRUhVBui%2FE2MqM%2BbA2NWZ0cPlBcCKp49rJm626k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:13.8656517","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:12 GMT
+      - Wed, 18 Oct 2023 20:50:13 GMT
       location:
-      - https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - eebdd1b1-2a13-4b82-8ca9-cf6750b2d76a
+      - f690ef50-56bd-424d-94bc-2d9bdcb6fbe9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -359,46 +359,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0556f433-e59a-4717-9251-def8a251f77a/214cd7e1-8950-4701-89f4-a16a1707ab21?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A12Z&sr=b&sp=r&sig=kXmg02EEIQUAsYWIiKELdGdn89g9oFTROhKe%2BOvtrys%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:12.9934915","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:50:12 GMT
-      mise-correlation-id:
-      - 544ecde5-04aa-4064-82a9-e6e0e15bbddf
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0556f433-e59a-4717-9251-def8a251f77a/214cd7e1-8950-4701-89f4-a16a1707ab21?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A18Z&sr=b&sp=r&sig=LDuEtQbRkWCFRvfLKa0O9m%2BFFNblUsBocI7u4W2Y%2BtY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:18.2481207","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3c99e00d-5338-4fb2-a627-5e4ed3700ba8/e61089e1-2669-4836-8726-7cfa345de953?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A14Z&sr=b&sp=r&sig=rbtlx%2BFgKiNTlCRJwhkQU4unZin2NxqKA5uQXyKpn%2B0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:14.1122786","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -409,9 +373,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:18 GMT
+      - Wed, 18 Oct 2023 20:50:14 GMT
       mise-correlation-id:
-      - e09d5a60-6be2-401d-a57d-f3e430115bf0
+      - 79cc027c-f325-403b-bd27-caf566ccfffa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -431,46 +395,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0556f433-e59a-4717-9251-def8a251f77a/214cd7e1-8950-4701-89f4-a16a1707ab21?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A23Z&sr=b&sp=r&sig=9T5GytMoRAJuPHuL4fo52eI%2BX5uC7q4z507oKFf2BHA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:23.5078428","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:50:23 GMT
-      mise-correlation-id:
-      - 04f87121-fd72-4d40-944b-1eced49258da
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0556f433-e59a-4717-9251-def8a251f77a/214cd7e1-8950-4701-89f4-a16a1707ab21?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A00%3A28Z&sr=b&sp=r&sig=pLfYnY86iMIvCx0nC9iuojEK%2BqevN4931KGB4u33EC8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:00:28.7639201","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3c99e00d-5338-4fb2-a627-5e4ed3700ba8/e61089e1-2669-4836-8726-7cfa345de953?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A19Z&sr=b&sp=r&sig=jj6J9vJXsTodgomuXVtXuVerLOba0SBWJn3213jADBA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:19.3578814","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -481,9 +409,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:28 GMT
+      - Wed, 18 Oct 2023 20:50:19 GMT
       mise-correlation-id:
-      - 0028bd48-9a15-42fd-aada-1d1f30bc831f
+      - 75a90cb1-72f5-429c-b100-b36ac391e32d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -503,11 +431,83 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6d5afa4d-3a62-459f-a5bb-2829dcc806c1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c980f503-1948-49f6-b6b5-ee12f32f08c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5889ca3-5ca7-4764-9d56-3387be193907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0556f433-e59a-4717-9251-def8a251f77a/214cd7e1-8950-4701-89f4-a16a1707ab21?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A50%3A29Z&sr=b&sp=r&sig=hZUxvzh1VTFo2jhdSO6nkaU7KihlIb%2BPqKM9hixkyOI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:50:29.0713954","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:50:11.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:25.795Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3c99e00d-5338-4fb2-a627-5e4ed3700ba8/e61089e1-2669-4836-8726-7cfa345de953?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A24Z&sr=b&sp=r&sig=Fd0ZBMNXDkN%2FEf1UMddfrJGtINVaT0s%2F%2Fhj1GSxfD30%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:24.641864","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '554'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:50:24 GMT
+      mise-correlation-id:
+      - 3f2d867b-a9c7-41ee-ad18-49f525626c1f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3c99e00d-5338-4fb2-a627-5e4ed3700ba8/e61089e1-2669-4836-8726-7cfa345de953?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A29Z&sr=b&sp=r&sig=kGFH5MvUb6o0nSbHsToKPZd2dudlDtl%2B3GUyD0Mtgb8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:29.9798341","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:50:29 GMT
+      mise-correlation-id:
+      - 7dbde900-7260-4290-9219-493144493087
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"aff13ba4-f177-4bec-bdcd-5833da9bd4b1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3ea92c26-7335-42be-b2fc-1e0c9a754084":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01c646b4-6dd3-4247-80a5-c3e6210d1b92":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3c99e00d-5338-4fb2-a627-5e4ed3700ba8/e61089e1-2669-4836-8726-7cfa345de953?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A50%3A30Z&sr=b&sp=r&sig=kCWWH8uCiWSQGukxYXBhW11JIAlOlvipu1wI1BqP%2FPM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:50:30.2231827","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:50:12.961Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:27.249Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -518,9 +518,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:29 GMT
+      - Wed, 18 Oct 2023 20:50:30 GMT
       mise-correlation-id:
-      - b6bda32d-c5ac-4de2-9e5a-9b56909252d9
+      - 99c3667d-ebf4-469a-8d67-b6011205291e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -543,18 +543,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:07.4361601Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:07.4361601Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.502241Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.502241Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:30 GMT
+      - Wed, 18 Oct 2023 20:50:31 GMT
       etag:
-      - '"d80186ba-0000-0100-0000-65294ad70000"'
+      - '"75003140-0000-0100-0000-653044cb0000"'
       expires:
       - '-1'
       pragma:
@@ -584,24 +584,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"6d5afa4d-3a62-459f-a5bb-2829dcc806c1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c980f503-1948-49f6-b6b5-ee12f32f08c1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"f5889ca3-5ca7-4764-9d56-3387be193907":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0556f433-e59a-4717-9251-def8a251f77a/214cd7e1-8950-4701-89f4-a16a1707ab21?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A50%3A31Z&sr=b&sp=r&sig=W2l4OAso27zus%2BHdI5Hs%2B2x8JW1zNn9Va37QfHqpuqw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:50:31.6775357","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:50:11.108Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:25.795Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"aff13ba4-f177-4bec-bdcd-5833da9bd4b1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3ea92c26-7335-42be-b2fc-1e0c9a754084":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01c646b4-6dd3-4247-80a5-c3e6210d1b92":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3c99e00d-5338-4fb2-a627-5e4ed3700ba8/e61089e1-2669-4836-8726-7cfa345de953?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A50%3A32Z&sr=b&sp=r&sig=ooKhP7DzdxIrNIcH38AA4nisSccHcd4VzLYQDAS%2FN9U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:50:32.3317061","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:50:12.961Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:27.249Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1600'
+      - '1598'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:31 GMT
+      - Wed, 18 Oct 2023 20:50:32 GMT
       mise-correlation-id:
-      - f277be4b-1970-4013-bfb9-1cef9c743071
+      - 2750e563-b3ce-4a41-8e58-e5f76f3f173a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -624,18 +624,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:07.4361601Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:07.4361601Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.502241Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.502241Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:32 GMT
+      - Wed, 18 Oct 2023 20:50:32 GMT
       etag:
-      - '"d80186ba-0000-0100-0000-65294ad70000"'
+      - '"75003140-0000-0100-0000-653044cb0000"'
       expires:
       - '-1'
       pragma:
@@ -654,9 +654,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-wx2jlwejr6cjmyjo7/providers/Microsoft.Storage/storageAccounts/clitestloadmzatmovx2":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-wx2jlwejr6cjmyjo7/providers/Microsoft.Storage/storageAccounts/clitestloadmzatmovx2",
-      "resourceName": "clitestloadmzatmovx2", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testId": "server-metric-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-n4uplbhh626nuajv6/providers/Microsoft.Storage/storageAccounts/clitestloadphksxorhe":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-n4uplbhh626nuajv6/providers/Microsoft.Storage/storageAccounts/clitestloadphksxorhe",
+      "resourceName": "clitestloadphksxorhe", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -672,10 +672,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-13T13:50:34.526Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:34.526Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-18T20:50:34.995Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:34.995Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -686,11 +686,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:34 GMT
+      - Wed, 18 Oct 2023 20:50:35 GMT
       location:
-      - https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+      - https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - 2be23363-cebe-4aa7-8ab4-c7a37b7d9b8e
+      - ec2b7547-63ab-43fa-9fa5-9f0dcbf2abd4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -713,18 +713,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:07.4361601Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:07.4361601Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.502241Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.502241Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:34 GMT
+      - Wed, 18 Oct 2023 20:50:35 GMT
       etag:
-      - '"d80186ba-0000-0100-0000-65294ad70000"'
+      - '"75003140-0000-0100-0000-653044cb0000"'
       expires:
       - '-1'
       pragma:
@@ -754,10 +754,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-13T13:50:34.526Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:34.526Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-18T20:50:34.995Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:34.995Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -768,9 +768,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:36 GMT
+      - Wed, 18 Oct 2023 20:50:36 GMT
       mise-correlation-id:
-      - 0fcc83d5-4a0d-4cfc-a178-0a3227e8874f
+      - 2fa208d9-3708-4772-b7f9-0c0756eddee8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -793,18 +793,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:07.4361601Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:07.4361601Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.502241Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.502241Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:37 GMT
+      - Wed, 18 Oct 2023 20:50:37 GMT
       etag:
-      - '"d80186ba-0000-0100-0000-65294ad70000"'
+      - '"75003140-0000-0100-0000-653044cb0000"'
       expires:
       - '-1'
       pragma:
@@ -823,9 +823,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-wx2jlwejr6cjmyjo7/providers/Microsoft.Storage/storageAccounts/clitestloadmzatmovx2/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-n4uplbhh626nuajv6/providers/Microsoft.Storage/storageAccounts/clitestloadphksxorhe/providers/microsoft.insights/metricdefinitions/Availability":
       {"name": " Availability", "metricNamespace": "microsoft.storage/storageaccounts",
-      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-wx2jlwejr6cjmyjo7/providers/Microsoft.Storage/storageAccounts/clitestloadmzatmovx2",
+      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-n4uplbhh626nuajv6/providers/Microsoft.Storage/storageAccounts/clitestloadphksxorhe",
       "resourceType": "Microsoft.Storage/storageAccounts"}}}'
     headers:
       Accept:
@@ -841,25 +841,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-13T13:50:34.608Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:39.22Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-18T20:50:35.059Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:38.177Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3234'
+      - '3235'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:39 GMT
+      - Wed, 18 Oct 2023 20:50:38 GMT
       mise-correlation-id:
-      - 4ba3c1e4-082f-49c1-ac86-3d3ce23edbac
+      - 66e6949e-ad5b-419b-bb9f-d8224c18672f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -882,18 +882,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:07.4361601Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:07.4361601Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.502241Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.502241Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:39 GMT
+      - Wed, 18 Oct 2023 20:50:39 GMT
       etag:
-      - '"d80186ba-0000-0100-0000-65294ad70000"'
+      - '"75003140-0000-0100-0000-653044cb0000"'
       expires:
       - '-1'
       pragma:
@@ -923,25 +923,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-13T13:50:34.608Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:39.22Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-18T20:50:35.059Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:38.177Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '3234'
+      - '3235'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:41 GMT
+      - Wed, 18 Oct 2023 20:50:40 GMT
       mise-correlation-id:
-      - 89385ac7-1fa6-47e9-b988-a4ab6b0b0fa0
+      - be52dfbd-a124-4591-83b0-4a55d60c642e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -964,18 +964,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:07.4361601Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:07.4361601Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.502241Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.502241Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:41 GMT
+      - Wed, 18 Oct 2023 20:50:40 GMT
       etag:
-      - '"d80186ba-0000-0100-0000-65294ad70000"'
+      - '"75003140-0000-0100-0000-653044cb0000"'
       expires:
       - '-1'
       pragma:
@@ -994,7 +994,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-wx2jlwejr6cjmyjo7/providers/Microsoft.Storage/storageAccounts/clitestloadmzatmovx2/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-n4uplbhh626nuajv6/providers/Microsoft.Storage/storageAccounts/clitestloadphksxorhe/providers/microsoft.insights/metricdefinitions/Availability":
       null}}'
     headers:
       Accept:
@@ -1010,10 +1010,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-13T13:50:34.608Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:43.291Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-18T20:50:35.059Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:42.533Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1024,9 +1024,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:43 GMT
+      - Wed, 18 Oct 2023 20:50:42 GMT
       mise-correlation-id:
-      - fb306dcd-c06c-4665-8770-ac8e4c5b9788
+      - 00364e60-035e-4b29-83b9-7b2840b774d0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1049,18 +1049,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:49:07.4361601Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:49:07.4361601Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.502241Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.502241Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '688'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:44 GMT
+      - Wed, 18 Oct 2023 20:50:43 GMT
       etag:
-      - '"d80186ba-0000-0100-0000-65294ad70000"'
+      - '"75003140-0000-0100-0000-653044cb0000"'
       expires:
       - '-1'
       pragma:
@@ -1090,10 +1090,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://02e985e5-e5e5-41c1-af27-934c95dcbaa6.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-13T13:50:34.608Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:43.291Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-18T20:50:35.059Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:42.533Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1104,9 +1104,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:45 GMT
+      - Wed, 18 Oct 2023 20:50:44 GMT
       mise-correlation-id:
-      - 28d58dde-d357-4238-be18-ced1cd901a84
+      - 3bae18a1-9419-48ba-bd17-8815dcbe47d1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_server_metric.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_server_metric.yaml
@@ -18,7 +18,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-09T16:10:20.1224602Z","key2":"2023-10-09T16:10:20.1224602Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T16:10:20.1380859Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T16:10:20.1380859Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-09T16:10:19.9349608Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-09T19:16:40.6491179Z","key2":"2023-10-09T19:16:40.6491179Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T19:16:40.6647645Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-09T19:16:40.6647645Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-09T19:16:40.4616170Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:10:41 GMT
+      - Mon, 09 Oct 2023 19:17:02 GMT
       expires:
       - '-1'
       pragma:
@@ -60,7 +60,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:44.6045964Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:44.6045964Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:03.8559563Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:03.8559563Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -69,9 +69,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:43 GMT
+      - Mon, 09 Oct 2023 19:17:04 GMT
       etag:
-      - '"92011094-0000-0100-0000-652425ca0000"'
+      - '"550015c7-0000-0100-0000-652451750000"'
       expires:
       - '-1'
       pragma:
@@ -101,7 +101,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -114,9 +114,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:10:44 GMT
+      - Mon, 09 Oct 2023 19:17:05 GMT
       mise-correlation-id:
-      - efc852d4-6622-4502-82f8-f3e67031cc00
+      - 92b883e9-2304-4cad-862a-a62ce8d96a18
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -133,10 +133,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"66e1d36e-a95d-4108-9f45-5fa163dc6c8e": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "18a1b316-19f3-4f4e-8063-11ad0fcdaffb":
+      {"passFailMetrics": {"230b3d9b-03f7-4242-8820-9036003f09e1": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "542cecdf-9a03-4008-8bf3-fc166fa76d17":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "229029b8-34d2-49e3-9e59-1d45f5317cc3": {"aggregate": "avg", "clientMetric":
+      "50"}, "2434475b-6162-472e-b2c4-0bb94171f981": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -152,11 +152,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"66e1d36e-a95d-4108-9f45-5fa163dc6c8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"18a1b316-19f3-4f4e-8063-11ad0fcdaffb":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229029b8-34d2-49e3-9e59-1d45f5317cc3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:10:45.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:45.019Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"230b3d9b-03f7-4242-8820-9036003f09e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"542cecdf-9a03-4008-8bf3-fc166fa76d17":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2434475b-6162-472e-b2c4-0bb94171f981":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:17:06.257Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:06.257Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -167,11 +167,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:45 GMT
+      - Mon, 09 Oct 2023 19:17:06 GMT
       location:
-      - https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+      - https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - eea6b4dd-8abf-4a89-8cc8-f91e8bab845b
+      - 62ec8db8-94ca-4a96-afc6-ef1464019619
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -191,7 +191,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
+    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -205,9 +205,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:45 GMT
+      - Mon, 09 Oct 2023 19:17:06 GMT
       mise-correlation-id:
-      - 2ccefa9a-a8c1-4fba-be97-b5b1bb25be8a
+      - ee29531e-9210-4f7e-9469-a3f2bf5ec408
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -321,25 +321,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/895e78a5-56a8-443f-bb2b-dd873a98b133/3e1214f6-6160-4b7f-9e96-d2b0e0fef41c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A45Z&sr=b&sp=r&sig=eHouxaWDYMXvsjbTvXusIJNDEAQN%2FrkyBg02aiSB%2F78%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:45.835813","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/89f816c6-7d99-40de-9c3d-dc658f4c4f3e/a5d0bd19-4814-411e-8960-b272c4f82cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A07Z&sr=b&sp=r&sig=8MSMh9DzKMVDNGRfFpB7NDZTP%2BuW4Ne1nISHEZ4wKgo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:07.8115413","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '552'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:45 GMT
+      - Mon, 09 Oct 2023 19:17:07 GMT
       location:
-      - https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 388a9e30-5fe3-4ccd-9261-1c5b533aa452
+      - 611d909d-92ac-45f8-8bcf-670f13abd68d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -359,10 +359,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/895e78a5-56a8-443f-bb2b-dd873a98b133/3e1214f6-6160-4b7f-9e96-d2b0e0fef41c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A46Z&sr=b&sp=r&sig=LuAnEof3pdE7%2FhvtmvC1K3HwFQl7OEzD4w86vCQiD3w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:46.1017717","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/89f816c6-7d99-40de-9c3d-dc658f4c4f3e/a5d0bd19-4814-411e-8960-b272c4f82cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A08Z&sr=b&sp=r&sig=LVDasA06E3dOt3lqN7oh8%2BCKSpBulqRb3EYwcshczZ4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:08.1011765","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -373,9 +373,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:46 GMT
+      - Mon, 09 Oct 2023 19:17:08 GMT
       mise-correlation-id:
-      - a3d809b4-c146-444f-ad8e-2a8dc9482402
+      - bef921a8-cfd6-4684-867b-3267db3ccccd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -395,23 +395,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/895e78a5-56a8-443f-bb2b-dd873a98b133/3e1214f6-6160-4b7f-9e96-d2b0e0fef41c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A51Z&sr=b&sp=r&sig=7UG06G9SCFj%2BpFto%2BcaHAzso2zvhsXxlp6R7EyDauqg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:51.3773953","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/89f816c6-7d99-40de-9c3d-dc658f4c4f3e/a5d0bd19-4814-411e-8960-b272c4f82cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A13Z&sr=b&sp=r&sig=mfTXw31y5O%2Bb9IjSv43eEGmZT%2Bmro87pdF4UZn4AQNI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:13.950551","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '552'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:51 GMT
+      - Mon, 09 Oct 2023 19:17:13 GMT
       mise-correlation-id:
-      - 3afa4181-2023-42d7-80fd-dfb5dfd1c5bd
+      - 5ed3e8c9-556b-4919-9b14-aa37767f0c75
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -431,23 +431,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/895e78a5-56a8-443f-bb2b-dd873a98b133/3e1214f6-6160-4b7f-9e96-d2b0e0fef41c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A56Z&sr=b&sp=r&sig=hMbrBFGoUDcRWn30%2ByM1d6s%2BVD5o59R1fr54q8vX778%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:56.6446696","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/89f816c6-7d99-40de-9c3d-dc658f4c4f3e/a5d0bd19-4814-411e-8960-b272c4f82cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A19Z&sr=b&sp=r&sig=AJ1%2BBWM6MgWyxvPItVt0CaESaS8xfHeSkc8DrTvQKMA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:19.2508913","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:56 GMT
+      - Mon, 09 Oct 2023 19:17:19 GMT
       mise-correlation-id:
-      - 2aefa28c-1fc9-4f5f-995c-03f078c36994
+      - ab402c5a-3f32-4c48-b01a-e72c75b45038
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -467,23 +467,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/895e78a5-56a8-443f-bb2b-dd873a98b133/3e1214f6-6160-4b7f-9e96-d2b0e0fef41c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A01Z&sr=b&sp=r&sig=T8FiOjuLgtJ78piG%2FzOFmynFO1rfP7SzxWVE2VN1Y3I%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:01.9121696","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/89f816c6-7d99-40de-9c3d-dc658f4c4f3e/a5d0bd19-4814-411e-8960-b272c4f82cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A24Z&sr=b&sp=r&sig=61tD5F6ZATPiS%2FpaG%2FEtKtQ0LsA8gzPt3WczGLK7P5g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:24.576677","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:01 GMT
+      - Mon, 09 Oct 2023 19:17:24 GMT
       mise-correlation-id:
-      - 2e4eb5d6-fa0c-4b95-8566-1d85babcee3c
+      - d87c44fe-ed01-4da9-ba95-5083d1da52fd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -503,24 +503,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"66e1d36e-a95d-4108-9f45-5fa163dc6c8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"18a1b316-19f3-4f4e-8063-11ad0fcdaffb":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229029b8-34d2-49e3-9e59-1d45f5317cc3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/895e78a5-56a8-443f-bb2b-dd873a98b133/3e1214f6-6160-4b7f-9e96-d2b0e0fef41c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A11%3A02Z&sr=b&sp=r&sig=LQOFLRNkKMX5U3WMWAE0fXbFsGNdRYBLmMdy4a5IYaA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:11:02.2111483","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:10:45.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:58.864Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"230b3d9b-03f7-4242-8820-9036003f09e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"542cecdf-9a03-4008-8bf3-fc166fa76d17":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2434475b-6162-472e-b2c4-0bb94171f981":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/89f816c6-7d99-40de-9c3d-dc658f4c4f3e/a5d0bd19-4814-411e-8960-b272c4f82cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A17%3A24Z&sr=b&sp=r&sig=MMVnZSL%2FV5ptAyLRM7x8oQIZoFnxYJbAcI4r%2FoFl4LE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:17:24.8291934","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:17:06.257Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:19.836Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1584'
+      - '1588'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:02 GMT
+      - Mon, 09 Oct 2023 19:17:24 GMT
       mise-correlation-id:
-      - 106bdb0b-456c-4528-9eb2-d21248f3ff1b
+      - cd96e8bc-2eda-4ac3-848d-fd786f6f66e5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -543,7 +543,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:44.6045964Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:44.6045964Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:03.8559563Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:03.8559563Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -552,9 +552,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:03 GMT
+      - Mon, 09 Oct 2023 19:17:25 GMT
       etag:
-      - '"92011094-0000-0100-0000-652425ca0000"'
+      - '"550015c7-0000-0100-0000-652451750000"'
       expires:
       - '-1'
       pragma:
@@ -584,24 +584,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"66e1d36e-a95d-4108-9f45-5fa163dc6c8e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"18a1b316-19f3-4f4e-8063-11ad0fcdaffb":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"229029b8-34d2-49e3-9e59-1d45f5317cc3":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/895e78a5-56a8-443f-bb2b-dd873a98b133/3e1214f6-6160-4b7f-9e96-d2b0e0fef41c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A11%3A04Z&sr=b&sp=r&sig=JMxqKwlvjUhgtW3TPIuZTvWDNj5Xdyj7kCq4h2pGkEo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:11:04.6324779","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:10:45.019Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:58.864Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"230b3d9b-03f7-4242-8820-9036003f09e1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"542cecdf-9a03-4008-8bf3-fc166fa76d17":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2434475b-6162-472e-b2c4-0bb94171f981":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/89f816c6-7d99-40de-9c3d-dc658f4c4f3e/a5d0bd19-4814-411e-8960-b272c4f82cd8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A17%3A26Z&sr=b&sp=r&sig=yHp%2FA4iECeRgCdOKzI%2BGpC2hZ6Cww767Btckbc6nizg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:17:26.6334413","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:17:06.257Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:19.836Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1596'
+      - '1600'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:04 GMT
+      - Mon, 09 Oct 2023 19:17:26 GMT
       mise-correlation-id:
-      - e5e8d9a7-0954-49bb-9011-f6ca884eb85c
+      - b9bf4a0a-e75c-4d4b-b212-8e7a4da8f302
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -624,7 +624,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:44.6045964Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:44.6045964Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:03.8559563Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:03.8559563Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -633,9 +633,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:05 GMT
+      - Mon, 09 Oct 2023 19:17:27 GMT
       etag:
-      - '"92011094-0000-0100-0000-652425ca0000"'
+      - '"550015c7-0000-0100-0000-652451750000"'
       expires:
       - '-1'
       pragma:
@@ -654,9 +654,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-hesv3uzf75hlibpqo/providers/Microsoft.Storage/storageAccounts/clitestloadkx4bmx665":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-hesv3uzf75hlibpqo/providers/Microsoft.Storage/storageAccounts/clitestloadkx4bmx665",
-      "resourceName": "clitestloadkx4bmx665", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testId": "server-metric-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-bqulgotcoeopvcxgz/providers/Microsoft.Storage/storageAccounts/clitestloadmtphbbmgg":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-bqulgotcoeopvcxgz/providers/Microsoft.Storage/storageAccounts/clitestloadmtphbbmgg",
+      "resourceName": "clitestloadmtphbbmgg", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -672,10 +672,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-09T16:11:07.018Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:07.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-09T19:17:29.196Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:29.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -686,11 +686,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:07 GMT
+      - Mon, 09 Oct 2023 19:17:29 GMT
       location:
-      - https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+      - https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - c20cf211-a20a-458d-8b5f-03332016e0a8
+      - 37e10461-66c5-4907-9779-77fddea23534
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -713,7 +713,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:44.6045964Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:44.6045964Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:03.8559563Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:03.8559563Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -722,9 +722,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:08 GMT
+      - Mon, 09 Oct 2023 19:17:30 GMT
       etag:
-      - '"92011094-0000-0100-0000-652425ca0000"'
+      - '"550015c7-0000-0100-0000-652451750000"'
       expires:
       - '-1'
       pragma:
@@ -754,10 +754,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-09T16:11:07.018Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:07.018Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-09T19:17:29.196Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:29.196Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -768,9 +768,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:09 GMT
+      - Mon, 09 Oct 2023 19:17:30 GMT
       mise-correlation-id:
-      - 8eb08dab-a5c9-4d8f-9835-fa6e33a1b06e
+      - 600dfb34-2057-418b-8b92-f072b49842bb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -793,7 +793,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:44.6045964Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:44.6045964Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:03.8559563Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:03.8559563Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -802,9 +802,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:10 GMT
+      - Mon, 09 Oct 2023 19:17:31 GMT
       etag:
-      - '"92011094-0000-0100-0000-652425ca0000"'
+      - '"550015c7-0000-0100-0000-652451750000"'
       expires:
       - '-1'
       pragma:
@@ -823,9 +823,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-hesv3uzf75hlibpqo/providers/Microsoft.Storage/storageAccounts/clitestloadkx4bmx665/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-bqulgotcoeopvcxgz/providers/Microsoft.Storage/storageAccounts/clitestloadmtphbbmgg/providers/microsoft.insights/metricdefinitions/Availability":
       {"name": " Availability", "metricNamespace": "microsoft.storage/storageaccounts",
-      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-hesv3uzf75hlibpqo/providers/Microsoft.Storage/storageAccounts/clitestloadkx4bmx665",
+      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-bqulgotcoeopvcxgz/providers/Microsoft.Storage/storageAccounts/clitestloadmtphbbmgg",
       "resourceType": "Microsoft.Storage/storageAccounts"}}}'
     headers:
       Accept:
@@ -841,12 +841,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T16:11:07.045Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:11.745Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T19:17:29.277Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:32.787Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -857,9 +857,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:11 GMT
+      - Mon, 09 Oct 2023 19:17:32 GMT
       mise-correlation-id:
-      - 610bcaee-ce25-48f3-92f4-a2cffd3b9dd4
+      - 6abba85b-673b-4439-bba2-adba083ddc97
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -882,7 +882,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:44.6045964Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:44.6045964Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:03.8559563Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:03.8559563Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -891,9 +891,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:11 GMT
+      - Mon, 09 Oct 2023 19:17:34 GMT
       etag:
-      - '"92011094-0000-0100-0000-652425ca0000"'
+      - '"550015c7-0000-0100-0000-652451750000"'
       expires:
       - '-1'
       pragma:
@@ -923,12 +923,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T16:11:07.045Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:11.745Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T19:17:29.277Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:32.787Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -939,9 +939,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:13 GMT
+      - Mon, 09 Oct 2023 19:17:35 GMT
       mise-correlation-id:
-      - 450b3061-3ad7-41ae-b026-a01894f8f82f
+      - 1eb1497d-2c74-40b8-98f1-4d2cd3fa5fc3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -964,7 +964,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:44.6045964Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:44.6045964Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:03.8559563Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:03.8559563Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -973,9 +973,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:14 GMT
+      - Mon, 09 Oct 2023 19:17:36 GMT
       etag:
-      - '"92011094-0000-0100-0000-652425ca0000"'
+      - '"550015c7-0000-0100-0000-652451750000"'
       expires:
       - '-1'
       pragma:
@@ -994,7 +994,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-hesv3uzf75hlibpqo/providers/Microsoft.Storage/storageAccounts/clitestloadkx4bmx665/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-bqulgotcoeopvcxgz/providers/Microsoft.Storage/storageAccounts/clitestloadmtphbbmgg/providers/microsoft.insights/metricdefinitions/Availability":
       null}}'
     headers:
       Accept:
@@ -1010,10 +1010,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T16:11:07.045Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:16.226Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T19:17:29.277Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:37.603Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1024,9 +1024,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:16 GMT
+      - Mon, 09 Oct 2023 19:17:37 GMT
       mise-correlation-id:
-      - 3b5cd48f-b1f2-492a-bf99-dff557f71552
+      - 3d58a151-00a0-4383-a8de-d8b6a2570543
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1049,7 +1049,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:44.6045964Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:44.6045964Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:16:03.8559563Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:16:03.8559563Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1058,9 +1058,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:17 GMT
+      - Mon, 09 Oct 2023 19:17:38 GMT
       etag:
-      - '"92011094-0000-0100-0000-652425ca0000"'
+      - '"550015c7-0000-0100-0000-652451750000"'
       expires:
       - '-1'
       pragma:
@@ -1090,10 +1090,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90d00229-7781-4afd-84f6-cbeb9496daa9.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://e22d0d31-95f1-4cb6-822d-5666846c20c4.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T16:11:07.045Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:16.226Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-09T19:17:29.277Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:37.603Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1104,9 +1104,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:18 GMT
+      - Mon, 09 Oct 2023 19:17:39 GMT
       mise-correlation-id:
-      - cebe37b1-6e33-4373-ad50-bdc90ee4bd15
+      - ccc0be01-b48e-4479-9b1b-7371e1036ce3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_server_metric.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_server_metric.yaml
@@ -18,7 +18,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-18T20:49:49.1193781Z","key2":"2023-10-18T20:49:49.1193781Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-18T20:49:49.1349786Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-18T20:49:49.1349786Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-18T20:49:48.9162257Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","name":"clitestload000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-10-24T12:26:32.8244469Z","key2":"2023-10-24T12:26:32.8244469Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-24T12:26:32.8401041Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-10-24T12:26:32.8401041Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-10-24T12:26:32.6369492Z","primaryEndpoints":{"blob":"https://clitestload000003.blob.core.windows.net/","queue":"https://clitestload000003.queue.core.windows.net/","table":"https://clitestload000003.table.core.windows.net/","file":"https://clitestload000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:50:10 GMT
+      - Tue, 24 Oct 2023 12:26:56 GMT
       expires:
       - '-1'
       pragma:
@@ -60,7 +60,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.502241Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.502241Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:56.206785Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:56.206785Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -69,9 +69,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:10 GMT
+      - Tue, 24 Oct 2023 12:26:56 GMT
       etag:
-      - '"75003140-0000-0100-0000-653044cb0000"'
+      - '"d300e334-0000-0100-0000-6537b7d60000"'
       expires:
       - '-1'
       pragma:
@@ -101,7 +101,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -114,9 +114,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:50:12 GMT
+      - Tue, 24 Oct 2023 12:26:58 GMT
       mise-correlation-id:
-      - f7ef9209-c10a-4945-ab86-f535def3c5b2
+      - ce0f9f1c-f71e-4c0d-9e20-ce42b93a9157
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -133,10 +133,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"aff13ba4-f177-4bec-bdcd-5833da9bd4b1": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "3ea92c26-7335-42be-b2fc-1e0c9a754084":
+      {"passFailMetrics": {"5dd62580-c48d-45ba-bce1-00b1083b1464": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "9e316a14-c780-4e1e-a4ed-3e359b66bf81":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "01c646b4-6dd3-4247-80a5-c3e6210d1b92": {"aggregate": "avg", "clientMetric":
+      "50"}, "2f8921d6-48a7-4421-b629-b9befca2c99d": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -152,11 +152,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aff13ba4-f177-4bec-bdcd-5833da9bd4b1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3ea92c26-7335-42be-b2fc-1e0c9a754084":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01c646b4-6dd3-4247-80a5-c3e6210d1b92":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:50:12.961Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:12.961Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5dd62580-c48d-45ba-bce1-00b1083b1464":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9e316a14-c780-4e1e-a4ed-3e359b66bf81":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2f8921d6-48a7-4421-b629-b9befca2c99d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:26:58.883Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:26:58.883Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -167,11 +167,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:12 GMT
+      - Tue, 24 Oct 2023 12:26:58 GMT
       location:
-      - https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
+      - https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 42c2e7c3-2454-4ddb-8041-a5f24cef28a6
+      - 69b0f0f8-e396-4d1c-9986-e01fd1f9bbc6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -191,7 +191,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
+    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -205,9 +205,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:13 GMT
+      - Tue, 24 Oct 2023 12:26:59 GMT
       mise-correlation-id:
-      - 2e2cfb0a-71b3-44ba-b8f5-30219006f7d8
+      - 56edca10-a17f-4297-9978-7234b6f04b6f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -321,25 +321,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3c99e00d-5338-4fb2-a627-5e4ed3700ba8/e61089e1-2669-4836-8726-7cfa345de953?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A13Z&sr=b&sp=r&sig=Il2yeRUhVBui%2FE2MqM%2BbA2NWZ0cPlBcCKp49rJm626k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:13.8656517","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/529f058f-3198-404f-8582-fc4fe6d3b00a/b17fbc46-72c2-4140-aeba-0a1b56767408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A59Z&sr=b&sp=r&sig=dwUQU2xRezkLQryDPehHkXR%2FLi9u%2BPU62%2BHttqH58Mw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:59.6470678","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:13 GMT
+      - Tue, 24 Oct 2023 12:26:59 GMT
       location:
-      - https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - f690ef50-56bd-424d-94bc-2d9bdcb6fbe9
+      - 21e56721-3842-4c80-918e-53df77e76e62
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -359,10 +359,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3c99e00d-5338-4fb2-a627-5e4ed3700ba8/e61089e1-2669-4836-8726-7cfa345de953?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A14Z&sr=b&sp=r&sig=rbtlx%2BFgKiNTlCRJwhkQU4unZin2NxqKA5uQXyKpn%2B0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:14.1122786","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/529f058f-3198-404f-8582-fc4fe6d3b00a/b17fbc46-72c2-4140-aeba-0a1b56767408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A36%3A59Z&sr=b&sp=r&sig=%2BiB7EdxP1uDWGjtWKgORIAIki672GEaUDdoW7Osy9NA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:36:59.9359393","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:26:59 GMT
+      mise-correlation-id:
+      - 8bfc3a33-92c8-4ec9-84cf-282c67c11494
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/529f058f-3198-404f-8582-fc4fe6d3b00a/b17fbc46-72c2-4140-aeba-0a1b56767408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A05Z&sr=b&sp=r&sig=0R%2FrynlcaJy%2FtXR43WGfTonJxb1TI5lzSFUc0htAKA4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:05.2557909","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -373,9 +409,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:14 GMT
+      - Tue, 24 Oct 2023 12:27:05 GMT
       mise-correlation-id:
-      - 79cc027c-f325-403b-bd27-caf566ccfffa
+      - ca795ae0-0342-4145-b2e3-306b0af06f7f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -395,10 +431,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3c99e00d-5338-4fb2-a627-5e4ed3700ba8/e61089e1-2669-4836-8726-7cfa345de953?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A19Z&sr=b&sp=r&sig=jj6J9vJXsTodgomuXVtXuVerLOba0SBWJn3213jADBA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:19.3578814","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/529f058f-3198-404f-8582-fc4fe6d3b00a/b17fbc46-72c2-4140-aeba-0a1b56767408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A10Z&sr=b&sp=r&sig=oYJjSjNdtASJimpeUiFz61idExUQQZ1n2J3ISEThR3g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:10.5606776","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -409,9 +445,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:19 GMT
+      - Tue, 24 Oct 2023 12:27:10 GMT
       mise-correlation-id:
-      - 75a90cb1-72f5-429c-b100-b36ac391e32d
+      - b7c7f9b3-482c-434d-959d-af93feecff86
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -431,23 +467,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3c99e00d-5338-4fb2-a627-5e4ed3700ba8/e61089e1-2669-4836-8726-7cfa345de953?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A24Z&sr=b&sp=r&sig=Fd0ZBMNXDkN%2FEf1UMddfrJGtINVaT0s%2F%2Fhj1GSxfD30%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:24.641864","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/529f058f-3198-404f-8582-fc4fe6d3b00a/b17fbc46-72c2-4140-aeba-0a1b56767408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A15Z&sr=b&sp=r&sig=%2Fv07J8BA%2BtjLMOCtj97qf0Fx8Jz%2F87Ro2fJg%2FvBqYvE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:15.83834","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '554'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:24 GMT
+      - Tue, 24 Oct 2023 12:27:15 GMT
       mise-correlation-id:
-      - 3f2d867b-a9c7-41ee-ad18-49f525626c1f
+      - f2c949e1-6cef-4039-b737-c3688de61fe3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -467,47 +503,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3c99e00d-5338-4fb2-a627-5e4ed3700ba8/e61089e1-2669-4836-8726-7cfa345de953?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A00%3A29Z&sr=b&sp=r&sig=kGFH5MvUb6o0nSbHsToKPZd2dudlDtl%2B3GUyD0Mtgb8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:00:29.9798341","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:50:29 GMT
-      mise-correlation-id:
-      - 7dbde900-7260-4290-9219-493144493087
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"aff13ba4-f177-4bec-bdcd-5833da9bd4b1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3ea92c26-7335-42be-b2fc-1e0c9a754084":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01c646b4-6dd3-4247-80a5-c3e6210d1b92":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3c99e00d-5338-4fb2-a627-5e4ed3700ba8/e61089e1-2669-4836-8726-7cfa345de953?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A50%3A30Z&sr=b&sp=r&sig=kCWWH8uCiWSQGukxYXBhW11JIAlOlvipu1wI1BqP%2FPM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:50:30.2231827","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:50:12.961Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:27.249Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"5dd62580-c48d-45ba-bce1-00b1083b1464":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9e316a14-c780-4e1e-a4ed-3e359b66bf81":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2f8921d6-48a7-4421-b629-b9befca2c99d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/529f058f-3198-404f-8582-fc4fe6d3b00a/b17fbc46-72c2-4140-aeba-0a1b56767408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A27%3A16Z&sr=b&sp=r&sig=1z7LOIs6Eeko12%2FNj4XyAeOD9xvjyYhvFdpR3VvPeTk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:27:16.0833247","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:26:58.883Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:12.359Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -518,9 +518,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:30 GMT
+      - Tue, 24 Oct 2023 12:27:16 GMT
       mise-correlation-id:
-      - 99c3667d-ebf4-469a-8d67-b6011205291e
+      - a42c9e93-5f77-4c6f-b622-83f5d99319d5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -543,7 +543,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.502241Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.502241Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:56.206785Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:56.206785Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -552,9 +552,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:31 GMT
+      - Tue, 24 Oct 2023 12:27:16 GMT
       etag:
-      - '"75003140-0000-0100-0000-653044cb0000"'
+      - '"d300e334-0000-0100-0000-6537b7d60000"'
       expires:
       - '-1'
       pragma:
@@ -584,11 +584,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"aff13ba4-f177-4bec-bdcd-5833da9bd4b1":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"3ea92c26-7335-42be-b2fc-1e0c9a754084":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"01c646b4-6dd3-4247-80a5-c3e6210d1b92":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3c99e00d-5338-4fb2-a627-5e4ed3700ba8/e61089e1-2669-4836-8726-7cfa345de953?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A50%3A32Z&sr=b&sp=r&sig=ooKhP7DzdxIrNIcH38AA4nisSccHcd4VzLYQDAS%2FN9U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:50:32.3317061","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:50:12.961Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:27.249Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"5dd62580-c48d-45ba-bce1-00b1083b1464":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9e316a14-c780-4e1e-a4ed-3e359b66bf81":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2f8921d6-48a7-4421-b629-b9befca2c99d":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/529f058f-3198-404f-8582-fc4fe6d3b00a/b17fbc46-72c2-4140-aeba-0a1b56767408?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A27%3A18Z&sr=b&sp=r&sig=ls4jF0ypq96gYKR7ZHJtmtQF8NREkC03X7C%2F8ZnpfYQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:27:18.2042364","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"server-metric-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:26:58.883Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:12.359Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -599,9 +599,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:32 GMT
+      - Tue, 24 Oct 2023 12:27:18 GMT
       mise-correlation-id:
-      - 2750e563-b3ce-4a41-8e58-e5f76f3f173a
+      - 5cd9129d-ff07-451d-a544-cee345308b2e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -624,7 +624,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.502241Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.502241Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:56.206785Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:56.206785Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -633,9 +633,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:32 GMT
+      - Tue, 24 Oct 2023 12:27:18 GMT
       etag:
-      - '"75003140-0000-0100-0000-653044cb0000"'
+      - '"d300e334-0000-0100-0000-6537b7d60000"'
       expires:
       - '-1'
       pragma:
@@ -654,9 +654,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-n4uplbhh626nuajv6/providers/Microsoft.Storage/storageAccounts/clitestloadphksxorhe":
-      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-n4uplbhh626nuajv6/providers/Microsoft.Storage/storageAccounts/clitestloadphksxorhe",
-      "resourceName": "clitestloadphksxorhe", "resourceType": "Microsoft.Storage/storageAccounts",
+    body: '{"testId": "server-metric-test-case", "components": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-mjtieyonooy3xpjks/providers/Microsoft.Storage/storageAccounts/clitestloadpwy3mvml3":
+      {"resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-mjtieyonooy3xpjks/providers/Microsoft.Storage/storageAccounts/clitestloadpwy3mvml3",
+      "resourceName": "clitestloadpwy3mvml3", "resourceType": "Microsoft.Storage/storageAccounts",
       "kind": "Storage"}}}'
     headers:
       Accept:
@@ -672,10 +672,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-18T20:50:34.995Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:34.995Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-24T12:27:19.805Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:19.805Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -686,11 +686,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:35 GMT
+      - Tue, 24 Oct 2023 12:27:19 GMT
       location:
-      - https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+      - https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
       mise-correlation-id:
-      - ec2b7547-63ab-43fa-9fa5-9f0dcbf2abd4
+      - 80442249-dcc9-491c-bd55-aac21d17c658
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -713,7 +713,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.502241Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.502241Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:56.206785Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:56.206785Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -722,9 +722,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:35 GMT
+      - Tue, 24 Oct 2023 12:27:21 GMT
       etag:
-      - '"75003140-0000-0100-0000-653044cb0000"'
+      - '"d300e334-0000-0100-0000-6537b7d60000"'
       expires:
       - '-1'
       pragma:
@@ -754,10 +754,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
+    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/app-components?api-version=2022-11-01
   response:
     body:
-      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-18T20:50:34.995Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:34.995Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"components":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","resourceName":"clitestload000003","resourceType":"Microsoft.Storage/storageAccounts","resourceGroup":"clitest-load-000001","subscriptionId":"7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a","kind":"Storage"}},"testId":"server-metric-test-case","createdDateTime":"2023-10-24T12:27:19.805Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:19.805Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -768,9 +768,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:36 GMT
+      - Tue, 24 Oct 2023 12:27:22 GMT
       mise-correlation-id:
-      - 2fa208d9-3708-4772-b7f9-0c0756eddee8
+      - 9d8b6e02-d313-43b9-b4e1-72d6798d1a0f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -793,7 +793,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.502241Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.502241Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:56.206785Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:56.206785Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -802,9 +802,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:37 GMT
+      - Tue, 24 Oct 2023 12:27:22 GMT
       etag:
-      - '"75003140-0000-0100-0000-653044cb0000"'
+      - '"d300e334-0000-0100-0000-6537b7d60000"'
       expires:
       - '-1'
       pragma:
@@ -823,9 +823,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-n4uplbhh626nuajv6/providers/Microsoft.Storage/storageAccounts/clitestloadphksxorhe/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-mjtieyonooy3xpjks/providers/Microsoft.Storage/storageAccounts/clitestloadpwy3mvml3/providers/microsoft.insights/metricdefinitions/Availability":
       {"name": " Availability", "metricNamespace": "microsoft.storage/storageaccounts",
-      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-n4uplbhh626nuajv6/providers/Microsoft.Storage/storageAccounts/clitestloadphksxorhe",
+      "aggregation": "Average", "resourceId": "/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-mjtieyonooy3xpjks/providers/Microsoft.Storage/storageAccounts/clitestloadpwy3mvml3",
       "resourceType": "Microsoft.Storage/storageAccounts"}}}'
     headers:
       Accept:
@@ -841,12 +841,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-18T20:50:35.059Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:38.177Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-24T12:27:19.835Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:23.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -857,9 +857,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:38 GMT
+      - Tue, 24 Oct 2023 12:27:23 GMT
       mise-correlation-id:
-      - 66e6949e-ad5b-419b-bb9f-d8224c18672f
+      - e6f1a824-0618-47e0-968d-213588d4c11b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -882,7 +882,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.502241Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.502241Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:56.206785Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:56.206785Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -891,9 +891,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:39 GMT
+      - Tue, 24 Oct 2023 12:27:25 GMT
       etag:
-      - '"75003140-0000-0100-0000-653044cb0000"'
+      - '"d300e334-0000-0100-0000-6537b7d60000"'
       expires:
       - '-1'
       pragma:
@@ -923,12 +923,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
       string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/Availability":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/
         Availability","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"
-        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-18T20:50:35.059Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:38.177Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        Availability","aggregation":"Average","resourceType":"Microsoft.Storage/storageAccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-24T12:27:19.835Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:23.814Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -939,9 +939,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:40 GMT
+      - Tue, 24 Oct 2023 12:27:26 GMT
       mise-correlation-id:
-      - be52dfbd-a124-4591-83b0-4a55d60c642e
+      - be160bb3-07a0-4299-b087-c00bcab6010d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -964,7 +964,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.502241Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.502241Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:56.206785Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:56.206785Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -973,9 +973,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:40 GMT
+      - Tue, 24 Oct 2023 12:27:26 GMT
       etag:
-      - '"75003140-0000-0100-0000-653044cb0000"'
+      - '"d300e334-0000-0100-0000-6537b7d60000"'
       expires:
       - '-1'
       pragma:
@@ -994,7 +994,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-n4uplbhh626nuajv6/providers/Microsoft.Storage/storageAccounts/clitestloadphksxorhe/providers/microsoft.insights/metricdefinitions/Availability":
+    body: '{"testId": "server-metric-test-case", "metrics": {"/subscriptions/7c71b563-0dc0-4bc0-bcf6-06f8f0516c7a/resourceGroups/clitest-load-mjtieyonooy3xpjks/providers/Microsoft.Storage/storageAccounts/clitestloadpwy3mvml3/providers/microsoft.insights/metricdefinitions/Availability":
       null}}'
     headers:
       Accept:
@@ -1010,10 +1010,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-18T20:50:35.059Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:42.533Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-24T12:27:19.835Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:27.826Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1024,9 +1024,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:42 GMT
+      - Tue, 24 Oct 2023 12:27:27 GMT
       mise-correlation-id:
-      - 00364e60-035e-4b29-83b9-7b2840b774d0
+      - 8c2e80fc-c27e-4af2-935e-0b4e64b69fa6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1049,7 +1049,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:49:14.502241Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:49:14.502241Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:25:56.206785Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:25:56.206785Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1058,9 +1058,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:43 GMT
+      - Tue, 24 Oct 2023 12:27:28 GMT
       etag:
-      - '"75003140-0000-0100-0000-653044cb0000"'
+      - '"d300e334-0000-0100-0000-6537b7d60000"'
       expires:
       - '-1'
       pragma:
@@ -1090,10 +1090,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://b5d8ed92-c4bf-4991-9cd2-580f787f5920.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
+    uri: https://1dce6b60-ab19-4e18-916f-33cdcb638348.eastus.cnt-prod.loadtesting.azure.com/tests/server-metric-test-case/server-metrics-config?api-version=2022-11-01
   response:
     body:
-      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-18T20:50:35.059Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:50:42.533Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"testId":"server-metric-test-case","metrics":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessE2ELatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessE2ELatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/UsedCapacity","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"UsedCapacity","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003/providers/microsoft.insights/metricdefinitions/SuccessServerLatency","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.Storage/storageAccounts/clitestload000003","metricNamespace":"microsoft.storage/storageaccounts","name":"SuccessServerLatency","aggregation":"Average","resourceType":"microsoft.storage/storageaccounts"}},"createdDateTime":"2023-10-24T12:27:19.835Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:27.826Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1104,9 +1104,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:44 GMT
+      - Tue, 24 Oct 2023 12:27:29 GMT
       mise-correlation-id:
-      - 3bae18a1-9419-48ba-bd17-8815dcbe47d1
+      - 02fb31e1-dd39-42f3-8288-29945ff2b3fd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_show.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_show.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:31.3743579Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:31.3743579Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:19:48.574001Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:19:48.574001Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"c6990cba-370d-43fa-8ce3-ba36efa942da.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '653'
+      - '651'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:06 GMT
+      - Mon, 30 Oct 2023 07:20:22 GMT
       etag:
-      - '"3c008125-0000-0100-0000-653eda770000"'
+      - '"3f00ca68-0000-0100-0000-653f59160000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://c6990cba-370d-43fa-8ce3-ba36efa942da.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:20:07 GMT
+      - Mon, 30 Oct 2023 07:20:24 GMT
       mise-correlation-id:
-      - b624f7e5-bc5e-4454-9de6-c3703b6770be
+      - 286ddd1f-d235-40fc-adb3-9bf44e4cad37
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"c95bf1c0-fb6d-4293-b28a-a3f62b71989a": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "065381e3-5df6-4f99-9756-200263879661":
+      {"passFailMetrics": {"d74204d5-9a7f-41c3-964f-943136f15fcf": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "d5b94b15-0964-4538-8507-b43864aa0fe6":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "ab0084ab-a07b-42f2-a1f2-2f777c8a50c8": {"aggregate": "avg", "clientMetric":
+      "50"}, "1070a471-02c5-4696-84e6-9c6367076913": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,26 +106,26 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://c6990cba-370d-43fa-8ce3-ba36efa942da.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c95bf1c0-fb6d-4293-b28a-a3f62b71989a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"065381e3-5df6-4f99-9756-200263879661":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab0084ab-a07b-42f2-a1f2-2f777c8a50c8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:20:08.085Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:08.085Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d74204d5-9a7f-41c3-964f-943136f15fcf":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d5b94b15-0964-4538-8507-b43864aa0fe6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1070a471-02c5-4696-84e6-9c6367076913":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:20:24.71Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:20:24.71Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1006'
+      - '1004'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:08 GMT
+      - Mon, 30 Oct 2023 07:20:24 GMT
       location:
-      - https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+      - https://c6990cba-370d-43fa-8ce3-ba36efa942da.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 5ea026af-389e-4aa3-918f-1be28cc3b2d8
+      - f09229df-e61b-46fe-a848-ca72b3ab9b59
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
+    uri: https://c6990cba-370d-43fa-8ce3-ba36efa942da.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:08 GMT
+      - Mon, 30 Oct 2023 07:20:25 GMT
       mise-correlation-id:
-      - a8be5bdc-4ce2-4f75-8d57-7735cface4b7
+      - fab0f4a9-66c5-475d-9afe-5172b5e63a95
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://c6990cba-370d-43fa-8ce3-ba36efa942da.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8f83e558-42d9-424a-a5d6-b5f4da50244c/7f1d6f19-2127-4e76-ba95-5d89c4988476?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A09Z&sr=b&sp=r&sig=Kc93%2FRfn55L6FW9nmmI9wXGbFh%2BYii6O9SycNZCfjQU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:09.7444263","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ae1ed13f-b588-4ef9-b789-646a295cf4c8/014c4aef-06a5-44c2-8fd3-2a44a0cdac30?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A30%3A25Z&sr=b&sp=r&sig=32FFjqdvBQcgbG%2BlZgDMxdYGmHh8QtPK7BUvBhbReFE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:30:25.629444","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:09 GMT
+      - Mon, 30 Oct 2023 07:20:25 GMT
       location:
-      - https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://c6990cba-370d-43fa-8ce3-ba36efa942da.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - f4aefe00-a9e0-489c-a17e-db337175e665
+      - 97a4cf17-b37a-43ae-add9-52870374674a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c6990cba-370d-43fa-8ce3-ba36efa942da.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8f83e558-42d9-424a-a5d6-b5f4da50244c/7f1d6f19-2127-4e76-ba95-5d89c4988476?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A09Z&sr=b&sp=r&sig=Tap8CyL5vmUUdnKygsXlaLyFHjWwJCwhwOHlHSsLOCU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:09.9873763","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ae1ed13f-b588-4ef9-b789-646a295cf4c8/014c4aef-06a5-44c2-8fd3-2a44a0cdac30?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A30%3A25Z&sr=b&sp=r&sig=iJDMwXN5OxDArdeP8XzEuAZmdQIDNPEjUi1R48Eweus%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:30:25.9801432","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:09 GMT
+      - Mon, 30 Oct 2023 07:20:25 GMT
       mise-correlation-id:
-      - 1426d327-4b16-493b-92d7-037786a9f9ad
+      - 6cdcfcf1-bcc6-4e20-87c5-d57c8fcb2c22
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,10 +349,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c6990cba-370d-43fa-8ce3-ba36efa942da.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8f83e558-42d9-424a-a5d6-b5f4da50244c/7f1d6f19-2127-4e76-ba95-5d89c4988476?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A15Z&sr=b&sp=r&sig=FtVLU1yVL3t09YLD9HKcl0u5VdYi39q3VLNs%2B9ztgyM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:15.9814431","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ae1ed13f-b588-4ef9-b789-646a295cf4c8/014c4aef-06a5-44c2-8fd3-2a44a0cdac30?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A30%3A31Z&sr=b&sp=r&sig=YmOlAqr1PK5krCpCAaPDv9GlXqloFIWadBZiU0L5egc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:30:31.2810542","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:20:31 GMT
+      mise-correlation-id:
+      - 0a41dfe4-d071-4268-be23-b33e1be33685
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://c6990cba-370d-43fa-8ce3-ba36efa942da.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ae1ed13f-b588-4ef9-b789-646a295cf4c8/014c4aef-06a5-44c2-8fd3-2a44a0cdac30?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A30%3A36Z&sr=b&sp=r&sig=n4%2BMsyN8MEz2LffRFBfoBDp7uxyPp7i7HrVVymtAvBA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:30:36.6233678","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:15 GMT
+      - Mon, 30 Oct 2023 07:20:36 GMT
       mise-correlation-id:
-      - e0c391d3-5d0e-4d42-bc25-526d02e743d1
+      - 546ca46d-4d9c-496c-b584-a499ac19fbd3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c6990cba-370d-43fa-8ce3-ba36efa942da.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8f83e558-42d9-424a-a5d6-b5f4da50244c/7f1d6f19-2127-4e76-ba95-5d89c4988476?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A21Z&sr=b&sp=r&sig=DIf1uWu7YcHe0Y%2FQBFJ9WRgVSk8byUWKP94u5cdwUEI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:21.2534605","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ae1ed13f-b588-4ef9-b789-646a295cf4c8/014c4aef-06a5-44c2-8fd3-2a44a0cdac30?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A30%3A41Z&sr=b&sp=r&sig=Ugph56d1jhPSNSf9VpeJOuKLsPeGCJBQCLZZ%2FMiB6U4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:30:41.9037921","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:21 GMT
+      - Mon, 30 Oct 2023 07:20:41 GMT
       mise-correlation-id:
-      - 1890ef1d-75c8-44fd-9492-0cd287fbe036
+      - bbde35fd-51f4-439f-8a4f-187d1751b019
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,60 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://c6990cba-370d-43fa-8ce3-ba36efa942da.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8f83e558-42d9-424a-a5d6-b5f4da50244c/7f1d6f19-2127-4e76-ba95-5d89c4988476?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A26Z&sr=b&sp=r&sig=Lr7XJoumsPdNz%2F3p%2B31fdjB7C5ciuFOlgE2%2F1FEAO7w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:26.7342829","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d74204d5-9a7f-41c3-964f-943136f15fcf":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d5b94b15-0964-4538-8507-b43864aa0fe6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1070a471-02c5-4696-84e6-9c6367076913":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ae1ed13f-b588-4ef9-b789-646a295cf4c8/014c4aef-06a5-44c2-8fd3-2a44a0cdac30?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A20%3A42Z&sr=b&sp=r&sig=gwN21%2FvTPJKMKI1yN4Mmzkhk1%2FefdawRGGUivXn9hT0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:20:42.15771","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:20:24.71Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:20:38.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '1576'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:26 GMT
+      - Mon, 30 Oct 2023 07:20:42 GMT
       mise-correlation-id:
-      - bcc5ae24-cadb-4b90-9757-2d52616906aa
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c95bf1c0-fb6d-4293-b28a-a3f62b71989a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"065381e3-5df6-4f99-9756-200263879661":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab0084ab-a07b-42f2-a1f2-2f777c8a50c8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8f83e558-42d9-424a-a5d6-b5f4da50244c/7f1d6f19-2127-4e76-ba95-5d89c4988476?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A20%3A27Z&sr=b&sp=r&sig=nwaT6KQ786%2BssIlzjDHFOKzUcwEoqBFmdGmmFRLr3g8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:20:27.0000033","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:20:08.085Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:25.921Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1577'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:20:27 GMT
-      mise-correlation-id:
-      - 587183e5-3c13-4477-93df-cb0f87f279a9
+      - 56f39e7d-674f-4ce6-95a0-d9e6579db132
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:31.3743579Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:31.3743579Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:19:48.574001Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:19:48.574001Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"c6990cba-370d-43fa-8ce3-ba36efa942da.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '653'
+      - '651'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:28 GMT
+      - Mon, 30 Oct 2023 07:20:42 GMT
       etag:
-      - '"3c008125-0000-0100-0000-653eda770000"'
+      - '"3f00ca68-0000-0100-0000-653f59160000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://c6990cba-370d-43fa-8ce3-ba36efa942da.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"c95bf1c0-fb6d-4293-b28a-a3f62b71989a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"065381e3-5df6-4f99-9756-200263879661":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab0084ab-a07b-42f2-a1f2-2f777c8a50c8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8f83e558-42d9-424a-a5d6-b5f4da50244c/7f1d6f19-2127-4e76-ba95-5d89c4988476?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A20%3A29Z&sr=b&sp=r&sig=Sw%2BY%2BKlrUVq6kwl4P9jMszvwqjJ%2FzUJj7EGLXrVU1fM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:20:29.5445671","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:20:08.085Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:25.921Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d74204d5-9a7f-41c3-964f-943136f15fcf":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d5b94b15-0964-4538-8507-b43864aa0fe6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1070a471-02c5-4696-84e6-9c6367076913":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ae1ed13f-b588-4ef9-b789-646a295cf4c8/014c4aef-06a5-44c2-8fd3-2a44a0cdac30?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A20%3A44Z&sr=b&sp=r&sig=Okb6OvstKMVeRCfDtd3GqNVyLaY17cDaR%2BDXJ5C7MTQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:20:44.8276153","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:20:24.71Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:20:38.061Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1593'
+      - '1588'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:29 GMT
+      - Mon, 30 Oct 2023 07:20:44 GMT
       mise-correlation-id:
-      - e7cc388f-970a-4a3d-8575-cea424442b67
+      - a44b8528-a48c-4c8f-8090-40bc56976778
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:31.3743579Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:31.3743579Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:19:48.574001Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:19:48.574001Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"c6990cba-370d-43fa-8ce3-ba36efa942da.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '653'
+      - '651'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:30 GMT
+      - Mon, 30 Oct 2023 07:20:45 GMT
       etag:
-      - '"3c008125-0000-0100-0000-653eda770000"'
+      - '"3f00ca68-0000-0100-0000-653f59160000"'
       expires:
       - '-1'
       pragma:
@@ -619,24 +619,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://c6990cba-370d-43fa-8ce3-ba36efa942da.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c95bf1c0-fb6d-4293-b28a-a3f62b71989a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"065381e3-5df6-4f99-9756-200263879661":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab0084ab-a07b-42f2-a1f2-2f777c8a50c8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8f83e558-42d9-424a-a5d6-b5f4da50244c/7f1d6f19-2127-4e76-ba95-5d89c4988476?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A20%3A31Z&sr=b&sp=r&sig=ajRNDo7KQLmh6iR%2BkucbfWLqx6S27yNXbgyVVF%2FVeXQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:20:31.8056772","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:20:08.085Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:25.921Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d74204d5-9a7f-41c3-964f-943136f15fcf":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"d5b94b15-0964-4538-8507-b43864aa0fe6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1070a471-02c5-4696-84e6-9c6367076913":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/ae1ed13f-b588-4ef9-b789-646a295cf4c8/014c4aef-06a5-44c2-8fd3-2a44a0cdac30?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A20%3A46Z&sr=b&sp=r&sig=Icjp9MuwDebVZD3rSACHhOa0tBMw2cnJAcQK9TL5CuE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:20:46.6191306","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:20:24.71Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:20:38.061Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1579'
+      - '1574'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:20:31 GMT
+      - Mon, 30 Oct 2023 07:20:46 GMT
       mise-correlation-id:
-      - 4d1d4dca-da20-4720-88b8-c6f52f019f45
+      - 765bedeb-6853-442d-b3bc-93b288b99ed0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_show.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_show.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:17.1513453Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:17.1513453Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:23.1466229Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:23.1466229Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:50 GMT
+      - Fri, 13 Oct 2023 13:50:57 GMT
       etag:
-      - '"5500a2f0-0000-0100-0000-652451bf0000"'
+      - '"d801fcd1-0000-0100-0000-65294b210000"'
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:17:51 GMT
+      - Fri, 13 Oct 2023 13:50:58 GMT
       mise-correlation-id:
-      - 350b242c-7c12-4de1-8a16-d75a9c75adc5
+      - 2209371c-3a3a-4158-a673-8c752d560ab9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"c0ea5d3b-969c-437a-97cc-db96ff400898": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "56ec61f4-ce9c-4b9a-b9f0-c81400c8d9b5":
+      {"passFailMetrics": {"b0371f02-3fda-4df0-ad7f-bf59074c34ed": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "14171043-65d1-482a-81aa-0906becc05c9":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "a7badcd8-b27f-4b5f-89da-d162e42a54b1": {"aggregate": "avg", "clientMetric":
+      "50"}, "fd00bd28-1334-44fb-968a-10561ae5fe76": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -104,13 +104,13 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c0ea5d3b-969c-437a-97cc-db96ff400898":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"56ec61f4-ce9c-4b9a-b9f0-c81400c8d9b5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"a7badcd8-b27f-4b5f-89da-d162e42a54b1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:17:52.216Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:52.216Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b0371f02-3fda-4df0-ad7f-bf59074c34ed":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"14171043-65d1-482a-81aa-0906becc05c9":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fd00bd28-1334-44fb-968a-10561ae5fe76":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:50:59.419Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:59.419Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:52 GMT
+      - Fri, 13 Oct 2023 13:50:59 GMT
       location:
-      - https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+      - https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 5355fa1a-8d4e-4b7c-8646-65774e362486
+      - 52aaaa15-c3d5-4be0-bf24-b315a337cb9c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -143,9 +143,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
+    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:52 GMT
+      - Fri, 13 Oct 2023 13:50:59 GMT
       mise-correlation-id:
-      - dd298add-e01c-4db3-875f-247426cee84f
+      - c75645bd-a57e-4e29-8fea-b3074e00be2c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -273,27 +273,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a3b0cc27-5ba1-40c9-96d2-9775830eea41/b547db8d-2870-4e20-ba7b-dcb78de245e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A53Z&sr=b&sp=r&sig=GaV9yh4zqJDxSussxeHMmItV%2BoJnYcm9KeksIC1msEQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:53.1237433","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/92732341-426b-4227-bf8f-6100ce7654cd/8f8e0b3a-f875-4469-be09-aec4e82676f5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A00Z&sr=b&sp=r&sig=fGOQcFquSzFWzZwDEO3bhTCsiTNOnitu%2FJmga2hwDA4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:00.715622","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:53 GMT
+      - Fri, 13 Oct 2023 13:51:00 GMT
       location:
-      - https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 6d7c787e-3dee-48ce-8fb0-d673cced15e6
+      - 0ad060df-8a25-4def-8807-b4d67ec3b748
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -311,48 +311,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a3b0cc27-5ba1-40c9-96d2-9775830eea41/b547db8d-2870-4e20-ba7b-dcb78de245e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A54Z&sr=b&sp=r&sig=%2FmkmUKEzR2xrxda179LzzvZhAat4ULC0PBN1WDQfJvE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:54.1743745","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:17:54 GMT
-      mise-correlation-id:
-      - a92a8b4b-d440-453f-8ddd-b58425ab42dd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a3b0cc27-5ba1-40c9-96d2-9775830eea41/b547db8d-2870-4e20-ba7b-dcb78de245e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A59Z&sr=b&sp=r&sig=c3Hvq91ejqamH59ZIr9IqOzS71xgF3iuqaYipY2uWO4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:59.4445367","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/92732341-426b-4227-bf8f-6100ce7654cd/8f8e0b3a-f875-4469-be09-aec4e82676f5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A01Z&sr=b&sp=r&sig=UivRGcy6ii3t5ZNLB0OIK00LHmUZbP9Ddj1dcF9xcb0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:01.0353213","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:17:59 GMT
+      - Fri, 13 Oct 2023 13:51:01 GMT
       mise-correlation-id:
-      - b1af3330-cbb8-4071-a6f7-01c9223562c3
+      - b79efe38-d61f-481d-bedb-aae8dc4dab25
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -383,12 +347,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a3b0cc27-5ba1-40c9-96d2-9775830eea41/b547db8d-2870-4e20-ba7b-dcb78de245e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A04Z&sr=b&sp=r&sig=cSMSKjARS4kUVyC%2FP%2BiejDunSIovPPhqwH1zoUj049c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:04.7231832","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/92732341-426b-4227-bf8f-6100ce7654cd/8f8e0b3a-f875-4469-be09-aec4e82676f5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A06Z&sr=b&sp=r&sig=eMXOoAKaIj4HA%2F0bwSwv3JBPlTRbPAd%2FGVnz72kV1Io%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:06.5044287","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:04 GMT
+      - Fri, 13 Oct 2023 13:51:06 GMT
       mise-correlation-id:
-      - 9e7e26af-deb0-4e0b-869a-700486844911
+      - 6ab0e327-6505-4621-80b5-5105d317e468
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -419,25 +383,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a3b0cc27-5ba1-40c9-96d2-9775830eea41/b547db8d-2870-4e20-ba7b-dcb78de245e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A10Z&sr=b&sp=r&sig=VE1U6O4uxT2JrzAIpsdBXyg4C4rBvsHQZtdOfZH55x0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:10.0430248","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/92732341-426b-4227-bf8f-6100ce7654cd/8f8e0b3a-f875-4469-be09-aec4e82676f5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A11Z&sr=b&sp=r&sig=DhEmoTr1Qz382sccgtCB6GHl5Fc8Zmp2bSe55T7RWLU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:11.7539331","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:10 GMT
+      - Fri, 13 Oct 2023 13:51:11 GMT
       mise-correlation-id:
-      - c3c6e996-b82a-46b3-b054-9aba2258e254
+      - b62218e2-22e7-4ce1-bd46-37ead1476616
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -455,26 +419,62 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c0ea5d3b-969c-437a-97cc-db96ff400898":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"56ec61f4-ce9c-4b9a-b9f0-c81400c8d9b5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"a7badcd8-b27f-4b5f-89da-d162e42a54b1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a3b0cc27-5ba1-40c9-96d2-9775830eea41/b547db8d-2870-4e20-ba7b-dcb78de245e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A10Z&sr=b&sp=r&sig=Koe0ymZ07xxUgYfYxKiveOo%2B4iMPemb1%2B8OkB6ICu6o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:10.304022","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:17:52.216Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:05.522Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/92732341-426b-4227-bf8f-6100ce7654cd/8f8e0b3a-f875-4469-be09-aec4e82676f5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A17Z&sr=b&sp=r&sig=QJ3%2FDOScW4TCbx2mGadRcqUaTHXqzpyAnT6kHe8Md0k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:17.0262801","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1578'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:10 GMT
+      - Fri, 13 Oct 2023 13:51:17 GMT
       mise-correlation-id:
-      - c7e7b3be-9970-4150-8eab-e195728f21c8
+      - fba24985-e86d-4fa6-9cca-8948642704b9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"b0371f02-3fda-4df0-ad7f-bf59074c34ed":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"14171043-65d1-482a-81aa-0906becc05c9":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fd00bd28-1334-44fb-968a-10561ae5fe76":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/92732341-426b-4227-bf8f-6100ce7654cd/8f8e0b3a-f875-4469-be09-aec4e82676f5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A17Z&sr=b&sp=r&sig=Mnj573DAtCGbCQCMT%2F1vHbSyUkQ7MkMEB114b5sRDtw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:17.2670073","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:50:59.419Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:13.166Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1577'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:51:17 GMT
+      mise-correlation-id:
+      - c05ef908-58f5-4e11-a375-ec177f75f3cb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:17.1513453Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:17.1513453Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:23.1466229Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:23.1466229Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:11 GMT
+      - Fri, 13 Oct 2023 13:51:17 GMT
       etag:
-      - '"5500a2f0-0000-0100-0000-652451bf0000"'
+      - '"d801fcd1-0000-0100-0000-65294b210000"'
       expires:
       - '-1'
       pragma:
@@ -536,26 +536,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"c0ea5d3b-969c-437a-97cc-db96ff400898":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"56ec61f4-ce9c-4b9a-b9f0-c81400c8d9b5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"a7badcd8-b27f-4b5f-89da-d162e42a54b1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a3b0cc27-5ba1-40c9-96d2-9775830eea41/b547db8d-2870-4e20-ba7b-dcb78de245e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A12Z&sr=b&sp=r&sig=s2dr3APXgegAjk4n6b%2BA%2BgSvQARCRC2d53GP4rdAjmM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:12.7217903","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:17:52.216Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:05.522Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"b0371f02-3fda-4df0-ad7f-bf59074c34ed":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"14171043-65d1-482a-81aa-0906becc05c9":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fd00bd28-1334-44fb-968a-10561ae5fe76":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/92732341-426b-4227-bf8f-6100ce7654cd/8f8e0b3a-f875-4469-be09-aec4e82676f5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A19Z&sr=b&sp=r&sig=VfxigteUiL6cZgWtXl5rYhWcZU6skfwuL%2F8DrTfciwY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:19.5629427","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:50:59.419Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:13.166Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1591'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:12 GMT
+      - Fri, 13 Oct 2023 13:51:19 GMT
       mise-correlation-id:
-      - 9156b1f5-b59f-405a-af31-5292d5414b43
+      - 9268b86f-831d-4ca1-8d3d-ea1610939079
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:17.1513453Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:17.1513453Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:23.1466229Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:23.1466229Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:13 GMT
+      - Fri, 13 Oct 2023 13:51:20 GMT
       etag:
-      - '"5500a2f0-0000-0100-0000-652451bf0000"'
+      - '"d801fcd1-0000-0100-0000-65294b210000"'
       expires:
       - '-1'
       pragma:
@@ -617,26 +617,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"c0ea5d3b-969c-437a-97cc-db96ff400898":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"56ec61f4-ce9c-4b9a-b9f0-c81400c8d9b5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"a7badcd8-b27f-4b5f-89da-d162e42a54b1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a3b0cc27-5ba1-40c9-96d2-9775830eea41/b547db8d-2870-4e20-ba7b-dcb78de245e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A15Z&sr=b&sp=r&sig=Wb2ucsC%2FVhtXkyLL703ojSpHOewKmJGGbXfDaNaXelc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:15.275985","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:17:52.216Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:05.522Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"b0371f02-3fda-4df0-ad7f-bf59074c34ed":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"14171043-65d1-482a-81aa-0906becc05c9":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fd00bd28-1334-44fb-968a-10561ae5fe76":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/92732341-426b-4227-bf8f-6100ce7654cd/8f8e0b3a-f875-4469-be09-aec4e82676f5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A21Z&sr=b&sp=r&sig=j8%2Fv7J%2BmI9sZjPopLpubY8pjpnEAnVGbqrBfhr03W64%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:21.8675902","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:50:59.419Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:13.166Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1576'
+      - '1579'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:15 GMT
+      - Fri, 13 Oct 2023 13:51:21 GMT
       mise-correlation-id:
-      - 91ce7008-2cbf-4f67-bc4f-618180931402
+      - a9910328-96c6-4e85-837d-f8ae644336cd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_show.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_show.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:50:30.4829836Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:50:30.4829836Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:03.3288778Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:03.3288778Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:03 GMT
+      - Tue, 24 Oct 2023 12:27:37 GMT
       etag:
-      - '"75008e47-0000-0100-0000-653045180000"'
+      - '"d3007837-0000-0100-0000-6537b8190000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:51:06 GMT
+      - Tue, 24 Oct 2023 12:27:38 GMT
       mise-correlation-id:
-      - eb516a9f-a978-4c7f-9ee9-6532aed66463
+      - d0f79a47-f907-45b0-9463-88a7cf9204ab
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"09a473f6-6a54-47ac-8812-f23e24bd26b8": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "1c198ba8-c859-48b8-bfcd-b4d85846ce40":
+      {"passFailMetrics": {"260ba844-0c73-4f65-b297-71354bd10e44": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "f4426194-2f7f-44b7-8886-ab03a28adae1":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "1c9d1712-6e36-418d-ae1e-ab71aed46deb": {"aggregate": "avg", "clientMetric":
+      "50"}, "c99c1618-a900-4606-a988-a0d218f2336f": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"09a473f6-6a54-47ac-8812-f23e24bd26b8":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1c198ba8-c859-48b8-bfcd-b4d85846ce40":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1c9d1712-6e36-418d-ae1e-ab71aed46deb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:06.926Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:06.926Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"260ba844-0c73-4f65-b297-71354bd10e44":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f4426194-2f7f-44b7-8886-ab03a28adae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c99c1618-a900-4606-a988-a0d218f2336f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:27:39.112Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:39.112Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:06 GMT
+      - Tue, 24 Oct 2023 12:27:39 GMT
       location:
-      - https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+      - https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 31903d33-c515-43df-bb18-d05903b89158
+      - 5d6c2f07-7644-405a-9967-d02f54a4dfc3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
+    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:07 GMT
+      - Tue, 24 Oct 2023 12:27:39 GMT
       mise-correlation-id:
-      - af7a3e30-80c0-4cda-997e-0f9641d6dd70
+      - 87f1fddb-06ec-47bd-bcb5-e698ee08b353
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0d3930cd-b7dc-4b1b-851a-7d3dfa040071/c597e0f9-2a20-4c91-aefd-e126b1004839?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A08Z&sr=b&sp=r&sig=uNygAmgpSyVxei65rGcnkEVeG3HEJ9DY0OXRsm02asA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:08.4129522","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e91ca5eb-097d-4f7c-a995-9208d2272841/bd224025-9d04-473f-9d28-213813ce8b49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A41Z&sr=b&sp=r&sig=F7BCW0eEB99Te0Qa%2BeNQmHqgvO3fQt1cgQeEZao3HFg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:41.5999485","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:08 GMT
+      - Tue, 24 Oct 2023 12:27:41 GMT
       location:
-      - https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 4a8b8ae4-febd-4b1f-8196-896157845835
+      - 7943b214-203c-42f9-85f9-7dc81f226872
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0d3930cd-b7dc-4b1b-851a-7d3dfa040071/c597e0f9-2a20-4c91-aefd-e126b1004839?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A08Z&sr=b&sp=r&sig=M8EZv9Fr8QQ3a5szw7ODXveTa3oaybA1gAxNxCaSGqw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:08.6859886","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e91ca5eb-097d-4f7c-a995-9208d2272841/bd224025-9d04-473f-9d28-213813ce8b49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A41Z&sr=b&sp=r&sig=i4tPOCbyguG%2F9uG%2FwcFmwKH0wcLuXS62kRVCMDTMpZ8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:41.9383706","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:08 GMT
+      - Tue, 24 Oct 2023 12:27:41 GMT
       mise-correlation-id:
-      - dd7ebb18-0e61-477a-96e9-d2bd7d8b25bf
+      - 2fae5374-c8ad-4f92-ad14-d36b9413ea71
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,46 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0d3930cd-b7dc-4b1b-851a-7d3dfa040071/c597e0f9-2a20-4c91-aefd-e126b1004839?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A14Z&sr=b&sp=r&sig=r2fV0fupjEBoK8sa71Ff%2BpCMv4%2FMB9TW4%2FjdpQavNxI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:14.011506","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '554'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:51:14 GMT
-      mise-correlation-id:
-      - e348ce75-b5c1-4c32-a8c1-93fac34ec3da
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0d3930cd-b7dc-4b1b-851a-7d3dfa040071/c597e0f9-2a20-4c91-aefd-e126b1004839?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A19Z&sr=b&sp=r&sig=cKExX1fLerirXKiI1fVa8pAaO132gGM1UV%2FXlCyNdKE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:19.3003147","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e91ca5eb-097d-4f7c-a995-9208d2272841/bd224025-9d04-473f-9d28-213813ce8b49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A47Z&sr=b&sp=r&sig=Wd3hmmTj3xnnz%2B75a3Ag4hyrhJNiLzOzzO2ROPleGyU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:47.2463861","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:19 GMT
+      - Tue, 24 Oct 2023 12:27:47 GMT
       mise-correlation-id:
-      - 2fccb731-bfcb-492c-bd15-8fd5cde7218f
+      - b73470fd-0410-4eb9-a605-3d8c0182a9cc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0d3930cd-b7dc-4b1b-851a-7d3dfa040071/c597e0f9-2a20-4c91-aefd-e126b1004839?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A24Z&sr=b&sp=r&sig=DpqF9ee22KcXwNNV6yliIYtRgsGXwOANQbt7g0jQR3Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:24.5561652","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e91ca5eb-097d-4f7c-a995-9208d2272841/bd224025-9d04-473f-9d28-213813ce8b49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A52Z&sr=b&sp=r&sig=POWYQgKwaTP%2FHr6sj%2FswJdLrhRbpu0wUhM5wf6VNcxM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:52.5642635","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:24 GMT
+      - Tue, 24 Oct 2023 12:27:52 GMT
       mise-correlation-id:
-      - b7019975-9890-4998-aca7-4a00b1a1375e
+      - 658dbbb5-62c7-45d4-9b5c-73e6f0c7f3c8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,11 +421,47 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"09a473f6-6a54-47ac-8812-f23e24bd26b8":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1c198ba8-c859-48b8-bfcd-b4d85846ce40":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1c9d1712-6e36-418d-ae1e-ab71aed46deb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0d3930cd-b7dc-4b1b-851a-7d3dfa040071/c597e0f9-2a20-4c91-aefd-e126b1004839?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A24Z&sr=b&sp=r&sig=AN5KkgXvlPm%2BA8z930iuVP7qsgr5it%2BqDTZsE1SCGSM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:24.8073492","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:06.926Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:22.425Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e91ca5eb-097d-4f7c-a995-9208d2272841/bd224025-9d04-473f-9d28-213813ce8b49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A57Z&sr=b&sp=r&sig=BF9kftIlyTvc%2Fe2ml%2BYjRM%2FBk8wu2Mi0JHuKNDgLt0o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:57.8409878","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:27:57 GMT
+      mise-correlation-id:
+      - 3dee5111-afdc-44d7-846b-43cea293dfee
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"260ba844-0c73-4f65-b297-71354bd10e44":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f4426194-2f7f-44b7-8886-ab03a28adae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c99c1618-a900-4606-a988-a0d218f2336f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e91ca5eb-097d-4f7c-a995-9208d2272841/bd224025-9d04-473f-9d28-213813ce8b49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A27%3A58Z&sr=b&sp=r&sig=4dGgVkVjaeHTlg8ow4ufPtjocGRpce%2FTVOvtXxuV2%2Fk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:27:58.0997875","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:27:39.112Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:54.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,9 +472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:24 GMT
+      - Tue, 24 Oct 2023 12:27:58 GMT
       mise-correlation-id:
-      - 9cebcbf5-141d-4f78-999a-54d1d7112fe8
+      - 92f5e2a8-d6ca-4f71-9fb0-14bbd5adb54e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:50:30.4829836Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:50:30.4829836Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:03.3288778Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:03.3288778Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:25 GMT
+      - Tue, 24 Oct 2023 12:27:59 GMT
       etag:
-      - '"75008e47-0000-0100-0000-653045180000"'
+      - '"d3007837-0000-0100-0000-6537b8190000"'
       expires:
       - '-1'
       pragma:
@@ -538,11 +538,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"09a473f6-6a54-47ac-8812-f23e24bd26b8":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1c198ba8-c859-48b8-bfcd-b4d85846ce40":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1c9d1712-6e36-418d-ae1e-ab71aed46deb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0d3930cd-b7dc-4b1b-851a-7d3dfa040071/c597e0f9-2a20-4c91-aefd-e126b1004839?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A26Z&sr=b&sp=r&sig=ezmg8H56YY6j6lPe7Ez%2FgoilGBuVrUcWRm75pDjrn78%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:26.4965179","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:06.926Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:22.425Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"260ba844-0c73-4f65-b297-71354bd10e44":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f4426194-2f7f-44b7-8886-ab03a28adae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c99c1618-a900-4606-a988-a0d218f2336f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e91ca5eb-097d-4f7c-a995-9208d2272841/bd224025-9d04-473f-9d28-213813ce8b49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A27%3A59Z&sr=b&sp=r&sig=%2BGzSWxutMXZz0rLIi1neayiG0fHFYIuxNh0jdsl92Qg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:27:59.9475867","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:27:39.112Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:54.031Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:26 GMT
+      - Tue, 24 Oct 2023 12:27:59 GMT
       mise-correlation-id:
-      - 220ae707-dbab-4c88-9366-95077c581290
+      - 39b0088a-61a1-4036-986c-a538aa0877be
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:50:30.4829836Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:50:30.4829836Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:03.3288778Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:03.3288778Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:27 GMT
+      - Tue, 24 Oct 2023 12:28:01 GMT
       etag:
-      - '"75008e47-0000-0100-0000-653045180000"'
+      - '"d3007837-0000-0100-0000-6537b8190000"'
       expires:
       - '-1'
       pragma:
@@ -619,24 +619,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"09a473f6-6a54-47ac-8812-f23e24bd26b8":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1c198ba8-c859-48b8-bfcd-b4d85846ce40":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1c9d1712-6e36-418d-ae1e-ab71aed46deb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0d3930cd-b7dc-4b1b-851a-7d3dfa040071/c597e0f9-2a20-4c91-aefd-e126b1004839?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A28Z&sr=b&sp=r&sig=RmyA6zvPXVKWUGfjITA%2B5OPJx%2FAXZK3GmFp5G8nJWYI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:28.6485413","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:06.926Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:22.425Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"260ba844-0c73-4f65-b297-71354bd10e44":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f4426194-2f7f-44b7-8886-ab03a28adae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c99c1618-a900-4606-a988-a0d218f2336f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e91ca5eb-097d-4f7c-a995-9208d2272841/bd224025-9d04-473f-9d28-213813ce8b49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A02Z&sr=b&sp=r&sig=ID14b9CncE8VHevEyIasTPqmcZCnhhaaiNhtj%2FVqfO0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:02.15373","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:27:39.112Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:54.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1579'
+      - '1575'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:28 GMT
+      - Tue, 24 Oct 2023 12:28:02 GMT
       mise-correlation-id:
-      - 5949837c-8e90-4d94-9ff7-093bfbb2bb20
+      - eeef0e30-d366-4bdd-b246-2b1cd23871a6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_show.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_show.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:10:57.5220608Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:10:57.5220608Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4ddb0b38-7500-490a-bd78-83d3229e3825.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:10:50.3263219Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:10:50.3263219Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:34 GMT
+      - Mon, 09 Oct 2023 16:11:23 GMT
       etag:
-      - '"1a0a6ab2-0000-0100-0000-64af08d20000"'
+      - '"9201d5a1-0000-0100-0000-6524260c0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4ddb0b38-7500-490a-bd78-83d3229e3825.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:11:35 GMT
+      - Mon, 09 Oct 2023 16:11:24 GMT
       mise-correlation-id:
-      - fafa336d-e330-488d-b985-f67142e43904
+      - 8c9556e6-c7b1-4d99-a16e-150b124ff49e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -85,12 +85,12 @@ interactions:
 - request:
     body: '{"displayName": "CLI-Test", "description": "Test created from az load test
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
-      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "loadTestConfiguration":
+      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"be625f53-376d-45ed-8d88-15c0cf5b39cb": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "915e5314-7231-4361-94a1-83929a7070d2":
+      {"passFailMetrics": {"d4583fc1-a01d-4eea-8d57-8fb4d87f9799": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "9a7f43bd-1aaf-4246-b118-fb0db7a93cf7":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "068f806a-4cbb-48ec-a1c8-7b019a8bf17b": {"aggregate": "avg", "clientMetric":
+      "50"}, "c787724e-953b-4ed1-8e8a-cb393b657cf5": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -100,32 +100,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '768'
+      - '789'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://4ddb0b38-7500-490a-bd78-83d3229e3825.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"be625f53-376d-45ed-8d88-15c0cf5b39cb":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"915e5314-7231-4361-94a1-83929a7070d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"068f806a-4cbb-48ec-a1c8-7b019a8bf17b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:11:35.931Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:11:35.931Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d4583fc1-a01d-4eea-8d57-8fb4d87f9799":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9a7f43bd-1aaf-4246-b118-fb0db7a93cf7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c787724e-953b-4ed1-8e8a-cb393b657cf5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:11:25.217Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:25.217Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1060'
+      - '1006'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:35 GMT
+      - Mon, 09 Oct 2023 16:11:25 GMT
       location:
-      - https://4ddb0b38-7500-490a-bd78-83d3229e3825.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+      - https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 71ce2816-4846-4f6a-ab85-360d72497543
+      - b40e8695-e316-4e9a-9d86-95a45b379dbb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4ddb0b38-7500-490a-bd78-83d3229e3825.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
+    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:36 GMT
+      - Mon, 09 Oct 2023 16:11:25 GMT
       mise-correlation-id:
-      - 2d5ff547-726b-4a58-8b54-5ba641d61621
+      - 8607461c-3490-4cad-81bc-7af554ab6a33
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://4ddb0b38-7500-490a-bd78-83d3229e3825.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7c6461f9-a0cc-4b5a-8cb9-d0ed6bca98f6/eb90cebb-55f7-4036-ac5e-d47ccab6da65?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A21%3A37Z&sr=b&sp=r&sig=R2NsFnGASmgH74SwOlllz%2BGKhc5%2Fmw6tIiz4%2BMzHdNg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:21:37.4117028","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ef9bf76-8e0b-4d22-935d-b371d933f02b/16c9e03e-27ac-4b45-ba7a-ac0d910192c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A26Z&sr=b&sp=r&sig=D1erQIUgQ5lq6pbKLg3TCRtrR0zDsfrVuSB%2FgkbOF78%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:26.9851","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '548'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:37 GMT
+      - Mon, 09 Oct 2023 16:11:26 GMT
       location:
-      - https://4ddb0b38-7500-490a-bd78-83d3229e3825.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 04e048ba-d603-4242-ba66-060ea294f3ee
+      - 6c79d849-1d03-4880-be41-c49628cf0f9d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4ddb0b38-7500-490a-bd78-83d3229e3825.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7c6461f9-a0cc-4b5a-8cb9-d0ed6bca98f6/eb90cebb-55f7-4036-ac5e-d47ccab6da65?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A21%3A38Z&sr=b&sp=r&sig=p2ZyLTYkAR8pUyxrRsvgjnhw97IeKxZ3y2zcdCfPTyA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:21:38.3645796","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:11:38 GMT
-      mise-correlation-id:
-      - 0fc41a82-1d3e-4526-a36d-fd02a6cf18bc
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4ddb0b38-7500-490a-bd78-83d3229e3825.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7c6461f9-a0cc-4b5a-8cb9-d0ed6bca98f6/eb90cebb-55f7-4036-ac5e-d47ccab6da65?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A37%3A23Z&ske=2023-07-13T08%3A07%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A21%3A43Z&sr=b&sp=r&sig=G1CSQgJTYc9FQP2Qd62jJ%2FHeWbOaq5mlqp%2FXx%2BW8TS8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:21:43.6524643","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:11:43 GMT
-      mise-correlation-id:
-      - f02ba71b-4cd4-48fd-9141-49b24c24ba44
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4ddb0b38-7500-490a-bd78-83d3229e3825.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7c6461f9-a0cc-4b5a-8cb9-d0ed6bca98f6/eb90cebb-55f7-4036-ac5e-d47ccab6da65?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A21%3A49Z&sr=b&sp=r&sig=0ST1wZR9TfwbjjHHyRPr%2BUjXoXMe7QDdzyqU%2BxQ44f0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:21:49.0067972","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ef9bf76-8e0b-4d22-935d-b371d933f02b/16c9e03e-27ac-4b45-ba7a-ac0d910192c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A27Z&sr=b&sp=r&sig=bUWClxSQFvp24mCp%2F4bAvN0WEB%2BwkQw056rEd0mM9hM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:27.2411575","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:48 GMT
+      - Mon, 09 Oct 2023 16:11:27 GMT
       mise-correlation-id:
-      - ed2e50d5-0409-44fb-a1b9-fde097467da9
+      - 12a5b973-e5c8-4645-a648-0df8a90afd8f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4ddb0b38-7500-490a-bd78-83d3229e3825.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7c6461f9-a0cc-4b5a-8cb9-d0ed6bca98f6/eb90cebb-55f7-4036-ac5e-d47ccab6da65?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A21%3A54Z&sr=b&sp=r&sig=hxyHnL6Cui0DFj2sNhlObkWKeDp%2F1NGgzlXijHgJhVE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:21:54.282015","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ef9bf76-8e0b-4d22-935d-b371d933f02b/16c9e03e-27ac-4b45-ba7a-ac0d910192c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A32Z&sr=b&sp=r&sig=REK34sx6qm2H%2FrBJ%2FWDGRysF10KavpavuvfBs%2BhqI14%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:32.5077202","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '548'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:54 GMT
+      - Mon, 09 Oct 2023 16:11:32 GMT
       mise-correlation-id:
-      - 0e114724-88ce-4cb5-970c-ca7e3b9f2b6a
+      - c015dd92-82c1-4960-848a-763116cb7f55
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +385,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4ddb0b38-7500-490a-bd78-83d3229e3825.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"be625f53-376d-45ed-8d88-15c0cf5b39cb":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"915e5314-7231-4361-94a1-83929a7070d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"068f806a-4cbb-48ec-a1c8-7b019a8bf17b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7c6461f9-a0cc-4b5a-8cb9-d0ed6bca98f6/eb90cebb-55f7-4036-ac5e-d47ccab6da65?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A11%3A54Z&sr=b&sp=r&sig=lRmuAI5Kn2MdyEQmgvKETBel%2B%2Bm3Mj44ymtrL5xTRLU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:11:54.5599252","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:11:35.931Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:11:51.862Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ef9bf76-8e0b-4d22-935d-b371d933f02b/16c9e03e-27ac-4b45-ba7a-ac0d910192c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A37Z&sr=b&sp=r&sig=3D6nsliuQfPF%2FbVifzCf7uQ6knwt2J4XbeX1HN2W7r8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:37.7826521","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1633'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:54 GMT
+      - Mon, 09 Oct 2023 16:11:37 GMT
       mise-correlation-id:
-      - 94ff5612-ce62-4160-a332-cf18b34bb81b
+      - c1c35b8e-c743-4978-ab00-2c94673f0aa9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ef9bf76-8e0b-4d22-935d-b371d933f02b/16c9e03e-27ac-4b45-ba7a-ac0d910192c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A43Z&sr=b&sp=r&sig=IYOyPHMnmLNFlgssE4b%2BJUdRnbY0Gh7mIB9NQm30H10%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:43.0560435","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:11:43 GMT
+      mise-correlation-id:
+      - af2c955f-152a-4f7d-8f2a-e5aa6110d8f0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"d4583fc1-a01d-4eea-8d57-8fb4d87f9799":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9a7f43bd-1aaf-4246-b118-fb0db7a93cf7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c787724e-953b-4ed1-8e8a-cb393b657cf5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ef9bf76-8e0b-4d22-935d-b371d933f02b/16c9e03e-27ac-4b45-ba7a-ac0d910192c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A11%3A43Z&sr=b&sp=r&sig=eoBkrkX6XvIVZsetwk644WjfRJbutFOwMnXrimy2Ums%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:11:43.3296592","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:11:25.217Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:39.596Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1575'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:11:43 GMT
+      mise-correlation-id:
+      - 6290f2e4-63ff-4ec9-934a-429447f96d79
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:10:57.5220608Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:10:57.5220608Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4ddb0b38-7500-490a-bd78-83d3229e3825.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:10:50.3263219Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:10:50.3263219Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:55 GMT
+      - Mon, 09 Oct 2023 16:11:44 GMT
       etag:
-      - '"1a0a6ab2-0000-0100-0000-64af08d20000"'
+      - '"9201d5a1-0000-0100-0000-6524260c0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4ddb0b38-7500-490a-bd78-83d3229e3825.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"be625f53-376d-45ed-8d88-15c0cf5b39cb":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"915e5314-7231-4361-94a1-83929a7070d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"068f806a-4cbb-48ec-a1c8-7b019a8bf17b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7c6461f9-a0cc-4b5a-8cb9-d0ed6bca98f6/eb90cebb-55f7-4036-ac5e-d47ccab6da65?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A11%3A56Z&sr=b&sp=r&sig=w4siamnhKMQ0aL72SxKbk5%2FbZ7gGdgdeKW7dl%2Fm5ZpI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:11:56.8389907","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:11:35.931Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:11:51.862Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d4583fc1-a01d-4eea-8d57-8fb4d87f9799":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9a7f43bd-1aaf-4246-b118-fb0db7a93cf7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c787724e-953b-4ed1-8e8a-cb393b657cf5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ef9bf76-8e0b-4d22-935d-b371d933f02b/16c9e03e-27ac-4b45-ba7a-ac0d910192c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A11%3A45Z&sr=b&sp=r&sig=e9R0Pfn8OUbyq9W%2FJWaOM62gUZenBlsjdHfDAJ3ndGc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:11:45.7018372","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:11:25.217Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:39.596Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1645'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:56 GMT
+      - Mon, 09 Oct 2023 16:11:45 GMT
       mise-correlation-id:
-      - d4e4c3fd-c121-4110-be32-c2ef49840db5
+      - 3afe0167-d921-4de7-aabb-6b969532cf20
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:10:57.5220608Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:10:57.5220608Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4ddb0b38-7500-490a-bd78-83d3229e3825.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:10:50.3263219Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:10:50.3263219Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:57 GMT
+      - Mon, 09 Oct 2023 16:11:46 GMT
       etag:
-      - '"1a0a6ab2-0000-0100-0000-64af08d20000"'
+      - '"9201d5a1-0000-0100-0000-6524260c0000"'
       expires:
       - '-1'
       pragma:
@@ -619,24 +619,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4ddb0b38-7500-490a-bd78-83d3229e3825.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"be625f53-376d-45ed-8d88-15c0cf5b39cb":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"915e5314-7231-4361-94a1-83929a7070d2":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"068f806a-4cbb-48ec-a1c8-7b019a8bf17b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7c6461f9-a0cc-4b5a-8cb9-d0ed6bca98f6/eb90cebb-55f7-4036-ac5e-d47ccab6da65?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A11%3A59Z&sr=b&sp=r&sig=yVTqApNoIFT4rBQKZia5Do3s4KVy7amNYrIhQJeXMQk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:11:59.6878791","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:11:35.931Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:11:51.862Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d4583fc1-a01d-4eea-8d57-8fb4d87f9799":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9a7f43bd-1aaf-4246-b118-fb0db7a93cf7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c787724e-953b-4ed1-8e8a-cb393b657cf5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ef9bf76-8e0b-4d22-935d-b371d933f02b/16c9e03e-27ac-4b45-ba7a-ac0d910192c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A11%3A47Z&sr=b&sp=r&sig=33LoZFGRNPIIURiUpULJ8JFWr8gL8w2a1OS9ExQQ%2BMo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:11:47.932938","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:11:25.217Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:39.596Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1629'
+      - '1576'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:11:59 GMT
+      - Mon, 09 Oct 2023 16:11:47 GMT
       mise-correlation-id:
-      - 6c51232f-3a57-4cfb-8026-0fa2caccca82
+      - 432f1c97-5619-419d-b38c-b7ff9125aa7c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_show.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_show.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:23.1466229Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:23.1466229Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:50:30.4829836Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:50:30.4829836Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:57 GMT
+      - Wed, 18 Oct 2023 20:51:03 GMT
       etag:
-      - '"d801fcd1-0000-0100-0000-65294b210000"'
+      - '"75008e47-0000-0100-0000-653045180000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:50:58 GMT
+      - Wed, 18 Oct 2023 20:51:06 GMT
       mise-correlation-id:
-      - 2209371c-3a3a-4158-a673-8c752d560ab9
+      - eb516a9f-a978-4c7f-9ee9-6532aed66463
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"b0371f02-3fda-4df0-ad7f-bf59074c34ed": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "14171043-65d1-482a-81aa-0906becc05c9":
+      {"passFailMetrics": {"09a473f6-6a54-47ac-8812-f23e24bd26b8": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "1c198ba8-c859-48b8-bfcd-b4d85846ce40":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "fd00bd28-1334-44fb-968a-10561ae5fe76": {"aggregate": "avg", "clientMetric":
+      "50"}, "1c9d1712-6e36-418d-ae1e-ab71aed46deb": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b0371f02-3fda-4df0-ad7f-bf59074c34ed":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"14171043-65d1-482a-81aa-0906becc05c9":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fd00bd28-1334-44fb-968a-10561ae5fe76":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:50:59.419Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:50:59.419Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"09a473f6-6a54-47ac-8812-f23e24bd26b8":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1c198ba8-c859-48b8-bfcd-b4d85846ce40":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1c9d1712-6e36-418d-ae1e-ab71aed46deb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:06.926Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:06.926Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:59 GMT
+      - Wed, 18 Oct 2023 20:51:06 GMT
       location:
-      - https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+      - https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 52aaaa15-c3d5-4be0-bf24-b315a337cb9c
+      - 31903d33-c515-43df-bb18-d05903b89158
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
+    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:50:59 GMT
+      - Wed, 18 Oct 2023 20:51:07 GMT
       mise-correlation-id:
-      - c75645bd-a57e-4e29-8fea-b3074e00be2c
+      - af7a3e30-80c0-4cda-997e-0f9641d6dd70
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/92732341-426b-4227-bf8f-6100ce7654cd/8f8e0b3a-f875-4469-be09-aec4e82676f5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A00Z&sr=b&sp=r&sig=fGOQcFquSzFWzZwDEO3bhTCsiTNOnitu%2FJmga2hwDA4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:00.715622","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0d3930cd-b7dc-4b1b-851a-7d3dfa040071/c597e0f9-2a20-4c91-aefd-e126b1004839?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A08Z&sr=b&sp=r&sig=uNygAmgpSyVxei65rGcnkEVeG3HEJ9DY0OXRsm02asA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:08.4129522","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:00 GMT
+      - Wed, 18 Oct 2023 20:51:08 GMT
       location:
-      - https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 0ad060df-8a25-4def-8807-b4d67ec3b748
+      - 4a8b8ae4-febd-4b1f-8196-896157845835
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/92732341-426b-4227-bf8f-6100ce7654cd/8f8e0b3a-f875-4469-be09-aec4e82676f5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A01Z&sr=b&sp=r&sig=UivRGcy6ii3t5ZNLB0OIK00LHmUZbP9Ddj1dcF9xcb0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:01.0353213","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0d3930cd-b7dc-4b1b-851a-7d3dfa040071/c597e0f9-2a20-4c91-aefd-e126b1004839?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A08Z&sr=b&sp=r&sig=M8EZv9Fr8QQ3a5szw7ODXveTa3oaybA1gAxNxCaSGqw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:08.6859886","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:01 GMT
+      - Wed, 18 Oct 2023 20:51:08 GMT
       mise-correlation-id:
-      - b79efe38-d61f-481d-bedb-aae8dc4dab25
+      - dd7ebb18-0e61-477a-96e9-d2bd7d8b25bf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/92732341-426b-4227-bf8f-6100ce7654cd/8f8e0b3a-f875-4469-be09-aec4e82676f5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A06Z&sr=b&sp=r&sig=eMXOoAKaIj4HA%2F0bwSwv3JBPlTRbPAd%2FGVnz72kV1Io%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:06.5044287","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0d3930cd-b7dc-4b1b-851a-7d3dfa040071/c597e0f9-2a20-4c91-aefd-e126b1004839?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A14Z&sr=b&sp=r&sig=r2fV0fupjEBoK8sa71Ff%2BpCMv4%2FMB9TW4%2FjdpQavNxI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:14.011506","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '554'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:06 GMT
+      - Wed, 18 Oct 2023 20:51:14 GMT
       mise-correlation-id:
-      - 6ab0e327-6505-4621-80b5-5105d317e468
+      - e348ce75-b5c1-4c32-a8c1-93fac34ec3da
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/92732341-426b-4227-bf8f-6100ce7654cd/8f8e0b3a-f875-4469-be09-aec4e82676f5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A11Z&sr=b&sp=r&sig=DhEmoTr1Qz382sccgtCB6GHl5Fc8Zmp2bSe55T7RWLU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:11.7539331","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0d3930cd-b7dc-4b1b-851a-7d3dfa040071/c597e0f9-2a20-4c91-aefd-e126b1004839?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A19Z&sr=b&sp=r&sig=cKExX1fLerirXKiI1fVa8pAaO132gGM1UV%2FXlCyNdKE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:19.3003147","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:11 GMT
+      - Wed, 18 Oct 2023 20:51:19 GMT
       mise-correlation-id:
-      - b62218e2-22e7-4ce1-bd46-37ead1476616
+      - 2fccb731-bfcb-492c-bd15-8fd5cde7218f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/92732341-426b-4227-bf8f-6100ce7654cd/8f8e0b3a-f875-4469-be09-aec4e82676f5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A17Z&sr=b&sp=r&sig=QJ3%2FDOScW4TCbx2mGadRcqUaTHXqzpyAnT6kHe8Md0k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:17.0262801","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0d3930cd-b7dc-4b1b-851a-7d3dfa040071/c597e0f9-2a20-4c91-aefd-e126b1004839?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A24Z&sr=b&sp=r&sig=DpqF9ee22KcXwNNV6yliIYtRgsGXwOANQbt7g0jQR3Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:24.5561652","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:17 GMT
+      - Wed, 18 Oct 2023 20:51:24 GMT
       mise-correlation-id:
-      - fba24985-e86d-4fa6-9cca-8948642704b9
+      - b7019975-9890-4998-aca7-4a00b1a1375e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,173 +457,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b0371f02-3fda-4df0-ad7f-bf59074c34ed":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"14171043-65d1-482a-81aa-0906becc05c9":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fd00bd28-1334-44fb-968a-10561ae5fe76":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/92732341-426b-4227-bf8f-6100ce7654cd/8f8e0b3a-f875-4469-be09-aec4e82676f5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A17Z&sr=b&sp=r&sig=Mnj573DAtCGbCQCMT%2F1vHbSyUkQ7MkMEB114b5sRDtw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:17.2670073","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:50:59.419Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:13.166Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1577'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:51:17 GMT
-      mise-correlation-id:
-      - c05ef908-58f5-4e11-a375-ec177f75f3cb
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:23.1466229Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:23.1466229Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:51:17 GMT
-      etag:
-      - '"d801fcd1-0000-0100-0000-65294b210000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
-  response:
-    body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"b0371f02-3fda-4df0-ad7f-bf59074c34ed":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"14171043-65d1-482a-81aa-0906becc05c9":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fd00bd28-1334-44fb-968a-10561ae5fe76":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/92732341-426b-4227-bf8f-6100ce7654cd/8f8e0b3a-f875-4469-be09-aec4e82676f5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A19Z&sr=b&sp=r&sig=VfxigteUiL6cZgWtXl5rYhWcZU6skfwuL%2F8DrTfciwY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:19.5629427","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:50:59.419Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:13.166Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1589'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:51:19 GMT
-      mise-correlation-id:
-      - 9268b86f-831d-4ca1-8d3d-ea1610939079
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:23.1466229Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:23.1466229Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:51:20 GMT
-      etag:
-      - '"d801fcd1-0000-0100-0000-65294b210000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://fb370017-6ee2-42ef-8a04-5a8dfbbf6f98.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b0371f02-3fda-4df0-ad7f-bf59074c34ed":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"14171043-65d1-482a-81aa-0906becc05c9":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fd00bd28-1334-44fb-968a-10561ae5fe76":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/92732341-426b-4227-bf8f-6100ce7654cd/8f8e0b3a-f875-4469-be09-aec4e82676f5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A21Z&sr=b&sp=r&sig=j8%2Fv7J%2BmI9sZjPopLpubY8pjpnEAnVGbqrBfhr03W64%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:21.8675902","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:50:59.419Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:13.166Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"09a473f6-6a54-47ac-8812-f23e24bd26b8":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1c198ba8-c859-48b8-bfcd-b4d85846ce40":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1c9d1712-6e36-418d-ae1e-ab71aed46deb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0d3930cd-b7dc-4b1b-851a-7d3dfa040071/c597e0f9-2a20-4c91-aefd-e126b1004839?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A24Z&sr=b&sp=r&sig=AN5KkgXvlPm%2BA8z930iuVP7qsgr5it%2BqDTZsE1SCGSM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:24.8073492","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:06.926Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:22.425Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -634,9 +472,171 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:21 GMT
+      - Wed, 18 Oct 2023 20:51:24 GMT
       mise-correlation-id:
-      - a9910328-96c6-4e85-837d-f8ae644336cd
+      - 9cebcbf5-141d-4f78-999a-54d1d7112fe8
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:50:30.4829836Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:50:30.4829836Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:51:25 GMT
+      etag:
+      - '"75008e47-0000-0100-0000-653045180000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+  response:
+    body:
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"09a473f6-6a54-47ac-8812-f23e24bd26b8":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1c198ba8-c859-48b8-bfcd-b4d85846ce40":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1c9d1712-6e36-418d-ae1e-ab71aed46deb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0d3930cd-b7dc-4b1b-851a-7d3dfa040071/c597e0f9-2a20-4c91-aefd-e126b1004839?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A26Z&sr=b&sp=r&sig=ezmg8H56YY6j6lPe7Ez%2FgoilGBuVrUcWRm75pDjrn78%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:26.4965179","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:06.926Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:22.425Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1589'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:51:26 GMT
+      mise-correlation-id:
+      - 220ae707-dbab-4c88-9366-95077c581290
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:50:30.4829836Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:50:30.4829836Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:51:27 GMT
+      etag:
+      - '"75008e47-0000-0100-0000-653045180000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://563b5494-419a-4b71-95dc-6a071e17fd4f.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"09a473f6-6a54-47ac-8812-f23e24bd26b8":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1c198ba8-c859-48b8-bfcd-b4d85846ce40":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"1c9d1712-6e36-418d-ae1e-ab71aed46deb":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/0d3930cd-b7dc-4b1b-851a-7d3dfa040071/c597e0f9-2a20-4c91-aefd-e126b1004839?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A28Z&sr=b&sp=r&sig=RmyA6zvPXVKWUGfjITA%2B5OPJx%2FAXZK3GmFp5G8nJWYI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:28.6485413","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:06.926Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:22.425Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1579'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:51:28 GMT
+      mise-correlation-id:
+      - 5949837c-8e90-4d94-9ff7-093bfbb2bb20
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_show.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_show.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:03.3288778Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:03.3288778Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:31.3743579Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:31.3743579Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:37 GMT
+      - Sun, 29 Oct 2023 22:20:06 GMT
       etag:
-      - '"d3007837-0000-0100-0000-6537b8190000"'
+      - '"3c008125-0000-0100-0000-653eda770000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:27:38 GMT
+      - Sun, 29 Oct 2023 22:20:07 GMT
       mise-correlation-id:
-      - d0f79a47-f907-45b0-9463-88a7cf9204ab
+      - b624f7e5-bc5e-4454-9de6-c3703b6770be
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"260ba844-0c73-4f65-b297-71354bd10e44": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "f4426194-2f7f-44b7-8886-ab03a28adae1":
+      {"passFailMetrics": {"c95bf1c0-fb6d-4293-b28a-a3f62b71989a": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "065381e3-5df6-4f99-9756-200263879661":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "c99c1618-a900-4606-a988-a0d218f2336f": {"aggregate": "avg", "clientMetric":
+      "50"}, "ab0084ab-a07b-42f2-a1f2-2f777c8a50c8": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"260ba844-0c73-4f65-b297-71354bd10e44":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f4426194-2f7f-44b7-8886-ab03a28adae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c99c1618-a900-4606-a988-a0d218f2336f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:27:39.112Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:39.112Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c95bf1c0-fb6d-4293-b28a-a3f62b71989a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"065381e3-5df6-4f99-9756-200263879661":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab0084ab-a07b-42f2-a1f2-2f777c8a50c8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:20:08.085Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:08.085Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:39 GMT
+      - Sun, 29 Oct 2023 22:20:08 GMT
       location:
-      - https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+      - https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 5d6c2f07-7644-405a-9967-d02f54a4dfc3
+      - 5ea026af-389e-4aa3-918f-1be28cc3b2d8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
+    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:39 GMT
+      - Sun, 29 Oct 2023 22:20:08 GMT
       mise-correlation-id:
-      - 87f1fddb-06ec-47bd-bcb5-e698ee08b353
+      - a8be5bdc-4ce2-4f75-8d57-7735cface4b7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e91ca5eb-097d-4f7c-a995-9208d2272841/bd224025-9d04-473f-9d28-213813ce8b49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A41Z&sr=b&sp=r&sig=F7BCW0eEB99Te0Qa%2BeNQmHqgvO3fQt1cgQeEZao3HFg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:41.5999485","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8f83e558-42d9-424a-a5d6-b5f4da50244c/7f1d6f19-2127-4e76-ba95-5d89c4988476?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A09Z&sr=b&sp=r&sig=Kc93%2FRfn55L6FW9nmmI9wXGbFh%2BYii6O9SycNZCfjQU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:09.7444263","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:41 GMT
+      - Sun, 29 Oct 2023 22:20:09 GMT
       location:
-      - https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 7943b214-203c-42f9-85f9-7dc81f226872
+      - f4aefe00-a9e0-489c-a17e-db337175e665
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e91ca5eb-097d-4f7c-a995-9208d2272841/bd224025-9d04-473f-9d28-213813ce8b49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A41Z&sr=b&sp=r&sig=i4tPOCbyguG%2F9uG%2FwcFmwKH0wcLuXS62kRVCMDTMpZ8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:41.9383706","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8f83e558-42d9-424a-a5d6-b5f4da50244c/7f1d6f19-2127-4e76-ba95-5d89c4988476?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A09Z&sr=b&sp=r&sig=Tap8CyL5vmUUdnKygsXlaLyFHjWwJCwhwOHlHSsLOCU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:09.9873763","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:41 GMT
+      - Sun, 29 Oct 2023 22:20:09 GMT
       mise-correlation-id:
-      - 2fae5374-c8ad-4f92-ad14-d36b9413ea71
+      - 1426d327-4b16-493b-92d7-037786a9f9ad
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,10 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e91ca5eb-097d-4f7c-a995-9208d2272841/bd224025-9d04-473f-9d28-213813ce8b49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A47Z&sr=b&sp=r&sig=Wd3hmmTj3xnnz%2B75a3Ag4hyrhJNiLzOzzO2ROPleGyU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:47.2463861","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8f83e558-42d9-424a-a5d6-b5f4da50244c/7f1d6f19-2127-4e76-ba95-5d89c4988476?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A15Z&sr=b&sp=r&sig=FtVLU1yVL3t09YLD9HKcl0u5VdYi39q3VLNs%2B9ztgyM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:15.9814431","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:47 GMT
+      - Sun, 29 Oct 2023 22:20:15 GMT
       mise-correlation-id:
-      - b73470fd-0410-4eb9-a605-3d8c0182a9cc
+      - e0c391d3-5d0e-4d42-bc25-526d02e743d1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,10 +385,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e91ca5eb-097d-4f7c-a995-9208d2272841/bd224025-9d04-473f-9d28-213813ce8b49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A52Z&sr=b&sp=r&sig=POWYQgKwaTP%2FHr6sj%2FswJdLrhRbpu0wUhM5wf6VNcxM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:52.5642635","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8f83e558-42d9-424a-a5d6-b5f4da50244c/7f1d6f19-2127-4e76-ba95-5d89c4988476?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A21Z&sr=b&sp=r&sig=DIf1uWu7YcHe0Y%2FQBFJ9WRgVSk8byUWKP94u5cdwUEI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:21.2534605","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:20:21 GMT
+      mise-correlation-id:
+      - 1890ef1d-75c8-44fd-9492-0cd287fbe036
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8f83e558-42d9-424a-a5d6-b5f4da50244c/7f1d6f19-2127-4e76-ba95-5d89c4988476?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A30%3A26Z&sr=b&sp=r&sig=Lr7XJoumsPdNz%2F3p%2B31fdjB7C5ciuFOlgE2%2F1FEAO7w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:30:26.7342829","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:52 GMT
+      - Sun, 29 Oct 2023 22:20:26 GMT
       mise-correlation-id:
-      - 658dbbb5-62c7-45d4-9b5c-73e6f0c7f3c8
+      - bcc5ae24-cadb-4b90-9757-2d52616906aa
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e91ca5eb-097d-4f7c-a995-9208d2272841/bd224025-9d04-473f-9d28-213813ce8b49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A37%3A57Z&sr=b&sp=r&sig=BF9kftIlyTvc%2Fe2ml%2BYjRM%2FBk8wu2Mi0JHuKNDgLt0o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:37:57.8409878","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c95bf1c0-fb6d-4293-b28a-a3f62b71989a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"065381e3-5df6-4f99-9756-200263879661":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab0084ab-a07b-42f2-a1f2-2f777c8a50c8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8f83e558-42d9-424a-a5d6-b5f4da50244c/7f1d6f19-2127-4e76-ba95-5d89c4988476?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A20%3A27Z&sr=b&sp=r&sig=nwaT6KQ786%2BssIlzjDHFOKzUcwEoqBFmdGmmFRLr3g8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:20:27.0000033","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:20:08.085Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:25.921Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '1577'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:57 GMT
+      - Sun, 29 Oct 2023 22:20:27 GMT
       mise-correlation-id:
-      - 3dee5111-afdc-44d7-846b-43cea293dfee
+      - 587183e5-3c13-4477-93df-cb0f87f279a9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -455,13 +492,138 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"260ba844-0c73-4f65-b297-71354bd10e44":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f4426194-2f7f-44b7-8886-ab03a28adae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c99c1618-a900-4606-a988-a0d218f2336f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e91ca5eb-097d-4f7c-a995-9208d2272841/bd224025-9d04-473f-9d28-213813ce8b49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A27%3A58Z&sr=b&sp=r&sig=4dGgVkVjaeHTlg8ow4ufPtjocGRpce%2FTVOvtXxuV2%2Fk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:27:58.0997875","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:27:39.112Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:54.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:31.3743579Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:31.3743579Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '653'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:20:28 GMT
+      etag:
+      - '"3c008125-0000-0100-0000-653eda770000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+  response:
+    body:
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"c95bf1c0-fb6d-4293-b28a-a3f62b71989a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"065381e3-5df6-4f99-9756-200263879661":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab0084ab-a07b-42f2-a1f2-2f777c8a50c8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8f83e558-42d9-424a-a5d6-b5f4da50244c/7f1d6f19-2127-4e76-ba95-5d89c4988476?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A20%3A29Z&sr=b&sp=r&sig=Sw%2BY%2BKlrUVq6kwl4P9jMszvwqjJ%2FzUJj7EGLXrVU1fM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:20:29.5445671","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:20:08.085Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:25.921Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1593'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:20:29 GMT
+      mise-correlation-id:
+      - e7cc388f-970a-4a3d-8575-cea424442b67
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:19:31.3743579Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:19:31.3743579Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '653'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:20:30 GMT
+      etag:
+      - '"3c008125-0000-0100-0000-653eda770000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://de7bb363-5a4f-4948-ae1f-7c24dc20946c.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c95bf1c0-fb6d-4293-b28a-a3f62b71989a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"065381e3-5df6-4f99-9756-200263879661":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ab0084ab-a07b-42f2-a1f2-2f777c8a50c8":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/8f83e558-42d9-424a-a5d6-b5f4da50244c/7f1d6f19-2127-4e76-ba95-5d89c4988476?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A20%3A31Z&sr=b&sp=r&sig=ajRNDo7KQLmh6iR%2BkucbfWLqx6S27yNXbgyVVF%2FVeXQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:20:31.8056772","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:20:08.085Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:20:25.921Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,171 +634,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:27:58 GMT
+      - Sun, 29 Oct 2023 22:20:31 GMT
       mise-correlation-id:
-      - 92f5e2a8-d6ca-4f71-9fb0-14bbd5adb54e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:03.3288778Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:03.3288778Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:27:59 GMT
-      etag:
-      - '"d3007837-0000-0100-0000-6537b8190000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
-  response:
-    body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"260ba844-0c73-4f65-b297-71354bd10e44":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f4426194-2f7f-44b7-8886-ab03a28adae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c99c1618-a900-4606-a988-a0d218f2336f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e91ca5eb-097d-4f7c-a995-9208d2272841/bd224025-9d04-473f-9d28-213813ce8b49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A27%3A59Z&sr=b&sp=r&sig=%2BGzSWxutMXZz0rLIi1neayiG0fHFYIuxNh0jdsl92Qg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:27:59.9475867","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:27:39.112Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:54.031Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1589'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:27:59 GMT
-      mise-correlation-id:
-      - 39b0088a-61a1-4036-986c-a538aa0877be
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:03.3288778Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:03.3288778Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:28:01 GMT
-      etag:
-      - '"d3007837-0000-0100-0000-6537b8190000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://77c2c920-b0dc-4bb4-a938-cee304520cb1.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"260ba844-0c73-4f65-b297-71354bd10e44":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f4426194-2f7f-44b7-8886-ab03a28adae1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c99c1618-a900-4606-a988-a0d218f2336f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e91ca5eb-097d-4f7c-a995-9208d2272841/bd224025-9d04-473f-9d28-213813ce8b49?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A02Z&sr=b&sp=r&sig=ID14b9CncE8VHevEyIasTPqmcZCnhhaaiNhtj%2FVqfO0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:02.15373","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:27:39.112Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:27:54.031Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1575'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:28:02 GMT
-      mise-correlation-id:
-      - eeef0e30-d366-4bdd-b246-2b1cd23871a6
+      - 4d1d4dca-da20-4720-88b8-c6f52f019f45
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_show.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_show.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:10:50.3263219Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:10:50.3263219Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:17.1513453Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:17.1513453Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:23 GMT
+      - Mon, 09 Oct 2023 19:17:50 GMT
       etag:
-      - '"9201d5a1-0000-0100-0000-6524260c0000"'
+      - '"5500a2f0-0000-0100-0000-652451bf0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:11:24 GMT
+      - Mon, 09 Oct 2023 19:17:51 GMT
       mise-correlation-id:
-      - 8c9556e6-c7b1-4d99-a16e-150b124ff49e
+      - 350b242c-7c12-4de1-8a16-d75a9c75adc5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"d4583fc1-a01d-4eea-8d57-8fb4d87f9799": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "9a7f43bd-1aaf-4246-b118-fb0db7a93cf7":
+      {"passFailMetrics": {"c0ea5d3b-969c-437a-97cc-db96ff400898": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "56ec61f4-ce9c-4b9a-b9f0-c81400c8d9b5":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "c787724e-953b-4ed1-8e8a-cb393b657cf5": {"aggregate": "avg", "clientMetric":
+      "50"}, "a7badcd8-b27f-4b5f-89da-d162e42a54b1": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d4583fc1-a01d-4eea-8d57-8fb4d87f9799":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9a7f43bd-1aaf-4246-b118-fb0db7a93cf7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c787724e-953b-4ed1-8e8a-cb393b657cf5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:11:25.217Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:25.217Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c0ea5d3b-969c-437a-97cc-db96ff400898":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"56ec61f4-ce9c-4b9a-b9f0-c81400c8d9b5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"a7badcd8-b27f-4b5f-89da-d162e42a54b1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:17:52.216Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:17:52.216Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:25 GMT
+      - Mon, 09 Oct 2023 19:17:52 GMT
       location:
-      - https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+      - https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - b40e8695-e316-4e9a-9d86-95a45b379dbb
+      - 5355fa1a-8d4e-4b7c-8646-65774e362486
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
+    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:25 GMT
+      - Mon, 09 Oct 2023 19:17:52 GMT
       mise-correlation-id:
-      - 8607461c-3490-4cad-81bc-7af554ab6a33
+      - dd298add-e01c-4db3-875f-247426cee84f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ef9bf76-8e0b-4d22-935d-b371d933f02b/16c9e03e-27ac-4b45-ba7a-ac0d910192c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A26Z&sr=b&sp=r&sig=D1erQIUgQ5lq6pbKLg3TCRtrR0zDsfrVuSB%2FgkbOF78%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:26.9851","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a3b0cc27-5ba1-40c9-96d2-9775830eea41/b547db8d-2870-4e20-ba7b-dcb78de245e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A53Z&sr=b&sp=r&sig=GaV9yh4zqJDxSussxeHMmItV%2BoJnYcm9KeksIC1msEQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:53.1237433","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '548'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:26 GMT
+      - Mon, 09 Oct 2023 19:17:53 GMT
       location:
-      - https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 6c79d849-1d03-4880-be41-c49628cf0f9d
+      - 6d7c787e-3dee-48ce-8fb0-d673cced15e6
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ef9bf76-8e0b-4d22-935d-b371d933f02b/16c9e03e-27ac-4b45-ba7a-ac0d910192c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A27Z&sr=b&sp=r&sig=bUWClxSQFvp24mCp%2F4bAvN0WEB%2BwkQw056rEd0mM9hM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:27.2411575","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:11:27 GMT
-      mise-correlation-id:
-      - 12a5b973-e5c8-4645-a648-0df8a90afd8f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ef9bf76-8e0b-4d22-935d-b371d933f02b/16c9e03e-27ac-4b45-ba7a-ac0d910192c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A32Z&sr=b&sp=r&sig=REK34sx6qm2H%2FrBJ%2FWDGRysF10KavpavuvfBs%2BhqI14%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:32.5077202","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:11:32 GMT
-      mise-correlation-id:
-      - c015dd92-82c1-4960-848a-763116cb7f55
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ef9bf76-8e0b-4d22-935d-b371d933f02b/16c9e03e-27ac-4b45-ba7a-ac0d910192c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A37Z&sr=b&sp=r&sig=3D6nsliuQfPF%2FbVifzCf7uQ6knwt2J4XbeX1HN2W7r8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:37.7826521","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a3b0cc27-5ba1-40c9-96d2-9775830eea41/b547db8d-2870-4e20-ba7b-dcb78de245e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A54Z&sr=b&sp=r&sig=%2FmkmUKEzR2xrxda179LzzvZhAat4ULC0PBN1WDQfJvE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:54.1743745","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:37 GMT
+      - Mon, 09 Oct 2023 19:17:54 GMT
       mise-correlation-id:
-      - c1c35b8e-c743-4978-ab00-2c94673f0aa9
+      - a92a8b4b-d440-453f-8ddd-b58425ab42dd
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,10 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ef9bf76-8e0b-4d22-935d-b371d933f02b/16c9e03e-27ac-4b45-ba7a-ac0d910192c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A43Z&sr=b&sp=r&sig=IYOyPHMnmLNFlgssE4b%2BJUdRnbY0Gh7mIB9NQm30H10%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:43.0560435","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a3b0cc27-5ba1-40c9-96d2-9775830eea41/b547db8d-2870-4e20-ba7b-dcb78de245e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A27%3A59Z&sr=b&sp=r&sig=c3Hvq91ejqamH59ZIr9IqOzS71xgF3iuqaYipY2uWO4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:27:59.4445367","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:43 GMT
+      - Mon, 09 Oct 2023 19:17:59 GMT
       mise-correlation-id:
-      - af2c955f-152a-4f7d-8f2a-e5aa6110d8f0
+      - b1af3330-cbb8-4071-a6f7-01c9223562c3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +385,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d4583fc1-a01d-4eea-8d57-8fb4d87f9799":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9a7f43bd-1aaf-4246-b118-fb0db7a93cf7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c787724e-953b-4ed1-8e8a-cb393b657cf5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ef9bf76-8e0b-4d22-935d-b371d933f02b/16c9e03e-27ac-4b45-ba7a-ac0d910192c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A11%3A43Z&sr=b&sp=r&sig=eoBkrkX6XvIVZsetwk644WjfRJbutFOwMnXrimy2Ums%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:11:43.3296592","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:11:25.217Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:39.596Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a3b0cc27-5ba1-40c9-96d2-9775830eea41/b547db8d-2870-4e20-ba7b-dcb78de245e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A04Z&sr=b&sp=r&sig=cSMSKjARS4kUVyC%2FP%2BiejDunSIovPPhqwH1zoUj049c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:04.7231832","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1575'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:43 GMT
+      - Mon, 09 Oct 2023 19:18:04 GMT
       mise-correlation-id:
-      - 6290f2e4-63ff-4ec9-934a-429447f96d79
+      - 9e7e26af-deb0-4e0b-869a-700486844911
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a3b0cc27-5ba1-40c9-96d2-9775830eea41/b547db8d-2870-4e20-ba7b-dcb78de245e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A10Z&sr=b&sp=r&sig=VE1U6O4uxT2JrzAIpsdBXyg4C4rBvsHQZtdOfZH55x0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:10.0430248","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '547'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:18:10 GMT
+      mise-correlation-id:
+      - c3c6e996-b82a-46b3-b054-9aba2258e254
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"c0ea5d3b-969c-437a-97cc-db96ff400898":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"56ec61f4-ce9c-4b9a-b9f0-c81400c8d9b5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"a7badcd8-b27f-4b5f-89da-d162e42a54b1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a3b0cc27-5ba1-40c9-96d2-9775830eea41/b547db8d-2870-4e20-ba7b-dcb78de245e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A10Z&sr=b&sp=r&sig=Koe0ymZ07xxUgYfYxKiveOo%2B4iMPemb1%2B8OkB6ICu6o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:10.304022","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:17:52.216Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:05.522Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1578'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:18:10 GMT
+      mise-correlation-id:
+      - c7e7b3be-9970-4150-8eab-e195728f21c8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:10:50.3263219Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:10:50.3263219Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:17.1513453Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:17.1513453Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:44 GMT
+      - Mon, 09 Oct 2023 19:18:11 GMT
       etag:
-      - '"9201d5a1-0000-0100-0000-6524260c0000"'
+      - '"5500a2f0-0000-0100-0000-652451bf0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"d4583fc1-a01d-4eea-8d57-8fb4d87f9799":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9a7f43bd-1aaf-4246-b118-fb0db7a93cf7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c787724e-953b-4ed1-8e8a-cb393b657cf5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ef9bf76-8e0b-4d22-935d-b371d933f02b/16c9e03e-27ac-4b45-ba7a-ac0d910192c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A11%3A45Z&sr=b&sp=r&sig=e9R0Pfn8OUbyq9W%2FJWaOM62gUZenBlsjdHfDAJ3ndGc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:11:45.7018372","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:11:25.217Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:39.596Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"c0ea5d3b-969c-437a-97cc-db96ff400898":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"56ec61f4-ce9c-4b9a-b9f0-c81400c8d9b5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"a7badcd8-b27f-4b5f-89da-d162e42a54b1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a3b0cc27-5ba1-40c9-96d2-9775830eea41/b547db8d-2870-4e20-ba7b-dcb78de245e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A12Z&sr=b&sp=r&sig=s2dr3APXgegAjk4n6b%2BA%2BgSvQARCRC2d53GP4rdAjmM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:12.7217903","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:17:52.216Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:05.522Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1589'
+      - '1591'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:45 GMT
+      - Mon, 09 Oct 2023 19:18:12 GMT
       mise-correlation-id:
-      - 3afe0167-d921-4de7-aabb-6b969532cf20
+      - 9156b1f5-b59f-405a-af31-5292d5414b43
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:10:50.3263219Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:10:50.3263219Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:17.1513453Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:17.1513453Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:46 GMT
+      - Mon, 09 Oct 2023 19:18:13 GMT
       etag:
-      - '"9201d5a1-0000-0100-0000-6524260c0000"'
+      - '"5500a2f0-0000-0100-0000-652451bf0000"'
       expires:
       - '-1'
       pragma:
@@ -619,11 +619,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://db6e976e-9005-4b7b-8308-b4797bb2edbb.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
+    uri: https://dd06d981-c1eb-4f61-b3eb-a266f4388248.eastus.cnt-prod.loadtesting.azure.com/tests/show-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d4583fc1-a01d-4eea-8d57-8fb4d87f9799":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"9a7f43bd-1aaf-4246-b118-fb0db7a93cf7":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c787724e-953b-4ed1-8e8a-cb393b657cf5":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7ef9bf76-8e0b-4d22-935d-b371d933f02b/16c9e03e-27ac-4b45-ba7a-ac0d910192c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A11%3A47Z&sr=b&sp=r&sig=33LoZFGRNPIIURiUpULJ8JFWr8gL8w2a1OS9ExQQ%2BMo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:11:47.932938","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:11:25.217Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:11:39.596Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"c0ea5d3b-969c-437a-97cc-db96ff400898":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"56ec61f4-ce9c-4b9a-b9f0-c81400c8d9b5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"a7badcd8-b27f-4b5f-89da-d162e42a54b1":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/a3b0cc27-5ba1-40c9-96d2-9775830eea41/b547db8d-2870-4e20-ba7b-dcb78de245e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A15Z&sr=b&sp=r&sig=Wb2ucsC%2FVhtXkyLL703ojSpHOewKmJGGbXfDaNaXelc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:15.275985","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"show-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:17:52.216Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:05.522Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -634,9 +634,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:47 GMT
+      - Mon, 09 Oct 2023 19:18:15 GMT
       mise-correlation-id:
-      - 432f1c97-5619-419d-b38c-b7ff9125aa7c
+      - 91ce7008-2cbf-4f67-bc4f-618180931402
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_update.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_update.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:36.9908212Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:36.9908212Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:20:25.2203587Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:20:25.2203587Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:09 GMT
+      - Mon, 30 Oct 2023 07:20:58 GMT
       etag:
-      - '"3c007327-0000-0100-0000-653edab70000"'
+      - '"3f00a569-0000-0100-0000-653f593b0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:21:10 GMT
+      - Mon, 30 Oct 2023 07:20:59 GMT
       mise-correlation-id:
-      - 02a16563-f2fc-43c9-a2c8-95e6fe3d5194
+      - 186307ab-ae36-4be5-826f-327c323d682f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"6d226d67-c609-45e8-9a39-eff2748cf164": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "67739d7a-b404-4490-9ceb-c07478319cde":
+      {"passFailMetrics": {"0a64837a-5bf9-47d6-b7eb-b027e292a109": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "81185497-09fb-44ff-b8c3-9b7f58ec9b92":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "b350050c-164e-4b14-80b8-5027d1a1a65e": {"aggregate": "avg", "clientMetric":
+      "50"}, "81cf12a8-0fac-43a2-9d1f-b5dc93e1180b": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6d226d67-c609-45e8-9a39-eff2748cf164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"67739d7a-b404-4490-9ceb-c07478319cde":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b350050c-164e-4b14-80b8-5027d1a1a65e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:11.188Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:11.188Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0a64837a-5bf9-47d6-b7eb-b027e292a109":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"81185497-09fb-44ff-b8c3-9b7f58ec9b92":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"81cf12a8-0fac-43a2-9d1f-b5dc93e1180b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:21:00.275Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:21:00.275Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:11 GMT
+      - Mon, 30 Oct 2023 07:21:00 GMT
       location:
-      - https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+      - https://e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 9dca9bb5-92d8-4cfd-a326-6aecd0edd69e
+      - ec7d5d34-f9a9-4c28-917e-45bda6eba33d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
+    uri: https://e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:11 GMT
+      - Mon, 30 Oct 2023 07:21:00 GMT
       mise-correlation-id:
-      - 802c6430-c074-4af2-83f9-272018f73101
+      - d3021206-16e7-4eb5-b775-82b7f1f2a8ad
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A11Z&sr=b&sp=r&sig=%2BhqYXMQG9f07RkroxWVnPb%2FF%2FdnIh9qtaLjYU3gMgwg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:11.9839257","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/00cc55f5-7358-4429-a642-b33299eecb1c/e236fa84-5519-415f-a2a4-0c2f6dfbc17d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A01Z&sr=b&sp=r&sig=MsqdnVon8%2FJDULI0yfmTM2Y9OLAcL2t5VCOCS7djr64%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:01.0379648","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:11 GMT
+      - Mon, 30 Oct 2023 07:21:01 GMT
       location:
-      - https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 7e2f461c-00cc-4c45-9e4d-d8fadf0cd8ee
+      - 13463d68-de43-415e-ab79-adbc4b0a2cb5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A12Z&sr=b&sp=r&sig=vn5SOn8iVDrvt7zhUGo4L0lrAqND1%2F73WedrJ%2F6EE78%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:12.2485993","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/00cc55f5-7358-4429-a642-b33299eecb1c/e236fa84-5519-415f-a2a4-0c2f6dfbc17d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A01Z&sr=b&sp=r&sig=E%2B9QXQCJN%2BZBwQ7YRxsT3GrKmudpAm6yaGRdhK4CZd4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:01.2962051","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:12 GMT
+      - Mon, 30 Oct 2023 07:21:01 GMT
       mise-correlation-id:
-      - 7e41cce5-8ce0-47d5-8bb1-0911f32d1786
+      - cc6f58bb-8a60-4b2f-8ec2-7d01b7b64feb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A17Z&sr=b&sp=r&sig=RjYThOuycz4HIArnzHMjKuLl1Ft4%2BahZlgRqh5fABnA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:17.5055646","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/00cc55f5-7358-4429-a642-b33299eecb1c/e236fa84-5519-415f-a2a4-0c2f6dfbc17d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A06Z&sr=b&sp=r&sig=2%2BTWp96JsOYJDYSb88nLCVUuGA3Tudi90%2B7is2ywjmw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:06.5602286","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:17 GMT
+      - Mon, 30 Oct 2023 07:21:06 GMT
       mise-correlation-id:
-      - b7377287-9af3-4a88-9eab-eb481bbad3ac
+      - c22b6725-ad44-42db-a2b4-07a394798c34
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A22Z&sr=b&sp=r&sig=e4mhRh6LptX%2F%2BmZromrr8MJGF18jQf1Q0%2BW%2Bi9h8sWk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:22.7554219","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/00cc55f5-7358-4429-a642-b33299eecb1c/e236fa84-5519-415f-a2a4-0c2f6dfbc17d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A11Z&sr=b&sp=r&sig=TCvrUJDiho2TdyP2HJPcq3ZYGvz84iiIRigRRw03Hsk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:11.8402517","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '557'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:22 GMT
+      - Mon, 30 Oct 2023 07:21:11 GMT
       mise-correlation-id:
-      - 4b47218b-3615-45c2-ace5-1a0da58e4ab9
+      - d51fda90-f679-4898-b9e7-480f8a5c5a42
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +421,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A28Z&sr=b&sp=r&sig=6dEbyrJtlSHX2FdatRa1bwf%2Fh%2BO8W7pRw%2FN%2FFNwJIp0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:28.2714924","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/00cc55f5-7358-4429-a642-b33299eecb1c/e236fa84-5519-415f-a2a4-0c2f6dfbc17d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A17Z&sr=b&sp=r&sig=i9nHPmXQvVDQN8STwDMvM8thujh1zwgFIg6mc0XP%2FJ0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:17.1721089","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:28 GMT
+      - Mon, 30 Oct 2023 07:21:17 GMT
       mise-correlation-id:
-      - 1babb236-4f02-4a66-8ba0-cc2b3ba7ed79
+      - 9ea549a5-2e6e-43af-81c9-082e64f2fea4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,11 +457,173 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6d226d67-c609-45e8-9a39-eff2748cf164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"67739d7a-b404-4490-9ceb-c07478319cde":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b350050c-164e-4b14-80b8-5027d1a1a65e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A28Z&sr=b&sp=r&sig=tqdHC4fg2j3hffNY5F9DAPZyKRAYTJA1cV%2BTRqH8tBA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:28.529149","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:11.188Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:26.314Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0a64837a-5bf9-47d6-b7eb-b027e292a109":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"81185497-09fb-44ff-b8c3-9b7f58ec9b92":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"81cf12a8-0fac-43a2-9d1f-b5dc93e1180b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/00cc55f5-7358-4429-a642-b33299eecb1c/e236fa84-5519-415f-a2a4-0c2f6dfbc17d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A21%3A17Z&sr=b&sp=r&sig=jq6QQcPDJdT28jQMiUeQufgl5tubgqGbDzXxno3lBgc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:21:17.4870276","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:21:00.275Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:21:13.25Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1576'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:21:17 GMT
+      mise-correlation-id:
+      - 8156f501-e0fc-4054-bded-2d5507d8f4ad
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:20:25.2203587Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:20:25.2203587Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '653'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:21:18 GMT
+      etag:
+      - '"3f00a569-0000-0100-0000-653f593b0000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+  response:
+    body:
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"0a64837a-5bf9-47d6-b7eb-b027e292a109":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"81185497-09fb-44ff-b8c3-9b7f58ec9b92":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"81cf12a8-0fac-43a2-9d1f-b5dc93e1180b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/00cc55f5-7358-4429-a642-b33299eecb1c/e236fa84-5519-415f-a2a4-0c2f6dfbc17d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A21%3A19Z&sr=b&sp=r&sig=2W9W1mM9PBLeWVkJ10zh7S2D%2BdynjMlJJ3HIF4WQClw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:21:19.2385644","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:21:00.275Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:21:13.25Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1590'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:21:19 GMT
+      mise-correlation-id:
+      - a3c2af74-1f3a-417f-b3dc-e8daf8fa3622
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:20:25.2203587Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:20:25.2203587Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '653'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:21:20 GMT
+      etag:
+      - '"3f00a569-0000-0100-0000-653f593b0000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"0a64837a-5bf9-47d6-b7eb-b027e292a109":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"81185497-09fb-44ff-b8c3-9b7f58ec9b92":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"81cf12a8-0fac-43a2-9d1f-b5dc93e1180b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/00cc55f5-7358-4429-a642-b33299eecb1c/e236fa84-5519-415f-a2a4-0c2f6dfbc17d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A21%3A21Z&sr=b&sp=r&sig=CfgPn11Mp5h6b6Gy24WrH%2Bz8pIapgf7E4DyDXOjGtoQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:21:21.8987896","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:21:00.275Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:21:13.25Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,171 +634,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:28 GMT
+      - Mon, 30 Oct 2023 07:21:21 GMT
       mise-correlation-id:
-      - 2759e1e4-7c9e-4959-9466-da5e3911c41a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:36.9908212Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:36.9908212Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '653'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:21:28 GMT
-      etag:
-      - '"3c007327-0000-0100-0000-653edab70000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
-  response:
-    body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"6d226d67-c609-45e8-9a39-eff2748cf164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"67739d7a-b404-4490-9ceb-c07478319cde":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b350050c-164e-4b14-80b8-5027d1a1a65e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A30Z&sr=b&sp=r&sig=32uzm6s86NDPuCI59UysgtaOybPcmMBeBHJJKpssiHk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:30.0283276","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:11.188Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:26.314Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1589'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:21:30 GMT
-      mise-correlation-id:
-      - 73d7ef5a-3caf-4275-890d-d9dc16d03904
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:36.9908212Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:36.9908212Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '653'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:21:30 GMT
-      etag:
-      - '"3c007327-0000-0100-0000-653edab70000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6d226d67-c609-45e8-9a39-eff2748cf164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"67739d7a-b404-4490-9ceb-c07478319cde":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b350050c-164e-4b14-80b8-5027d1a1a65e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A31Z&sr=b&sp=r&sig=edUSsmY3QO1g8Ghf%2FSAYyeAYtkORX1bnI1hv20yl7%2B8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:31.4441085","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:11.188Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:26.314Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1581'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:21:31 GMT
-      mise-correlation-id:
-      - d806a679-0966-4884-8d14-ccc4a24a3544
+      - 6b173bba-b1cf-48a5-b4f4-ae1ed0508a30
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -663,24 +663,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6d226d67-c609-45e8-9a39-eff2748cf164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"67739d7a-b404-4490-9ceb-c07478319cde":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b350050c-164e-4b14-80b8-5027d1a1a65e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A31Z&sr=b&sp=r&sig=ocLcMKtGOODTULsgOMIAawmheJ69q3tYZziVEhzLM9o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:31.8157669","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:11.188Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:31.807Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0a64837a-5bf9-47d6-b7eb-b027e292a109":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"81185497-09fb-44ff-b8c3-9b7f58ec9b92":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"81cf12a8-0fac-43a2-9d1f-b5dc93e1180b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/00cc55f5-7358-4429-a642-b33299eecb1c/e236fa84-5519-415f-a2a4-0c2f6dfbc17d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A21%3A22Z&sr=b&sp=r&sig=xmLjxVq8FyxmBnSv4WnxCNh%2FT4crDqRB%2BO%2B9PF0Xm5g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:21:22.346186","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:21:00.275Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:21:22.337Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1578'
+      - '1583'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:31 GMT
+      - Mon, 30 Oct 2023 07:21:22 GMT
       mise-correlation-id:
-      - afed53dc-48b2-417f-8492-8abcf769221d
+      - 33239715-db84-4653-961c-c3ebcae178d3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,24 +700,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6d226d67-c609-45e8-9a39-eff2748cf164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"67739d7a-b404-4490-9ceb-c07478319cde":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b350050c-164e-4b14-80b8-5027d1a1a65e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A32Z&sr=b&sp=r&sig=x6QM8gM0Js7lmnmSlb16sPKEwYK6NAb0fJ6cJoAtMgU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:32.0571907","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:11.188Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:31.807Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0a64837a-5bf9-47d6-b7eb-b027e292a109":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"81185497-09fb-44ff-b8c3-9b7f58ec9b92":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"81cf12a8-0fac-43a2-9d1f-b5dc93e1180b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/00cc55f5-7358-4429-a642-b33299eecb1c/e236fa84-5519-415f-a2a4-0c2f6dfbc17d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A21%3A22Z&sr=b&sp=r&sig=xmLjxVq8FyxmBnSv4WnxCNh%2FT4crDqRB%2BO%2B9PF0Xm5g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:21:22.6025608","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:21:00.275Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:21:22.337Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1578'
+      - '1584'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:32 GMT
+      - Mon, 30 Oct 2023 07:21:22 GMT
       mise-correlation-id:
-      - bf17b46b-a029-488c-a546-ab5271662a26
+      - 0139e1a1-0928-4b1d-ad87-4e8655a47478
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -740,7 +740,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:36.9908212Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:36.9908212Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:20:25.2203587Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:20:25.2203587Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -749,9 +749,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:32 GMT
+      - Mon, 30 Oct 2023 07:21:24 GMT
       etag:
-      - '"3c007327-0000-0100-0000-653edab70000"'
+      - '"3f00a569-0000-0100-0000-653f593b0000"'
       expires:
       - '-1'
       pragma:
@@ -781,24 +781,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"6d226d67-c609-45e8-9a39-eff2748cf164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"67739d7a-b404-4490-9ceb-c07478319cde":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b350050c-164e-4b14-80b8-5027d1a1a65e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A34Z&sr=b&sp=r&sig=6d7zKb27oU0VP5xGG2sUyIktmcDjJl8Okg2Cw0Mj9A4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:34.1592898","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:11.188Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:31.807Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"0a64837a-5bf9-47d6-b7eb-b027e292a109":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"81185497-09fb-44ff-b8c3-9b7f58ec9b92":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"81cf12a8-0fac-43a2-9d1f-b5dc93e1180b":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/00cc55f5-7358-4429-a642-b33299eecb1c/e236fa84-5519-415f-a2a4-0c2f6dfbc17d?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A21%3A25Z&sr=b&sp=r&sig=nv8NinHlTc8l4hu3%2FV1KzYgt1KhMZJDybEsHy3UB88o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:21:25.1797077","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:21:00.275Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:21:22.337Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1578'
+      - '1580'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:34 GMT
+      - Mon, 30 Oct 2023 07:21:25 GMT
       mise-correlation-id:
-      - 4381a80a-6b10-45a8-bb04-1ae4a1060bd9
+      - 95ea1726-5c25-4013-946e-f9de8e1dcc52
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -821,7 +821,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:36.9908212Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:36.9908212Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:20:25.2203587Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:20:25.2203587Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -830,9 +830,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:34 GMT
+      - Mon, 30 Oct 2023 07:21:26 GMT
       etag:
-      - '"3c007327-0000-0100-0000-653edab70000"'
+      - '"3f00a569-0000-0100-0000-653f593b0000"'
       expires:
       - '-1'
       pragma:
@@ -862,7 +862,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-update-test-case?api-version=2022-11-01
+    uri: https://e3a49656-18cf-4f2d-b714-d2ded723203e.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -875,9 +875,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:21:35 GMT
+      - Mon, 30 Oct 2023 07:21:27 GMT
       mise-correlation-id:
-      - dcee033c-9889-4f78-9e39-e4c1dfce5cf3
+      - 4ec75f20-2ed7-401d-904b-fb68b2169e05
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_update.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_update.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:55.0507735Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:55.0507735Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:50:54.9538102Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:50:54.9538102Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:27 GMT
+      - Wed, 18 Oct 2023 20:50:59 GMT
       etag:
-      - '"d8017bdd-0000-0100-0000-65294b400000"'
+      - '"7500324a-0000-0100-0000-653045310000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:51:28 GMT
+      - Wed, 18 Oct 2023 20:51:00 GMT
       mise-correlation-id:
-      - f5a3d76c-da85-4b05-b1da-817417ce0372
+      - ebc01ab1-c4a0-4815-9994-d1f156e84dfb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"bac30fb5-755e-4585-8e74-b82ca1b7f9a0": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "c83e108a-2e9e-438e-9a95-4e9d5af40188":
+      {"passFailMetrics": {"3a011dc8-ef23-4b7d-bb90-23907fc404cf": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "21a034c9-2c93-48f6-bf3d-34339f15714c":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "fe7ceeb8-8a8c-4713-80eb-ca8ba1045c73": {"aggregate": "avg", "clientMetric":
+      "50"}, "ec00df68-9f58-4562-8dc7-53e4bad8167f": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,26 +106,26 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"bac30fb5-755e-4585-8e74-b82ca1b7f9a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c83e108a-2e9e-438e-9a95-4e9d5af40188":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fe7ceeb8-8a8c-4713-80eb-ca8ba1045c73":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:29.254Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:29.254Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3a011dc8-ef23-4b7d-bb90-23907fc404cf":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"21a034c9-2c93-48f6-bf3d-34339f15714c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec00df68-9f58-4562-8dc7-53e4bad8167f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:00.88Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:00.88Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1008'
+      - '1006'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:29 GMT
+      - Wed, 18 Oct 2023 20:51:00 GMT
       location:
-      - https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+      - https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 73a38ffd-0a32-4a84-b99e-c1cec38af273
+      - 45efb4f5-145a-4435-acc5-2936e06d8080
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
+    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:29 GMT
+      - Wed, 18 Oct 2023 20:51:01 GMT
       mise-correlation-id:
-      - 4615b39e-b428-44ff-a884-82be1d9a8173
+      - 45ee61b8-ccc0-480c-9787-fd5d4f0943f1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A30Z&sr=b&sp=r&sig=I%2FFwYof9txo8qWb5nZJscAVbACsIei5BddiFo%2BbEiW0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:30.0045074","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A01Z&sr=b&sp=r&sig=%2Fj3I%2FhGvmnTqbNBOBEhZvduRq%2Ff5kH0aeynZNHG39po%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:01.7977652","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:29 GMT
+      - Wed, 18 Oct 2023 20:51:01 GMT
       location:
-      - https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 40c2a285-48a1-4ca7-bd75-3dd6ace072cf
+      - f548a588-dc31-49b7-a057-4765fcf55512
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,23 +313,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A30Z&sr=b&sp=r&sig=mXD2cEgSyZRrl5TKpQfFtNQ76w5T%2BQKJhvcLM0e8jwc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:30.2593577","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A02Z&sr=b&sp=r&sig=FkFpcgFAgykJ%2BHQSpSTw%2FODjo5LUBWXxwwtNOkV395E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:02.1380353","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:30 GMT
+      - Wed, 18 Oct 2023 20:51:02 GMT
       mise-correlation-id:
-      - c54be20c-1ebe-4d87-8581-beddcbc561d1
+      - f7357774-4cae-4b2b-b760-66a9307bf899
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A35Z&sr=b&sp=r&sig=qt0d72skWAnLocaTkxquhBonDF50%2FPU9RhGYkizwJcU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:35.4965247","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A07Z&sr=b&sp=r&sig=n4%2FRFtr8wIeC9Rlfcf5oMJ%2FBneVU%2F45p%2FxMx9gPqcvc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:07.3904366","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '557'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:35 GMT
+      - Wed, 18 Oct 2023 20:51:07 GMT
       mise-correlation-id:
-      - 39fed69c-963b-4397-a6cf-5d39b730e4ed
+      - 9d5470ff-76f7-42e3-891f-eac9ff39c281
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,10 +385,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A40Z&sr=b&sp=r&sig=rzR4ExzAgVj6vxFtO86tr9MXJNuLC8RsoD26ZHii9SQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:40.7614519","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A12Z&sr=b&sp=r&sig=wXttNzKsfdFXdEzgUF58FNuIPr1%2Bz7Z8O5mBAnodLlA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:12.663019","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '550'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:51:12 GMT
+      mise-correlation-id:
+      - 43b84789-84ba-4264-959c-fe92812005cf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A17Z&sr=b&sp=r&sig=aHKAIN0me%2BJb3FAcZQ2oWORuP2FlemCrZyYpWrxInYc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:17.9169916","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:40 GMT
+      - Wed, 18 Oct 2023 20:51:17 GMT
       mise-correlation-id:
-      - 5dce3923-fae6-4533-bb52-bfa7ad1e4054
+      - 509e7b2b-928b-442f-b86f-ed720bc699e3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A46Z&sr=b&sp=r&sig=hm5eW2KAlwXbT0HoKHyYW8J2L9QQ%2B9aMnZvjpuN1Xdc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:46.0392366","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3a011dc8-ef23-4b7d-bb90-23907fc404cf":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"21a034c9-2c93-48f6-bf3d-34339f15714c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec00df68-9f58-4562-8dc7-53e4bad8167f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A18Z&sr=b&sp=r&sig=b6%2F7pCJ0wZBQXiptz1ZbZq2pJCK454djda7dop7tLiY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:18.1588408","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:00.88Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:14.267Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '1578'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:46 GMT
+      - Wed, 18 Oct 2023 20:51:18 GMT
       mise-correlation-id:
-      - fdd3454e-6d09-4c7f-bbd3-9f73c079703c
+      - 58a490cd-9e32-45d6-b62f-ab0a087abe7a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -455,13 +492,138 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"bac30fb5-755e-4585-8e74-b82ca1b7f9a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c83e108a-2e9e-438e-9a95-4e9d5af40188":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fe7ceeb8-8a8c-4713-80eb-ca8ba1045c73":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A46Z&sr=b&sp=r&sig=Vmvhc7f1BKBejh89icn50k8A3aylrViw9RxqKQC7xYI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:46.285202","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:29.254Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:43.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:50:54.9538102Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:50:54.9538102Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:51:18 GMT
+      etag:
+      - '"7500324a-0000-0100-0000-653045310000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+  response:
+    body:
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"3a011dc8-ef23-4b7d-bb90-23907fc404cf":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"21a034c9-2c93-48f6-bf3d-34339f15714c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec00df68-9f58-4562-8dc7-53e4bad8167f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A20Z&sr=b&sp=r&sig=Mkh2WMxYlAzstrFgmJWmo1a3kcRXnCB9wtr%2FbfUk3Gg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:20.1826242","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:00.88Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:14.267Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1590'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:51:20 GMT
+      mise-correlation-id:
+      - 7bf698a5-5503-439d-9262-c3a25d8cb158
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:50:54.9538102Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:50:54.9538102Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:51:21 GMT
+      etag:
+      - '"7500324a-0000-0100-0000-653045310000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"3a011dc8-ef23-4b7d-bb90-23907fc404cf":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"21a034c9-2c93-48f6-bf3d-34339f15714c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec00df68-9f58-4562-8dc7-53e4bad8167f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A22Z&sr=b&sp=r&sig=MvYTqoI8DMKqgccprJi5azgvwz3RSCZBph9pjvFKuys%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:22.4391727","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:00.88Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:14.267Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,171 +634,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:46 GMT
+      - Wed, 18 Oct 2023 20:51:22 GMT
       mise-correlation-id:
-      - 4ef26f1a-0598-423b-b4bf-d0271a4a9c86
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:55.0507735Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:55.0507735Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:51:47 GMT
-      etag:
-      - '"d8017bdd-0000-0100-0000-65294b400000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
-  response:
-    body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"bac30fb5-755e-4585-8e74-b82ca1b7f9a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c83e108a-2e9e-438e-9a95-4e9d5af40188":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fe7ceeb8-8a8c-4713-80eb-ca8ba1045c73":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A47Z&sr=b&sp=r&sig=z2wmXjYn8oyoT%2B5CBq%2BWzZqYO6T1A7EnUzalXnZwJI4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:47.9806138","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:29.254Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:43.998Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1593'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:51:48 GMT
-      mise-correlation-id:
-      - 87b1b47f-033e-40bd-9d7f-797df51f9e0e
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:55.0507735Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:55.0507735Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:51:49 GMT
-      etag:
-      - '"d8017bdd-0000-0100-0000-65294b400000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"bac30fb5-755e-4585-8e74-b82ca1b7f9a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c83e108a-2e9e-438e-9a95-4e9d5af40188":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fe7ceeb8-8a8c-4713-80eb-ca8ba1045c73":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A50Z&sr=b&sp=r&sig=uRpo1uHYQY8C58e8Qyhywa6I5pQK99Hy2BuhzM05tvE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:50.1528907","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:29.254Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:43.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1577'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:51:50 GMT
-      mise-correlation-id:
-      - fe15dcfe-4efc-4a32-9b0f-e70dcad17fce
+      - 94e1bb34-b758-4785-bd5e-ff1c8a59061c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -663,24 +663,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"bac30fb5-755e-4585-8e74-b82ca1b7f9a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c83e108a-2e9e-438e-9a95-4e9d5af40188":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fe7ceeb8-8a8c-4713-80eb-ca8ba1045c73":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A50Z&sr=b&sp=r&sig=JFF4ybeP63NEgF5UdNq8m9XDDK5LCgWa6qJ4vq8VM28%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:50.488568","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:29.254Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:50.48Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3a011dc8-ef23-4b7d-bb90-23907fc404cf":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"21a034c9-2c93-48f6-bf3d-34339f15714c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec00df68-9f58-4562-8dc7-53e4bad8167f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A22Z&sr=b&sp=r&sig=1tPZ89gC2pfRcdQmx6hPO1%2B0zDTMbjBm%2B0CGH5%2BBiPU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:22.8058026","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:00.88Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:22.798Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1576'
+      - '1583'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:50 GMT
+      - Wed, 18 Oct 2023 20:51:22 GMT
       mise-correlation-id:
-      - 74b65474-ca17-45a2-97ad-2844284a5a31
+      - e4ce7cf5-e9a6-4998-8a2b-b2020dd7ce39
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,24 +700,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"bac30fb5-755e-4585-8e74-b82ca1b7f9a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c83e108a-2e9e-438e-9a95-4e9d5af40188":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fe7ceeb8-8a8c-4713-80eb-ca8ba1045c73":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A50Z&sr=b&sp=r&sig=cjgAATANZkHrOpndAxYsNQ55J6lhgIUkIwNqW0e9qRw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:50.7741276","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:29.254Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:50.48Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3a011dc8-ef23-4b7d-bb90-23907fc404cf":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"21a034c9-2c93-48f6-bf3d-34339f15714c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec00df68-9f58-4562-8dc7-53e4bad8167f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A23Z&sr=b&sp=r&sig=CnqfaSNOcAn9YSMiXV6rCRXJdPrta%2B%2FqJ%2FsDBVlL%2FDU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:23.0520437","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:00.88Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:22.798Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1577'
+      - '1585'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:50 GMT
+      - Wed, 18 Oct 2023 20:51:23 GMT
       mise-correlation-id:
-      - f4ae4094-eb1e-4165-be09-d5ede2b67f78
+      - 6fe87a75-ab1d-4c68-ac85-15cea7b19b61
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -740,7 +740,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:55.0507735Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:55.0507735Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:50:54.9538102Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:50:54.9538102Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -749,9 +749,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:52 GMT
+      - Wed, 18 Oct 2023 20:51:24 GMT
       etag:
-      - '"d8017bdd-0000-0100-0000-65294b400000"'
+      - '"7500324a-0000-0100-0000-653045310000"'
       expires:
       - '-1'
       pragma:
@@ -781,24 +781,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"bac30fb5-755e-4585-8e74-b82ca1b7f9a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c83e108a-2e9e-438e-9a95-4e9d5af40188":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fe7ceeb8-8a8c-4713-80eb-ca8ba1045c73":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A53Z&sr=b&sp=r&sig=Qd1zBprEaWXqYhl8rF3JICgNFriW8UzYyjeqUrCOZrI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:53.0542223","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:29.254Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:50.48Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"3a011dc8-ef23-4b7d-bb90-23907fc404cf":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"21a034c9-2c93-48f6-bf3d-34339f15714c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec00df68-9f58-4562-8dc7-53e4bad8167f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A25Z&sr=b&sp=r&sig=U%2Bf%2F4XWnsUszHxUFA91IVwUMocDhaxM5pvY2t95Tcmo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:25.2029197","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:00.88Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:22.798Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1577'
+      - '1581'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:53 GMT
+      - Wed, 18 Oct 2023 20:51:25 GMT
       mise-correlation-id:
-      - 5223f95c-eaac-409f-82e8-4916e94dd719
+      - 079a7837-5dcb-4090-a2f1-0a74dec1517e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -821,7 +821,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:55.0507735Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:55.0507735Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:50:54.9538102Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:50:54.9538102Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -830,9 +830,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:53 GMT
+      - Wed, 18 Oct 2023 20:51:25 GMT
       etag:
-      - '"d8017bdd-0000-0100-0000-65294b400000"'
+      - '"7500324a-0000-0100-0000-653045310000"'
       expires:
       - '-1'
       pragma:
@@ -862,7 +862,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-update-test-case?api-version=2022-11-01
+    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -875,9 +875,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:51:54 GMT
+      - Wed, 18 Oct 2023 20:51:26 GMT
       mise-correlation-id:
-      - 36154c36-781a-4eba-9186-4caee5456b3a
+      - f6cc6179-3b45-48e7-af54-cfa91ae34ce1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_update.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_update.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:50:54.9538102Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:50:54.9538102Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:45.5289007Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:45.5289007Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:50:59 GMT
+      - Tue, 24 Oct 2023 12:28:19 GMT
       etag:
-      - '"7500324a-0000-0100-0000-653045310000"'
+      - '"d300313a-0000-0100-0000-6537b8430000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:51:00 GMT
+      - Tue, 24 Oct 2023 12:28:21 GMT
       mise-correlation-id:
-      - ebc01ab1-c4a0-4815-9994-d1f156e84dfb
+      - 85eedd18-305f-4fa0-afdd-6387c5636beb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"3a011dc8-ef23-4b7d-bb90-23907fc404cf": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "21a034c9-2c93-48f6-bf3d-34339f15714c":
+      {"passFailMetrics": {"ee98010c-b7ac-4d34-bfa0-06fbfb85b78d": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "7908e8b3-9e11-4740-85ce-78f2b72c2948":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "ec00df68-9f58-4562-8dc7-53e4bad8167f": {"aggregate": "avg", "clientMetric":
+      "50"}, "6d9791cc-f48b-4e8e-887e-275292f4e638": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3a011dc8-ef23-4b7d-bb90-23907fc404cf":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"21a034c9-2c93-48f6-bf3d-34339f15714c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec00df68-9f58-4562-8dc7-53e4bad8167f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:00.88Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:00.88Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ee98010c-b7ac-4d34-bfa0-06fbfb85b78d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7908e8b3-9e11-4740-85ce-78f2b72c2948":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6d9791cc-f48b-4e8e-887e-275292f4e638":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:21.77Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:21.77Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:00 GMT
+      - Tue, 24 Oct 2023 12:28:21 GMT
       location:
-      - https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+      - https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 45efb4f5-145a-4435-acc5-2936e06d8080
+      - 32a67ed3-a78e-4df0-abbf-9837f5012580
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
+    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:01 GMT
+      - Tue, 24 Oct 2023 12:28:22 GMT
       mise-correlation-id:
-      - 45ee61b8-ccc0-480c-9787-fd5d4f0943f1
+      - 20464b54-3b6c-44d8-82d8-c4a2f179bf70
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A01Z&sr=b&sp=r&sig=%2Fj3I%2FhGvmnTqbNBOBEhZvduRq%2Ff5kH0aeynZNHG39po%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:01.7977652","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A22Z&sr=b&sp=r&sig=3fHUnfhgrOg2FnTdJgyMcoSUlwvdEOK1FM26k2HZnHc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:22.8567759","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:01 GMT
+      - Tue, 24 Oct 2023 12:28:22 GMT
       location:
-      - https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - f548a588-dc31-49b7-a057-4765fcf55512
+      - afad6e3a-3c5b-4d86-89b9-f66ee752f333
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,10 +313,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A02Z&sr=b&sp=r&sig=FkFpcgFAgykJ%2BHQSpSTw%2FODjo5LUBWXxwwtNOkV395E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:02.1380353","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A23Z&sr=b&sp=r&sig=ibX1%2B2CBmiunnHaILBL6mUNiLbVQlOA9C1k7wD4Lx%2BI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:23.186359","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '552'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:28:23 GMT
+      mise-correlation-id:
+      - 4519d956-d248-4c66-909c-f1d7a0e56192
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A28Z&sr=b&sp=r&sig=TRR6KRdZmCP7i8ImxIEuapQxo16EH7NckvD2zXvrcKw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:28.808667","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '548'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:28:28 GMT
+      mise-correlation-id:
+      - a69e6620-2b5a-40d2-88a9-be3ff6a92cbe
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A34Z&sr=b&sp=r&sig=enH8AdeuNkpohPaO%2BA7PICBu960RljO62PIiA4W25Xk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:34.1628976","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:28:34 GMT
+      mise-correlation-id:
+      - b9f44d27-d93c-4985-9e0f-78b63f54edcf
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A39Z&sr=b&sp=r&sig=drOxDTYAYIW%2F0O4L4OxacNk%2B72xsG%2FcDZNiHaVTkZqM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:39.4008759","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -327,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:02 GMT
+      - Tue, 24 Oct 2023 12:28:39 GMT
       mise-correlation-id:
-      - f7357774-4cae-4b2b-b760-66a9307bf899
+      - d542cf9a-951e-4e8c-9c22-661b0c8cbb5d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -349,119 +457,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A07Z&sr=b&sp=r&sig=n4%2FRFtr8wIeC9Rlfcf5oMJ%2FBneVU%2F45p%2FxMx9gPqcvc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:07.3904366","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '557'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:51:07 GMT
-      mise-correlation-id:
-      - 9d5470ff-76f7-42e3-891f-eac9ff39c281
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A12Z&sr=b&sp=r&sig=wXttNzKsfdFXdEzgUF58FNuIPr1%2Bz7Z8O5mBAnodLlA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:12.663019","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '550'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:51:12 GMT
-      mise-correlation-id:
-      - 43b84789-84ba-4264-959c-fe92812005cf
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A17Z&sr=b&sp=r&sig=aHKAIN0me%2BJb3FAcZQ2oWORuP2FlemCrZyYpWrxInYc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:17.9169916","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:51:17 GMT
-      mise-correlation-id:
-      - 509e7b2b-928b-442f-b86f-ed720bc699e3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3a011dc8-ef23-4b7d-bb90-23907fc404cf":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"21a034c9-2c93-48f6-bf3d-34339f15714c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec00df68-9f58-4562-8dc7-53e4bad8167f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A18Z&sr=b&sp=r&sig=b6%2F7pCJ0wZBQXiptz1ZbZq2pJCK454djda7dop7tLiY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:18.1588408","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:00.88Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:14.267Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ee98010c-b7ac-4d34-bfa0-06fbfb85b78d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7908e8b3-9e11-4740-85ce-78f2b72c2948":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6d9791cc-f48b-4e8e-887e-275292f4e638":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A40Z&sr=b&sp=r&sig=yc4PJz3g2VofJSfMYnrUxRU3UZLuDw1B2pMcr%2FY0xvQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:40.5593164","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:21.77Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:37.528Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,9 +472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:18 GMT
+      - Tue, 24 Oct 2023 12:28:40 GMT
       mise-correlation-id:
-      - 58a490cd-9e32-45d6-b62f-ab0a087abe7a
+      - 57a3c7e0-fe7f-4163-87dc-ccd9b89f73ac
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:50:54.9538102Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:50:54.9538102Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:45.5289007Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:45.5289007Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:18 GMT
+      - Tue, 24 Oct 2023 12:28:41 GMT
       etag:
-      - '"7500324a-0000-0100-0000-653045310000"'
+      - '"d300313a-0000-0100-0000-6537b8430000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"3a011dc8-ef23-4b7d-bb90-23907fc404cf":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"21a034c9-2c93-48f6-bf3d-34339f15714c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec00df68-9f58-4562-8dc7-53e4bad8167f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A20Z&sr=b&sp=r&sig=Mkh2WMxYlAzstrFgmJWmo1a3kcRXnCB9wtr%2FbfUk3Gg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:20.1826242","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:00.88Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:14.267Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ee98010c-b7ac-4d34-bfa0-06fbfb85b78d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7908e8b3-9e11-4740-85ce-78f2b72c2948":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6d9791cc-f48b-4e8e-887e-275292f4e638":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A42Z&sr=b&sp=r&sig=pd9jXOl%2BlZAdmpkTUiv9QT4P9NyQ%2F9D02P2%2BvOmSKj4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:42.2377907","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:21.77Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:37.528Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1590'
+      - '1594'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:20 GMT
+      - Tue, 24 Oct 2023 12:28:42 GMT
       mise-correlation-id:
-      - 7bf698a5-5503-439d-9262-c3a25d8cb158
+      - 9e6251dc-9c02-4652-a350-7ae24479b0a3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:50:54.9538102Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:50:54.9538102Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:45.5289007Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:45.5289007Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:21 GMT
+      - Tue, 24 Oct 2023 12:28:43 GMT
       etag:
-      - '"7500324a-0000-0100-0000-653045310000"'
+      - '"d300313a-0000-0100-0000-6537b8430000"'
       expires:
       - '-1'
       pragma:
@@ -619,11 +619,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3a011dc8-ef23-4b7d-bb90-23907fc404cf":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"21a034c9-2c93-48f6-bf3d-34339f15714c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec00df68-9f58-4562-8dc7-53e4bad8167f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A22Z&sr=b&sp=r&sig=MvYTqoI8DMKqgccprJi5azgvwz3RSCZBph9pjvFKuys%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:22.4391727","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:00.88Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:14.267Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ee98010c-b7ac-4d34-bfa0-06fbfb85b78d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7908e8b3-9e11-4740-85ce-78f2b72c2948":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6d9791cc-f48b-4e8e-887e-275292f4e638":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A44Z&sr=b&sp=r&sig=RrfjbCFpPS8rL4q3b2UVm8NcERNQO7mPVWBXsNxw8Os%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:44.4903364","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:21.77Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:37.528Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -634,9 +634,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:22 GMT
+      - Tue, 24 Oct 2023 12:28:44 GMT
       mise-correlation-id:
-      - 94e1bb34-b758-4785-bd5e-ff1c8a59061c
+      - 92da65e0-36bc-4334-94e9-e6a585ebe554
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -663,24 +663,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3a011dc8-ef23-4b7d-bb90-23907fc404cf":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"21a034c9-2c93-48f6-bf3d-34339f15714c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec00df68-9f58-4562-8dc7-53e4bad8167f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A22Z&sr=b&sp=r&sig=1tPZ89gC2pfRcdQmx6hPO1%2B0zDTMbjBm%2B0CGH5%2BBiPU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:22.8058026","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:00.88Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:22.798Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ee98010c-b7ac-4d34-bfa0-06fbfb85b78d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7908e8b3-9e11-4740-85ce-78f2b72c2948":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6d9791cc-f48b-4e8e-887e-275292f4e638":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A44Z&sr=b&sp=r&sig=PN12sGnfXAqhAd9qkXfpEhxWECmoSRhzrK%2BQl3oY9tY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:44.9418328","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:21.77Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:44.934Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1583'
+      - '1579'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:22 GMT
+      - Tue, 24 Oct 2023 12:28:44 GMT
       mise-correlation-id:
-      - e4ce7cf5-e9a6-4998-8a2b-b2020dd7ce39
+      - cc116b89-adb8-4f87-a56b-9cbe470f2183
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,24 +700,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3a011dc8-ef23-4b7d-bb90-23907fc404cf":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"21a034c9-2c93-48f6-bf3d-34339f15714c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec00df68-9f58-4562-8dc7-53e4bad8167f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A23Z&sr=b&sp=r&sig=CnqfaSNOcAn9YSMiXV6rCRXJdPrta%2B%2FqJ%2FsDBVlL%2FDU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:23.0520437","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:00.88Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:22.798Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ee98010c-b7ac-4d34-bfa0-06fbfb85b78d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7908e8b3-9e11-4740-85ce-78f2b72c2948":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6d9791cc-f48b-4e8e-887e-275292f4e638":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A45Z&sr=b&sp=r&sig=aFNhF%2F9UzdSlA402E5d4OlXdaHU4pjhceoMVrOAWB6w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:45.1776087","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:21.77Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:44.934Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1585'
+      - '1579'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:23 GMT
+      - Tue, 24 Oct 2023 12:28:45 GMT
       mise-correlation-id:
-      - 6fe87a75-ab1d-4c68-ac85-15cea7b19b61
+      - c896fbdb-6dba-4e34-b713-36b514f67a52
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -740,7 +740,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:50:54.9538102Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:50:54.9538102Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:45.5289007Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:45.5289007Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -749,9 +749,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:24 GMT
+      - Tue, 24 Oct 2023 12:28:46 GMT
       etag:
-      - '"7500324a-0000-0100-0000-653045310000"'
+      - '"d300313a-0000-0100-0000-6537b8430000"'
       expires:
       - '-1'
       pragma:
@@ -781,24 +781,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"3a011dc8-ef23-4b7d-bb90-23907fc404cf":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"21a034c9-2c93-48f6-bf3d-34339f15714c":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"ec00df68-9f58-4562-8dc7-53e4bad8167f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/bdcd7268-f497-458f-a984-76c582631214/2f2ce197-1c0a-4238-8284-ea405a00c9c3?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A22%3A20Z&ske=2023-10-20T01%3A52%3A20Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A25Z&sr=b&sp=r&sig=U%2Bf%2F4XWnsUszHxUFA91IVwUMocDhaxM5pvY2t95Tcmo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:25.2029197","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:00.88Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:22.798Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"ee98010c-b7ac-4d34-bfa0-06fbfb85b78d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7908e8b3-9e11-4740-85ce-78f2b72c2948":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6d9791cc-f48b-4e8e-887e-275292f4e638":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A47Z&sr=b&sp=r&sig=%2BcTxuSGfMHFGMPpWbu2XICnBstVoSHkooovhp8PYYQ0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:47.5758649","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:21.77Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:44.934Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1581'
+      - '1579'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:25 GMT
+      - Tue, 24 Oct 2023 12:28:47 GMT
       mise-correlation-id:
-      - 079a7837-5dcb-4090-a2f1-0a74dec1517e
+      - 854bab14-30ed-4231-a2df-8fd80aaaff1a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -821,7 +821,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:50:54.9538102Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:50:54.9538102Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:45.5289007Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:45.5289007Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -830,9 +830,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:25 GMT
+      - Tue, 24 Oct 2023 12:28:48 GMT
       etag:
-      - '"7500324a-0000-0100-0000-653045310000"'
+      - '"d300313a-0000-0100-0000-6537b8430000"'
       expires:
       - '-1'
       pragma:
@@ -862,7 +862,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://79bb62ac-412d-4575-b1bb-c2d676c5a9e6.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-update-test-case?api-version=2022-11-01
+    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -875,9 +875,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:51:26 GMT
+      - Tue, 24 Oct 2023 12:28:49 GMT
       mise-correlation-id:
-      - f6cc6179-3b45-48e7-af54-cfa91ae34ce1
+      - d415f98e-f50e-4c65-87f7-37958b20eb53
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_update.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_update.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:28.0755084Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:28.0755084Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:59.5754937Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:59.5754937Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:01 GMT
+      - Mon, 09 Oct 2023 19:18:34 GMT
       etag:
-      - '"920137a8-0000-0100-0000-652426320000"'
+      - '"56005a06-0000-0100-0000-652451ea0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:12:02 GMT
+      - Mon, 09 Oct 2023 19:18:36 GMT
       mise-correlation-id:
-      - 63671e69-6b0d-40fe-9fbd-43e4a198a609
+      - ec037e89-563c-432a-be0a-8670177afe9b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"1bb9ab47-bc04-42f5-a6ec-f7c1b09a05d4": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "75d15d2f-c618-4e9b-98b4-79c9757c58f6":
+      {"passFailMetrics": {"9f55c300-b83a-4d0d-8aca-3ff8ce8e8164": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "989c5b06-ea8a-4e34-b5bd-dfb14e685a8d":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "c34c34c7-15b0-49c8-862f-6b511ed94668": {"aggregate": "avg", "clientMetric":
+      "50"}, "2779132b-00be-4a63-8e37-fad331b53b4c": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,11 +106,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1bb9ab47-bc04-42f5-a6ec-f7c1b09a05d4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75d15d2f-c618-4e9b-98b4-79c9757c58f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c34c34c7-15b0-49c8-862f-6b511ed94668":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:03.201Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:03.201Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9f55c300-b83a-4d0d-8aca-3ff8ce8e8164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"989c5b06-ea8a-4e34-b5bd-dfb14e685a8d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2779132b-00be-4a63-8e37-fad331b53b4c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:36.904Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:36.904Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:03 GMT
+      - Mon, 09 Oct 2023 19:18:36 GMT
       location:
-      - https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+      - https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - cc16b7c4-eb6b-46ec-88ea-df9814af3d61
+      - 138323ad-f1f1-42fd-b501-3ad9dcc926a8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
+    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:03 GMT
+      - Mon, 09 Oct 2023 19:18:37 GMT
       mise-correlation-id:
-      - cce582cd-ad26-4a2f-8399-eee7e315b9ed
+      - 845cfa0a-0a0f-4780-a04a-21428594f1ba
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A03Z&sr=b&sp=r&sig=UVZEm0VbMY0fK4%2BIZ0TngXtN4c2%2F5a%2FVsPwh0SymL2s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:03.9673693","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A37Z&sr=b&sp=r&sig=Ijg3c49YL4YXM3MZeYxRn435oSJ8gLXq448S6MT9n2g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:37.7503482","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:03 GMT
+      - Mon, 09 Oct 2023 19:18:37 GMT
       location:
-      - https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 1d327a1e-99cf-4d35-93cc-733bdb955561
+      - 6fce4705-3987-400a-9196-2faf3fb5a53a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,46 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A04Z&sr=b&sp=r&sig=fJMf1BY8IuFXcWMs697BdDerxEWmU56dMpc7%2FIokQBw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:04.2325864","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:12:04 GMT
-      mise-correlation-id:
-      - 193c8e53-13e8-4d93-a695-1036db189a19
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A09Z&sr=b&sp=r&sig=xK6YSKwfPi59KrFcLBX2TP13CjTAl%2BQ38fkYJ7j%2Fh7s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:09.5070848","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A38Z&sr=b&sp=r&sig=ImyKEE%2F3dvp%2BNQ6RIGj8FbKZQ7CHIMF3NlXKIBvWbD0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:38.0003412","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:09 GMT
+      - Mon, 09 Oct 2023 19:18:38 GMT
       mise-correlation-id:
-      - ca41ea22-5b47-42df-9970-9a1b944010c2
+      - aed512b7-95c0-4e20-933c-49aa0c6ac8e2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,10 +349,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A14Z&sr=b&sp=r&sig=mwF5Bmy9D585RJQ8CTHxZy%2B4TYZZtzNRJhsMGWIzTjw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:14.8095927","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A43Z&sr=b&sp=r&sig=2cl2QfyJt31c0XYQSZpTc7epBNvSz92myVUOTvVc%2Fm8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:43.3189164","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:14 GMT
+      - Mon, 09 Oct 2023 19:18:43 GMT
       mise-correlation-id:
-      - f832d0db-7070-4883-8c92-9e39f2eac680
+      - bd52eeef-a43d-4916-8811-e170c36fb8f5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +385,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A20Z&sr=b&sp=r&sig=xhTweD4Pp7cIReebPK9gokRNtHGqy0g1bmykI0u3rmw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:20.0827544","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A48Z&sr=b&sp=r&sig=Ch3Mwp7fAZjlQj53L0bk6O2nkFfciwfUEckTsgL%2Freg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:48.5843523","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:20 GMT
+      - Mon, 09 Oct 2023 19:18:48 GMT
       mise-correlation-id:
-      - 3ff0d0a9-dedc-4d6b-8a86-9f4408867ed8
+      - 8436f3c6-71ca-469e-8ef1-f7c1d00787f7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +421,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1bb9ab47-bc04-42f5-a6ec-f7c1b09a05d4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75d15d2f-c618-4e9b-98b4-79c9757c58f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c34c34c7-15b0-49c8-862f-6b511ed94668":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A20Z&sr=b&sp=r&sig=E7Vzt%2F4HHLG2ALAncf%2F1eZZ%2BHQ5fDNOGG8knPztKRnM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:20.3499953","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:03.201Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:16.808Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A53Z&sr=b&sp=r&sig=K1pVKMfHeJcHFrlXsWIg8YScKo0uo2hzTVz%2FOoeXq3s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:53.8693422","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1583'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:20 GMT
+      - Mon, 09 Oct 2023 19:18:53 GMT
       mise-correlation-id:
-      - 09bfe2fe-0357-4c75-bf34-45c8a96cbe2c
+      - 7e7794f4-4695-43e7-8e03-3dc7ccc07fa1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9f55c300-b83a-4d0d-8aca-3ff8ce8e8164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"989c5b06-ea8a-4e34-b5bd-dfb14e685a8d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2779132b-00be-4a63-8e37-fad331b53b4c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A54Z&sr=b&sp=r&sig=9H3FGaXh1lDPylFiTXHIy0M1BKguCojqGr2cddRcLlg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:54.6651144","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:36.904Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:52.431Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1577'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:18:54 GMT
+      mise-correlation-id:
+      - 5a2ebb54-8f93-4270-b931-a17f93d30111
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:28.0755084Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:28.0755084Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:59.5754937Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:59.5754937Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:21 GMT
+      - Mon, 09 Oct 2023 19:18:55 GMT
       etag:
-      - '"920137a8-0000-0100-0000-652426320000"'
+      - '"56005a06-0000-0100-0000-652451ea0000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"1bb9ab47-bc04-42f5-a6ec-f7c1b09a05d4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75d15d2f-c618-4e9b-98b4-79c9757c58f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c34c34c7-15b0-49c8-862f-6b511ed94668":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A22Z&sr=b&sp=r&sig=tYSz7KGfzaVnIjizn2J%2Fm%2BfhCxV3ACS%2BIHY%2F0%2Fs11Kw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:22.6222974","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:03.201Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:16.808Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"9f55c300-b83a-4d0d-8aca-3ff8ce8e8164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"989c5b06-ea8a-4e34-b5bd-dfb14e685a8d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2779132b-00be-4a63-8e37-fad331b53b4c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A56Z&sr=b&sp=r&sig=7A7Jdmj%2B%2F2nysmRSAzQHdUdBScDpHw0qrBgVAQBIGZg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:56.8425797","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:36.904Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:52.431Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1599'
+      - '1593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:22 GMT
+      - Mon, 09 Oct 2023 19:18:56 GMT
       mise-correlation-id:
-      - 70030762-9ae1-4ffd-97d7-ba7a25834d96
+      - 32cd3dac-309a-447e-be67-2f6d4a2ea113
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:28.0755084Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:28.0755084Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:59.5754937Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:59.5754937Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:23 GMT
+      - Mon, 09 Oct 2023 19:18:57 GMT
       etag:
-      - '"920137a8-0000-0100-0000-652426320000"'
+      - '"56005a06-0000-0100-0000-652451ea0000"'
       expires:
       - '-1'
       pragma:
@@ -619,24 +619,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1bb9ab47-bc04-42f5-a6ec-f7c1b09a05d4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75d15d2f-c618-4e9b-98b4-79c9757c58f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c34c34c7-15b0-49c8-862f-6b511ed94668":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A24Z&sr=b&sp=r&sig=Pwsgo%2FA%2FYNWlke9SoP2MF11qxAl95GLChOQPeeUaa0A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:24.125814","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:03.201Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:16.808Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9f55c300-b83a-4d0d-8aca-3ff8ce8e8164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"989c5b06-ea8a-4e34-b5bd-dfb14e685a8d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2779132b-00be-4a63-8e37-fad331b53b4c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A59Z&sr=b&sp=r&sig=vIiS1LswYRSMy4dJlRfe%2BfdJaAmY6UIgb1VgmhBaIuY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:59.2075845","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:36.904Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:52.431Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1580'
+      - '1579'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:24 GMT
+      - Mon, 09 Oct 2023 19:18:59 GMT
       mise-correlation-id:
-      - c2de09b4-e150-41b1-894c-ed4398533c49
+      - d706972c-8c75-49b7-987f-ad4baaebdb04
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -663,11 +663,48 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1bb9ab47-bc04-42f5-a6ec-f7c1b09a05d4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75d15d2f-c618-4e9b-98b4-79c9757c58f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c34c34c7-15b0-49c8-862f-6b511ed94668":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A24Z&sr=b&sp=r&sig=QNPkzXpH%2F8U9jJy3P6mU%2BxttbYQIK9SZo0LHJ%2BTDrqE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:24.9305371","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:03.201Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:24.923Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9f55c300-b83a-4d0d-8aca-3ff8ce8e8164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"989c5b06-ea8a-4e34-b5bd-dfb14e685a8d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2779132b-00be-4a63-8e37-fad331b53b4c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A59Z&sr=b&sp=r&sig=tgMbh6Wwg8pptkPpZglGy0g7khBtKjU7vmSQoC4JNnQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:59.5923491","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:36.904Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:59.583Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1578'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:18:59 GMT
+      mise-correlation-id:
+      - 57a71cd3-19a1-4cc9-b77c-20437981a2f5
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"9f55c300-b83a-4d0d-8aca-3ff8ce8e8164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"989c5b06-ea8a-4e34-b5bd-dfb14e685a8d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2779132b-00be-4a63-8e37-fad331b53b4c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A59Z&sr=b&sp=r&sig=M%2BKZf%2BVKiyMyGcc2CXQ88clM3IWEmHjK6khA8%2BMjhks%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:59.8470997","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:36.904Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:59.583Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -678,46 +715,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:24 GMT
+      - Mon, 09 Oct 2023 19:18:59 GMT
       mise-correlation-id:
-      - 36418553-d4d8-44aa-ba59-29d2b14b0f74
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1bb9ab47-bc04-42f5-a6ec-f7c1b09a05d4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75d15d2f-c618-4e9b-98b4-79c9757c58f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c34c34c7-15b0-49c8-862f-6b511ed94668":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A25Z&sr=b&sp=r&sig=Qt1L8D%2FsrLIJf5etOQiMA8ILQPE8vQtoIMM5t7h5GVo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:25.2096895","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:03.201Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:24.923Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1580'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:12:25 GMT
-      mise-correlation-id:
-      - 4553a0e6-416a-43cd-b498-dfd0d73e6978
+      - 523f9443-3149-47e2-9e1e-ec30ebd45c94
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -740,7 +740,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:28.0755084Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:28.0755084Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:59.5754937Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:59.5754937Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -749,9 +749,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:25 GMT
+      - Mon, 09 Oct 2023 19:19:01 GMT
       etag:
-      - '"920137a8-0000-0100-0000-652426320000"'
+      - '"56005a06-0000-0100-0000-652451ea0000"'
       expires:
       - '-1'
       pragma:
@@ -781,24 +781,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"1bb9ab47-bc04-42f5-a6ec-f7c1b09a05d4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75d15d2f-c618-4e9b-98b4-79c9757c58f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c34c34c7-15b0-49c8-862f-6b511ed94668":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A27Z&sr=b&sp=r&sig=1bNitcSwjXNp2isNYrGfCm5%2F1uLCnwI%2FHISSadqjKzE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:27.4372566","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:03.201Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:24.923Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"9f55c300-b83a-4d0d-8aca-3ff8ce8e8164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"989c5b06-ea8a-4e34-b5bd-dfb14e685a8d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2779132b-00be-4a63-8e37-fad331b53b4c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A02Z&sr=b&sp=r&sig=OSDfeXeqQBkg1XS7SQs63WANsFuTzcsVbfVmVeSeows%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:02.5249632","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:36.904Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:59.583Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1582'
+      - '1578'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:27 GMT
+      - Mon, 09 Oct 2023 19:19:02 GMT
       mise-correlation-id:
-      - 788e6662-b8ab-4478-88ea-ecbebcfc2c0b
+      - e331676d-06db-4722-bea3-65874b235c17
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -821,7 +821,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:28.0755084Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:28.0755084Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:59.5754937Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:59.5754937Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -830,9 +830,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:28 GMT
+      - Mon, 09 Oct 2023 19:19:03 GMT
       etag:
-      - '"920137a8-0000-0100-0000-652426320000"'
+      - '"56005a06-0000-0100-0000-652451ea0000"'
       expires:
       - '-1'
       pragma:
@@ -862,7 +862,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-update-test-case?api-version=2022-11-01
+    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -875,9 +875,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:12:29 GMT
+      - Mon, 09 Oct 2023 19:19:04 GMT
       mise-correlation-id:
-      - 5713d965-6962-4ed3-85bf-8dde3e20d45c
+      - 24b489a9-e323-490d-8eec-63506f07a8e3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_update.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_update.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:59.5754937Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:59.5754937Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:55.0507735Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:55.0507735Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:34 GMT
+      - Fri, 13 Oct 2023 13:51:27 GMT
       etag:
-      - '"56005a06-0000-0100-0000-652451ea0000"'
+      - '"d8017bdd-0000-0100-0000-65294b400000"'
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:18:36 GMT
+      - Fri, 13 Oct 2023 13:51:28 GMT
       mise-correlation-id:
-      - ec037e89-563c-432a-be0a-8670177afe9b
+      - f5a3d76c-da85-4b05-b1da-817417ce0372
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"9f55c300-b83a-4d0d-8aca-3ff8ce8e8164": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "989c5b06-ea8a-4e34-b5bd-dfb14e685a8d":
+      {"passFailMetrics": {"bac30fb5-755e-4585-8e74-b82ca1b7f9a0": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "c83e108a-2e9e-438e-9a95-4e9d5af40188":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "2779132b-00be-4a63-8e37-fad331b53b4c": {"aggregate": "avg", "clientMetric":
+      "50"}, "fe7ceeb8-8a8c-4713-80eb-ca8ba1045c73": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -104,13 +104,13 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9f55c300-b83a-4d0d-8aca-3ff8ce8e8164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"989c5b06-ea8a-4e34-b5bd-dfb14e685a8d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2779132b-00be-4a63-8e37-fad331b53b4c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:36.904Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:36.904Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"bac30fb5-755e-4585-8e74-b82ca1b7f9a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c83e108a-2e9e-438e-9a95-4e9d5af40188":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fe7ceeb8-8a8c-4713-80eb-ca8ba1045c73":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:29.254Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:29.254Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -121,11 +121,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:36 GMT
+      - Fri, 13 Oct 2023 13:51:29 GMT
       location:
-      - https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+      - https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 138323ad-f1f1-42fd-b501-3ad9dcc926a8
+      - 73a38ffd-0a32-4a84-b99e-c1cec38af273
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -143,9 +143,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
+    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:37 GMT
+      - Fri, 13 Oct 2023 13:51:29 GMT
       mise-correlation-id:
-      - 845cfa0a-0a0f-4780-a04a-21428594f1ba
+      - 4615b39e-b428-44ff-a884-82be1d9a8173
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -273,27 +273,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A37Z&sr=b&sp=r&sig=Ijg3c49YL4YXM3MZeYxRn435oSJ8gLXq448S6MT9n2g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:37.7503482","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A30Z&sr=b&sp=r&sig=I%2FFwYof9txo8qWb5nZJscAVbACsIei5BddiFo%2BbEiW0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:30.0045074","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:37 GMT
+      - Fri, 13 Oct 2023 13:51:29 GMT
       location:
-      - https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 6fce4705-3987-400a-9196-2faf3fb5a53a
+      - 40c2a285-48a1-4ca7-bd75-3dd6ace072cf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -311,48 +311,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A38Z&sr=b&sp=r&sig=ImyKEE%2F3dvp%2BNQ6RIGj8FbKZQ7CHIMF3NlXKIBvWbD0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:38.0003412","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:18:38 GMT
-      mise-correlation-id:
-      - aed512b7-95c0-4e20-933c-49aa0c6ac8e2
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A43Z&sr=b&sp=r&sig=2cl2QfyJt31c0XYQSZpTc7epBNvSz92myVUOTvVc%2Fm8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:43.3189164","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A30Z&sr=b&sp=r&sig=mXD2cEgSyZRrl5TKpQfFtNQ76w5T%2BQKJhvcLM0e8jwc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:30.2593577","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:43 GMT
+      - Fri, 13 Oct 2023 13:51:30 GMT
       mise-correlation-id:
-      - bd52eeef-a43d-4916-8811-e170c36fb8f5
+      - c54be20c-1ebe-4d87-8581-beddcbc561d1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -383,12 +347,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A48Z&sr=b&sp=r&sig=Ch3Mwp7fAZjlQj53L0bk6O2nkFfciwfUEckTsgL%2Freg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:48.5843523","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A35Z&sr=b&sp=r&sig=qt0d72skWAnLocaTkxquhBonDF50%2FPU9RhGYkizwJcU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:35.4965247","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +363,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:48 GMT
+      - Fri, 13 Oct 2023 13:51:35 GMT
       mise-correlation-id:
-      - 8436f3c6-71ca-469e-8ef1-f7c1d00787f7
+      - 39fed69c-963b-4397-a6cf-5d39b730e4ed
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -419,12 +383,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A53Z&sr=b&sp=r&sig=K1pVKMfHeJcHFrlXsWIg8YScKo0uo2hzTVz%2FOoeXq3s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:53.8693422","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A40Z&sr=b&sp=r&sig=rzR4ExzAgVj6vxFtO86tr9MXJNuLC8RsoD26ZHii9SQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:40.7614519","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:53 GMT
+      - Fri, 13 Oct 2023 13:51:40 GMT
       mise-correlation-id:
-      - 7e7794f4-4695-43e7-8e03-3dc7ccc07fa1
+      - 5dce3923-fae6-4533-bb52-bfa7ad1e4054
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -455,26 +419,62 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9f55c300-b83a-4d0d-8aca-3ff8ce8e8164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"989c5b06-ea8a-4e34-b5bd-dfb14e685a8d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2779132b-00be-4a63-8e37-fad331b53b4c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A54Z&sr=b&sp=r&sig=9H3FGaXh1lDPylFiTXHIy0M1BKguCojqGr2cddRcLlg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:54.6651144","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:36.904Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:52.431Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A46Z&sr=b&sp=r&sig=hm5eW2KAlwXbT0HoKHyYW8J2L9QQ%2B9aMnZvjpuN1Xdc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:46.0392366","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1577'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:54 GMT
+      - Fri, 13 Oct 2023 13:51:46 GMT
       mise-correlation-id:
-      - 5a2ebb54-8f93-4270-b931-a17f93d30111
+      - fdd3454e-6d09-4c7f-bbd3-9f73c079703c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"bac30fb5-755e-4585-8e74-b82ca1b7f9a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c83e108a-2e9e-438e-9a95-4e9d5af40188":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fe7ceeb8-8a8c-4713-80eb-ca8ba1045c73":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A46Z&sr=b&sp=r&sig=Vmvhc7f1BKBejh89icn50k8A3aylrViw9RxqKQC7xYI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:46.285202","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:29.254Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:43.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1576'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:51:46 GMT
+      mise-correlation-id:
+      - 4ef26f1a-0598-423b-b4bf-d0271a4a9c86
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:59.5754937Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:59.5754937Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:55.0507735Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:55.0507735Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:55 GMT
+      - Fri, 13 Oct 2023 13:51:47 GMT
       etag:
-      - '"56005a06-0000-0100-0000-652451ea0000"'
+      - '"d8017bdd-0000-0100-0000-65294b400000"'
       expires:
       - '-1'
       pragma:
@@ -536,13 +536,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"9f55c300-b83a-4d0d-8aca-3ff8ce8e8164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"989c5b06-ea8a-4e34-b5bd-dfb14e685a8d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2779132b-00be-4a63-8e37-fad331b53b4c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A56Z&sr=b&sp=r&sig=7A7Jdmj%2B%2F2nysmRSAzQHdUdBScDpHw0qrBgVAQBIGZg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:56.8425797","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:36.904Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:52.431Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"bac30fb5-755e-4585-8e74-b82ca1b7f9a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c83e108a-2e9e-438e-9a95-4e9d5af40188":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fe7ceeb8-8a8c-4713-80eb-ca8ba1045c73":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A47Z&sr=b&sp=r&sig=z2wmXjYn8oyoT%2B5CBq%2BWzZqYO6T1A7EnUzalXnZwJI4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:47.9806138","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:29.254Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:43.998Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -553,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:56 GMT
+      - Fri, 13 Oct 2023 13:51:48 GMT
       mise-correlation-id:
-      - 32cd3dac-309a-447e-be67-2f6d4a2ea113
+      - 87b1b47f-033e-40bd-9d7f-797df51f9e0e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:59.5754937Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:59.5754937Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:55.0507735Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:55.0507735Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:57 GMT
+      - Fri, 13 Oct 2023 13:51:49 GMT
       etag:
-      - '"56005a06-0000-0100-0000-652451ea0000"'
+      - '"d8017bdd-0000-0100-0000-65294b400000"'
       expires:
       - '-1'
       pragma:
@@ -617,26 +617,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9f55c300-b83a-4d0d-8aca-3ff8ce8e8164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"989c5b06-ea8a-4e34-b5bd-dfb14e685a8d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2779132b-00be-4a63-8e37-fad331b53b4c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A59Z&sr=b&sp=r&sig=vIiS1LswYRSMy4dJlRfe%2BfdJaAmY6UIgb1VgmhBaIuY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:59.2075845","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:36.904Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:52.431Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"bac30fb5-755e-4585-8e74-b82ca1b7f9a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c83e108a-2e9e-438e-9a95-4e9d5af40188":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fe7ceeb8-8a8c-4713-80eb-ca8ba1045c73":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A50Z&sr=b&sp=r&sig=uRpo1uHYQY8C58e8Qyhywa6I5pQK99Hy2BuhzM05tvE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:50.1528907","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:29.254Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:43.998Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1579'
+      - '1577'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:59 GMT
+      - Fri, 13 Oct 2023 13:51:50 GMT
       mise-correlation-id:
-      - d706972c-8c75-49b7-987f-ad4baaebdb04
+      - fe15dcfe-4efc-4a32-9b0f-e70dcad17fce
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -661,26 +661,26 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9f55c300-b83a-4d0d-8aca-3ff8ce8e8164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"989c5b06-ea8a-4e34-b5bd-dfb14e685a8d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2779132b-00be-4a63-8e37-fad331b53b4c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A59Z&sr=b&sp=r&sig=tgMbh6Wwg8pptkPpZglGy0g7khBtKjU7vmSQoC4JNnQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:59.5923491","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:36.904Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:59.583Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"bac30fb5-755e-4585-8e74-b82ca1b7f9a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c83e108a-2e9e-438e-9a95-4e9d5af40188":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fe7ceeb8-8a8c-4713-80eb-ca8ba1045c73":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A50Z&sr=b&sp=r&sig=JFF4ybeP63NEgF5UdNq8m9XDDK5LCgWa6qJ4vq8VM28%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:50.488568","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:29.254Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:50.48Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1578'
+      - '1576'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:59 GMT
+      - Fri, 13 Oct 2023 13:51:50 GMT
       mise-correlation-id:
-      - 57a71cd3-19a1-4cc9-b77c-20437981a2f5
+      - 74b65474-ca17-45a2-97ad-2844284a5a31
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -698,26 +698,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9f55c300-b83a-4d0d-8aca-3ff8ce8e8164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"989c5b06-ea8a-4e34-b5bd-dfb14e685a8d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2779132b-00be-4a63-8e37-fad331b53b4c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A59Z&sr=b&sp=r&sig=M%2BKZf%2BVKiyMyGcc2CXQ88clM3IWEmHjK6khA8%2BMjhks%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:59.8470997","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:36.904Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:59.583Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"bac30fb5-755e-4585-8e74-b82ca1b7f9a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c83e108a-2e9e-438e-9a95-4e9d5af40188":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fe7ceeb8-8a8c-4713-80eb-ca8ba1045c73":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A50Z&sr=b&sp=r&sig=cjgAATANZkHrOpndAxYsNQ55J6lhgIUkIwNqW0e9qRw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:50.7741276","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:29.254Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:50.48Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1584'
+      - '1577'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:59 GMT
+      - Fri, 13 Oct 2023 13:51:50 GMT
       mise-correlation-id:
-      - 523f9443-3149-47e2-9e1e-ec30ebd45c94
+      - f4ae4094-eb1e-4165-be09-d5ede2b67f78
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -740,7 +740,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:59.5754937Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:59.5754937Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:55.0507735Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:55.0507735Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -749,9 +749,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:01 GMT
+      - Fri, 13 Oct 2023 13:51:52 GMT
       etag:
-      - '"56005a06-0000-0100-0000-652451ea0000"'
+      - '"d8017bdd-0000-0100-0000-65294b400000"'
       expires:
       - '-1'
       pragma:
@@ -779,26 +779,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"9f55c300-b83a-4d0d-8aca-3ff8ce8e8164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"989c5b06-ea8a-4e34-b5bd-dfb14e685a8d":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"2779132b-00be-4a63-8e37-fad331b53b4c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/52d7099b-19a8-4994-9b27-4eb88db5d214/5961b222-e874-4de2-8e50-8db8842fd5f8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A02Z&sr=b&sp=r&sig=OSDfeXeqQBkg1XS7SQs63WANsFuTzcsVbfVmVeSeows%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:02.5249632","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:36.904Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:59.583Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"bac30fb5-755e-4585-8e74-b82ca1b7f9a0":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"c83e108a-2e9e-438e-9a95-4e9d5af40188":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"fe7ceeb8-8a8c-4713-80eb-ca8ba1045c73":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/d22950e1-d0b1-492a-8d0f-219b75ab05f2/62c32c88-2bbd-4d7d-988a-ef990d7ce5e7?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A53Z&sr=b&sp=r&sig=Qd1zBprEaWXqYhl8rF3JICgNFriW8UzYyjeqUrCOZrI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:53.0542223","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:29.254Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:50.48Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1578'
+      - '1577'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:02 GMT
+      - Fri, 13 Oct 2023 13:51:53 GMT
       mise-correlation-id:
-      - e331676d-06db-4722-bea3-65874b235c17
+      - 5223f95c-eaac-409f-82e8-4916e94dd719
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -821,7 +821,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:59.5754937Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:59.5754937Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:55.0507735Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:55.0507735Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -830,9 +830,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:03 GMT
+      - Fri, 13 Oct 2023 13:51:53 GMT
       etag:
-      - '"56005a06-0000-0100-0000-652451ea0000"'
+      - '"d8017bdd-0000-0100-0000-65294b400000"'
       expires:
       - '-1'
       pragma:
@@ -860,9 +860,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://f31d1aca-f854-4662-80e1-412943cce663.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-update-test-case?api-version=2022-11-01
+    uri: https://9aef9dbf-de14-403f-b769-eca3c524c708.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -875,9 +875,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:19:04 GMT
+      - Fri, 13 Oct 2023 13:51:54 GMT
       mise-correlation-id:
-      - 24b489a9-e323-490d-8eec-63506f07a8e3
+      - 36154c36-781a-4eba-9186-4caee5456b3a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_update.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_update.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:11:33.5976413Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:11:33.5976413Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:28.0755084Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:28.0755084Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:08 GMT
+      - Mon, 09 Oct 2023 16:12:01 GMT
       etag:
-      - '"1a0a82b8-0000-0100-0000-64af08f60000"'
+      - '"920137a8-0000-0100-0000-652426320000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:12:09 GMT
+      - Mon, 09 Oct 2023 16:12:02 GMT
       mise-correlation-id:
-      - 52c1f485-0e8b-4a7e-8349-58696a0f24b6
+      - 63671e69-6b0d-40fe-9fbd-43e4a198a609
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -85,12 +85,12 @@ interactions:
 - request:
     body: '{"displayName": "CLI-Test", "description": "Test created from az load test
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
-      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "loadTestConfiguration":
+      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"b602375d-0d82-406d-a0bb-f4a18694f369": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "3bae8483-60f7-40bb-bc5f-2c88714c74b1":
+      {"passFailMetrics": {"1bb9ab47-bc04-42f5-a6ec-f7c1b09a05d4": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "75d15d2f-c618-4e9b-98b4-79c9757c58f6":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "6072949d-dbd2-491c-ac1b-01bbf7917bc4": {"aggregate": "avg", "clientMetric":
+      "50"}, "c34c34c7-15b0-49c8-862f-6b511ed94668": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -100,32 +100,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '768'
+      - '789'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b602375d-0d82-406d-a0bb-f4a18694f369":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"3bae8483-60f7-40bb-bc5f-2c88714c74b1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"6072949d-dbd2-491c-ac1b-01bbf7917bc4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:12:10.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:12:10.822Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1bb9ab47-bc04-42f5-a6ec-f7c1b09a05d4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75d15d2f-c618-4e9b-98b4-79c9757c58f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c34c34c7-15b0-49c8-862f-6b511ed94668":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:03.201Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:03.201Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1062'
+      - '1008'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:10 GMT
+      - Mon, 09 Oct 2023 16:12:03 GMT
       location:
-      - https://c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+      - https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 4aeb2403-8fed-4447-95cf-aec74d0769df
+      - cc16b7c4-eb6b-46ec-88ea-df9814af3d61
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
+    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:11 GMT
+      - Mon, 09 Oct 2023 16:12:03 GMT
       mise-correlation-id:
-      - 2f478452-0c98-4b17-a2cc-bac6deb477af
+      - cce582cd-ad26-4a2f-8399-eee7e315b9ed
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7f66806f-ed83-42f1-8d04-aadc79bed23a/423764c4-fa3c-46df-8af4-153abc1c9ede?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A22%3A11Z&sr=b&sp=r&sig=XDQ4zQH50bNUtKZrILXnkiK4EYRR8bu7fst1xZRw51Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:22:11.6317914","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A03Z&sr=b&sp=r&sig=UVZEm0VbMY0fK4%2BIZ0TngXtN4c2%2F5a%2FVsPwh0SymL2s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:03.9673693","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:11 GMT
+      - Mon, 09 Oct 2023 16:12:03 GMT
       location:
-      - https://c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 5f97a632-0d5d-4db2-93ef-34a28c6454f3
+      - 1d327a1e-99cf-4d35-93cc-733bdb955561
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,46 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7f66806f-ed83-42f1-8d04-aadc79bed23a/423764c4-fa3c-46df-8af4-153abc1c9ede?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A22%3A12Z&sr=b&sp=r&sig=MnOIewQVPA6mt2AOpzcZIqIwrDdGOPZqf1twMOGjTC8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:22:12.1129048","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 12 Jul 2023 20:12:12 GMT
-      mise-correlation-id:
-      - 04740b7d-e37f-46aa-bd6a-53feac8a00bd
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7f66806f-ed83-42f1-8d04-aadc79bed23a/423764c4-fa3c-46df-8af4-153abc1c9ede?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A22%3A17Z&sr=b&sp=r&sig=KbZvbWzd%2Bhm8JRJY8MnibVKgO2DGBDyjh7P2cosUaXo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:22:17.3950118","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A04Z&sr=b&sp=r&sig=fJMf1BY8IuFXcWMs697BdDerxEWmU56dMpc7%2FIokQBw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:04.2325864","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -363,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:17 GMT
+      - Mon, 09 Oct 2023 16:12:04 GMT
       mise-correlation-id:
-      - 7f2b02cc-c1b8-4e1c-b80e-9d8b00322eca
+      - 193c8e53-13e8-4d93-a695-1036db189a19
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -385,23 +349,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7f66806f-ed83-42f1-8d04-aadc79bed23a/423764c4-fa3c-46df-8af4-153abc1c9ede?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T19%3A43%3A51Z&ske=2023-07-13T10%3A13%3A51Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A22%3A23Z&sr=b&sp=r&sig=wSylbIkNSwzFZ2fNu4HAwFyh0uJasomrJPwNYpjgROI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:22:23.0389727","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A09Z&sr=b&sp=r&sig=xK6YSKwfPi59KrFcLBX2TP13CjTAl%2BQ38fkYJ7j%2Fh7s%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:09.5070848","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:23 GMT
+      - Mon, 09 Oct 2023 16:12:09 GMT
       mise-correlation-id:
-      - e692f03d-a765-408d-800d-89bf12e7b9c6
+      - ca41ea22-5b47-42df-9970-9a1b944010c2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,10 +385,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7f66806f-ed83-42f1-8d04-aadc79bed23a/423764c4-fa3c-46df-8af4-153abc1c9ede?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T20%3A22%3A28Z&sr=b&sp=r&sig=tMHjhuZ85sm0MjjlsdLqkVl19Xy9bFYl5tndzc4MYU4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T20:22:28.3285504","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A14Z&sr=b&sp=r&sig=mwF5Bmy9D585RJQ8CTHxZy%2B4TYZZtzNRJhsMGWIzTjw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:14.8095927","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:12:14 GMT
+      mise-correlation-id:
+      - f832d0db-7070-4883-8c92-9e39f2eac680
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A20Z&sr=b&sp=r&sig=xhTweD4Pp7cIReebPK9gokRNtHGqy0g1bmykI0u3rmw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:20.0827544","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:28 GMT
+      - Mon, 09 Oct 2023 16:12:20 GMT
       mise-correlation-id:
-      - dd1ac4e4-7f3a-4bbf-b33a-4f887df9e91c
+      - 3ff0d0a9-dedc-4d6b-8a86-9f4408867ed8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,24 +457,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b602375d-0d82-406d-a0bb-f4a18694f369":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"3bae8483-60f7-40bb-bc5f-2c88714c74b1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"6072949d-dbd2-491c-ac1b-01bbf7917bc4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7f66806f-ed83-42f1-8d04-aadc79bed23a/423764c4-fa3c-46df-8af4-153abc1c9ede?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A12%3A28Z&sr=b&sp=r&sig=jAfuqaoL%2BRfxYRIkvyMdpAYNmSQCKG%2FXJztV5txfCxM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:12:28.6950425","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:12:10.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:12:23.924Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1bb9ab47-bc04-42f5-a6ec-f7c1b09a05d4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75d15d2f-c618-4e9b-98b4-79c9757c58f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c34c34c7-15b0-49c8-862f-6b511ed94668":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A20Z&sr=b&sp=r&sig=E7Vzt%2F4HHLG2ALAncf%2F1eZZ%2BHQ5fDNOGG8knPztKRnM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:20.3499953","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:03.201Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:16.808Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1635'
+      - '1583'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:28 GMT
+      - Mon, 09 Oct 2023 16:12:20 GMT
       mise-correlation-id:
-      - 4b9138b6-5be7-4dba-be67-a0e1b270cc2a
+      - 09bfe2fe-0357-4c75-bf34-45c8a96cbe2c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,7 +497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:11:33.5976413Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:11:33.5976413Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:28.0755084Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:28.0755084Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -506,9 +506,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:30 GMT
+      - Mon, 09 Oct 2023 16:12:21 GMT
       etag:
-      - '"1a0a82b8-0000-0100-0000-64af08f60000"'
+      - '"920137a8-0000-0100-0000-652426320000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"b602375d-0d82-406d-a0bb-f4a18694f369":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"3bae8483-60f7-40bb-bc5f-2c88714c74b1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"6072949d-dbd2-491c-ac1b-01bbf7917bc4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7f66806f-ed83-42f1-8d04-aadc79bed23a/423764c4-fa3c-46df-8af4-153abc1c9ede?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T17%3A47%3A18Z&ske=2023-07-13T08%3A17%3A18Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A12%3A31Z&sr=b&sp=r&sig=3ibokk3l5FmxyrhZYgncJyux3P5SIK0sQqU6E4985JU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:12:31.2018497","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:12:10.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:12:23.924Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"1bb9ab47-bc04-42f5-a6ec-f7c1b09a05d4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75d15d2f-c618-4e9b-98b4-79c9757c58f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c34c34c7-15b0-49c8-862f-6b511ed94668":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A22Z&sr=b&sp=r&sig=tYSz7KGfzaVnIjizn2J%2Fm%2BfhCxV3ACS%2BIHY%2F0%2Fs11Kw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:22.6222974","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:03.201Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:16.808Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1643'
+      - '1599'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:31 GMT
+      - Mon, 09 Oct 2023 16:12:22 GMT
       mise-correlation-id:
-      - 11f00a4b-7f11-4c33-875c-5acd6e61c63f
+      - 70030762-9ae1-4ffd-97d7-ba7a25834d96
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,7 +578,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:11:33.5976413Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:11:33.5976413Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:28.0755084Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:28.0755084Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,9 +587,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:32 GMT
+      - Mon, 09 Oct 2023 16:12:23 GMT
       etag:
-      - '"1a0a82b8-0000-0100-0000-64af08f60000"'
+      - '"920137a8-0000-0100-0000-652426320000"'
       expires:
       - '-1'
       pragma:
@@ -619,24 +619,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b602375d-0d82-406d-a0bb-f4a18694f369":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"3bae8483-60f7-40bb-bc5f-2c88714c74b1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"6072949d-dbd2-491c-ac1b-01bbf7917bc4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7f66806f-ed83-42f1-8d04-aadc79bed23a/423764c4-fa3c-46df-8af4-153abc1c9ede?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T20%3A07%3A24Z&ske=2023-07-13T10%3A07%3A24Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A12%3A33Z&sr=b&sp=r&sig=xSGWSltU83T1rEUG2lospxHsr60VqZkEGp%2F8O8U2HBk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:12:33.752259","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:12:10.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:12:23.924Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1bb9ab47-bc04-42f5-a6ec-f7c1b09a05d4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75d15d2f-c618-4e9b-98b4-79c9757c58f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c34c34c7-15b0-49c8-862f-6b511ed94668":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A24Z&sr=b&sp=r&sig=Pwsgo%2FA%2FYNWlke9SoP2MF11qxAl95GLChOQPeeUaa0A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:24.125814","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:03.201Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:16.808Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1632'
+      - '1580'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:33 GMT
+      - Mon, 09 Oct 2023 16:12:24 GMT
       mise-correlation-id:
-      - 28ca35b7-7ba8-4aee-bbd8-4e82632c81b7
+      - c2de09b4-e150-41b1-894c-ed4398533c49
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -663,24 +663,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b602375d-0d82-406d-a0bb-f4a18694f369":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"3bae8483-60f7-40bb-bc5f-2c88714c74b1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"6072949d-dbd2-491c-ac1b-01bbf7917bc4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7f66806f-ed83-42f1-8d04-aadc79bed23a/423764c4-fa3c-46df-8af4-153abc1c9ede?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A02%3A28Z&ske=2023-07-13T08%3A32%3A28Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A12%3A36Z&sr=b&sp=r&sig=uFynzEzlAzjT6ZxYfo3LeQT6yAv8a9si4iTmQyeh7RY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:12:36.2516558","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:12:10.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:12:36.244Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1bb9ab47-bc04-42f5-a6ec-f7c1b09a05d4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75d15d2f-c618-4e9b-98b4-79c9757c58f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c34c34c7-15b0-49c8-862f-6b511ed94668":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A24Z&sr=b&sp=r&sig=QNPkzXpH%2F8U9jJy3P6mU%2BxttbYQIK9SZo0LHJ%2BTDrqE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:24.9305371","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:03.201Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:24.923Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1632'
+      - '1584'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:36 GMT
+      - Mon, 09 Oct 2023 16:12:24 GMT
       mise-correlation-id:
-      - fde46fcb-fe25-4c8b-9875-edfc067da886
+      - 36418553-d4d8-44aa-ba59-29d2b14b0f74
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,24 +700,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b602375d-0d82-406d-a0bb-f4a18694f369":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"3bae8483-60f7-40bb-bc5f-2c88714c74b1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"6072949d-dbd2-491c-ac1b-01bbf7917bc4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7f66806f-ed83-42f1-8d04-aadc79bed23a/423764c4-fa3c-46df-8af4-153abc1c9ede?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A12%3A36Z&sr=b&sp=r&sig=tkJWcEi2tP8oKWgGcEcz9O%2BIQ%2FZpL5ZP1Xm45f%2BuTXA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:12:36.6174123","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:12:10.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:12:36.244Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1bb9ab47-bc04-42f5-a6ec-f7c1b09a05d4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75d15d2f-c618-4e9b-98b4-79c9757c58f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c34c34c7-15b0-49c8-862f-6b511ed94668":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A25Z&sr=b&sp=r&sig=Qt1L8D%2FsrLIJf5etOQiMA8ILQPE8vQtoIMM5t7h5GVo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:25.2096895","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:03.201Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:24.923Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1638'
+      - '1580'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:36 GMT
+      - Mon, 09 Oct 2023 16:12:25 GMT
       mise-correlation-id:
-      - d597db06-2d0f-4c57-93c0-5fa7f1f4271b
+      - 4553a0e6-416a-43cd-b498-dfd0d73e6978
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -740,7 +740,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:11:33.5976413Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:11:33.5976413Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:28.0755084Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:28.0755084Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -749,9 +749,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:37 GMT
+      - Mon, 09 Oct 2023 16:12:25 GMT
       etag:
-      - '"1a0a82b8-0000-0100-0000-64af08f60000"'
+      - '"920137a8-0000-0100-0000-652426320000"'
       expires:
       - '-1'
       pragma:
@@ -781,24 +781,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"b602375d-0d82-406d-a0bb-f4a18694f369":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue","result":"passed"},"3bae8483-60f7-40bb-bc5f-2c88714c74b1":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue","result":"passed"},"6072949d-dbd2-491c-ac1b-01bbf7917bc4":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue","result":"passed"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/7f66806f-ed83-42f1-8d04-aadc79bed23a/423764c4-fa3c-46df-8af4-153abc1c9ede?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-07-12T18%3A58%3A40Z&ske=2023-07-13T09%3A28%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-07-12T21%3A12%3A38Z&sr=b&sp=r&sig=L9ZruMt3LpDP245Fxq98FE0wQxRWlw5QKkt%2Bh8AZMY4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-07-12T21:12:38.9476822","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-07-12T20:12:10.822Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-07-12T20:12:36.244Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"1bb9ab47-bc04-42f5-a6ec-f7c1b09a05d4":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"75d15d2f-c618-4e9b-98b4-79c9757c58f6":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"c34c34c7-15b0-49c8-862f-6b511ed94668":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/5a84c9b2-8a62-4a2c-963c-2c34fb825d55/e0f7b27c-9872-438c-b0a2-db22c843f559?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A27Z&sr=b&sp=r&sig=1bNitcSwjXNp2isNYrGfCm5%2F1uLCnwI%2FHISSadqjKzE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:27.4372566","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:03.201Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:24.923Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1634'
+      - '1582'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:38 GMT
+      - Mon, 09 Oct 2023 16:12:27 GMT
       mise-correlation-id:
-      - 175a8cc3-6706-4c2a-8c30-790108b3f159
+      - 788e6662-b8ab-4478-88ea-ecbebcfc2c0b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -821,7 +821,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-07-12T20:11:33.5976413Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-07-12T20:11:33.5976413Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:28.0755084Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:28.0755084Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -830,9 +830,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 12 Jul 2023 20:12:40 GMT
+      - Mon, 09 Oct 2023 16:12:28 GMT
       etag:
-      - '"1a0a82b8-0000-0100-0000-64af08f60000"'
+      - '"920137a8-0000-0100-0000-652426320000"'
       expires:
       - '-1'
       pragma:
@@ -862,7 +862,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://c4ab8c3d-b30b-4fd6-95b0-25048551ec88.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-update-test-case?api-version=2022-11-01
+    uri: https://4a8f23b3-e038-4a55-9b75-70e382303966.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -875,9 +875,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 12 Jul 2023 20:12:42 GMT
+      - Mon, 09 Oct 2023 16:12:29 GMT
       mise-correlation-id:
-      - 09d406c0-a6c5-49f0-b0e0-ee786ef64ddc
+      - 5713d965-6962-4ed3-85bf-8dde3e20d45c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_update.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_update.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:45.5289007Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:45.5289007Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:36.9908212Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:36.9908212Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:19 GMT
+      - Sun, 29 Oct 2023 22:21:09 GMT
       etag:
-      - '"d300313a-0000-0100-0000-6537b8430000"'
+      - '"3c007327-0000-0100-0000-653edab70000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:28:21 GMT
+      - Sun, 29 Oct 2023 22:21:10 GMT
       mise-correlation-id:
-      - 85eedd18-305f-4fa0-afdd-6387c5636beb
+      - 02a16563-f2fc-43c9-a2c8-95e6fe3d5194
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -87,10 +87,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
       {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"ee98010c-b7ac-4d34-bfa0-06fbfb85b78d": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "7908e8b3-9e11-4740-85ce-78f2b72c2948":
+      {"passFailMetrics": {"6d226d67-c609-45e8-9a39-eff2748cf164": {"aggregate": "avg",
+      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "67739d7a-b404-4490-9ceb-c07478319cde":
       {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "6d9791cc-f48b-4e8e-887e-275292f4e638": {"aggregate": "avg", "clientMetric":
+      "50"}, "b350050c-164e-4b14-80b8-5027d1a1a65e": {"aggregate": "avg", "clientMetric":
       "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
     headers:
       Accept:
@@ -106,26 +106,26 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ee98010c-b7ac-4d34-bfa0-06fbfb85b78d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7908e8b3-9e11-4740-85ce-78f2b72c2948":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6d9791cc-f48b-4e8e-887e-275292f4e638":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:21.77Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:21.77Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6d226d67-c609-45e8-9a39-eff2748cf164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"67739d7a-b404-4490-9ceb-c07478319cde":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b350050c-164e-4b14-80b8-5027d1a1a65e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:11.188Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:11.188Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1006'
+      - '1008'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:21 GMT
+      - Sun, 29 Oct 2023 22:21:11 GMT
       location:
-      - https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+      - https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 32a67ed3-a78e-4df0-abbf-9837f5012580
+      - 9dca9bb5-92d8-4cfd-a326-6aecd0edd69e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +145,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
+    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +159,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:22 GMT
+      - Sun, 29 Oct 2023 22:21:11 GMT
       mise-correlation-id:
-      - 20464b54-3b6c-44d8-82d8-c4a2f179bf70
+      - 802c6430-c074-4af2-83f9-272018f73101
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +275,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A22Z&sr=b&sp=r&sig=3fHUnfhgrOg2FnTdJgyMcoSUlwvdEOK1FM26k2HZnHc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:22.8567759","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A11Z&sr=b&sp=r&sig=%2BhqYXMQG9f07RkroxWVnPb%2FF%2FdnIh9qtaLjYU3gMgwg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:11.9839257","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:22 GMT
+      - Sun, 29 Oct 2023 22:21:11 GMT
       location:
-      - https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - afad6e3a-3c5b-4d86-89b9-f66ee752f333
+      - 7e2f461c-00cc-4c45-9e4d-d8fadf0cd8ee
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,118 +313,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A23Z&sr=b&sp=r&sig=ibX1%2B2CBmiunnHaILBL6mUNiLbVQlOA9C1k7wD4Lx%2BI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:23.186359","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '552'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:28:23 GMT
-      mise-correlation-id:
-      - 4519d956-d248-4c66-909c-f1d7a0e56192
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A28Z&sr=b&sp=r&sig=TRR6KRdZmCP7i8ImxIEuapQxo16EH7NckvD2zXvrcKw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:28.808667","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '548'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:28:28 GMT
-      mise-correlation-id:
-      - a69e6620-2b5a-40d2-88a9-be3ff6a92cbe
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A34Z&sr=b&sp=r&sig=enH8AdeuNkpohPaO%2BA7PICBu960RljO62PIiA4W25Xk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:34.1628976","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:28:34 GMT
-      mise-correlation-id:
-      - b9f44d27-d93c-4985-9e0f-78b63f54edcf
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A39Z&sr=b&sp=r&sig=drOxDTYAYIW%2F0O4L4OxacNk%2B72xsG%2FcDZNiHaVTkZqM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:39.4008759","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A12Z&sr=b&sp=r&sig=vn5SOn8iVDrvt7zhUGo4L0lrAqND1%2F73WedrJ%2F6EE78%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:12.2485993","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -435,9 +327,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:39 GMT
+      - Sun, 29 Oct 2023 22:21:12 GMT
       mise-correlation-id:
-      - d542cf9a-951e-4e8c-9c22-661b0c8cbb5d
+      - 7e41cce5-8ce0-47d5-8bb1-0911f32d1786
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,11 +349,119 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ee98010c-b7ac-4d34-bfa0-06fbfb85b78d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7908e8b3-9e11-4740-85ce-78f2b72c2948":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6d9791cc-f48b-4e8e-887e-275292f4e638":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A40Z&sr=b&sp=r&sig=yc4PJz3g2VofJSfMYnrUxRU3UZLuDw1B2pMcr%2FY0xvQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:40.5593164","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:21.77Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:37.528Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A17Z&sr=b&sp=r&sig=RjYThOuycz4HIArnzHMjKuLl1Ft4%2BahZlgRqh5fABnA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:17.5055646","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:21:17 GMT
+      mise-correlation-id:
+      - b7377287-9af3-4a88-9eab-eb481bbad3ac
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A22Z&sr=b&sp=r&sig=e4mhRh6LptX%2F%2BmZromrr8MJGF18jQf1Q0%2BW%2Bi9h8sWk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:22.7554219","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '557'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:21:22 GMT
+      mise-correlation-id:
+      - 4b47218b-3615-45c2-ace5-1a0da58e4ab9
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A28Z&sr=b&sp=r&sig=6dEbyrJtlSHX2FdatRa1bwf%2Fh%2BO8W7pRw%2FN%2FFNwJIp0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:28.2714924","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '555'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:21:28 GMT
+      mise-correlation-id:
+      - 1babb236-4f02-4a66-8ba0-cc2b3ba7ed79
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"6d226d67-c609-45e8-9a39-eff2748cf164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"67739d7a-b404-4490-9ceb-c07478319cde":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b350050c-164e-4b14-80b8-5027d1a1a65e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A28Z&sr=b&sp=r&sig=tqdHC4fg2j3hffNY5F9DAPZyKRAYTJA1cV%2BTRqH8tBA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:28.529149","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:11.188Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:26.314Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,9 +472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:40 GMT
+      - Sun, 29 Oct 2023 22:21:28 GMT
       mise-correlation-id:
-      - 57a3c7e0-fe7f-4163-87dc-ccd9b89f73ac
+      - 2759e1e4-7c9e-4959-9466-da5e3911c41a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -497,18 +497,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:45.5289007Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:45.5289007Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:36.9908212Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:36.9908212Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:41 GMT
+      - Sun, 29 Oct 2023 22:21:28 GMT
       etag:
-      - '"d300313a-0000-0100-0000-6537b8430000"'
+      - '"3c007327-0000-0100-0000-653edab70000"'
       expires:
       - '-1'
       pragma:
@@ -538,24 +538,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"ee98010c-b7ac-4d34-bfa0-06fbfb85b78d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7908e8b3-9e11-4740-85ce-78f2b72c2948":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6d9791cc-f48b-4e8e-887e-275292f4e638":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A42Z&sr=b&sp=r&sig=pd9jXOl%2BlZAdmpkTUiv9QT4P9NyQ%2F9D02P2%2BvOmSKj4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:42.2377907","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:21.77Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:37.528Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"6d226d67-c609-45e8-9a39-eff2748cf164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"67739d7a-b404-4490-9ceb-c07478319cde":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b350050c-164e-4b14-80b8-5027d1a1a65e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A30Z&sr=b&sp=r&sig=32uzm6s86NDPuCI59UysgtaOybPcmMBeBHJJKpssiHk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:30.0283276","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:11.188Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:26.314Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1594'
+      - '1589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:42 GMT
+      - Sun, 29 Oct 2023 22:21:30 GMT
       mise-correlation-id:
-      - 9e6251dc-9c02-4652-a350-7ae24479b0a3
+      - 73d7ef5a-3caf-4275-890d-d9dc16d03904
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -578,18 +578,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:45.5289007Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:45.5289007Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:36.9908212Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:36.9908212Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:43 GMT
+      - Sun, 29 Oct 2023 22:21:30 GMT
       etag:
-      - '"d300313a-0000-0100-0000-6537b8430000"'
+      - '"3c007327-0000-0100-0000-653edab70000"'
       expires:
       - '-1'
       pragma:
@@ -619,24 +619,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ee98010c-b7ac-4d34-bfa0-06fbfb85b78d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7908e8b3-9e11-4740-85ce-78f2b72c2948":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6d9791cc-f48b-4e8e-887e-275292f4e638":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A44Z&sr=b&sp=r&sig=RrfjbCFpPS8rL4q3b2UVm8NcERNQO7mPVWBXsNxw8Os%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:44.4903364","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:21.77Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:37.528Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6d226d67-c609-45e8-9a39-eff2748cf164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"67739d7a-b404-4490-9ceb-c07478319cde":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b350050c-164e-4b14-80b8-5027d1a1a65e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A31Z&sr=b&sp=r&sig=edUSsmY3QO1g8Ghf%2FSAYyeAYtkORX1bnI1hv20yl7%2B8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:31.4441085","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:11.188Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:26.314Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1576'
+      - '1581'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:44 GMT
+      - Sun, 29 Oct 2023 22:21:31 GMT
       mise-correlation-id:
-      - 92da65e0-36bc-4334-94e9-e6a585ebe554
+      - d806a679-0966-4884-8d14-ccc4a24a3544
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -663,24 +663,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ee98010c-b7ac-4d34-bfa0-06fbfb85b78d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7908e8b3-9e11-4740-85ce-78f2b72c2948":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6d9791cc-f48b-4e8e-887e-275292f4e638":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A44Z&sr=b&sp=r&sig=PN12sGnfXAqhAd9qkXfpEhxWECmoSRhzrK%2BQl3oY9tY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:44.9418328","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:21.77Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:44.934Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6d226d67-c609-45e8-9a39-eff2748cf164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"67739d7a-b404-4490-9ceb-c07478319cde":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b350050c-164e-4b14-80b8-5027d1a1a65e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A31Z&sr=b&sp=r&sig=ocLcMKtGOODTULsgOMIAawmheJ69q3tYZziVEhzLM9o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:31.8157669","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:11.188Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:31.807Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1579'
+      - '1578'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:44 GMT
+      - Sun, 29 Oct 2023 22:21:31 GMT
       mise-correlation-id:
-      - cc116b89-adb8-4f87-a56b-9cbe470f2183
+      - afed53dc-48b2-417f-8492-8abcf769221d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -700,24 +700,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ee98010c-b7ac-4d34-bfa0-06fbfb85b78d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7908e8b3-9e11-4740-85ce-78f2b72c2948":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6d9791cc-f48b-4e8e-887e-275292f4e638":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A45Z&sr=b&sp=r&sig=aFNhF%2F9UzdSlA402E5d4OlXdaHU4pjhceoMVrOAWB6w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:45.1776087","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:21.77Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:44.934Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6d226d67-c609-45e8-9a39-eff2748cf164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"67739d7a-b404-4490-9ceb-c07478319cde":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b350050c-164e-4b14-80b8-5027d1a1a65e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A32Z&sr=b&sp=r&sig=x6QM8gM0Js7lmnmSlb16sPKEwYK6NAb0fJ6cJoAtMgU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:32.0571907","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:11.188Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:31.807Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1579'
+      - '1578'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:45 GMT
+      - Sun, 29 Oct 2023 22:21:32 GMT
       mise-correlation-id:
-      - c896fbdb-6dba-4e34-b713-36b514f67a52
+      - bf17b46b-a029-488c-a546-ab5271662a26
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -740,18 +740,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:45.5289007Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:45.5289007Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:36.9908212Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:36.9908212Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:46 GMT
+      - Sun, 29 Oct 2023 22:21:32 GMT
       etag:
-      - '"d300313a-0000-0100-0000-6537b8430000"'
+      - '"3c007327-0000-0100-0000-653edab70000"'
       expires:
       - '-1'
       pragma:
@@ -781,24 +781,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
+    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/update-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"ee98010c-b7ac-4d34-bfa0-06fbfb85b78d":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7908e8b3-9e11-4740-85ce-78f2b72c2948":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"6d9791cc-f48b-4e8e-887e-275292f4e638":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/fc09d573-2eb7-4a67-9e6f-ec6337ff47b7/8dae78ae-f0e5-45f3-aad6-70508990bf4b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A47Z&sr=b&sp=r&sig=%2BcTxuSGfMHFGMPpWbu2XICnBstVoSHkooovhp8PYYQ0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:47.5758649","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:21.77Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:44.934Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"6d226d67-c609-45e8-9a39-eff2748cf164":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"67739d7a-b404-4490-9ceb-c07478319cde":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"b350050c-164e-4b14-80b8-5027d1a1a65e":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":11,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/e8b5bb3b-65b6-4fc0-9fee-72fbce5fef5b/3d4c94e6-3ec8-4692-ba8c-464f130ab968?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A34Z&sr=b&sp=r&sig=6d7zKb27oU0VP5xGG2sUyIktmcDjJl8Okg2Cw0Mj9A4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:34.1592898","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:11.188Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:31.807Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1579'
+      - '1578'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:47 GMT
+      - Sun, 29 Oct 2023 22:21:34 GMT
       mise-correlation-id:
-      - 854bab14-30ed-4231-a2df-8fd80aaaff1a
+      - 4381a80a-6b10-45a8-bb04-1ae4a1060bd9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -821,18 +821,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:45.5289007Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:45.5289007Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:36.9908212Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:36.9908212Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:48 GMT
+      - Sun, 29 Oct 2023 22:21:34 GMT
       etag:
-      - '"d300313a-0000-0100-0000-6537b8430000"'
+      - '"3c007327-0000-0100-0000-653edab70000"'
       expires:
       - '-1'
       pragma:
@@ -862,7 +862,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://2575e1ee-209f-497c-832d-df0d0dabc55c.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-update-test-case?api-version=2022-11-01
+    uri: https://90be1553-68a7-4649-a15d-b066a96c25c3.eastus.cnt-prod.loadtesting.azure.com/tests/invalid-update-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -875,9 +875,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:28:49 GMT
+      - Sun, 29 Oct 2023 22:21:35 GMT
       mise-correlation-id:
-      - d415f98e-f50e-4c65-87f7-37958b20eb53
+      - dcee033c-9889-4f78-9e39-e4c1dfce5cf3
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_update_with_config.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_update_with_config.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:33.4404467Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:33.4404467Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:20:25.7543113Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:20:25.7543113Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:07 GMT
+      - Mon, 30 Oct 2023 07:20:59 GMT
       etag:
-      - '"3c006327-0000-0100-0000-653edab30000"'
+      - '"3f00a269-0000-0100-0000-653f593b0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 29 Oct 2023 22:21:08 GMT
+      - Mon, 30 Oct 2023 07:21:00 GMT
       mise-correlation-id:
-      - 6fa8d03c-0c43-4ebe-aeec-c4d995b3a7eb
+      - 70cd0fda-6961-4204-9d25-8b826c280313
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -101,11 +101,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:09.451Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:09.451Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:21:00.936Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:21:00.936Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -116,11 +116,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:09 GMT
+      - Mon, 30 Oct 2023 07:21:00 GMT
       location:
-      - https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+      - https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 3de90d66-86b9-4317-bf61-3d2afde3c3cc
+      - 26ed2b9e-2d2c-43df-aa23-b228999a13e8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -140,7 +140,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -154,9 +154,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:10 GMT
+      - Mon, 30 Oct 2023 07:21:01 GMT
       mise-correlation-id:
-      - 931f3186-8109-44dc-be0f-2e78192dcf3a
+      - 36327564-6651-4459-a482-5d3933d01f6b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -270,25 +270,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/3ff8d0d3-fbcc-46ed-8772-354aa9ff05de?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A11Z&sr=b&sp=r&sig=IgQKbC1WSSQipLIB0dDhWJyJhSz8D93iv%2Bqn24cdi9k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:11.4496553","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f76389e7-4e81-4d45-a3ec-84efeed4a6cf/8dcc6b2b-b2dd-4690-949a-d3cab7b0e2b5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A02Z&sr=b&sp=r&sig=eaJE%2FI%2FqQAwglanFJaQbL7q81BC%2FhS3dxkCLsVLwt0w%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:02.6364478","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:11 GMT
+      - Mon, 30 Oct 2023 07:21:02 GMT
       location:
-      - https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - bd1e14f3-2b14-4008-8853-e47a7c6f028f
+      - 37ed663e-80f6-40fe-80b5-a38d8a8aaaf9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -308,10 +308,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/3ff8d0d3-fbcc-46ed-8772-354aa9ff05de?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A11Z&sr=b&sp=r&sig=Trrf0hTuWN2iYiSqQqEXA20g1CY71QxYAs1O1iSfugM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:11.7354017","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f76389e7-4e81-4d45-a3ec-84efeed4a6cf/8dcc6b2b-b2dd-4690-949a-d3cab7b0e2b5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A02Z&sr=b&sp=r&sig=R6jFHy9dmqyaobzydItIXRhe3ukLTD7H6vGnIrnJjkI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:02.9461217","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -322,9 +322,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:11 GMT
+      - Mon, 30 Oct 2023 07:21:02 GMT
       mise-correlation-id:
-      - a9ac0745-00bb-481a-bd30-491b6dae276f
+      - c53396b4-be66-40b9-a7e5-eeced5069388
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -344,10 +344,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/3ff8d0d3-fbcc-46ed-8772-354aa9ff05de?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A17Z&sr=b&sp=r&sig=qHXEG2%2FluQ8gLMyKEPA6qBKfAPGu1bObQ8yaSxL%2B2Zo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:17.0491529","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f76389e7-4e81-4d45-a3ec-84efeed4a6cf/8dcc6b2b-b2dd-4690-949a-d3cab7b0e2b5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A08Z&sr=b&sp=r&sig=mFT0de1sCu3rMVba1LEF9%2FuZd9Cbsa2UAx0vdFOA%2FTA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:08.2441868","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -358,9 +358,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:17 GMT
+      - Mon, 30 Oct 2023 07:21:08 GMT
       mise-correlation-id:
-      - 4c1dfb44-0a16-4dda-819f-b05a2d5f5955
+      - e6ab092c-6e1c-43b3-ac5c-8cfddf683adb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -380,10 +380,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/3ff8d0d3-fbcc-46ed-8772-354aa9ff05de?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A22Z&sr=b&sp=r&sig=1Bc%2BBEpY76C1GGtiAVruMQMULXzDJ%2FAebs3DbM7lNWA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:22.3061426","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f76389e7-4e81-4d45-a3ec-84efeed4a6cf/8dcc6b2b-b2dd-4690-949a-d3cab7b0e2b5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A13Z&sr=b&sp=r&sig=ZkxF92kXdFmAdvpVuNxYc%2F%2F18eb%2FK5VUoZwpGTSOy34%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:13.6604539","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '555'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:21:13 GMT
+      mise-correlation-id:
+      - 9916e23e-1a12-4d92-89f7-6be21719e68a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f76389e7-4e81-4d45-a3ec-84efeed4a6cf/8dcc6b2b-b2dd-4690-949a-d3cab7b0e2b5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A18Z&sr=b&sp=r&sig=E%2BUNoZ4nup6CG5%2B3A1As5EfrA4TIEA8AH7PE%2B9ruq9g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:18.9113369","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -394,9 +430,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:22 GMT
+      - Mon, 30 Oct 2023 07:21:18 GMT
       mise-correlation-id:
-      - 4e1c5a4d-77aa-4a15-988d-a5af449ce142
+      - 82d6fae2-8eba-46f0-a477-f7a349a54558
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -416,47 +452,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/3ff8d0d3-fbcc-46ed-8772-354aa9ff05de?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A27Z&sr=b&sp=r&sig=SQQMMI7eZ2VUz71lRW4dFAOtYLpbVUxp3m91a1%2B4MlU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:27.5443906","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:21:27 GMT
-      mise-correlation-id:
-      - 53dc5ff0-b2d8-45bd-82e4-e80f182e5440
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/3ff8d0d3-fbcc-46ed-8772-354aa9ff05de?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A27Z&sr=b&sp=r&sig=6C1yKKhmyw39miq3oiI8p55MUnbcEPHCsFIkKD15XXo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:27.8126544","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:09.451Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:24.145Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f76389e7-4e81-4d45-a3ec-84efeed4a6cf/8dcc6b2b-b2dd-4690-949a-d3cab7b0e2b5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A21%3A19Z&sr=b&sp=r&sig=gFwNBNepfe0cCTBJKBNL6AhwfsmqWZCfzXHpJtGnQlA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:21:19.2381049","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:21:00.936Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:21:15.719Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -467,9 +467,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:27 GMT
+      - Mon, 30 Oct 2023 07:21:19 GMT
       mise-correlation-id:
-      - 6881310c-1a33-4ca0-a5f1-0ee7a0062beb
+      - c9dabb27-12d2-4cab-b5a0-054b9d94e989
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -492,7 +492,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:33.4404467Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:33.4404467Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:20:25.7543113Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:20:25.7543113Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -501,9 +501,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:28 GMT
+      - Mon, 30 Oct 2023 07:21:20 GMT
       etag:
-      - '"3c006327-0000-0100-0000-653edab30000"'
+      - '"3f00a269-0000-0100-0000-653f593b0000"'
       expires:
       - '-1'
       pragma:
@@ -533,11 +533,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/3ff8d0d3-fbcc-46ed-8772-354aa9ff05de?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A30Z&sr=b&sp=r&sig=aKtKNlHvbB1s9yjipMPZ2VtykETVyeN4oWg8hhEmfLA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:30.0246839","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:09.451Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:24.145Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f76389e7-4e81-4d45-a3ec-84efeed4a6cf/8dcc6b2b-b2dd-4690-949a-d3cab7b0e2b5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A21%3A21Z&sr=b&sp=r&sig=yz1h6pvtWtCg60cVm5J6OE4f4MaCOmcEAAvJzQpJwpU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:21:21.8986711","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:21:00.936Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:21:15.719Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -548,9 +548,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:30 GMT
+      - Mon, 30 Oct 2023 07:21:21 GMT
       mise-correlation-id:
-      - a6f70fbc-c282-429d-b976-f97bc3a9c579
+      - 2520c85a-f7fc-4fe8-a3ad-360c372ce3b8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -563,10 +563,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"a": null, "b": null, "rps": 1, "c": "5"}, "secrets": {}, "certificate": null,
       "loadTestConfiguration": {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs":
-      true}, "passFailCriteria": {"passFailMetrics": {"4727cb2b-6f51-42ab-b498-bf0950a1fdc5":
+      true}, "passFailCriteria": {"passFailMetrics": {"66adde92-b467-4c32-a0bc-f12bfd18515a":
       {"aggregate": "avg", "clientMetric": "requests_per_sec", "condition": ">", "value":
-      "78"}, "f625e4c6-bdbd-47e4-8934-9dbdd008abd5": {"aggregate": "percentage", "clientMetric":
-      "error", "condition": ">", "value": "50"}, "95026edf-8043-45e0-bb97-99ed1b3599e7":
+      "78"}, "a6050a13-f746-4fe4-b50b-f9fca8812115": {"aggregate": "percentage", "clientMetric":
+      "error", "condition": ">", "value": "50"}, "57fd7cfa-cb15-4ceb-92f9-b2513fad4b4f":
       {"aggregate": "avg", "clientMetric": "latency", "condition": ">", "value": "200",
       "requestName": "GetCustomerDetails"}}}}'
     headers:
@@ -583,24 +583,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4727cb2b-6f51-42ab-b498-bf0950a1fdc5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f625e4c6-bdbd-47e4-8934-9dbdd008abd5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"95026edf-8043-45e0-bb97-99ed1b3599e7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/3ff8d0d3-fbcc-46ed-8772-354aa9ff05de?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A30Z&sr=b&sp=r&sig=1YzqclZB3OVOerNSweJ2N841K9MYbAitil%2Fn3HUKDaU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:30.3753728","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:09.451Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:30.366Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"66adde92-b467-4c32-a0bc-f12bfd18515a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6050a13-f746-4fe4-b50b-f9fca8812115":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57fd7cfa-cb15-4ceb-92f9-b2513fad4b4f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f76389e7-4e81-4d45-a3ec-84efeed4a6cf/8dcc6b2b-b2dd-4690-949a-d3cab7b0e2b5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A21%3A23Z&sr=b&sp=r&sig=iB6JRaq7dFjH3C0lSGWr%2FopEm632GvSQA%2Br6705QKBk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:21:23.0887035","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:21:00.936Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:21:23.079Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1576'
+      - '1578'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:30 GMT
+      - Mon, 30 Oct 2023 07:21:23 GMT
       mise-correlation-id:
-      - 2f1b6ffe-8c05-4d51-a8c1-95379a9b7461
+      - ed4a0916-3be7-4405-b8e4-c70bef51a0ca
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -620,23 +620,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/3ff8d0d3-fbcc-46ed-8772-354aa9ff05de?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A30Z&sr=b&sp=r&sig=%2FWdPkRFvw41D5TSKaNI1mX%2F%2BhYUrMQiuxgs5Nar74%2FU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:30.6099582","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f76389e7-4e81-4d45-a3ec-84efeed4a6cf/8dcc6b2b-b2dd-4690-949a-d3cab7b0e2b5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A23Z&sr=b&sp=r&sig=CeCov7l574WA4FLfSi3yjenhohZKpAtLPSd1B%2FPUfH8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:23.3604054","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '567'
+      - '561'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:30 GMT
+      - Mon, 30 Oct 2023 07:21:23 GMT
       mise-correlation-id:
-      - 01719e73-bb66-44b9-a8c8-cb93127eaf4b
+      - 08816247-8c6a-42c9-a8f9-befba8ea9b63
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -658,7 +658,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -668,9 +668,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Sun, 29 Oct 2023 22:21:31 GMT
+      - Mon, 30 Oct 2023 07:21:24 GMT
       mise-correlation-id:
-      - ebb49249-2cb8-46fd-83a2-d29ed82be13f
+      - 49a50fee-8125-44e5-91fa-79546d307ca1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -784,25 +784,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/2d53f92c-b4b8-4967-9d63-da63703046f1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A31Z&sr=b&sp=r&sig=ykn2Wp3fouF2dg5hTABvvtJ9s6nLHV%2FVbgYNuYBtrTo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:31.7864536","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f76389e7-4e81-4d45-a3ec-84efeed4a6cf/b2a61539-e2f7-4a46-afab-8c61dda58d04?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A24Z&sr=b&sp=r&sig=O%2BeZK4sbxYIljYcAjdb%2BdCwsuSRJwcVbRkMV%2Bjd9sfo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:24.8565663","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:31 GMT
+      - Mon, 30 Oct 2023 07:21:24 GMT
       location:
-      - https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 776111df-2aa3-4c99-9cd2-afaaafdec506
+      - 93514746-3eb1-4841-a6aa-1b6fecd6359c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -822,10 +822,82 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/2d53f92c-b4b8-4967-9d63-da63703046f1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A32Z&sr=b&sp=r&sig=MPXSDOB3ysKU5jwlOdGoW8cPu26%2FNL3dJJPgpI8eKbI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:32.0199698","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f76389e7-4e81-4d45-a3ec-84efeed4a6cf/b2a61539-e2f7-4a46-afab-8c61dda58d04?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A11%3A14Z&ske=2023-10-31T11%3A41%3A14Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A25Z&sr=b&sp=r&sig=fE38XTxEpakqNwzzSThDEJOREO4rA5Q39eI3Rv1BD%2B8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:25.613866","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '550'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:21:25 GMT
+      mise-correlation-id:
+      - 424e7ec1-8ec5-4e75-a241-deaa5012bac3
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f76389e7-4e81-4d45-a3ec-84efeed4a6cf/b2a61539-e2f7-4a46-afab-8c61dda58d04?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T02%3A21%3A46Z&ske=2023-10-31T09%3A51%3A46Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A30Z&sr=b&sp=r&sig=IU5LWPTPuh4nC2DTUNxNB3094DzNZEVhv899CddZ0CQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:30.8875166","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Oct 2023 07:21:30 GMT
+      mise-correlation-id:
+      - 869dd912-4c38-48cb-94dc-fde877ae116f
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f76389e7-4e81-4d45-a3ec-84efeed4a6cf/b2a61539-e2f7-4a46-afab-8c61dda58d04?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T01%3A47%3A17Z&ske=2023-10-31T09%3A17%3A17Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A36Z&sr=b&sp=r&sig=KK3XnB2q%2FXUlTC41gUUgOvKBhfu157wPX891RfV7H1c%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:36.2211759","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -836,9 +908,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:32 GMT
+      - Mon, 30 Oct 2023 07:21:36 GMT
       mise-correlation-id:
-      - e6e647d3-358a-4450-8a74-adbec5ba510e
+      - 850a916f-4f94-4bc7-94d1-188c0843a99c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -858,23 +930,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/2d53f92c-b4b8-4967-9d63-da63703046f1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A37Z&sr=b&sp=r&sig=M0PWILkqLdjDNNE%2B2SJlpcDG0kiHa2IK9H4ZRHqZzDg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:37.3061631","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f76389e7-4e81-4d45-a3ec-84efeed4a6cf/b2a61539-e2f7-4a46-afab-8c61dda58d04?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A30%3A56Z&ske=2023-10-31T12%3A00%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T07%3A31%3A41Z&sr=b&sp=r&sig=Xpy9y6mMAf9mDtTe2YGnLHl65stLkf2vd5RgjQbv%2BhQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T07:31:41.5523259","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:37 GMT
+      - Mon, 30 Oct 2023 07:21:41 GMT
       mise-correlation-id:
-      - 171d80cc-d586-4d18-ba62-25ecb057afbf
+      - 4e1c4dd7-b7b7-4fe6-8dfc-ab6019f24b22
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -894,83 +966,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/2d53f92c-b4b8-4967-9d63-da63703046f1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A42Z&sr=b&sp=r&sig=nFmgvyRxJ62rdzsS4%2B6J51jPN50BJKmmo%2B29eCl%2BaKM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:42.5504738","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:21:42 GMT
-      mise-correlation-id:
-      - b43ddbac-e7f0-4367-83e3-8837e6413c3d
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/2d53f92c-b4b8-4967-9d63-da63703046f1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A48Z&sr=b&sp=r&sig=eRy%2F%2FaWx48icFkMwzzkFDhohdkzOHFt%2BsVTmW0hZsig%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:48.504847","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '552'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 29 Oct 2023 22:21:48 GMT
-      mise-correlation-id:
-      - 5a528303-ae42-4db7-9601-424f2cd50351
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4727cb2b-6f51-42ab-b498-bf0950a1fdc5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f625e4c6-bdbd-47e4-8934-9dbdd008abd5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"95026edf-8043-45e0-bb97-99ed1b3599e7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/2d53f92c-b4b8-4967-9d63-da63703046f1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A49Z&sr=b&sp=r&sig=M8jsanfPPhWLvsg8W2yXVojgEmxHVXl%2BAzQJjgNhgro%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:49.1588304","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:09.451Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:45.507Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"66adde92-b467-4c32-a0bc-f12bfd18515a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6050a13-f746-4fe4-b50b-f9fca8812115":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57fd7cfa-cb15-4ceb-92f9-b2513fad4b4f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f76389e7-4e81-4d45-a3ec-84efeed4a6cf/b2a61539-e2f7-4a46-afab-8c61dda58d04?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A26%3A56Z&ske=2023-10-31T11%3A56%3A56Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A21%3A41Z&sr=b&sp=r&sig=Xoo0VYsN%2FZItoTCZEMmyNRYYM42qElrRcI9JeVUluS4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:21:41.8073938","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:21:00.936Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:21:37.922Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -981,9 +981,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:49 GMT
+      - Mon, 30 Oct 2023 07:21:41 GMT
       mise-correlation-id:
-      - d7eaebc3-e7e6-4810-8ca0-7041907cb6b5
+      - 20f3c268-05ee-450d-b7ff-1271abd4de3f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1006,7 +1006,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:33.4404467Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:33.4404467Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-30T07:20:25.7543113Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-30T07:20:25.7543113Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1015,9 +1015,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:49 GMT
+      - Mon, 30 Oct 2023 07:21:42 GMT
       etag:
-      - '"3c006327-0000-0100-0000-653edab30000"'
+      - '"3f00a269-0000-0100-0000-653f593b0000"'
       expires:
       - '-1'
       pragma:
@@ -1047,24 +1047,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://2eeea29b-64a6-4209-be8e-b5041d85e426.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"4727cb2b-6f51-42ab-b498-bf0950a1fdc5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f625e4c6-bdbd-47e4-8934-9dbdd008abd5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"95026edf-8043-45e0-bb97-99ed1b3599e7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/2d53f92c-b4b8-4967-9d63-da63703046f1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A51Z&sr=b&sp=r&sig=N3U0XJbAnS6q%2FHBgqamK6ni9coEX0xvpfdK4onxLcdo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:51.4616098","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:09.451Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:45.507Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"66adde92-b467-4c32-a0bc-f12bfd18515a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"a6050a13-f746-4fe4-b50b-f9fca8812115":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"57fd7cfa-cb15-4ceb-92f9-b2513fad4b4f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/f76389e7-4e81-4d45-a3ec-84efeed4a6cf/b2a61539-e2f7-4a46-afab-8c61dda58d04?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-30T04%3A03%3A19Z&ske=2023-10-31T11%3A33%3A19Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-30T08%3A21%3A44Z&sr=b&sp=r&sig=xbEEFqnc1U9qiMVZon5EIUYv7HOYjxA%2BOPM%2FcIhiX1o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-30T08:21:44.4675736","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-30T07:21:00.936Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-30T07:21:37.922Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1576'
+      - '1578'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 29 Oct 2023 22:21:51 GMT
+      - Mon, 30 Oct 2023 07:21:44 GMT
       mise-correlation-id:
-      - 0cae38cc-ff09-4245-a3b7-68065f6a9783
+      - a641f0d4-1515-4f4e-99f3-415580fbae9b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_update_with_config.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_update_with_config.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:48.1592261Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:48.1592261Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:55.0803542Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:55.0803542Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:21 GMT
+      - Fri, 13 Oct 2023 13:51:28 GMT
       etag:
-      - '"5600b100-0000-0100-0000-652451de0000"'
+      - '"d801a7dd-0000-0100-0000-65294b400000"'
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 19:18:22 GMT
+      - Fri, 13 Oct 2023 13:51:29 GMT
       mise-correlation-id:
-      - f1d3bfd9-8b43-417b-af2d-1ffbbcb9ccd7
+      - 02103249-1396-4de4-9102-8d410787e8e4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -99,28 +99,28 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:23.31Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:23.31Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:30.047Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:30.047Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '529'
+      - '531'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:23 GMT
+      - Fri, 13 Oct 2023 13:51:30 GMT
       location:
-      - https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+      - https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - e8f49ef1-88f2-42a2-9e2b-42e175e581b4
+      - 7e97d22f-a4db-4b09-981a-681bdebd34e7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -138,9 +138,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -154,9 +154,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:23 GMT
+      - Fri, 13 Oct 2023 13:51:30 GMT
       mise-correlation-id:
-      - 01bf98b8-b223-490e-bad5-225ed716d7e2
+      - b36b1b8d-8c6e-4ec1-a1f1-6d2f380a1d4c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -268,12 +268,12 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/e75f949d-302f-42e1-a3f0-d66af650a5db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A24Z&sr=b&sp=r&sig=bdrbGvIbHgXfD8v606AuAzKSfg%2B6cZj92jb%2FtEE93iE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:24.2651406","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/1fbce307-ede1-4c7d-8339-b1b88e883e23?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A30Z&sr=b&sp=r&sig=l6dBJ8A3KfpAGewwIo8LsuuRp7%2BxkPHPxr%2FN2rNjNOE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:30.9136249","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -284,11 +284,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:24 GMT
+      - Fri, 13 Oct 2023 13:51:30 GMT
       location:
-      - https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - b3090399-bf77-4613-bbbe-21e3200fb568
+      - c235772b-20ec-4b69-a307-310664c9775e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -306,120 +306,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/e75f949d-302f-42e1-a3f0-d66af650a5db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A24Z&sr=b&sp=r&sig=SrxyLtBEP4cbP612XL2dfGjH8mYBVeopuCfqCTvQ1Vo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:24.5154132","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:18:24 GMT
-      mise-correlation-id:
-      - b3151087-106e-4fd2-bcb7-ec6f27b11395
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/e75f949d-302f-42e1-a3f0-d66af650a5db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A29Z&sr=b&sp=r&sig=GlcLdRSm5feV4eseSyhHiOeybQpTF86BoZP7hGrRDmQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:29.9644075","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:18:29 GMT
-      mise-correlation-id:
-      - 1b48d03c-a82a-4776-a87b-a6980b763669
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/e75f949d-302f-42e1-a3f0-d66af650a5db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A35Z&sr=b&sp=r&sig=ynCZtWJcY3znrK2inakrtFRu1QqOuiirJuCEh31LLxc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:35.2535834","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 19:18:35 GMT
-      mise-correlation-id:
-      - 49271749-3ee1-4ef4-8d7b-828958e1d48a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/e75f949d-302f-42e1-a3f0-d66af650a5db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A40Z&sr=b&sp=r&sig=GujAbC2RR20%2BODMj8GqYvgUOerdVCepmTa9nMN%2FGu0o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:40.5058361","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/1fbce307-ede1-4c7d-8339-b1b88e883e23?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A31Z&sr=b&sp=r&sig=KojpMzAqoneG0KinJgDl7B%2FOHFDEKN9z3R8KiDdnbNk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:31.2921701","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -430,9 +322,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:40 GMT
+      - Fri, 13 Oct 2023 13:51:31 GMT
       mise-correlation-id:
-      - 1cff5c1a-5eb9-4a40-8865-7981c6b83fcb
+      - 6b107d05-550c-4fe4-9c3c-a82373564480
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -450,26 +342,134 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/e75f949d-302f-42e1-a3f0-d66af650a5db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A40Z&sr=b&sp=r&sig=KA0uKDKz3TTAqHKIIMIE0n7n6WyMfkOqJun37Dx%2BpA0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:40.7646788","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:23.31Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:36.145Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/1fbce307-ede1-4c7d-8339-b1b88e883e23?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A36Z&sr=b&sp=r&sig=EY0xCYFe0qAclg38hmc6sosWFdqoT%2BsgbAfGWwtquxw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:36.5427975","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1101'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:40 GMT
+      - Fri, 13 Oct 2023 13:51:36 GMT
       mise-correlation-id:
-      - 6766efb4-c8fa-4b3d-8a14-c3b34f7ccc29
+      - ac971ba5-dbad-4436-ac17-0a01e1580123
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/1fbce307-ede1-4c7d-8339-b1b88e883e23?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A41Z&sr=b&sp=r&sig=IUq7p3YyQePELjU1Fh26LBPn%2BPZYEOd3MFsn%2Fp9jrIo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:41.8017646","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:51:41 GMT
+      mise-correlation-id:
+      - 5d75069b-fa9f-4860-9184-9a9029639f8c
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/1fbce307-ede1-4c7d-8339-b1b88e883e23?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A47Z&sr=b&sp=r&sig=Ge4i2j9SiNObGUu1V06gcrS%2BRVDd%2B3voCFIcDv27HeE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:47.0452486","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:51:47 GMT
+      mise-correlation-id:
+      - a8207fea-ff19-41d9-93f1-0c15d1462b4b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/1fbce307-ede1-4c7d-8339-b1b88e883e23?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A47Z&sr=b&sp=r&sig=pAPDVUVALVa3n1pymP0ekaJt2s6AmZVHW%2FGBY3RW3QA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:47.3139207","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:30.047Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:43.038Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1102'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 13 Oct 2023 13:51:47 GMT
+      mise-correlation-id:
+      - 085dc723-00ed-4857-bca5-262bb8165e99
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -492,7 +492,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:48.1592261Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:48.1592261Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:55.0803542Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:55.0803542Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -501,9 +501,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:42 GMT
+      - Fri, 13 Oct 2023 13:51:48 GMT
       etag:
-      - '"5600b100-0000-0100-0000-652451de0000"'
+      - '"d801a7dd-0000-0100-0000-65294b400000"'
       expires:
       - '-1'
       pragma:
@@ -531,26 +531,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/e75f949d-302f-42e1-a3f0-d66af650a5db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A42Z&sr=b&sp=r&sig=BlCBjPCZ%2BDZgPv6MZAppAPTgRKJG1HW%2BEs8eaP7UrJU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:42.9855146","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:23.31Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:36.145Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/1fbce307-ede1-4c7d-8339-b1b88e883e23?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A49Z&sr=b&sp=r&sig=8UeoeDBrL36Vtn%2BgHeL4aN%2BSfSxFPI9%2FR6WxMLNHBNk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:49.6085617","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:30.047Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:43.038Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1103'
+      - '1106'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:43 GMT
+      - Fri, 13 Oct 2023 13:51:49 GMT
       mise-correlation-id:
-      - be5e72ba-49d9-4167-9d46-b697f3fa6d05
+      - 4f5f9689-ab21-4786-a9c4-cdf14dde8966
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -563,10 +563,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"a": null, "b": null, "rps": 1, "c": "5"}, "secrets": {}, "certificate": null,
       "loadTestConfiguration": {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs":
-      true}, "passFailCriteria": {"passFailMetrics": {"f2cc11d6-7c4b-454d-bed7-546b26196dba":
+      true}, "passFailCriteria": {"passFailMetrics": {"d644f5c2-b366-4176-b8e8-e540534f432e":
       {"aggregate": "avg", "clientMetric": "requests_per_sec", "condition": ">", "value":
-      "78"}, "fee27d95-f059-469e-b672-29be99d5f61a": {"aggregate": "percentage", "clientMetric":
-      "error", "condition": ">", "value": "50"}, "199c5dc1-b7cb-4a07-b9b9-e678dc2c4966":
+      "78"}, "7124a5be-911a-43a8-b7ac-6db62b3a313b": {"aggregate": "percentage", "clientMetric":
+      "error", "condition": ">", "value": "50"}, "dd97f346-f69b-4cef-90be-63ef9a3ac55f":
       {"aggregate": "avg", "clientMetric": "latency", "condition": ">", "value": "200",
       "requestName": "GetCustomerDetails"}}}}'
     headers:
@@ -581,26 +581,26 @@ interactions:
       Content-Type:
       - application/merge-patch+json
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f2cc11d6-7c4b-454d-bed7-546b26196dba":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fee27d95-f059-469e-b672-29be99d5f61a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"199c5dc1-b7cb-4a07-b9b9-e678dc2c4966":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/e75f949d-302f-42e1-a3f0-d66af650a5db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A44Z&sr=b&sp=r&sig=%2BIwvPc6FzxoSSdJ6xPA2Zr4iua3u1YGQ%2BdsbjrjGJvM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:44.3591339","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:23.31Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:44.35Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d644f5c2-b366-4176-b8e8-e540534f432e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7124a5be-911a-43a8-b7ac-6db62b3a313b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"dd97f346-f69b-4cef-90be-63ef9a3ac55f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/1fbce307-ede1-4c7d-8339-b1b88e883e23?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A49Z&sr=b&sp=r&sig=IRH475EYo8EvZBIvLbyW2FMnis9jENGsHExgmuLCN7k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:49.949316","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:30.047Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:49.942Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1576'
+      - '1573'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:44 GMT
+      - Fri, 13 Oct 2023 13:51:49 GMT
       mise-correlation-id:
-      - a38ca02c-d082-457c-9223-afa2d1a9002a
+      - 6ac4f045-868c-4ee5-bd13-1bced5354f4d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -618,25 +618,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/e75f949d-302f-42e1-a3f0-d66af650a5db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A44Z&sr=b&sp=r&sig=2sghkPySq%2Ftbd9793a%2FAvs8eigKJVavpmXcG0HpuOCw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:44.6766982","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/1fbce307-ede1-4c7d-8339-b1b88e883e23?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A50Z&sr=b&sp=r&sig=I2OoA%2BzqsCSkzhMjCZjuRHMNNcljzBIBXLK6w5A2vz0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:50.2273984","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '563'
+      - '561'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:44 GMT
+      - Fri, 13 Oct 2023 13:51:50 GMT
       mise-correlation-id:
-      - 91fbdc5c-3290-4f21-8989-2e42f729ae00
+      - 60d1c486-8b1f-4c9a-9b01-a2036ea159d8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -656,9 +656,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -668,9 +668,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Mon, 09 Oct 2023 19:18:45 GMT
+      - Fri, 13 Oct 2023 13:51:50 GMT
       mise-correlation-id:
-      - 9937ddcd-8d29-4ac4-8b9a-633b0dd7608d
+      - c2648e7b-5552-4743-80b9-f8c3442b93b8
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -782,27 +782,27 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/d754cc18-1e85-4de3-a782-0cbdc4a7d3d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A45Z&sr=b&sp=r&sig=GaCOBBx%2FtnlZPQ5uHlPAUG6niNh96n0PfpGXCtfZKFc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:45.6401901","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/fb751104-60b8-4d83-afac-a922f6622a8e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A50Z&sr=b&sp=r&sig=hxRlww5hviY5cTIgNoQwp%2FiukcBuMJI7aIAUGEL%2FGAY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:50.9887304","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:45 GMT
+      - Fri, 13 Oct 2023 13:51:50 GMT
       location:
-      - https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 7500def8-a476-4002-9126-789aa555b884
+      - 26bba518-89b9-4e73-ad02-64a31e9029d7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -820,12 +820,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/d754cc18-1e85-4de3-a782-0cbdc4a7d3d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A45Z&sr=b&sp=r&sig=G8yflfSO9CI5jfQCb830z1Mafwm4QXWTkaQw8Dak5HE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:45.9905713","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/fb751104-60b8-4d83-afac-a922f6622a8e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A51Z&sr=b&sp=r&sig=PMmCVXldSxJHIfAnAsZabC8dmx7YvQt9it3HmEoou28%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:51.2418881","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -836,9 +836,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:45 GMT
+      - Fri, 13 Oct 2023 13:51:51 GMT
       mise-correlation-id:
-      - b2b9c89d-15e6-4288-a1d8-d394560d7c0a
+      - cc146cf4-d86d-4cb7-bd81-0d7e70e0e430
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -856,12 +856,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/d754cc18-1e85-4de3-a782-0cbdc4a7d3d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A51Z&sr=b&sp=r&sig=VpBwdAAUPFfIXmJ11qvDmiZMmIvWlz%2FOJxbMoBfbD60%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:51.3055951","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/fb751104-60b8-4d83-afac-a922f6622a8e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A56Z&sr=b&sp=r&sig=mW1Z3KajuueRZ4AG3trwUzvtJqJ49SnEaqBo94OKk%2FQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:56.4907332","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -872,9 +872,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:51 GMT
+      - Fri, 13 Oct 2023 13:51:56 GMT
       mise-correlation-id:
-      - bd6c9cfd-1bb9-448d-80e6-789c2f3860c7
+      - 8fa08dfd-92c1-4a07-b862-7e9c51557cef
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -892,25 +892,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/d754cc18-1e85-4de3-a782-0cbdc4a7d3d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A56Z&sr=b&sp=r&sig=qxzfYLAcPj94xXSdH6qVUjYw7f4xj%2B%2BkA1zzLJUGgrw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:56.5717299","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/fb751104-60b8-4d83-afac-a922f6622a8e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A01Z&sr=b&sp=r&sig=HzKxkfHsCgWCf7EY0SXbBpWoasTxEn0Y1gGP1JCemHg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:01.7380931","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:18:56 GMT
+      - Fri, 13 Oct 2023 13:52:01 GMT
       mise-correlation-id:
-      - bbee749e-f875-45aa-9405-6a9a5b7b1047
+      - 11a3841b-1ba8-4ee4-b99c-cc764d8ed1ae
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -928,25 +928,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/d754cc18-1e85-4de3-a782-0cbdc4a7d3d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A01Z&sr=b&sp=r&sig=FsttyuPG3cfyXvMfwl4RErGdT0fjFCFqGdhI6DiB0ow%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:01.8708352","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/fb751104-60b8-4d83-afac-a922f6622a8e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A07Z&sr=b&sp=r&sig=04uwngiEw06n4M06ZY7%2BzW7npmeBWGBlk94MRJc3JMs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:07.0075407","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:01 GMT
+      - Fri, 13 Oct 2023 13:52:07 GMT
       mise-correlation-id:
-      - 7b002fac-4a5e-4417-b351-8edd6d961e41
+      - 9d50f047-f9fc-43e0-b163-09431befc16d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -964,26 +964,26 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f2cc11d6-7c4b-454d-bed7-546b26196dba":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fee27d95-f059-469e-b672-29be99d5f61a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"199c5dc1-b7cb-4a07-b9b9-e678dc2c4966":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/d754cc18-1e85-4de3-a782-0cbdc4a7d3d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A02Z&sr=b&sp=r&sig=BlhYUPxPwjVkB8l%2BFhItN7XlhEMlL4zNVI%2F5tlTyHTc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:02.1227872","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:23.31Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:59.78Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d644f5c2-b366-4176-b8e8-e540534f432e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7124a5be-911a-43a8-b7ac-6db62b3a313b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"dd97f346-f69b-4cef-90be-63ef9a3ac55f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/fb751104-60b8-4d83-afac-a922f6622a8e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A07Z&sr=b&sp=r&sig=SDy%2Fmybt782%2F%2B59tU%2BViCnAy7OIgI20ZG6bYu8mU2wE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:07.2782338","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:30.047Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:04.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1576'
+      - '1582'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:02 GMT
+      - Fri, 13 Oct 2023 13:52:07 GMT
       mise-correlation-id:
-      - cbe3fdce-f184-4305-ba36-c12037cb0388
+      - 2f3406d8-0691-4976-b29e-ce8711ec17e7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1006,7 +1006,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:48.1592261Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:48.1592261Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:55.0803542Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:55.0803542Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1015,9 +1015,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:03 GMT
+      - Fri, 13 Oct 2023 13:52:08 GMT
       etag:
-      - '"5600b100-0000-0100-0000-652451de0000"'
+      - '"d801a7dd-0000-0100-0000-65294b400000"'
       expires:
       - '-1'
       pragma:
@@ -1045,13 +1045,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f2cc11d6-7c4b-454d-bed7-546b26196dba":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fee27d95-f059-469e-b672-29be99d5f61a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"199c5dc1-b7cb-4a07-b9b9-e678dc2c4966":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/d754cc18-1e85-4de3-a782-0cbdc4a7d3d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A04Z&sr=b&sp=r&sig=mGlVRI%2BS1ZjglyDq35WRgEvvgfNAhpLl5oxFHsEDoK4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:04.4786405","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:23.31Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:59.78Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"d644f5c2-b366-4176-b8e8-e540534f432e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7124a5be-911a-43a8-b7ac-6db62b3a313b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"dd97f346-f69b-4cef-90be-63ef9a3ac55f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/fb751104-60b8-4d83-afac-a922f6622a8e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A09Z&sr=b&sp=r&sig=MUYzSIZfH2fYMTRe9U3x5aUVF43LGsmjHsbO8cMUhYU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:09.9794874","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:30.047Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:04.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1062,9 +1062,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 19:19:04 GMT
+      - Fri, 13 Oct 2023 13:52:09 GMT
       mise-correlation-id:
-      - 08a70107-776e-4ef6-8909-4de2bfc11d14
+      - 1416782a-42eb-4c9f-a743-2d34c2059d56
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_update_with_config.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_update_with_config.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:27.0373117Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:27.0373117Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:48.1592261Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:48.1592261Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:01 GMT
+      - Mon, 09 Oct 2023 19:18:21 GMT
       etag:
-      - '"9201eba7-0000-0100-0000-652426310000"'
+      - '"5600b100-0000-0100-0000-652451de0000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:12:02 GMT
+      - Mon, 09 Oct 2023 19:18:22 GMT
       mise-correlation-id:
-      - 06aed824-0314-465c-b0b0-35a09737e9fb
+      - f1d3bfd9-8b43-417b-af2d-1ffbbcb9ccd7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -101,26 +101,26 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:02.819Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:02.819Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:23.31Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:23.31Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '531'
+      - '529'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:02 GMT
+      - Mon, 09 Oct 2023 19:18:23 GMT
       location:
-      - https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+      - https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - c45500a2-ac2b-4cd1-a387-af70f93bac6d
+      - e8f49ef1-88f2-42a2-9e2b-42e175e581b4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -140,7 +140,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -154,9 +154,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:03 GMT
+      - Mon, 09 Oct 2023 19:18:23 GMT
       mise-correlation-id:
-      - 7135ce96-7f0f-49cb-a0df-a30aeb482c60
+      - 01bf98b8-b223-490e-bad5-225ed716d7e2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -270,25 +270,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/23666a64-0fe8-4f63-9b60-92f64c491b6b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A03Z&sr=b&sp=r&sig=Y3WyUP6raaWA%2F3hUp%2B6H0i%2FI5n9ulvz6wZH5Soeidsk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:03.6203185","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/e75f949d-302f-42e1-a3f0-d66af650a5db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A24Z&sr=b&sp=r&sig=bdrbGvIbHgXfD8v606AuAzKSfg%2B6cZj92jb%2FtEE93iE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:24.2651406","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:03 GMT
+      - Mon, 09 Oct 2023 19:18:24 GMT
       location:
-      - https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 2deed28b-40bc-4d53-8b3f-ce2decd7f21a
+      - b3090399-bf77-4613-bbbe-21e3200fb568
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -308,10 +308,118 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/23666a64-0fe8-4f63-9b60-92f64c491b6b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A03Z&sr=b&sp=r&sig=EHwDy1IRFOvrk5tiua%2F5FAB0OszXIZUoPbl4ScZDu84%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:03.8845122","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/e75f949d-302f-42e1-a3f0-d66af650a5db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A24Z&sr=b&sp=r&sig=SrxyLtBEP4cbP612XL2dfGjH8mYBVeopuCfqCTvQ1Vo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:24.5154132","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:18:24 GMT
+      mise-correlation-id:
+      - b3151087-106e-4fd2-bcb7-ec6f27b11395
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/e75f949d-302f-42e1-a3f0-d66af650a5db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A29Z&sr=b&sp=r&sig=GlcLdRSm5feV4eseSyhHiOeybQpTF86BoZP7hGrRDmQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:29.9644075","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:18:29 GMT
+      mise-correlation-id:
+      - 1b48d03c-a82a-4776-a87b-a6980b763669
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/e75f949d-302f-42e1-a3f0-d66af650a5db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A35Z&sr=b&sp=r&sig=ynCZtWJcY3znrK2inakrtFRu1QqOuiirJuCEh31LLxc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:35.2535834","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:18:35 GMT
+      mise-correlation-id:
+      - 49271749-3ee1-4ef4-8d7b-828958e1d48a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/e75f949d-302f-42e1-a3f0-d66af650a5db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A40Z&sr=b&sp=r&sig=GujAbC2RR20%2BODMj8GqYvgUOerdVCepmTa9nMN%2FGu0o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:40.5058361","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -322,9 +430,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:03 GMT
+      - Mon, 09 Oct 2023 19:18:40 GMT
       mise-correlation-id:
-      - d77d2eec-9398-4a2f-a735-ab7a13c63e62
+      - 1cff5c1a-5eb9-4a40-8865-7981c6b83fcb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -344,132 +452,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/23666a64-0fe8-4f63-9b60-92f64c491b6b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A09Z&sr=b&sp=r&sig=Trged6X8PK8A1n%2BZ3WKQQljq5gHsbj2ZO5EYyEuErwk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:09.1624704","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/e75f949d-302f-42e1-a3f0-d66af650a5db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A40Z&sr=b&sp=r&sig=KA0uKDKz3TTAqHKIIMIE0n7n6WyMfkOqJun37Dx%2BpA0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:40.7646788","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:23.31Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:36.145Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '1101'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:09 GMT
+      - Mon, 09 Oct 2023 19:18:40 GMT
       mise-correlation-id:
-      - df90cded-0604-40bb-8428-e6e8c2fac256
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/23666a64-0fe8-4f63-9b60-92f64c491b6b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A14Z&sr=b&sp=r&sig=EsO6%2BWftMLQ7xZ88c2eMLnIEi6qgSnO4tzbFDcdW8s8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:14.4351041","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:12:14 GMT
-      mise-correlation-id:
-      - fc094093-4100-406b-b0b1-fc9c7efc972a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/23666a64-0fe8-4f63-9b60-92f64c491b6b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A19Z&sr=b&sp=r&sig=GTI9qNRYB6qPzu%2BMf%2FvRmQLk3Bgrd0dBl120s2hRe%2F4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:19.7078802","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:12:19 GMT
-      mise-correlation-id:
-      - 93c1068c-7374-4700-9147-6a7815be8017
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/23666a64-0fe8-4f63-9b60-92f64c491b6b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A19Z&sr=b&sp=r&sig=T84G5CdtKIrOG66SfpxJk1M4iKbqNcvzbxETSaGbeYo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:19.9921312","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:02.819Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:17.276Z","lastModifiedBy":"hbisht@microsoft.com"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '1100'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:12:19 GMT
-      mise-correlation-id:
-      - 5ebf099e-5906-4a30-b72e-5fe12b371f05
+      - 6766efb4-c8fa-4b3d-8a14-c3b34f7ccc29
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -492,7 +492,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:27.0373117Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:27.0373117Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:48.1592261Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:48.1592261Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -501,9 +501,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:21 GMT
+      - Mon, 09 Oct 2023 19:18:42 GMT
       etag:
-      - '"9201eba7-0000-0100-0000-652426310000"'
+      - '"5600b100-0000-0100-0000-652451de0000"'
       expires:
       - '-1'
       pragma:
@@ -533,24 +533,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/23666a64-0fe8-4f63-9b60-92f64c491b6b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A22Z&sr=b&sp=r&sig=xjPJC7FpwO8cvSCFlvDkSthVX9Rz4cfwezU4yUIZP2U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:22.2078858","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:02.819Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:17.276Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/e75f949d-302f-42e1-a3f0-d66af650a5db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A42Z&sr=b&sp=r&sig=BlCBjPCZ%2BDZgPv6MZAppAPTgRKJG1HW%2BEs8eaP7UrJU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:42.9855146","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:23.31Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:36.145Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1100'
+      - '1103'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:22 GMT
+      - Mon, 09 Oct 2023 19:18:43 GMT
       mise-correlation-id:
-      - 0f895127-9855-44ea-84d7-a62cfdbfd69a
+      - be5e72ba-49d9-4167-9d46-b697f3fa6d05
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -563,10 +563,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"a": null, "b": null, "rps": 1, "c": "5"}, "secrets": {}, "certificate": null,
       "loadTestConfiguration": {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs":
-      true}, "passFailCriteria": {"passFailMetrics": {"e70fc29a-37fa-43c4-a8a2-c55805b054af":
+      true}, "passFailCriteria": {"passFailMetrics": {"f2cc11d6-7c4b-454d-bed7-546b26196dba":
       {"aggregate": "avg", "clientMetric": "requests_per_sec", "condition": ">", "value":
-      "78"}, "78413f80-77b8-4f6d-a636-99caa4dfd401": {"aggregate": "percentage", "clientMetric":
-      "error", "condition": ">", "value": "50"}, "9538e4f8-3341-4d0f-9dc4-c97e67a1f04c":
+      "78"}, "fee27d95-f059-469e-b672-29be99d5f61a": {"aggregate": "percentage", "clientMetric":
+      "error", "condition": ">", "value": "50"}, "199c5dc1-b7cb-4a07-b9b9-e678dc2c4966":
       {"aggregate": "avg", "clientMetric": "latency", "condition": ">", "value": "200",
       "requestName": "GetCustomerDetails"}}}}'
     headers:
@@ -583,24 +583,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"e70fc29a-37fa-43c4-a8a2-c55805b054af":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"78413f80-77b8-4f6d-a636-99caa4dfd401":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9538e4f8-3341-4d0f-9dc4-c97e67a1f04c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/23666a64-0fe8-4f63-9b60-92f64c491b6b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A22Z&sr=b&sp=r&sig=kcB5E4WCVC3RiWglgEdHdDCiJ32tF6wT1bRbiUP090Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:22.5884381","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:02.819Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:22.579Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f2cc11d6-7c4b-454d-bed7-546b26196dba":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fee27d95-f059-469e-b672-29be99d5f61a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"199c5dc1-b7cb-4a07-b9b9-e678dc2c4966":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/e75f949d-302f-42e1-a3f0-d66af650a5db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A18%3A44Z&sr=b&sp=r&sig=%2BIwvPc6FzxoSSdJ6xPA2Zr4iua3u1YGQ%2BdsbjrjGJvM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:18:44.3591339","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:23.31Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:44.35Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1574'
+      - '1576'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:22 GMT
+      - Mon, 09 Oct 2023 19:18:44 GMT
       mise-correlation-id:
-      - 9272a82d-a85d-4bfe-a382-a690cf3cd9a0
+      - a38ca02c-d082-457c-9223-afa2d1a9002a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -620,23 +620,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/23666a64-0fe8-4f63-9b60-92f64c491b6b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A22Z&sr=b&sp=r&sig=mDxqAsJaw82xJuQddggfwG4%2FnLcZ53VW3eUe1GG9r2g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:22.8586139","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/e75f949d-302f-42e1-a3f0-d66af650a5db?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A44Z&sr=b&sp=r&sig=2sghkPySq%2Ftbd9793a%2FAvs8eigKJVavpmXcG0HpuOCw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:44.6766982","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '561'
+      - '563'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:22 GMT
+      - Mon, 09 Oct 2023 19:18:44 GMT
       mise-correlation-id:
-      - 7878d8bc-8acc-4aee-bf10-cd143c1f383d
+      - 91fbdc5c-3290-4f21-8989-2e42f729ae00
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -658,7 +658,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -668,9 +668,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Mon, 09 Oct 2023 16:12:23 GMT
+      - Mon, 09 Oct 2023 19:18:45 GMT
       mise-correlation-id:
-      - d80d0dcd-ec83-40ed-a363-2b678ea29066
+      - 9937ddcd-8d29-4ac4-8b9a-633b0dd7608d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -784,25 +784,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/969f609a-7c5e-4cfd-ac37-c201d9219cc9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A23Z&sr=b&sp=r&sig=uLQooBlPF%2BXZtAxmVRYl3GTSeatlcFWVRRV7yXxz%2Fes%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:23.7145538","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/d754cc18-1e85-4de3-a782-0cbdc4a7d3d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T17%3A22%3A08Z&ske=2023-10-11T00%3A52%3A08Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A45Z&sr=b&sp=r&sig=GaCOBBx%2FtnlZPQ5uHlPAUG6niNh96n0PfpGXCtfZKFc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:45.6401901","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:23 GMT
+      - Mon, 09 Oct 2023 19:18:45 GMT
       location:
-      - https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 4b29e6ee-4f34-4408-86b4-36af8e314e6e
+      - 7500def8-a476-4002-9126-789aa555b884
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -822,10 +822,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/969f609a-7c5e-4cfd-ac37-c201d9219cc9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A23Z&sr=b&sp=r&sig=D0yXpous1nRQF94ZrXclq%2FiaHZJF870RbBasMoJsGA0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:23.9806843","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/d754cc18-1e85-4de3-a782-0cbdc4a7d3d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A09%3A43Z&ske=2023-10-11T01%3A39%3A43Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A45Z&sr=b&sp=r&sig=G8yflfSO9CI5jfQCb830z1Mafwm4QXWTkaQw8Dak5HE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:45.9905713","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:18:45 GMT
+      mise-correlation-id:
+      - b2b9c89d-15e6-4288-a1d8-d394560d7c0a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/d754cc18-1e85-4de3-a782-0cbdc4a7d3d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T16%3A13%3A35Z&ske=2023-10-10T23%3A43%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A51Z&sr=b&sp=r&sig=VpBwdAAUPFfIXmJ11qvDmiZMmIvWlz%2FOJxbMoBfbD60%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:51.3055951","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -836,9 +872,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:23 GMT
+      - Mon, 09 Oct 2023 19:18:51 GMT
       mise-correlation-id:
-      - 4be86ecc-fa1b-4f3d-8841-d8ca92c45ac0
+      - bd6c9cfd-1bb9-448d-80e6-789c2f3860c7
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -858,82 +894,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/969f609a-7c5e-4cfd-ac37-c201d9219cc9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A29Z&sr=b&sp=r&sig=EOqmrrwDGU98hx74%2Fs3PH0KlSX6JbhQeqfVUbixvYbs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:29.257052","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '550'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:12:29 GMT
-      mise-correlation-id:
-      - 2e5e268a-7843-499d-a56b-017ab724e7e5
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/969f609a-7c5e-4cfd-ac37-c201d9219cc9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A34Z&sr=b&sp=r&sig=hhzrWQ55cZk0HCmL2JR1UHPVdtxV6KAaV7h%2FE6z3Sbs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:34.5244147","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:12:34 GMT
-      mise-correlation-id:
-      - dcacd873-292b-4a8d-9c63-5b1961115753
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/969f609a-7c5e-4cfd-ac37-c201d9219cc9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A39Z&sr=b&sp=r&sig=2Gz%2FgfozURdWhVFcuad9aAagt1Kzm2Is%2FEnLIf%2FcKIQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:39.8083017","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/d754cc18-1e85-4de3-a782-0cbdc4a7d3d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A28%3A56Z&sr=b&sp=r&sig=qxzfYLAcPj94xXSdH6qVUjYw7f4xj%2B%2BkA1zzLJUGgrw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:28:56.5717299","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -944,9 +908,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:39 GMT
+      - Mon, 09 Oct 2023 19:18:56 GMT
       mise-correlation-id:
-      - 4cadea35-4504-4d2c-bec3-9cc472ed37cb
+      - bbee749e-f875-45aa-9405-6a9a5b7b1047
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -966,11 +930,47 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"e70fc29a-37fa-43c4-a8a2-c55805b054af":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"78413f80-77b8-4f6d-a636-99caa4dfd401":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9538e4f8-3341-4d0f-9dc4-c97e67a1f04c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/969f609a-7c5e-4cfd-ac37-c201d9219cc9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A40Z&sr=b&sp=r&sig=CKhALKn02FjOFn03MKtr6i%2FcKKWRIsArjc7lVZ3Mmhs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:40.0736388","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:02.819Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:36.029Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/d754cc18-1e85-4de3-a782-0cbdc4a7d3d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T19%3A29%3A01Z&sr=b&sp=r&sig=FsttyuPG3cfyXvMfwl4RErGdT0fjFCFqGdhI6DiB0ow%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T19:29:01.8708352","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '547'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 19:19:01 GMT
+      mise-correlation-id:
+      - 7b002fac-4a5e-4417-b351-8edd6d961e41
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"f2cc11d6-7c4b-454d-bed7-546b26196dba":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fee27d95-f059-469e-b672-29be99d5f61a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"199c5dc1-b7cb-4a07-b9b9-e678dc2c4966":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/d754cc18-1e85-4de3-a782-0cbdc4a7d3d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T18%3A22%3A04Z&ske=2023-10-11T01%3A52%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A02Z&sr=b&sp=r&sig=BlhYUPxPwjVkB8l%2BFhItN7XlhEMlL4zNVI%2F5tlTyHTc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:02.1227872","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:23.31Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:59.78Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -981,9 +981,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:40 GMT
+      - Mon, 09 Oct 2023 19:19:02 GMT
       mise-correlation-id:
-      - 3b940332-5d92-42c3-9b28-0cd5d9d4a725
+      - cbe3fdce-f184-4305-ba36-c12037cb0388
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1006,7 +1006,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:27.0373117Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:27.0373117Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T19:17:48.1592261Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T19:17:48.1592261Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1015,9 +1015,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:41 GMT
+      - Mon, 09 Oct 2023 19:19:03 GMT
       etag:
-      - '"9201eba7-0000-0100-0000-652426310000"'
+      - '"5600b100-0000-0100-0000-652451de0000"'
       expires:
       - '-1'
       pragma:
@@ -1047,11 +1047,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://5cad8bac-4841-40ba-a41e-51ab4fb218a3.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"e70fc29a-37fa-43c4-a8a2-c55805b054af":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"78413f80-77b8-4f6d-a636-99caa4dfd401":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9538e4f8-3341-4d0f-9dc4-c97e67a1f04c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/969f609a-7c5e-4cfd-ac37-c201d9219cc9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A42Z&sr=b&sp=r&sig=mnRJ8Xo1Z8HLSDIPWvhQpjrYXF6UOLsFmjrHnwa3IYM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:42.2650614","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:02.819Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:36.029Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"f2cc11d6-7c4b-454d-bed7-546b26196dba":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"fee27d95-f059-469e-b672-29be99d5f61a":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"199c5dc1-b7cb-4a07-b9b9-e678dc2c4966":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/920750f8-4df2-4121-b874-36d2f48297df/d754cc18-1e85-4de3-a782-0cbdc4a7d3d8?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T20%3A19%3A04Z&sr=b&sp=r&sig=mGlVRI%2BS1ZjglyDq35WRgEvvgfNAhpLl5oxFHsEDoK4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T20:19:04.4786405","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T19:18:23.31Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T19:18:59.78Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -1062,9 +1062,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:12:42 GMT
+      - Mon, 09 Oct 2023 19:19:04 GMT
       mise-correlation-id:
-      - afc9d033-40ca-4ae2-9d0b-400ecd380104
+      - 08a70107-776e-4ef6-8909-4de2bfc11d14
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_update_with_config.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_update_with_config.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:55.0803542Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:55.0803542Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:00.0044305Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:00.0044305Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:28 GMT
+      - Wed, 18 Oct 2023 20:51:32 GMT
       etag:
-      - '"d801a7dd-0000-0100-0000-65294b400000"'
+      - '"7500a84a-0000-0100-0000-653045350000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 13 Oct 2023 13:51:29 GMT
+      - Wed, 18 Oct 2023 20:51:34 GMT
       mise-correlation-id:
-      - 02103249-1396-4de4-9102-8d410787e8e4
+      - 209b556e-740a-4af7-a20e-928d1ead8a9e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -101,11 +101,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:30.047Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:30.047Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:34.811Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:34.811Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -116,11 +116,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:30 GMT
+      - Wed, 18 Oct 2023 20:51:34 GMT
       location:
-      - https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+      - https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 7e97d22f-a4db-4b09-981a-681bdebd34e7
+      - 8a8457d5-362e-441e-b5d5-a38831f9d480
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -140,7 +140,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -154,9 +154,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:30 GMT
+      - Wed, 18 Oct 2023 20:51:35 GMT
       mise-correlation-id:
-      - b36b1b8d-8c6e-4ec1-a1f1-6d2f380a1d4c
+      - 373f553f-9db5-4248-91bd-773027b56332
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -270,25 +270,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/1fbce307-ede1-4c7d-8339-b1b88e883e23?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A30Z&sr=b&sp=r&sig=l6dBJ8A3KfpAGewwIo8LsuuRp7%2BxkPHPxr%2FN2rNjNOE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:30.9136249","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/bc00885c-c27a-4a62-b119-d030ef7624c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A36Z&sr=b&sp=r&sig=SWWX3jLojZciGM024OryVMut99UxKFrPsH%2B7alnKFnY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:36.5163455","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:30 GMT
+      - Wed, 18 Oct 2023 20:51:36 GMT
       location:
-      - https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - c235772b-20ec-4b69-a307-310664c9775e
+      - bbd44f7b-bbc6-4c1d-be42-aeda596956bc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -308,10 +308,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/1fbce307-ede1-4c7d-8339-b1b88e883e23?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A31Z&sr=b&sp=r&sig=KojpMzAqoneG0KinJgDl7B%2FOHFDEKN9z3R8KiDdnbNk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:31.2921701","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/bc00885c-c27a-4a62-b119-d030ef7624c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A36Z&sr=b&sp=r&sig=%2FU%2B59eB7lR33yFUX92Vob5UD%2FEadSqWf%2BSShBITRkDw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:36.7622316","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '557'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:51:36 GMT
+      mise-correlation-id:
+      - f51cffd7-b808-4330-b197-af602c5978c0
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/bc00885c-c27a-4a62-b119-d030ef7624c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A42Z&sr=b&sp=r&sig=XqyiDxJhMxcBujF%2BMjIrxu9zWpkn3JQa6USYmCIWS6U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:42.0258318","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -322,9 +358,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:31 GMT
+      - Wed, 18 Oct 2023 20:51:42 GMT
       mise-correlation-id:
-      - 6b107d05-550c-4fe4-9c3c-a82373564480
+      - c855e617-3935-4c45-8a8b-b050df5ca25f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -344,23 +380,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/1fbce307-ede1-4c7d-8339-b1b88e883e23?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A36Z&sr=b&sp=r&sig=EY0xCYFe0qAclg38hmc6sosWFdqoT%2BsgbAfGWwtquxw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:36.5427975","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/bc00885c-c27a-4a62-b119-d030ef7624c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A47Z&sr=b&sp=r&sig=huNzaM28s8QOrRfkBb8oJ6H4493KQZf5aCZDSaW2kNs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:47.2894071","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:36 GMT
+      - Wed, 18 Oct 2023 20:51:47 GMT
       mise-correlation-id:
-      - ac971ba5-dbad-4436-ac17-0a01e1580123
+      - 736702d6-71e3-4f7b-9c22-786377193c99
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -380,23 +416,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/1fbce307-ede1-4c7d-8339-b1b88e883e23?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A41Z&sr=b&sp=r&sig=IUq7p3YyQePELjU1Fh26LBPn%2BPZYEOd3MFsn%2Fp9jrIo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:41.8017646","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/bc00885c-c27a-4a62-b119-d030ef7624c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A52Z&sr=b&sp=r&sig=h8jvHLsZJcACPKyQbujYTSQ4G1wAyOQKPY8dM78Wqno%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:52.6191623","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:41 GMT
+      - Wed, 18 Oct 2023 20:51:52 GMT
       mise-correlation-id:
-      - 5d75069b-fa9f-4860-9184-9a9029639f8c
+      - dc537924-d442-477d-ae97-0b1ebc62e732
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -416,47 +452,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/1fbce307-ede1-4c7d-8339-b1b88e883e23?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A47Z&sr=b&sp=r&sig=Ge4i2j9SiNObGUu1V06gcrS%2BRVDd%2B3voCFIcDv27HeE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:47.0452486","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:51:47 GMT
-      mise-correlation-id:
-      - a8207fea-ff19-41d9-93f1-0c15d1462b4b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
-  response:
-    body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/1fbce307-ede1-4c7d-8339-b1b88e883e23?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A47Z&sr=b&sp=r&sig=pAPDVUVALVa3n1pymP0ekaJt2s6AmZVHW%2FGBY3RW3QA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:47.3139207","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:30.047Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:43.038Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/bc00885c-c27a-4a62-b119-d030ef7624c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A52Z&sr=b&sp=r&sig=h%2BUmqSrQ7ecRw2VobuvZVjIU7wAHVhjY7Ff07z3xwOc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:52.8672091","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:34.811Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:48.499Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -467,9 +467,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:47 GMT
+      - Wed, 18 Oct 2023 20:51:52 GMT
       mise-correlation-id:
-      - 085dc723-00ed-4857-bca5-262bb8165e99
+      - 33643799-aac7-4280-b15e-7694defb4c2b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -492,7 +492,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:55.0803542Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:55.0803542Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:00.0044305Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:00.0044305Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -501,9 +501,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:48 GMT
+      - Wed, 18 Oct 2023 20:51:53 GMT
       etag:
-      - '"d801a7dd-0000-0100-0000-65294b400000"'
+      - '"7500a84a-0000-0100-0000-653045350000"'
       expires:
       - '-1'
       pragma:
@@ -533,24 +533,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/1fbce307-ede1-4c7d-8339-b1b88e883e23?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A49Z&sr=b&sp=r&sig=8UeoeDBrL36Vtn%2BgHeL4aN%2BSfSxFPI9%2FR6WxMLNHBNk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:49.6085617","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:30.047Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:43.038Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/bc00885c-c27a-4a62-b119-d030ef7624c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A55Z&sr=b&sp=r&sig=V030pSNbPu5t6PItF9QgZbqLzWuuhdxFevKJ2UHgzLQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:55.1518952","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:34.811Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:48.499Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1106'
+      - '1100'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:49 GMT
+      - Wed, 18 Oct 2023 20:51:55 GMT
       mise-correlation-id:
-      - 4f5f9689-ab21-4786-a9c4-cdf14dde8966
+      - b63cecfa-f4c7-48f9-983c-677d05cca070
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -563,10 +563,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"a": null, "b": null, "rps": 1, "c": "5"}, "secrets": {}, "certificate": null,
       "loadTestConfiguration": {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs":
-      true}, "passFailCriteria": {"passFailMetrics": {"d644f5c2-b366-4176-b8e8-e540534f432e":
+      true}, "passFailCriteria": {"passFailMetrics": {"06a4f220-bc27-4113-b387-bdaf458fd95a":
       {"aggregate": "avg", "clientMetric": "requests_per_sec", "condition": ">", "value":
-      "78"}, "7124a5be-911a-43a8-b7ac-6db62b3a313b": {"aggregate": "percentage", "clientMetric":
-      "error", "condition": ">", "value": "50"}, "dd97f346-f69b-4cef-90be-63ef9a3ac55f":
+      "78"}, "131623de-383c-4ebe-9c49-a0beb9fda712": {"aggregate": "percentage", "clientMetric":
+      "error", "condition": ">", "value": "50"}, "3b1169f5-2dbf-40cd-8c86-07dc8d73a4f0":
       {"aggregate": "avg", "clientMetric": "latency", "condition": ">", "value": "200",
       "requestName": "GetCustomerDetails"}}}}'
     headers:
@@ -583,24 +583,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d644f5c2-b366-4176-b8e8-e540534f432e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7124a5be-911a-43a8-b7ac-6db62b3a313b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"dd97f346-f69b-4cef-90be-63ef9a3ac55f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/1fbce307-ede1-4c7d-8339-b1b88e883e23?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A41%3A42Z&ske=2023-10-14T19%3A11%3A42Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A51%3A49Z&sr=b&sp=r&sig=IRH475EYo8EvZBIvLbyW2FMnis9jENGsHExgmuLCN7k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:51:49.949316","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:30.047Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:51:49.942Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"06a4f220-bc27-4113-b387-bdaf458fd95a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"131623de-383c-4ebe-9c49-a0beb9fda712":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3b1169f5-2dbf-40cd-8c86-07dc8d73a4f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/bc00885c-c27a-4a62-b119-d030ef7624c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A55Z&sr=b&sp=r&sig=qp%2BJyeGMQgARrbJeBXYUFMil0zlKpedQI9YAiVUlYrw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:55.5253775","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:34.811Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:55.514Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1573'
+      - '1576'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:49 GMT
+      - Wed, 18 Oct 2023 20:51:55 GMT
       mise-correlation-id:
-      - 6ac4f045-868c-4ee5-bd13-1bced5354f4d
+      - 6c1b0240-7de7-4e63-9a28-7e35e30e1fa2
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -620,10 +620,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/1fbce307-ede1-4c7d-8339-b1b88e883e23?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T07%3A48%3A35Z&ske=2023-10-14T15%3A18%3A35Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A50Z&sr=b&sp=r&sig=I2OoA%2BzqsCSkzhMjCZjuRHMNNcljzBIBXLK6w5A2vz0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:50.2273984","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/bc00885c-c27a-4a62-b119-d030ef7624c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A55Z&sr=b&sp=r&sig=zuV9IIzIPV2PAkbC762n91YQj1JRSU5%2Bikk0XucUAJs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:55.7840187","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -634,9 +634,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:50 GMT
+      - Wed, 18 Oct 2023 20:51:55 GMT
       mise-correlation-id:
-      - 60d1c486-8b1f-4c9a-9b01-a2036ea159d8
+      - 377af9eb-d012-4d02-935b-f1f5b5e3e8eb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -658,7 +658,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -668,9 +668,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Fri, 13 Oct 2023 13:51:50 GMT
+      - Wed, 18 Oct 2023 20:51:56 GMT
       mise-correlation-id:
-      - c2648e7b-5552-4743-80b9-f8c3442b93b8
+      - 617a9c5d-2d96-4180-a736-26c727acea90
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -784,25 +784,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/fb751104-60b8-4d83-afac-a922f6622a8e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A50Z&sr=b&sp=r&sig=hxRlww5hviY5cTIgNoQwp%2FiukcBuMJI7aIAUGEL%2FGAY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:50.9887304","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/c6c42096-7ae4-458a-a174-db531a980d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A56Z&sr=b&sp=r&sig=5bTdI8u0uJQbTY8Rz88zsMwhIgIP8kLYQ5QR%2BqPmSHI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:56.5968824","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '553'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:50 GMT
+      - Wed, 18 Oct 2023 20:51:56 GMT
       location:
-      - https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 26bba518-89b9-4e73-ad02-64a31e9029d7
+      - 44c2b38b-11f1-45d6-9425-de352ef520ca
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -822,10 +822,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/fb751104-60b8-4d83-afac-a922f6622a8e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T10%3A21%3A55Z&ske=2023-10-14T17%3A51%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A51Z&sr=b&sp=r&sig=PMmCVXldSxJHIfAnAsZabC8dmx7YvQt9it3HmEoou28%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:51.2418881","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/c6c42096-7ae4-458a-a174-db531a980d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A56Z&sr=b&sp=r&sig=1GMk0qsi2NwQhsn1bNLHNHtCYPnmpjDHBbelzIrtSSQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:56.8426872","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -836,9 +836,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:51 GMT
+      - Wed, 18 Oct 2023 20:51:56 GMT
       mise-correlation-id:
-      - cc146cf4-d86d-4cb7-bd81-0d7e70e0e430
+      - 9f1cbcab-8b0c-4e7e-ae49-d2ea42c71a06
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -858,23 +858,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/fb751104-60b8-4d83-afac-a922f6622a8e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A01%3A56Z&sr=b&sp=r&sig=mW1Z3KajuueRZ4AG3trwUzvtJqJ49SnEaqBo94OKk%2FQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:01:56.4907332","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/c6c42096-7ae4-458a-a174-db531a980d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A02Z&sr=b&sp=r&sig=ilpzFz3RBtMQKZVcETysvISy%2BvyyAJbv%2FTl0ltaM0gM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:02.1373636","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:51:56 GMT
+      - Wed, 18 Oct 2023 20:52:02 GMT
       mise-correlation-id:
-      - 8fa08dfd-92c1-4a07-b862-7e9c51557cef
+      - 3a66d99e-d1cf-4682-8652-19e3a7257c69
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -894,46 +894,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/fb751104-60b8-4d83-afac-a922f6622a8e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T06%3A33%3A03Z&ske=2023-10-14T14%3A03%3A03Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A01Z&sr=b&sp=r&sig=HzKxkfHsCgWCf7EY0SXbBpWoasTxEn0Y1gGP1JCemHg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:01.7380931","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Oct 2023 13:52:01 GMT
-      mise-correlation-id:
-      - 11a3841b-1ba8-4ee4-b99c-cc764d8ed1ae
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/fb751104-60b8-4d83-afac-a922f6622a8e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A02%3A07Z&sr=b&sp=r&sig=04uwngiEw06n4M06ZY7%2BzW7npmeBWGBlk94MRJc3JMs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:02:07.0075407","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/c6c42096-7ae4-458a-a174-db531a980d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A07Z&sr=b&sp=r&sig=ZpmgwEnsaDQ1S9qJWDzPlDUbkIFhFofUHGBq48yScwY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:07.4225292","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -944,9 +908,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:07 GMT
+      - Wed, 18 Oct 2023 20:52:07 GMT
       mise-correlation-id:
-      - 9d50f047-f9fc-43e0-b163-09431befc16d
+      - f9849637-b13d-4e56-b3d6-6f5e2408e640
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -966,24 +930,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d644f5c2-b366-4176-b8e8-e540534f432e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7124a5be-911a-43a8-b7ac-6db62b3a313b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"dd97f346-f69b-4cef-90be-63ef9a3ac55f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/fb751104-60b8-4d83-afac-a922f6622a8e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T09%3A21%3A40Z&ske=2023-10-14T16%3A51%3A40Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A07Z&sr=b&sp=r&sig=SDy%2Fmybt782%2F%2B59tU%2BViCnAy7OIgI20ZG6bYu8mU2wE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:07.2782338","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:30.047Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:04.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/c6c42096-7ae4-458a-a174-db531a980d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A12Z&sr=b&sp=r&sig=nB1LV57fGMzmQqpzgPKa56a9PpqE9vqABxVJngk7Chw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:12.6777542","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1582'
+      - '547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:07 GMT
+      - Wed, 18 Oct 2023 20:52:12 GMT
       mise-correlation-id:
-      - 2f3406d8-0691-4976-b29e-ce8711ec17e7
+      - 6feef90e-55aa-4c1e-a135-cd8aba38041a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"06a4f220-bc27-4113-b387-bdaf458fd95a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"131623de-383c-4ebe-9c49-a0beb9fda712":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3b1169f5-2dbf-40cd-8c86-07dc8d73a4f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/c6c42096-7ae4-458a-a174-db531a980d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A12Z&sr=b&sp=r&sig=yAtjZSHZnnJfVZ8ZH1dGHzLLBTYzyvqC55d8OvSE61E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:12.992206","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:34.811Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:08.631Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1573'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 18 Oct 2023 20:52:12 GMT
+      mise-correlation-id:
+      - 13aa75d6-bdeb-43cb-84f5-4de14db2488c
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1006,7 +1006,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-13T13:50:55.0803542Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-13T13:50:55.0803542Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:00.0044305Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:00.0044305Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1015,9 +1015,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:08 GMT
+      - Wed, 18 Oct 2023 20:52:12 GMT
       etag:
-      - '"d801a7dd-0000-0100-0000-65294b400000"'
+      - '"7500a84a-0000-0100-0000-653045350000"'
       expires:
       - '-1'
       pragma:
@@ -1047,24 +1047,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://031d4720-3eb4-466a-9d78-cf23e0a54035.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"d644f5c2-b366-4176-b8e8-e540534f432e":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"7124a5be-911a-43a8-b7ac-6db62b3a313b":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"dd97f346-f69b-4cef-90be-63ef9a3ac55f":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/3cde01d6-8e2a-4109-884d-00702656938f/fb751104-60b8-4d83-afac-a922f6622a8e?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-13T11%3A03%3A11Z&ske=2023-10-14T18%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-13T14%3A52%3A09Z&sr=b&sp=r&sig=MUYzSIZfH2fYMTRe9U3x5aUVF43LGsmjHsbO8cMUhYU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-13T14:52:09.9794874","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-13T13:51:30.047Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-13T13:52:04.554Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"06a4f220-bc27-4113-b387-bdaf458fd95a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"131623de-383c-4ebe-9c49-a0beb9fda712":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3b1169f5-2dbf-40cd-8c86-07dc8d73a4f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/c6c42096-7ae4-458a-a174-db531a980d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A14Z&sr=b&sp=r&sig=uDSHnd7%2BULYrNi1hCrNc5HhZwSzaXOGTny%2Bt8Pi2lwE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:14.6401646","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:34.811Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:08.631Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1574'
+      - '1578'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Oct 2023 13:52:09 GMT
+      - Wed, 18 Oct 2023 20:52:14 GMT
       mise-correlation-id:
-      - 1416782a-42eb-4c9f-a743-2d34c2059d56
+      - ab07fbc4-940d-40a9-8f7d-f6390ca4a99b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_update_with_config.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_update_with_config.yaml
@@ -14,18 +14,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:33.1373332Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:33.1373332Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:33.4404467Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:33.4404467Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:05 GMT
+      - Sun, 29 Oct 2023 22:21:07 GMT
       etag:
-      - '"d3004d39-0000-0100-0000-6537b8360000"'
+      - '"3c006327-0000-0100-0000-653edab30000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 24 Oct 2023 12:28:06 GMT
+      - Sun, 29 Oct 2023 22:21:08 GMT
       mise-correlation-id:
-      - 2bdea251-e08c-4f21-87ce-da7a7f3b6950
+      - 6fa8d03c-0c43-4ebe-aeec-c4d995b3a7eb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -101,26 +101,26 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:07Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:07Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:09.451Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:09.451Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '523'
+      - '531'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:07 GMT
+      - Sun, 29 Oct 2023 22:21:09 GMT
       location:
-      - https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+      - https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 58abc321-7336-4874-a1a2-e019a140c185
+      - 3de90d66-86b9-4317-bf61-3d2afde3c3cc
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -140,7 +140,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -154,9 +154,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:07 GMT
+      - Sun, 29 Oct 2023 22:21:10 GMT
       mise-correlation-id:
-      - ea93d207-2f71-4216-9021-778498dbb4e1
+      - 931f3186-8109-44dc-be0f-2e78192dcf3a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -270,10 +270,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/83767374-609f-432a-af93-54a67fe1a1d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A07Z&sr=b&sp=r&sig=dHpOrsghD3V4q4GZB76aSr8x8bib908E8eOAyE%2BRvXE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:07.8627865","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/3ff8d0d3-fbcc-46ed-8772-354aa9ff05de?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A11Z&sr=b&sp=r&sig=IgQKbC1WSSQipLIB0dDhWJyJhSz8D93iv%2Bqn24cdi9k%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:11.4496553","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -284,11 +284,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:07 GMT
+      - Sun, 29 Oct 2023 22:21:11 GMT
       location:
-      - https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 04528c16-67a3-4a9e-a3db-03eb90cb96c1
+      - bd1e14f3-2b14-4008-8853-e47a7c6f028f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -308,10 +308,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/83767374-609f-432a-af93-54a67fe1a1d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A08Z&sr=b&sp=r&sig=cYnQ2uVLwj94CJMYZRLrT4nFgyPUWFtUIe9dyFATpTc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:08.1142697","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/3ff8d0d3-fbcc-46ed-8772-354aa9ff05de?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A11Z&sr=b&sp=r&sig=Trrf0hTuWN2iYiSqQqEXA20g1CY71QxYAs1O1iSfugM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:11.7354017","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -322,9 +322,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:08 GMT
+      - Sun, 29 Oct 2023 22:21:11 GMT
       mise-correlation-id:
-      - 93ae755a-9bbc-4b6e-9f77-3307dee7e2d1
+      - a9ac0745-00bb-481a-bd30-491b6dae276f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -344,46 +344,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/83767374-609f-432a-af93-54a67fe1a1d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A13Z&sr=b&sp=r&sig=vUs%2BQDWtAEEc%2B8XP%2FOI%2B2mWv3sZhWLOWCREP3Tc7O7g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:13.4580758","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '557'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:28:13 GMT
-      mise-correlation-id:
-      - 4a3de0bc-fce8-471c-a320-5170c29fb088
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/83767374-609f-432a-af93-54a67fe1a1d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A18Z&sr=b&sp=r&sig=xEHuMKxr%2Bmo73ZmxMyE68Qu%2FwHqKHyxB7n2RX7I2lF4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:18.8217629","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/3ff8d0d3-fbcc-46ed-8772-354aa9ff05de?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A17Z&sr=b&sp=r&sig=qHXEG2%2FluQ8gLMyKEPA6qBKfAPGu1bObQ8yaSxL%2B2Zo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:17.0491529","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -394,9 +358,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:18 GMT
+      - Sun, 29 Oct 2023 22:21:17 GMT
       mise-correlation-id:
-      - cc041e73-e2cf-4e82-a7c2-5c65fa45531b
+      - 4c1dfb44-0a16-4dda-819f-b05a2d5f5955
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -416,10 +380,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/83767374-609f-432a-af93-54a67fe1a1d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A24Z&sr=b&sp=r&sig=UdsdP60%2F9LTCofNWnTT4TVWYak8VPoPndzEl3O90fLA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:24.0774826","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/3ff8d0d3-fbcc-46ed-8772-354aa9ff05de?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A30%3A45Z&ske=2023-10-31T04%3A00%3A45Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A22Z&sr=b&sp=r&sig=1Bc%2BBEpY76C1GGtiAVruMQMULXzDJ%2FAebs3DbM7lNWA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:22.3061426","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:21:22 GMT
+      mise-correlation-id:
+      - 4e1c5a4d-77aa-4a15-988d-a5af449ce142
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/3ff8d0d3-fbcc-46ed-8772-354aa9ff05de?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A27Z&sr=b&sp=r&sig=SQQMMI7eZ2VUz71lRW4dFAOtYLpbVUxp3m91a1%2B4MlU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:27.5443906","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -430,9 +430,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:24 GMT
+      - Sun, 29 Oct 2023 22:21:27 GMT
       mise-correlation-id:
-      - f487f77a-11a9-4a46-9004-130d452975b1
+      - 53dc5ff0-b2d8-45bd-82e4-e80f182e5440
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -452,24 +452,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/83767374-609f-432a-af93-54a67fe1a1d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A24Z&sr=b&sp=r&sig=YAVgfrxZSFwarqdILsuuT38mB0fpfdMykyvhq1%2BNoEs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:24.4546921","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:07Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:22.347Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/3ff8d0d3-fbcc-46ed-8772-354aa9ff05de?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A25%3A23Z&ske=2023-10-30T23%3A55%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A27Z&sr=b&sp=r&sig=6C1yKKhmyw39miq3oiI8p55MUnbcEPHCsFIkKD15XXo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:27.8126544","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:09.451Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:24.145Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1098'
+      - '1100'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:24 GMT
+      - Sun, 29 Oct 2023 22:21:27 GMT
       mise-correlation-id:
-      - 68110006-4497-4320-a77e-204692e55d5b
+      - 6881310c-1a33-4ca0-a5f1-0ee7a0062beb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -492,18 +492,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:33.1373332Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:33.1373332Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:33.4404467Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:33.4404467Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:25 GMT
+      - Sun, 29 Oct 2023 22:21:28 GMT
       etag:
-      - '"d3004d39-0000-0100-0000-6537b8360000"'
+      - '"3c006327-0000-0100-0000-653edab30000"'
       expires:
       - '-1'
       pragma:
@@ -533,24 +533,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/83767374-609f-432a-af93-54a67fe1a1d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A27Z&sr=b&sp=r&sig=R5uHPRib434DBdeP5UIS2n2HVjon8fiLme0QYj1gX%2BA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:27.0021784","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:07Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:22.347Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/3ff8d0d3-fbcc-46ed-8772-354aa9ff05de?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A30Z&sr=b&sp=r&sig=aKtKNlHvbB1s9yjipMPZ2VtykETVyeN4oWg8hhEmfLA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:30.0246839","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:09.451Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:24.145Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1098'
+      - '1100'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:27 GMT
+      - Sun, 29 Oct 2023 22:21:30 GMT
       mise-correlation-id:
-      - 38b0865f-d1c9-4000-9de9-4d88343a4786
+      - a6f70fbc-c282-429d-b976-f97bc3a9c579
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -563,10 +563,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"a": null, "b": null, "rps": 1, "c": "5"}, "secrets": {}, "certificate": null,
       "loadTestConfiguration": {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs":
-      true}, "passFailCriteria": {"passFailMetrics": {"53bc7b0e-f729-42a0-8df8-d4b3ae400e25":
+      true}, "passFailCriteria": {"passFailMetrics": {"4727cb2b-6f51-42ab-b498-bf0950a1fdc5":
       {"aggregate": "avg", "clientMetric": "requests_per_sec", "condition": ">", "value":
-      "78"}, "ebd31f2c-f7f7-44f8-b01f-94dafef7c5cf": {"aggregate": "percentage", "clientMetric":
-      "error", "condition": ">", "value": "50"}, "cda72dae-924c-4055-9059-2079684bfb19":
+      "78"}, "f625e4c6-bdbd-47e4-8934-9dbdd008abd5": {"aggregate": "percentage", "clientMetric":
+      "error", "condition": ">", "value": "50"}, "95026edf-8043-45e0-bb97-99ed1b3599e7":
       {"aggregate": "avg", "clientMetric": "latency", "condition": ">", "value": "200",
       "requestName": "GetCustomerDetails"}}}}'
     headers:
@@ -583,24 +583,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"53bc7b0e-f729-42a0-8df8-d4b3ae400e25":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ebd31f2c-f7f7-44f8-b01f-94dafef7c5cf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"cda72dae-924c-4055-9059-2079684bfb19":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/83767374-609f-432a-af93-54a67fe1a1d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A27Z&sr=b&sp=r&sig=9jB%2BUrRe72isN1azbw0IfTLD2XMZzqoIY%2Bkq%2Fm6FuXw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:27.3629286","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:07Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:27.35Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4727cb2b-6f51-42ab-b498-bf0950a1fdc5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f625e4c6-bdbd-47e4-8934-9dbdd008abd5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"95026edf-8043-45e0-bb97-99ed1b3599e7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/3ff8d0d3-fbcc-46ed-8772-354aa9ff05de?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A30Z&sr=b&sp=r&sig=1YzqclZB3OVOerNSweJ2N841K9MYbAitil%2Fn3HUKDaU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:30.3753728","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:09.451Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:30.366Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1575'
+      - '1576'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:27 GMT
+      - Sun, 29 Oct 2023 22:21:30 GMT
       mise-correlation-id:
-      - 579dc323-45d1-4d90-bc0f-9b7cd81583b4
+      - 2f1b6ffe-8c05-4d51-a8c1-95379a9b7461
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -620,23 +620,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/83767374-609f-432a-af93-54a67fe1a1d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A27Z&sr=b&sp=r&sig=OhRqw948uag%2BVH3Xk1kMlxRgTNlVC2%2BgsFs5qJIf4L4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:27.6129843","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/3ff8d0d3-fbcc-46ed-8772-354aa9ff05de?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A30Z&sr=b&sp=r&sig=%2FWdPkRFvw41D5TSKaNI1mX%2F%2BhYUrMQiuxgs5Nar74%2FU%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:30.6099582","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '563'
+      - '567'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:27 GMT
+      - Sun, 29 Oct 2023 22:21:30 GMT
       mise-correlation-id:
-      - 5f100e0c-5d99-4bdc-b506-95270840ad98
+      - 01719e73-bb66-44b9-a8c8-cb93127eaf4b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -658,7 +658,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -668,9 +668,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Tue, 24 Oct 2023 12:28:28 GMT
+      - Sun, 29 Oct 2023 22:21:31 GMT
       mise-correlation-id:
-      - a946e8ed-4cc3-4dd3-9692-379b6a1f98e1
+      - ebb49249-2cb8-46fd-83a2-d29ed82be13f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -784,25 +784,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/7ac27cbe-3f0e-4bd9-9537-30f0a7a4f68c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A28Z&sr=b&sp=r&sig=FXDb6r2Ku9TiAGKHT8T0QgdYSnDKGKtBlm0UTEdRQCw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:28.7958483","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/2d53f92c-b4b8-4967-9d63-da63703046f1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A31Z&sr=b&sp=r&sig=ykn2Wp3fouF2dg5hTABvvtJ9s6nLHV%2FVbgYNuYBtrTo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:31.7864536","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:28 GMT
+      - Sun, 29 Oct 2023 22:21:31 GMT
       location:
-      - https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 942d36e7-0d1e-47a4-ac40-fc7f3a645eb9
+      - 776111df-2aa3-4c99-9cd2-afaaafdec506
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -822,46 +822,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/7ac27cbe-3f0e-4bd9-9537-30f0a7a4f68c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A29Z&sr=b&sp=r&sig=THMWtfF4nKQKm%2FnuZ4qcnxAxOYqQ1B3Dm6694ASS%2BvA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:29.1344491","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 24 Oct 2023 12:28:29 GMT
-      mise-correlation-id:
-      - 07e30515-795b-4db5-b410-3174b543f69b
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/7ac27cbe-3f0e-4bd9-9537-30f0a7a4f68c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A34Z&sr=b&sp=r&sig=bWXFuTqZVdO6U522X7pJdtApgHhkMIruQ99Y%2BdySapo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:34.3899846","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/2d53f92c-b4b8-4967-9d63-da63703046f1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A32Z&sr=b&sp=r&sig=MPXSDOB3ysKU5jwlOdGoW8cPu26%2FNL3dJJPgpI8eKbI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:32.0199698","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -872,9 +836,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:34 GMT
+      - Sun, 29 Oct 2023 22:21:32 GMT
       mise-correlation-id:
-      - 4c072fdb-9dc0-4ef6-aa23-6f6dde32f238
+      - e6e647d3-358a-4450-8a74-adbec5ba510e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -894,10 +858,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/7ac27cbe-3f0e-4bd9-9537-30f0a7a4f68c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A39Z&sr=b&sp=r&sig=X3DQzSrNGJa2uyGhetPsY92hNZADfiR2hGRb%2FY8LdL0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:39.6550924","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/2d53f92c-b4b8-4967-9d63-da63703046f1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A37Z&sr=b&sp=r&sig=M0PWILkqLdjDNNE%2B2SJlpcDG0kiHa2IK9H4ZRHqZzDg%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:37.3061631","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -908,9 +872,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:39 GMT
+      - Sun, 29 Oct 2023 22:21:37 GMT
       mise-correlation-id:
-      - 4ff6176a-86dd-439f-b8e8-f2b19f88f49a
+      - 171d80cc-d586-4d18-ba62-25ecb057afbf
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -930,23 +894,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/7ac27cbe-3f0e-4bd9-9537-30f0a7a4f68c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A45Z&sr=b&sp=r&sig=v7k6XSCHfThKgiwLvp5pmtuTkxiBCy3UgtRC2bw3Dnk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:45.5482955","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/2d53f92c-b4b8-4967-9d63-da63703046f1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T16%3A06%3A52Z&ske=2023-10-30T23%3A36%3A52Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A42Z&sr=b&sp=r&sig=nFmgvyRxJ62rdzsS4%2B6J51jPN50BJKmmo%2B29eCl%2BaKM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:42.5504738","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:45 GMT
+      - Sun, 29 Oct 2023 22:21:42 GMT
       mise-correlation-id:
-      - 232a17fd-3996-47ab-a616-e53e4dbeff1a
+      - b43ddbac-e7f0-4367-83e3-8837e6413c3d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -966,24 +930,60 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"53bc7b0e-f729-42a0-8df8-d4b3ae400e25":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ebd31f2c-f7f7-44f8-b01f-94dafef7c5cf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"cda72dae-924c-4055-9059-2079684bfb19":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/7ac27cbe-3f0e-4bd9-9537-30f0a7a4f68c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A45Z&sr=b&sp=r&sig=b9ZEplacjCzH4HNsa0COxv2AlqfQRF1hcGw5WboED3E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:45.8083649","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:07Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:40.592Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/2d53f92c-b4b8-4967-9d63-da63703046f1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T22%3A07%3A21Z&ske=2023-10-31T05%3A37%3A21Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T22%3A31%3A48Z&sr=b&sp=r&sig=eRy%2F%2FaWx48icFkMwzzkFDhohdkzOHFt%2BsVTmW0hZsig%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T22:31:48.504847","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1570'
+      - '552'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:45 GMT
+      - Sun, 29 Oct 2023 22:21:48 GMT
       mise-correlation-id:
-      - c3ab6d9a-61c1-4647-b25a-c27f6abc5b5f
+      - 5a528303-ae42-4db7-9601-424f2cd50351
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"4727cb2b-6f51-42ab-b498-bf0950a1fdc5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f625e4c6-bdbd-47e4-8934-9dbdd008abd5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"95026edf-8043-45e0-bb97-99ed1b3599e7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/2d53f92c-b4b8-4967-9d63-da63703046f1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T20%3A10%3A53Z&ske=2023-10-31T03%3A40%3A53Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A49Z&sr=b&sp=r&sig=M8jsanfPPhWLvsg8W2yXVojgEmxHVXl%2BAzQJjgNhgro%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:49.1588304","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:09.451Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:45.507Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1576'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 29 Oct 2023 22:21:49 GMT
+      mise-correlation-id:
+      - d7eaebc3-e7e6-4810-8ca0-7041907cb6b5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1006,18 +1006,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:33.1373332Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:33.1373332Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-29T22:20:33.4404467Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-29T22:20:33.4404467Z"},"identity":{"type":"None"},"properties":{"dataPlaneURI":"ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '690'
+      - '653'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:46 GMT
+      - Sun, 29 Oct 2023 22:21:49 GMT
       etag:
-      - '"d3004d39-0000-0100-0000-6537b8360000"'
+      - '"3c006327-0000-0100-0000-653edab30000"'
       expires:
       - '-1'
       pragma:
@@ -1047,24 +1047,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://ffdc83b0-0653-4296-8bad-18a1afd84d09.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"53bc7b0e-f729-42a0-8df8-d4b3ae400e25":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ebd31f2c-f7f7-44f8-b01f-94dafef7c5cf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"cda72dae-924c-4055-9059-2079684bfb19":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/7ac27cbe-3f0e-4bd9-9537-30f0a7a4f68c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A48Z&sr=b&sp=r&sig=WwEEH3rpk7QnwdsKN44WRYEkm180VCzmoTa6BnmFVYk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:48.0440022","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:07Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:40.592Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"4727cb2b-6f51-42ab-b498-bf0950a1fdc5":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"f625e4c6-bdbd-47e4-8934-9dbdd008abd5":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"95026edf-8043-45e0-bb97-99ed1b3599e7":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/acf1a8ad-7c62-4905-a48d-b6b7a4894fd3/2d53f92c-b4b8-4967-9d63-da63703046f1?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-29T19%3A27%3A01Z&ske=2023-10-31T02%3A57%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-29T23%3A21%3A51Z&sr=b&sp=r&sig=N3U0XJbAnS6q%2FHBgqamK6ni9coEX0xvpfdK4onxLcdo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-29T23:21:51.4616098","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-29T22:21:09.451Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-29T22:21:45.507Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1570'
+      - '1576'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 24 Oct 2023 12:28:48 GMT
+      - Sun, 29 Oct 2023 22:21:51 GMT
       mise-correlation-id:
-      - d548d590-2064-44f3-bfa4-644339c77a98
+      - 0cae38cc-ff09-4245-a3b7-68065f6a9783
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_update_with_config.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_update_with_config.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:00.0044305Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:00.0044305Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:33.1373332Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:33.1373332Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:32 GMT
+      - Tue, 24 Oct 2023 12:28:05 GMT
       etag:
-      - '"7500a84a-0000-0100-0000-653045350000"'
+      - '"d3004d39-0000-0100-0000-6537b8360000"'
       expires:
       - '-1'
       pragma:
@@ -55,7 +55,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 18 Oct 2023 20:51:34 GMT
+      - Tue, 24 Oct 2023 12:28:06 GMT
       mise-correlation-id:
-      - 209b556e-740a-4af7-a20e-928d1ead8a9e
+      - 2bdea251-e08c-4f21-87ce-da7a7f3b6950
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -101,26 +101,26 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:34.811Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:34.811Z","lastModifiedBy":"hbisht@microsoft.com"}'
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:07Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:07Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '531'
+      - '523'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:34 GMT
+      - Tue, 24 Oct 2023 12:28:07 GMT
       location:
-      - https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+      - https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 8a8457d5-362e-441e-b5d5-a38831f9d480
+      - 58abc321-7336-4874-a1a2-e019a140c185
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -140,7 +140,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -154,9 +154,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:35 GMT
+      - Tue, 24 Oct 2023 12:28:07 GMT
       mise-correlation-id:
-      - 373f553f-9db5-4248-91bd-773027b56332
+      - ea93d207-2f71-4216-9021-778498dbb4e1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -270,10 +270,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/bc00885c-c27a-4a62-b119-d030ef7624c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A36Z&sr=b&sp=r&sig=SWWX3jLojZciGM024OryVMut99UxKFrPsH%2B7alnKFnY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:36.5163455","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/83767374-609f-432a-af93-54a67fe1a1d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A07Z&sr=b&sp=r&sig=dHpOrsghD3V4q4GZB76aSr8x8bib908E8eOAyE%2BRvXE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:07.8627865","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -284,11 +284,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:36 GMT
+      - Tue, 24 Oct 2023 12:28:07 GMT
       location:
-      - https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - bbd44f7b-bbc6-4c1d-be42-aeda596956bc
+      - 04528c16-67a3-4a9e-a3db-03eb90cb96c1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -308,82 +308,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/bc00885c-c27a-4a62-b119-d030ef7624c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A36Z&sr=b&sp=r&sig=%2FU%2B59eB7lR33yFUX92Vob5UD%2FEadSqWf%2BSShBITRkDw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:36.7622316","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '557'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:51:36 GMT
-      mise-correlation-id:
-      - f51cffd7-b808-4330-b197-af602c5978c0
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/bc00885c-c27a-4a62-b119-d030ef7624c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A42Z&sr=b&sp=r&sig=XqyiDxJhMxcBujF%2BMjIrxu9zWpkn3JQa6USYmCIWS6U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:42.0258318","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:51:42 GMT
-      mise-correlation-id:
-      - c855e617-3935-4c45-8a8b-b050df5ca25f
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/bc00885c-c27a-4a62-b119-d030ef7624c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A47Z&sr=b&sp=r&sig=huNzaM28s8QOrRfkBb8oJ6H4493KQZf5aCZDSaW2kNs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:47.2894071","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/83767374-609f-432a-af93-54a67fe1a1d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A08Z&sr=b&sp=r&sig=cYnQ2uVLwj94CJMYZRLrT4nFgyPUWFtUIe9dyFATpTc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:08.1142697","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -394,9 +322,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:47 GMT
+      - Tue, 24 Oct 2023 12:28:08 GMT
       mise-correlation-id:
-      - 736702d6-71e3-4f7b-9c22-786377193c99
+      - 93ae755a-9bbc-4b6e-9f77-3307dee7e2d1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -416,23 +344,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/bc00885c-c27a-4a62-b119-d030ef7624c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A52Z&sr=b&sp=r&sig=h8jvHLsZJcACPKyQbujYTSQ4G1wAyOQKPY8dM78Wqno%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:52.6191623","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/83767374-609f-432a-af93-54a67fe1a1d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A13Z&sr=b&sp=r&sig=vUs%2BQDWtAEEc%2B8XP%2FOI%2B2mWv3sZhWLOWCREP3Tc7O7g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:13.4580758","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '547'
+      - '557'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:52 GMT
+      - Tue, 24 Oct 2023 12:28:13 GMT
       mise-correlation-id:
-      - dc537924-d442-477d-ae97-0b1ebc62e732
+      - 4a3de0bc-fce8-471c-a320-5170c29fb088
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -452,24 +380,96 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/bc00885c-c27a-4a62-b119-d030ef7624c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A52Z&sr=b&sp=r&sig=h%2BUmqSrQ7ecRw2VobuvZVjIU7wAHVhjY7Ff07z3xwOc%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:52.8672091","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:34.811Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:48.499Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/83767374-609f-432a-af93-54a67fe1a1d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A18Z&sr=b&sp=r&sig=xEHuMKxr%2Bmo73ZmxMyE68Qu%2FwHqKHyxB7n2RX7I2lF4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:18.8217629","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1102'
+      - '553'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:52 GMT
+      - Tue, 24 Oct 2023 12:28:18 GMT
       mise-correlation-id:
-      - 33643799-aac7-4280-b15e-7694defb4c2b
+      - cc041e73-e2cf-4e82-a7c2-5c65fa45531b
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/83767374-609f-432a-af93-54a67fe1a1d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A24Z&sr=b&sp=r&sig=UdsdP60%2F9LTCofNWnTT4TVWYak8VPoPndzEl3O90fLA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:24.0774826","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '549'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:28:24 GMT
+      mise-correlation-id:
+      - f487f77a-11a9-4a46-9004-130d452975b1
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/83767374-609f-432a-af93-54a67fe1a1d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A24Z&sr=b&sp=r&sig=YAVgfrxZSFwarqdILsuuT38mB0fpfdMykyvhq1%2BNoEs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:24.4546921","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:07Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:22.347Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1098'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:28:24 GMT
+      mise-correlation-id:
+      - 68110006-4497-4320-a77e-204692e55d5b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -492,7 +492,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:00.0044305Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:00.0044305Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:33.1373332Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:33.1373332Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -501,9 +501,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:53 GMT
+      - Tue, 24 Oct 2023 12:28:25 GMT
       etag:
-      - '"7500a84a-0000-0100-0000-653045350000"'
+      - '"d3004d39-0000-0100-0000-6537b8360000"'
       expires:
       - '-1'
       pragma:
@@ -533,24 +533,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/bc00885c-c27a-4a62-b119-d030ef7624c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A55Z&sr=b&sp=r&sig=V030pSNbPu5t6PItF9QgZbqLzWuuhdxFevKJ2UHgzLQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:55.1518952","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
-        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:34.811Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:48.499Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/83767374-609f-432a-af93-54a67fe1a1d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A33%3A11Z&ske=2023-10-25T14%3A03%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A27Z&sr=b&sp=r&sig=R5uHPRib434DBdeP5UIS2n2HVjon8fiLme0QYj1gX%2BA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:27.0021784","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:07Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:22.347Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1100'
+      - '1098'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:55 GMT
+      - Tue, 24 Oct 2023 12:28:27 GMT
       mise-correlation-id:
-      - b63cecfa-f4c7-48f9-983c-677d05cca070
+      - 38b0865f-d1c9-4000-9de9-4d88343a4786
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -563,10 +563,10 @@ interactions:
       command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
       {"a": null, "b": null, "rps": 1, "c": "5"}, "secrets": {}, "certificate": null,
       "loadTestConfiguration": {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs":
-      true}, "passFailCriteria": {"passFailMetrics": {"06a4f220-bc27-4113-b387-bdaf458fd95a":
+      true}, "passFailCriteria": {"passFailMetrics": {"53bc7b0e-f729-42a0-8df8-d4b3ae400e25":
       {"aggregate": "avg", "clientMetric": "requests_per_sec", "condition": ">", "value":
-      "78"}, "131623de-383c-4ebe-9c49-a0beb9fda712": {"aggregate": "percentage", "clientMetric":
-      "error", "condition": ">", "value": "50"}, "3b1169f5-2dbf-40cd-8c86-07dc8d73a4f0":
+      "78"}, "ebd31f2c-f7f7-44f8-b01f-94dafef7c5cf": {"aggregate": "percentage", "clientMetric":
+      "error", "condition": ">", "value": "50"}, "cda72dae-924c-4055-9059-2079684bfb19":
       {"aggregate": "avg", "clientMetric": "latency", "condition": ">", "value": "200",
       "requestName": "GetCustomerDetails"}}}}'
     headers:
@@ -583,24 +583,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"06a4f220-bc27-4113-b387-bdaf458fd95a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"131623de-383c-4ebe-9c49-a0beb9fda712":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3b1169f5-2dbf-40cd-8c86-07dc8d73a4f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/bc00885c-c27a-4a62-b119-d030ef7624c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A51%3A55Z&sr=b&sp=r&sig=qp%2BJyeGMQgARrbJeBXYUFMil0zlKpedQI9YAiVUlYrw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:51:55.5253775","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:34.811Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:51:55.514Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"53bc7b0e-f729-42a0-8df8-d4b3ae400e25":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ebd31f2c-f7f7-44f8-b01f-94dafef7c5cf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"cda72dae-924c-4055-9059-2079684bfb19":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/83767374-609f-432a-af93-54a67fe1a1d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A27Z&sr=b&sp=r&sig=9jB%2BUrRe72isN1azbw0IfTLD2XMZzqoIY%2Bkq%2Fm6FuXw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:27.3629286","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:07Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:27.35Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1576'
+      - '1575'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:55 GMT
+      - Tue, 24 Oct 2023 12:28:27 GMT
       mise-correlation-id:
-      - 6c1b0240-7de7-4e63-9a28-7e35e30e1fa2
+      - 579dc323-45d1-4d90-bc0f-9b7cd81583b4
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -620,23 +620,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/bc00885c-c27a-4a62-b119-d030ef7624c5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T19%3A07%3A11Z&ske=2023-10-20T02%3A37%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A55Z&sr=b&sp=r&sig=zuV9IIzIPV2PAkbC762n91YQj1JRSU5%2Bikk0XucUAJs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:55.7840187","validationStatus":"VALIDATION_SUCCESS"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/83767374-609f-432a-af93-54a67fe1a1d2?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A27Z&sr=b&sp=r&sig=OhRqw948uag%2BVH3Xk1kMlxRgTNlVC2%2BgsFs5qJIf4L4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:27.6129843","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '561'
+      - '563'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:55 GMT
+      - Tue, 24 Oct 2023 12:28:27 GMT
       mise-correlation-id:
-      - 377af9eb-d012-4d02-935b-f1f5b5e3e8eb
+      - 5f100e0c-5d99-4bdc-b506-95270840ad98
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -658,7 +658,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -668,9 +668,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Wed, 18 Oct 2023 20:51:56 GMT
+      - Tue, 24 Oct 2023 12:28:28 GMT
       mise-correlation-id:
-      - 617a9c5d-2d96-4180-a736-26c727acea90
+      - a946e8ed-4cc3-4dd3-9692-379b6a1f98e1
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -784,25 +784,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/c6c42096-7ae4-458a-a174-db531a980d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A47%3A10Z&ske=2023-10-19T23%3A17%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A56Z&sr=b&sp=r&sig=5bTdI8u0uJQbTY8Rz88zsMwhIgIP8kLYQ5QR%2BqPmSHI%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:56.5968824","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/7ac27cbe-3f0e-4bd9-9537-30f0a7a4f68c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A28Z&sr=b&sp=r&sig=FXDb6r2Ku9TiAGKHT8T0QgdYSnDKGKtBlm0UTEdRQCw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:28.7958483","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '551'
+      - '549'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:51:56 GMT
+      - Tue, 24 Oct 2023 12:28:28 GMT
       location:
-      - https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 44c2b38b-11f1-45d6-9425-de352ef520ca
+      - 942d36e7-0d1e-47a4-ac40-fc7f3a645eb9
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -822,46 +822,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/c6c42096-7ae4-458a-a174-db531a980d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A01%3A56Z&sr=b&sp=r&sig=1GMk0qsi2NwQhsn1bNLHNHtCYPnmpjDHBbelzIrtSSQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:01:56.8426872","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Oct 2023 20:51:56 GMT
-      mise-correlation-id:
-      - 9f1cbcab-8b0c-4e7e-ae49-d2ea42c71a06
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/c6c42096-7ae4-458a-a174-db531a980d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A02Z&sr=b&sp=r&sig=ilpzFz3RBtMQKZVcETysvISy%2BvyyAJbv%2FTl0ltaM0gM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:02.1373636","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/7ac27cbe-3f0e-4bd9-9537-30f0a7a4f68c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A01%3A55Z&ske=2023-10-25T18%3A31%3A55Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A29Z&sr=b&sp=r&sig=THMWtfF4nKQKm%2FnuZ4qcnxAxOYqQ1B3Dm6694ASS%2BvA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:29.1344491","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -872,9 +836,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:02 GMT
+      - Tue, 24 Oct 2023 12:28:29 GMT
       mise-correlation-id:
-      - 3a66d99e-d1cf-4682-8652-19e3a7257c69
+      - 07e30515-795b-4db5-b410-3174b543f69b
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -894,23 +858,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/c6c42096-7ae4-458a-a174-db531a980d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A07Z&sr=b&sp=r&sig=ZpmgwEnsaDQ1S9qJWDzPlDUbkIFhFofUHGBq48yScwY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:07.4225292","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/7ac27cbe-3f0e-4bd9-9537-30f0a7a4f68c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A34Z&sr=b&sp=r&sig=bWXFuTqZVdO6U522X7pJdtApgHhkMIruQ99Y%2BdySapo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:34.3899846","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '549'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:07 GMT
+      - Tue, 24 Oct 2023 12:28:34 GMT
       mise-correlation-id:
-      - f9849637-b13d-4e56-b3d6-6f5e2408e640
+      - 4c072fdb-9dc0-4ef6-aa23-6f6dde32f238
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -930,10 +894,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/c6c42096-7ae4-458a-a174-db531a980d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T16%3A22%3A01Z&ske=2023-10-19T23%3A52%3A01Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A02%3A12Z&sr=b&sp=r&sig=nB1LV57fGMzmQqpzgPKa56a9PpqE9vqABxVJngk7Chw%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:02:12.6777542","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/7ac27cbe-3f0e-4bd9-9537-30f0a7a4f68c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T06%3A42%3A10Z&ske=2023-10-25T14%3A12%3A10Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A39Z&sr=b&sp=r&sig=X3DQzSrNGJa2uyGhetPsY92hNZADfiR2hGRb%2FY8LdL0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:39.6550924","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 24 Oct 2023 12:28:39 GMT
+      mise-correlation-id:
+      - 4ff6176a-86dd-439f-b8e8-f2b19f88f49a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/7ac27cbe-3f0e-4bd9-9537-30f0a7a4f68c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T09%3A22%3A05Z&ske=2023-10-25T16%3A52%3A05Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T12%3A38%3A45Z&sr=b&sp=r&sig=v7k6XSCHfThKgiwLvp5pmtuTkxiBCy3UgtRC2bw3Dnk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T12:38:45.5482955","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -944,9 +944,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:12 GMT
+      - Tue, 24 Oct 2023 12:28:45 GMT
       mise-correlation-id:
-      - 6feef90e-55aa-4c1e-a135-cd8aba38041a
+      - 232a17fd-3996-47ab-a616-e53e4dbeff1a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -966,24 +966,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"06a4f220-bc27-4113-b387-bdaf458fd95a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"131623de-383c-4ebe-9c49-a0beb9fda712":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3b1169f5-2dbf-40cd-8c86-07dc8d73a4f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/c6c42096-7ae4-458a-a174-db531a980d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T18%3A03%3A13Z&ske=2023-10-20T01%3A33%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A12Z&sr=b&sp=r&sig=yAtjZSHZnnJfVZ8ZH1dGHzLLBTYzyvqC55d8OvSE61E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:12.992206","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:34.811Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:08.631Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"53bc7b0e-f729-42a0-8df8-d4b3ae400e25":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ebd31f2c-f7f7-44f8-b01f-94dafef7c5cf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"cda72dae-924c-4055-9059-2079684bfb19":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/7ac27cbe-3f0e-4bd9-9537-30f0a7a4f68c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T11%3A25%3A47Z&ske=2023-10-25T18%3A55%3A47Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A45Z&sr=b&sp=r&sig=b9ZEplacjCzH4HNsa0COxv2AlqfQRF1hcGw5WboED3E%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:45.8083649","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:07Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:40.592Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1573'
+      - '1570'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:12 GMT
+      - Tue, 24 Oct 2023 12:28:45 GMT
       mise-correlation-id:
-      - 13aa75d6-bdeb-43cb-84f5-4de14db2488c
+      - c3ab6d9a-61c1-4647-b25a-c27f6abc5b5f
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1006,7 +1006,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-18T20:51:00.0044305Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-18T20:51:00.0044305Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-24T12:27:33.1373332Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-24T12:27:33.1373332Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1015,9 +1015,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:12 GMT
+      - Tue, 24 Oct 2023 12:28:46 GMT
       etag:
-      - '"7500a84a-0000-0100-0000-653045350000"'
+      - '"d3004d39-0000-0100-0000-6537b8360000"'
       expires:
       - '-1'
       pragma:
@@ -1047,24 +1047,24 @@ interactions:
       User-Agent:
       - AZURECLI/2.53.0 azsdk-python-core/1.26.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://9e052cb8-14cb-41d1-96ef-a1cf051c1fd0.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+    uri: https://bf4882e7-b649-4c0f-8d26-173765d4db45.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"06a4f220-bc27-4113-b387-bdaf458fd95a":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"131623de-383c-4ebe-9c49-a0beb9fda712":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"3b1169f5-2dbf-40cd-8c86-07dc8d73a4f0":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/9239e39f-cb84-48e5-b427-6567ce621560/c6c42096-7ae4-458a-a174-db531a980d79?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-18T15%3A26%3A00Z&ske=2023-10-19T22%3A56%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-18T21%3A52%3A14Z&sr=b&sp=r&sig=uDSHnd7%2BULYrNi1hCrNc5HhZwSzaXOGTny%2Bt8Pi2lwE%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-18T21:52:14.6401646","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-18T20:51:34.811Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-18T20:52:08.631Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"53bc7b0e-f729-42a0-8df8-d4b3ae400e25":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"ebd31f2c-f7f7-44f8-b01f-94dafef7c5cf":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"cda72dae-924c-4055-9059-2079684bfb19":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/1be5271c-ea40-4042-ab24-740de12eda6b/7ac27cbe-3f0e-4bd9-9537-30f0a7a4f68c?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-24T07%3A22%3A00Z&ske=2023-10-25T14%3A52%3A00Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-24T13%3A28%3A48Z&sr=b&sp=r&sig=WwEEH3rpk7QnwdsKN44WRYEkm180VCzmoTa6BnmFVYk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-24T13:28:48.0440022","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-24T12:28:07Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-24T12:28:40.592Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1578'
+      - '1570'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Oct 2023 20:52:14 GMT
+      - Tue, 24 Oct 2023 12:28:48 GMT
       mise-correlation-id:
-      - ab07fbc4-940d-40a9-8f7d-f6390ca4a99b
+      - d548d590-2064-44f3-bfa4-644339c77a98
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:

--- a/src/load/azext_load/tests/latest/recordings/test_load_test_update_with_config.yaml
+++ b/src/load/azext_load/tests/latest/recordings/test_load_test_update_with_config.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:58.5677517Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:58.5677517Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:27.0373117Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:27.0373117Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -23,9 +23,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:32 GMT
+      - Mon, 09 Oct 2023 16:12:01 GMT
       etag:
-      - '"9201ee96-0000-0100-0000-652425d90000"'
+      - '"9201eba7-0000-0100-0000-652426310000"'
       expires:
       - '-1'
       pragma:
@@ -55,11 +55,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"TestNotFound","message":"Test couldn''t find with
-        given identifier file-test-case","target":null,"details":null}}'
+        given identifier update-with-config-test-case","target":null,"details":null}}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -68,9 +68,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 09 Oct 2023 16:10:33 GMT
+      - Mon, 09 Oct 2023 16:12:02 GMT
       mise-correlation-id:
-      - 473d04da-49d9-48a2-8249-017ec12b2099
+      - 06aed824-0314-465c-b0b0-35a09737e9fb
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       transfer-encoding:
@@ -83,15 +83,10 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"displayName": "CLI-Test", "description": "Test created from az load test
-      command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
-      {"rps": 1, "duration_in_sec": "1"}, "secrets": {}, "certificate": null, "loadTestConfiguration":
-      {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs": false}, "passFailCriteria":
-      {"passFailMetrics": {"f1031edb-1077-4996-9aba-e9f2a5ae6f66": {"aggregate": "avg",
-      "clientMetric": "requests_per_sec", "condition": ">", "value": "78"}, "1f15e734-c205-472d-8db8-670165b574ba":
-      {"aggregate": "percentage", "clientMetric": "error", "condition": ">", "value":
-      "50"}, "d7cdca7d-179b-4d71-8d89-db24c73787bf": {"aggregate": "avg", "clientMetric":
-      "latency", "condition": ">", "value": "200", "requestName": "GetCustomerDetails"}}}}'
+    body: '{"displayName": "Create_with_args_test", "description": "This is a load
+      test created with arguments", "keyvaultReferenceIdentityType": "SystemAssigned",
+      "environmentVariables": {"a": "2", "b": "3"}, "secrets": {}, "loadTestConfiguration":
+      {"engineInstances": 5, "quickStartTest": false, "splitAllCSVs": false}}'
     headers:
       Accept:
       - application/json
@@ -100,32 +95,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '789'
+      - '310'
       Content-Type:
       - application/merge-patch+json
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PATCH
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f1031edb-1077-4996-9aba-e9f2a5ae6f66":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1f15e734-c205-472d-8db8-670165b574ba":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d7cdca7d-179b-4d71-8d89-db24c73787bf":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:10:34.569Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:34.569Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:02.819Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:02.819Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1006'
+      - '531'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:34 GMT
+      - Mon, 09 Oct 2023 16:12:02 GMT
       location:
-      - https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+      - https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
       mise-correlation-id:
-      - 68202cd5-4ff3-48fb-aef5-8e2940bf555e
+      - c45500a2-ac2b-4cd1-a387-af70f93bac6d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -145,7 +140,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
   response:
     body:
       string: '{"value":[]}'
@@ -159,9 +154,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:34 GMT
+      - Mon, 09 Oct 2023 16:12:03 GMT
       mise-correlation-id:
-      - f903845c-d793-4322-913c-9ebfd3322392
+      - 7135ce96-7f0f-49cb-a0df-a30aeb482c60
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -275,25 +270,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/56e6a696-040b-487d-a86a-1331e0c82bd5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A35Z&sr=b&sp=r&sig=l2bT6T7XHYlbdkPrf6Dn5MsXHFA%2BOq7ErzOCMsbfljQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:35.390411","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/23666a64-0fe8-4f63-9b60-92f64c491b6b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A03Z&sr=b&sp=r&sig=Y3WyUP6raaWA%2F3hUp%2B6H0i%2FI5n9ulvz6wZH5Soeidsk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:03.6203185","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '550'
+      - '555'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:35 GMT
+      - Mon, 09 Oct 2023 16:12:03 GMT
       location:
-      - https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - e2c70368-ca3f-4e1a-987f-647a24e1dd7e
+      - 2deed28b-40bc-4d53-8b3f-ce2decd7f21a
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -313,82 +308,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/56e6a696-040b-487d-a86a-1331e0c82bd5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A35Z&sr=b&sp=r&sig=cke9Y3fFoB%2FoSVavEvoTDPjMbDiBUEq2z%2B3%2F3bmJ910%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:35.9194169","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '555'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:10:35 GMT
-      mise-correlation-id:
-      - 2ea74362-796e-432b-9088-594d6eaebf2a
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/56e6a696-040b-487d-a86a-1331e0c82bd5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A41Z&sr=b&sp=r&sig=qB2c9ymlLGWeHBHwJpPO39UZmJchFvjH1OUaTcCDp7g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:41.2280139","validationStatus":"VALIDATION_INITIATED"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '549'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:10:41 GMT
-      mise-correlation-id:
-      - ae40716c-7de9-4dea-b4c2-3481792a6cc3
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/56e6a696-040b-487d-a86a-1331e0c82bd5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A46Z&sr=b&sp=r&sig=Yws2SsdT7My5%2BBvaO6UQ60rHlP1nhrf05vaiIWOhw7o%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:46.5376017","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/23666a64-0fe8-4f63-9b60-92f64c491b6b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A03Z&sr=b&sp=r&sig=EHwDy1IRFOvrk5tiua%2F5FAB0OszXIZUoPbl4ScZDu84%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:03.8845122","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -399,9 +322,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:46 GMT
+      - Mon, 09 Oct 2023 16:12:03 GMT
       mise-correlation-id:
-      - cb831a47-bfe5-4229-9116-1cc6c8f1c0c0
+      - d77d2eec-9398-4a2f-a735-ab7a13c63e62
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -421,23 +344,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/56e6a696-040b-487d-a86a-1331e0c82bd5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A20%3A51Z&sr=b&sp=r&sig=GnK3BjVu15Q1vRNjw%2BpoahazcVoGS%2FFldG2%2B%2FvqHjtA%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:20:51.8648996","validationStatus":"VALIDATION_SUCCESS"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/23666a64-0fe8-4f63-9b60-92f64c491b6b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A09Z&sr=b&sp=r&sig=Trged6X8PK8A1n%2BZ3WKQQljq5gHsbj2ZO5EYyEuErwk%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:09.1624704","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '555'
+      - '551'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:51 GMT
+      - Mon, 09 Oct 2023 16:12:09 GMT
       mise-correlation-id:
-      - 7b02a0d4-3086-4d9b-bf26-3bc16cba3f9e
+      - df90cded-0604-40bb-8428-e6e8c2fac256
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -457,11 +380,214 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case?api-version=2022-11-01
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"passFailCriteria":{"passFailMetrics":{"f1031edb-1077-4996-9aba-e9f2a5ae6f66":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1f15e734-c205-472d-8db8-670165b574ba":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d7cdca7d-179b-4d71-8d89-db24c73787bf":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/56e6a696-040b-487d-a86a-1331e0c82bd5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A10%3A52Z&sr=b&sp=r&sig=aLhWzsRCRczJXSLzVuC4XgGk7XKzz8sVTv3sypREfw0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:10:52.124739","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:10:34.569Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:47.982Z","lastModifiedBy":"hbisht@microsoft.com"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/23666a64-0fe8-4f63-9b60-92f64c491b6b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A14Z&sr=b&sp=r&sig=EsO6%2BWftMLQ7xZ88c2eMLnIEi6qgSnO4tzbFDcdW8s8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:14.4351041","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:12:14 GMT
+      mise-correlation-id:
+      - fc094093-4100-406b-b0b1-fc9c7efc972a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/23666a64-0fe8-4f63-9b60-92f64c491b6b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A19Z&sr=b&sp=r&sig=GTI9qNRYB6qPzu%2BMf%2FvRmQLk3Bgrd0dBl120s2hRe%2F4%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:19.7078802","validationStatus":"VALIDATION_SUCCESS"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:12:19 GMT
+      mise-correlation-id:
+      - 93c1068c-7374-4700-9147-6a7815be8017
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/23666a64-0fe8-4f63-9b60-92f64c491b6b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A19Z&sr=b&sp=r&sig=T84G5CdtKIrOG66SfpxJk1M4iKbqNcvzbxETSaGbeYo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:19.9921312","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:02.819Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:17.276Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1100'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:12:19 GMT
+      mise-correlation-id:
+      - 5ebf099e-5906-4a30-b72e-5fe12b371f05
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:27.0373117Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:27.0373117Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:12:21 GMT
+      etag:
+      - '"9201eba7-0000-0100-0000-652426310000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"environmentVariables":{"a":"2","b":"3"},"loadTestConfiguration":{"engineInstances":5,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/23666a64-0fe8-4f63-9b60-92f64c491b6b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A22Z&sr=b&sp=r&sig=xjPJC7FpwO8cvSCFlvDkSthVX9Rz4cfwezU4yUIZP2U%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:22.2078858","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"This
+        is a load test created with arguments","displayName":"Create_with_args_test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:02.819Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:17.276Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1100'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:12:22 GMT
+      mise-correlation-id:
+      - 0f895127-9855-44ea-84d7-a62cfdbfd69a
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"displayName": "CLI-Test", "description": "Test created from az load test
+      command", "keyvaultReferenceIdentityType": "SystemAssigned", "environmentVariables":
+      {"a": null, "b": null, "rps": 1, "c": "5"}, "secrets": {}, "certificate": null,
+      "loadTestConfiguration": {"engineInstances": 1, "quickStartTest": false, "splitAllCSVs":
+      true}, "passFailCriteria": {"passFailMetrics": {"e70fc29a-37fa-43c4-a8a2-c55805b054af":
+      {"aggregate": "avg", "clientMetric": "requests_per_sec", "condition": ">", "value":
+      "78"}, "78413f80-77b8-4f6d-a636-99caa4dfd401": {"aggregate": "percentage", "clientMetric":
+      "error", "condition": ">", "value": "50"}, "9538e4f8-3341-4d0f-9dc4-c97e67a1f04c":
+      {"aggregate": "avg", "clientMetric": "latency", "condition": ">", "value": "200",
+      "requestName": "GetCustomerDetails"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '796'
+      Content-Type:
+      - application/merge-patch+json
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: PATCH
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"e70fc29a-37fa-43c4-a8a2-c55805b054af":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"78413f80-77b8-4f6d-a636-99caa4dfd401":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9538e4f8-3341-4d0f-9dc4-c97e67a1f04c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/23666a64-0fe8-4f63-9b60-92f64c491b6b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A22Z&sr=b&sp=r&sig=kcB5E4WCVC3RiWglgEdHdDCiJ32tF6wT1bRbiUP090Y%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:22.5884381","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:02.819Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:22.579Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -472,57 +598,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:52 GMT
+      - Mon, 09 Oct 2023 16:12:22 GMT
       mise-correlation-id:
-      - 4dc219b2-bbdf-4d6e-a75f-5ac4dd059239
+      - 9272a82d-a85d-4bfe-a382-a690cf3cd9a0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
       - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:58.5677517Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:58.5677517Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:10:52 GMT
-      etag:
-      - '"9201ee96-0000-0100-0000-652425d90000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
     status:
       code: 200
       message: OK
@@ -538,72 +620,27 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests?api-version=2022-11-01
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"passFailCriteria":{"passFailMetrics":{"f1031edb-1077-4996-9aba-e9f2a5ae6f66":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"1f15e734-c205-472d-8db8-670165b574ba":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"d7cdca7d-179b-4d71-8d89-db24c73787bf":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","duration_in_sec":"1"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":false,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/56e6a696-040b-487d-a86a-1331e0c82bd5?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A10%3A53Z&sr=b&sp=r&sig=YbGDVhQ47BkwrFVtzqGwOn%2BDnAZPD%2FajzcckHjJeBK8%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:10:53.8063922","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"file-test-case","description":"Test
-        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:10:34.569Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:10:47.982Z","lastModifiedBy":"hbisht@microsoft.com"}]}'
+      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/23666a64-0fe8-4f63-9b60-92f64c491b6b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A22Z&sr=b&sp=r&sig=mDxqAsJaw82xJuQddggfwG4%2FnLcZ53VW3eUe1GG9r2g%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:22.8586139","validationStatus":"VALIDATION_SUCCESS"}]}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '1591'
+      - '561'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:10:53 GMT
+      - Mon, 09 Oct 2023 16:12:22 GMT
       mise-correlation-id:
-      - afcc6e98-f009-4b24-b099-5cab4d1df2d2
+      - 7878d8bc-8acc-4aee-bf10-cd143c1f383d
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
       - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:58.5677517Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:58.5677517Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:10:54 GMT
-      etag:
-      - '"9201ee96-0000-0100-0000-652425d90000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
     status:
       code: 200
       message: OK
@@ -621,7 +658,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -631,9 +668,9 @@ interactions:
       connection:
       - keep-alive
       date:
-      - Mon, 09 Oct 2023 16:10:56 GMT
+      - Mon, 09 Oct 2023 16:12:23 GMT
       mise-correlation-id:
-      - 59949f69-984b-448d-9572-09c95a003c4b
+      - d80d0dcd-ec83-40ed-a363-2b678ea29066
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -641,130 +678,6 @@ interactions:
     status:
       code: 204
       message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:58.5677517Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:58.5677517Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:10:57 GMT
-      etag:
-      - '"9201ee96-0000-0100-0000-652425d90000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:10:58 GMT
-      mise-correlation-id:
-      - ff210269-447e-4789-b04a-2cde322e0b97
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:58.5677517Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:58.5677517Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:11:00 GMT
-      etag:
-      - '"9201ee96-0000-0100-0000-652425d90000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
 - request:
     body: !!python/object/new:_io.BytesIO
       state: !!python/tuple
@@ -871,10 +784,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?fileType=JMX_FILE&api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/65e56535-8aef-4dfd-a459-9703f191df7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A02Z&sr=b&sp=r&sig=MtvbPC2ZL%2Fe%2BEtrcDpVf3yLH2KVXTZT6i2l3F2VuqgY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:02.9718868","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/969f609a-7c5e-4cfd-ac37-c201d9219cc9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A23Z&sr=b&sp=r&sig=uLQooBlPF%2BXZtAxmVRYl3GTSeatlcFWVRRV7yXxz%2Fes%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:23.7145538","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -885,11 +798,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:02 GMT
+      - Mon, 09 Oct 2023 16:12:23 GMT
       location:
-      - https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+      - https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
       mise-correlation-id:
-      - 2449f433-a1e0-47db-bb59-8623877b39cb
+      - 4b29e6ee-4f34-4408-86b4-36af8e314e6e
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -909,10 +822,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/65e56535-8aef-4dfd-a459-9703f191df7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A03Z&sr=b&sp=r&sig=m1MaEcG5r%2BbY4VHPHfUXFcUBHJCnf2NINrl3GTryC3A%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:03.3490215","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/969f609a-7c5e-4cfd-ac37-c201d9219cc9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A23Z&sr=b&sp=r&sig=D0yXpous1nRQF94ZrXclq%2FiaHZJF870RbBasMoJsGA0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:23.9806843","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -923,9 +836,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:03 GMT
+      - Mon, 09 Oct 2023 16:12:23 GMT
       mise-correlation-id:
-      - d163d35c-071d-4d9c-bb69-60f0eff872c7
+      - 4be86ecc-fa1b-4f3d-8841-d8ca92c45ac0
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -945,23 +858,23 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/65e56535-8aef-4dfd-a459-9703f191df7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A02%3A04Z&ske=2023-10-10T19%3A32%3A04Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A08Z&sr=b&sp=r&sig=YH%2FaTJQ9%2BchRn3WHV2veRj424hRxn59G4VP37nuI4YY%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:08.669138","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/969f609a-7c5e-4cfd-ac37-c201d9219cc9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A09%3A23Z&ske=2023-10-10T18%3A39%3A23Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A29Z&sr=b&sp=r&sig=EOqmrrwDGU98hx74%2Fs3PH0KlSX6JbhQeqfVUbixvYbs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:29.257052","validationStatus":"VALIDATION_INITIATED"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '552'
+      - '550'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:08 GMT
+      - Mon, 09 Oct 2023 16:12:29 GMT
       mise-correlation-id:
-      - 2584420e-7dd8-4293-9268-a8eef56cf201
+      - 2e5e268a-7843-499d-a56b-017ab724e7e5
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -981,10 +894,46 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
   response:
     body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/65e56535-8aef-4dfd-a459-9703f191df7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A13Z&sr=b&sp=r&sig=qwQDa8r%2FJ%2FhazsYX4ZinD10OGvRmyIM9I14V3GtImQo%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:13.9958529","validationStatus":"VALIDATION_INITIATED"}'
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/969f609a-7c5e-4cfd-ac37-c201d9219cc9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T10%3A03%3A11Z&ske=2023-10-10T17%3A33%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A34Z&sr=b&sp=r&sig=hhzrWQ55cZk0HCmL2JR1UHPVdtxV6KAaV7h%2FE6z3Sbs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:34.5244147","validationStatus":"VALIDATION_INITIATED"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '551'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:12:34 GMT
+      mise-correlation-id:
+      - dcacd873-292b-4a8d-9c63-5b1961115753
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
+  response:
+    body:
+      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/969f609a-7c5e-4cfd-ac37-c201d9219cc9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A22%3A39Z&sr=b&sp=r&sig=2Gz%2FgfozURdWhVFcuad9aAagt1Kzm2Is%2FEnLIf%2FcKIQ%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:22:39.8083017","validationStatus":"VALIDATION_SUCCESS"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
@@ -995,9 +944,46 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:13 GMT
+      - Mon, 09 Oct 2023 16:12:39 GMT
       mise-correlation-id:
-      - c962f202-bb3e-4821-aca2-528d7466a8aa
+      - 4cadea35-4504-4d2c-bec3-9cc472ed37cb
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
+  response:
+    body:
+      string: '{"passFailCriteria":{"passFailMetrics":{"e70fc29a-37fa-43c4-a8a2-c55805b054af":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"78413f80-77b8-4f6d-a636-99caa4dfd401":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9538e4f8-3341-4d0f-9dc4-c97e67a1f04c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/969f609a-7c5e-4cfd-ac37-c201d9219cc9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T11%3A06%3A38Z&ske=2023-10-10T18%3A36%3A38Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A40Z&sr=b&sp=r&sig=CKhALKn02FjOFn03MKtr6i%2FcKKWRIsArjc7lVZ3Mmhs%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:40.0736388","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:02.819Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:36.029Z","lastModifiedBy":"hbisht@microsoft.com"}'
+    headers:
+      api-supported-versions:
+      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
+      connection:
+      - keep-alive
+      content-length:
+      - '1576'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 09 Oct 2023 16:12:40 GMT
+      mise-correlation-id:
+      - 3b940332-5d92-42c3-9b28-0cd5d9d4a725
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
@@ -1020,7 +1006,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:58.5677517Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:58.5677517Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:11:27.0373117Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:11:27.0373117Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1029,9 +1015,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:14 GMT
+      - Mon, 09 Oct 2023 16:12:41 GMT
       etag:
-      - '"9201ee96-0000-0100-0000-652425d90000"'
+      - '"9201eba7-0000-0100-0000-652426310000"'
       expires:
       - '-1'
       pragma:
@@ -1061,220 +1047,28 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files?api-version=2022-11-01
+    uri: https://60471e49-9927-4ddb-bcbd-ea64579bbe1b.eastus.cnt-prod.loadtesting.azure.com/tests/update-with-config-test-case?api-version=2022-11-01
   response:
     body:
-      string: '{"value":[{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/65e56535-8aef-4dfd-a459-9703f191df7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A15Z&sr=b&sp=r&sig=eBkPBRUAxpxlZdQn0sTAOlOVw8XX1gddFHJqOvo5%2Bp0%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:15.7412449","validationStatus":"VALIDATION_INITIATED"}]}'
+      string: '{"passFailCriteria":{"passFailMetrics":{"e70fc29a-37fa-43c4-a8a2-c55805b054af":{"clientMetric":"requests_per_sec","aggregate":"avg","condition":">","value":78.0,"action":"continue"},"78413f80-77b8-4f6d-a636-99caa4dfd401":{"clientMetric":"error","aggregate":"percentage","condition":">","value":50.0,"action":"continue"},"9538e4f8-3341-4d0f-9dc4-c97e67a1f04c":{"clientMetric":"latency","aggregate":"avg","condition":">","requestName":"GetCustomerDetails","value":200.0,"action":"continue"}}},"environmentVariables":{"rps":"1","c":"5"},"loadTestConfiguration":{"engineInstances":1,"splitAllCSVs":true,"quickStartTest":false},"inputArtifacts":{"testScriptFileInfo":{"url":"https://maltccstorageaccounteus.blob.core.windows.net/6711ac50-3b99-44a6-8d71-bd5f1a83f77f/969f609a-7c5e-4cfd-ac37-c201d9219cc9?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T17%3A12%3A42Z&sr=b&sp=r&sig=mnRJ8Xo1Z8HLSDIPWvhQpjrYXF6UOLsFmjrHnwa3IYM%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T17:12:42.2650614","validationStatus":"VALIDATION_SUCCESS"},"additionalFileInfo":[]},"testId":"update-with-config-test-case","description":"Test
+        created from az load test command","displayName":"CLI-Test","keyvaultReferenceIdentityType":"SystemAssigned","createdDateTime":"2023-10-09T16:12:02.819Z","createdBy":"hbisht@microsoft.com","lastModifiedDateTime":"2023-10-09T16:12:36.029Z","lastModifiedBy":"hbisht@microsoft.com"}'
     headers:
       api-supported-versions:
       - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
       connection:
       - keep-alive
       content-length:
-      - '563'
+      - '1574'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 09 Oct 2023 16:11:15 GMT
+      - Mon, 09 Oct 2023 16:12:42 GMT
       mise-correlation-id:
-      - bc68cc02-30c1-48e7-948f-e676789c4d70
+      - afc9d033-40ca-4ae2-9d0b-400ecd380104
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       x-content-type-options:
       - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-mgmt-loadtesting/1.0.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002?api-version=2022-12-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-load-000001/providers/Microsoft.LoadTestService/loadTests/clitest-load-000002","name":"clitest-load-000002","type":"microsoft.loadtestservice/loadtests","location":"eastus","systemData":{"createdBy":"hbisht@microsoft.com","createdByType":"User","createdAt":"2023-10-09T16:09:58.5677517Z","lastModifiedBy":"hbisht@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-10-09T16:09:58.5677517Z"},"identity":{"type":"None"},"properties":{"description":null,"dataPlaneURI":"be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com","encryption":null,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '690'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:11:16 GMT
-      etag:
-      - '"9201ee96-0000-0100-0000-652425d90000"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-providerhub-traffic:
-      - 'True'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-core/1.24.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
-    method: GET
-    uri: https://be20f0d8-3453-461d-8963-3edce8d63b39.eastus.cnt-prod.loadtesting.azure.com/tests/file-test-case/files/sample-JMX-file.jmx?api-version=2022-11-01
-  response:
-    body:
-      string: '{"url":"https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/65e56535-8aef-4dfd-a459-9703f191df7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A17Z&sr=b&sp=r&sig=mOe9JbCGp4YYMduRRdYH0kGNtfuZHOyPulS90X%2Fd%2Fps%3D","fileName":"sample-JMX-file.jmx","fileType":"JMX_FILE","expireDateTime":"2023-10-09T16:21:17.9891097","validationStatus":"VALIDATION_SUCCESS"}'
-    headers:
-      api-supported-versions:
-      - 2021-07-01-preview, 2022-06-01-preview, 2022-11-01, 2023-04-01-preview
-      connection:
-      - keep-alive
-      content-length:
-      - '551'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 09 Oct 2023 16:11:17 GMT
-      mise-correlation-id:
-      - 06bf1be2-7e1a-4f96-ad9b-5d68be2e6bf9
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: https://maltccstorageaccounteus.blob.core.windows.net/c816ea8f-89e0-4044-9561-8a712b81a3fa/65e56535-8aef-4dfd-a459-9703f191df7b?skoid=713ccf3d-dc33-4787-a1ee-6b0cc537c37a&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skt=2023-10-09T15%3A02%3A11Z&ske=2023-10-11T00%3A32%3A11Z&sks=b&skv=2021-10-04&sv=2021-10-04&se=2023-10-09T16%3A21%3A17Z&sr=b&sp=r&sig=mOe9JbCGp4YYMduRRdYH0kGNtfuZHOyPulS90X%2Fd%2Fps%3D
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<jmeterTestPlan version=\"1.2\"
-        properties=\"5.0\" jmeter=\"5.5\">\r\n  <hashTree>\r\n    <TestPlan guiclass=\"TestPlanGui\"
-        testclass=\"TestPlan\" testname=\"Azure Load Testing\" enabled=\"true\">\r\n
-        \     <stringProp name=\"TestPlan.comments\"></stringProp>\r\n      <boolProp
-        name=\"TestPlan.functional_mode\">false</boolProp>\r\n      <boolProp name=\"TestPlan.tearDown_on_shutdown\">true</boolProp>\r\n
-        \     <boolProp name=\"TestPlan.serialize_threadgroups\">false</boolProp>\r\n
-        \     <elementProp name=\"TestPlan.user_defined_variables\" elementType=\"Arguments\"
-        guiclass=\"ArgumentsPanel\" testclass=\"Arguments\" testname=\"User Defined
-        Variables\" enabled=\"true\">\r\n        <collectionProp name=\"Arguments.arguments\"/>\r\n
-        \     </elementProp>\r\n      <stringProp name=\"TestPlan.user_define_classpath\"></stringProp>\r\n
-        \   </TestPlan>\r\n    <hashTree>\r\n      <Arguments guiclass=\"ArgumentsPanel\"
-        testclass=\"Arguments\" testname=\"User Defined Variables\" enabled=\"true\">\r\n
-        \       <collectionProp name=\"Arguments.arguments\">\r\n          <elementProp
-        name=\"duration_in_sec\" elementType=\"Argument\">\r\n            <stringProp
-        name=\"Argument.name\">duration_in_sec</stringProp>\r\n            <stringProp
-        name=\"Argument.value\">${__groovy( System.getenv(&quot;duration_in_sec&quot;)
-        ?: &quot;10&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
-        \         </elementProp>\r\n          <elementProp name=\"rps\" elementType=\"Argument\">\r\n
-        \           <stringProp name=\"Argument.name\">rps</stringProp>\r\n            <stringProp
-        name=\"Argument.value\">${__groovy( System.getenv(&quot;rps&quot;) ?: &quot;1&quot;
-        )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
-        \         </elementProp>\r\n          <elementProp name=\"domain\" elementType=\"Argument\">\r\n
-        \           <stringProp name=\"Argument.name\">domain</stringProp>\r\n            <stringProp
-        name=\"Argument.value\">${__groovy( System.getenv(&quot;domain&quot;) ?: &quot;example.com&quot;
-        )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
-        \         </elementProp>\r\n          <elementProp name=\"protocol\" elementType=\"Argument\">\r\n
-        \           <stringProp name=\"Argument.name\">protocol</stringProp>\r\n            <stringProp
-        name=\"Argument.value\">${__groovy( System.getenv(&quot;protocol&quot;) ?:
-        &quot;https&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
-        \         </elementProp>\r\n          <elementProp name=\"url_path\" elementType=\"Argument\">\r\n
-        \           <stringProp name=\"Argument.name\">url_path</stringProp>\r\n            <stringProp
-        name=\"Argument.value\">${__groovy( System.getenv(&quot;url_path&quot;) ?:
-        &quot;/&quot; )}</stringProp>\r\n            <stringProp name=\"Argument.metadata\">=</stringProp>\r\n
-        \         </elementProp>\r\n        </collectionProp>\r\n      </Arguments>\r\n
-        \     <hashTree/>\r\n      <OpenModelThreadGroup guiclass=\"OpenModelThreadGroupGui\"
-        testclass=\"OpenModelThreadGroup\" testname=\"Open Model Thread Group\" enabled=\"true\">\r\n
-        \       <elementProp name=\"ThreadGroup.main_controller\" elementType=\"OpenModelThreadGroupController\"/>\r\n
-        \       <stringProp name=\"ThreadGroup.on_sample_error\">continue</stringProp>\r\n
-        \       <stringProp name=\"OpenModelThreadGroup.schedule\">rate(${rps}/sec)
-        random_arrivals(${duration_in_sec} sec)</stringProp>\r\n        <stringProp
-        name=\"OpenModelThreadGroup.random_seed\"></stringProp>\r\n      </OpenModelThreadGroup>\r\n
-        \     <hashTree>\r\n        <HTTPSamplerProxy guiclass=\"HttpTestSampleGui\"
-        testclass=\"HTTPSamplerProxy\" testname=\"HTTP Request\" enabled=\"true\">\r\n
-        \         <elementProp name=\"HTTPsampler.Arguments\" elementType=\"Arguments\"
-        guiclass=\"HTTPArgumentsPanel\" testclass=\"Arguments\" testname=\"User Defined
-        Variables\" enabled=\"true\">\r\n            <collectionProp name=\"Arguments.arguments\"/>\r\n
-        \         </elementProp>\r\n          <stringProp name=\"HTTPSampler.domain\">${domain}</stringProp>\r\n
-        \         <stringProp name=\"HTTPSampler.port\"></stringProp>\r\n          <stringProp
-        name=\"HTTPSampler.protocol\">${protocol}</stringProp>\r\n          <stringProp
-        name=\"HTTPSampler.contentEncoding\"></stringProp>\r\n          <stringProp
-        name=\"HTTPSampler.path\">${url_path}</stringProp>\r\n          <stringProp
-        name=\"HTTPSampler.method\">GET</stringProp>\r\n          <boolProp name=\"HTTPSampler.follow_redirects\">true</boolProp>\r\n
-        \         <boolProp name=\"HTTPSampler.auto_redirects\">false</boolProp>\r\n
-        \         <boolProp name=\"HTTPSampler.use_keepalive\">true</boolProp>\r\n
-        \         <boolProp name=\"HTTPSampler.DO_MULTIPART_POST\">false</boolProp>\r\n
-        \         <stringProp name=\"HTTPSampler.embedded_url_re\"></stringProp>\r\n
-        \         <stringProp name=\"HTTPSampler.connect_timeout\"></stringProp>\r\n
-        \         <stringProp name=\"HTTPSampler.response_timeout\"></stringProp>\r\n
-        \       </HTTPSamplerProxy>\r\n        <hashTree/>\r\n      </hashTree>\r\n
-        \   </hashTree>\r\n  </hashTree>\r\n</jmeterTestPlan>\r\n"
-    headers:
-      accept-ranges:
-      - bytes
-      content-length:
-      - '4870'
-      content-md5:
-      - xGA4QxS45K0eB2EZNBGk8w==
-      content-type:
-      - application/octet-stream
-      date:
-      - Mon, 09 Oct 2023 16:11:18 GMT
-      etag:
-      - '"0x8DBC8E255A8B8EF"'
-      last-modified:
-      - Mon, 09 Oct 2023 16:11:02 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-blob-type:
-      - BlockBlob
-      x-ms-creation-time:
-      - Mon, 09 Oct 2023 16:11:02 GMT
-      x-ms-lease-state:
-      - available
-      x-ms-lease-status:
-      - unlocked
-      x-ms-meta-filename:
-      - c2FtcGxlLUpNWC1maWxlLmpteA==
-      x-ms-meta-filetype:
-      - JMX_FILE
-      x-ms-meta-isencoded:
-      - 'true'
-      x-ms-server-encrypted:
-      - 'true'
-      x-ms-version:
-      - '2021-10-04'
     status:
       code: 200
       message: OK

--- a/src/load/azext_load/tests/latest/test_load_test.py
+++ b/src/load/azext_load/tests/latest/test_load_test.py
@@ -52,6 +52,7 @@ sa_params = {
     "length": 20,
 }
 
+
 class LoadTestScenario(ScenarioTest):
     def __init__(self, *args, **kwargs):
         super(LoadTestScenario, self).__init__(*args, **kwargs)
@@ -80,7 +81,7 @@ class LoadTestScenario(ScenarioTest):
                 "keyvault_reference_id": LoadTestConstants.KEYVAULT_REFERENCE_ID,
                 "env": LoadTestConstants.VALID_ENV_RPS,
                 "split_csv": LoadTestConstants.SPLIT_CSV_TRUE,
-                "subnet_id": subnet_id
+                "subnet_id": subnet_id,
             }
         )
 
@@ -135,7 +136,9 @@ class LoadTestScenario(ScenarioTest):
         )
 
         # verify failureCriteria
-        pass_fail_metric = response.get("passFailCriteria",{}).get("passFailMetrics",{})
+        pass_fail_metric = response.get("passFailCriteria", {}).get(
+            "passFailMetrics", {}
+        )
         for item in pass_fail_metric.values():
             if item.get("clientMetric") == "requests_per_sec":
                 assert item.get("value") == 78.0
@@ -151,7 +154,7 @@ class LoadTestScenario(ScenarioTest):
                 assert item.get("aggregate") == "avg"
                 assert item.get("requestName") == "GetCustomerDetails"
 
-        #Invalid create test cases
+        # Invalid create test cases
         # 1. Creating test with existing test id
         try:
             self.cmd(
@@ -174,7 +177,7 @@ class LoadTestScenario(ScenarioTest):
             )
         except Exception as e:
             assert "Provided path" in str(e)
-        
+
         self.kwargs.update(
             {
                 "certificate": LoadTestConstants.INVALID_CERTIFICATE,
@@ -408,7 +411,7 @@ class LoadTestScenario(ScenarioTest):
             )
         except Exception as e:
             assert "Provided path" in str(e)
-        
+
         time.sleep(10)
 
     @ResourceGroupPreparer(**rg_params)
@@ -499,13 +502,11 @@ class LoadTestScenario(ScenarioTest):
         self.kwargs.update(
             {
                 "load_test_config_file": LoadTestConstants.LOAD_TEST_CONFIG_FILE,
-                "env": "c=5"
+                "env": "c=5",
             }
         )
         checks = [
-            JMESPathCheck(
-                "loadTestConfiguration.engineInstances", 1
-            ),
+            JMESPathCheck("loadTestConfiguration.engineInstances", 1),
             JMESPathCheck("keyvaultReferenceIdentityType", "SystemAssigned"),
             JMESPathCheck("loadTestConfiguration.splitAllCSVs", True),
         ]
@@ -532,7 +533,6 @@ class LoadTestScenario(ScenarioTest):
         assert response.get("environmentVariables").get("rps") == "1"
         assert not response.get("environmentVariables").get("a")
 
-
     @ResourceGroupPreparer(**rg_params)
     @LoadTestResourcePreparer(**load_params)
     def test_load_test_update(self, rg, load):
@@ -549,7 +549,7 @@ class LoadTestScenario(ScenarioTest):
             {
                 "engine_instance": 11,
                 "keyvault_reference_id": "null",
-                "split_csv": LoadTestConstants.SPLIT_CSV_FALSE
+                "split_csv": LoadTestConstants.SPLIT_CSV_FALSE,
             }
         )
         checks = [
@@ -767,7 +767,7 @@ class LoadTestScenario(ScenarioTest):
         server_metric = server_metrics.get("metrics", {}).get(
             self.kwargs["server_metric_id"]
         )
-        
+
         # REMOVE SERVER METRIC AND LIST IT TO CHECK
         assert server_metric is not None
         # assert self.kwargs[

--- a/src/load/setup.py
+++ b/src/load/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 
 # HISTORY.rst entry.
-VERSION = '0.3.1'
+VERSION = '0.3.2'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
---
This PR is for bug fixes in our existing extension for Azure Load Testing service under "load" extension. 
Changes in this PR:

1. Changed logical implementation of a two commands.

> - Added null support for argument --certificate and --subnet in commands "az load update" and "az load create" to remove those properties from test.
> - Added support to remove certificate, subnet from config file when provided in commands "az load update" and "az load create".
> - Logical implementation changed when using config file using argument --load-test-config-file in commands "az load test update" and "az load test create".  
> 

2. Added a new test case to cover new cases.

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
Changes will be reflected for following commands "az load test create" and "az load test update".

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
